### PR TITLE
feat: Gmail MCP Server with dynamic OAuth tokens

### DIFF
--- a/custom-nodes/n8n-nodes-gmail-dynamic/nodes/GmailToolDynamic/GmailToolDynamic.node.ts
+++ b/custom-nodes/n8n-nodes-gmail-dynamic/nodes/GmailToolDynamic/GmailToolDynamic.node.ts
@@ -581,6 +581,7 @@ async function executeDraftOperation(
       return gmailRequest.call(this, accessToken, 'GET', `/drafts/${draftId}`);
     }
 
+    case 'getAll':
     case 'getMany': {
       const maxResults = this.getNodeParameter('maxResults', itemIndex, 10) as number;
       return gmailRequest.call(this, accessToken, 'GET', '/drafts', undefined, { maxResults });
@@ -662,6 +663,7 @@ async function executeThreadOperation(
       return gmailRequest.call(this, accessToken, 'GET', `/threads/${threadId}`);
     }
 
+    case 'getAll':
     case 'getMany': {
       const maxResults = this.getNodeParameter('maxResults', itemIndex, 10) as number;
       return gmailRequest.call(this, accessToken, 'GET', '/threads', undefined, { maxResults });

--- a/custom-nodes/n8n-nodes-gmail-dynamic/nodes/GmailToolDynamic/GmailToolDynamic.node.ts
+++ b/custom-nodes/n8n-nodes-gmail-dynamic/nodes/GmailToolDynamic/GmailToolDynamic.node.ts
@@ -103,13 +103,13 @@ export class GmailToolDynamic implements INodeType {
           show: { resource: ['label'] },
         },
         options: [
-          { name: 'List', value: 'list', description: 'List all labels' },
+          { name: 'Get All', value: 'getAll', description: 'List all labels' },
           { name: 'Get', value: 'get', description: 'Get a label by ID' },
           { name: 'Create', value: 'create', description: 'Create a label' },
           { name: 'Delete', value: 'delete', description: 'Delete a label' },
           { name: 'Update', value: 'update', description: 'Update a label' },
         ],
-        default: 'list',
+        default: 'getAll',
       },
       // === OPERATIONS: THREAD ===
       {
@@ -184,36 +184,36 @@ export class GmailToolDynamic implements INodeType {
         displayName: 'To',
         name: 'to',
         type: 'string',
-        required: true,
+        required: false,
         displayOptions: {
           show: { resource: ['message', 'draft'], operation: ['send', 'reply', 'create'] },
         },
         default: '',
         placeholder: 'recipient@example.com',
-        description: 'Recipient email address',
+        description: 'Recipient email address (can also be passed via webhook body as "to")',
       },
       {
         displayName: 'Subject',
         name: 'subject',
         type: 'string',
-        required: true,
+        required: false,
         displayOptions: {
           show: { resource: ['message', 'draft'], operation: ['send', 'create'] },
         },
         default: '',
-        description: 'Email subject line',
+        description: 'Email subject line (can also be passed via webhook body as "subject")',
       },
       {
         displayName: 'Body',
         name: 'body',
         type: 'string',
         typeOptions: { rows: 5 },
-        required: true,
+        required: false,
         displayOptions: {
           show: { resource: ['message', 'draft'], operation: ['send', 'reply', 'create'] },
         },
         default: '',
-        description: 'Email body content',
+        description: 'Email body content (can also be passed via webhook body as "body" or "message")',
       },
       {
         displayName: 'CC',
@@ -258,35 +258,35 @@ export class GmailToolDynamic implements INodeType {
         displayName: 'Label Name',
         name: 'labelName',
         type: 'string',
-        required: true,
+        required: false,
         displayOptions: {
           show: { resource: ['label'], operation: ['create', 'update'] },
         },
         default: '',
-        description: 'Name of the label',
+        description: 'Name of the label (can also be passed via webhook body as "label_name")',
       },
       {
         displayName: 'Label ID',
         name: 'labelId',
         type: 'string',
-        required: true,
+        required: false,
         displayOptions: {
           show: { resource: ['label'], operation: ['get', 'delete', 'update'] },
         },
         default: '',
-        description: 'The ID of the label',
+        description: 'The ID of the label (can also be passed via webhook body as "label_id")',
       },
       // === PARAMETERS: DRAFT ===
       {
         displayName: 'Draft ID',
         name: 'draftId',
         type: 'string',
-        required: true,
+        required: false,
         displayOptions: {
           show: { resource: ['draft'], operation: ['get', 'delete', 'send'] },
         },
         default: '',
-        description: 'The ID of the draft',
+        description: 'The ID of the draft (can also be passed via webhook body as "draft_id")',
       },
       // === PARAMETERS: THREAD ===
       {
@@ -610,6 +610,7 @@ async function executeLabelOperation(
   itemIndex: number,
 ): Promise<unknown> {
   switch (operation) {
+    case 'getAll':
     case 'list': {
       return gmailRequest.call(this, accessToken, 'GET', '/labels');
     }

--- a/scripts/n8n_api.sh
+++ b/scripts/n8n_api.sh
@@ -162,17 +162,67 @@ if found == 0:
 "
         ;;
 
+    update)
+        # Update existing workflow from JSON file
+        # Usage: update <workflow_id> <json_file>
+        if [ -z "$2" ] || [ -z "$3" ]; then
+            echo "Usage: $0 update <workflow_id> <json_file>"
+            exit 1
+        fi
+        WORKFLOW_ID="$2"
+        JSON_FILE="$3"
+
+        if [ ! -f "$JSON_FILE" ]; then
+            echo "Error: File not found: $JSON_FILE"
+            exit 1
+        fi
+
+        echo "📋 Updating workflow $WORKFLOW_ID..."
+
+        # Step 1: Deactivate if active
+        echo "1️⃣ Deactivating workflow..."
+        n8n_api POST "/workflows/$WORKFLOW_ID/deactivate" > /dev/null 2>&1
+
+        # Step 2: Update with PUT
+        echo "2️⃣ Updating workflow content..."
+        result=$(curl -s -X PUT "${N8N_API_URL}/workflows/$WORKFLOW_ID" \
+            -H "X-N8N-API-KEY: $N8N_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d @"$JSON_FILE")
+
+        # Check if update succeeded
+        updated_id=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null)
+
+        if [ "$updated_id" = "$WORKFLOW_ID" ]; then
+            echo "3️⃣ Reactivating workflow..."
+            n8n_api POST "/workflows/$WORKFLOW_ID/activate" > /dev/null 2>&1
+
+            # Verify final state
+            n8n_api GET "/workflows/$WORKFLOW_ID" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+status = '✅' if d.get('active') else '❌'
+print(f\"{status} Updated workflow: {d.get('name')} (ID: {d.get('id')})\")
+print(f\"   Nodes: {len(d.get('nodes', []))}\")
+"
+        else
+            echo "❌ Update failed: $result"
+            exit 1
+        fi
+        ;;
+
     *)
         echo "n8n API Helper Script"
         echo ""
         echo "Usage: $0 <action> [params]"
         echo ""
         echo "Actions:"
-        echo "  list                    List all workflows"
+        echo "  list [name]             List all workflows (optional name filter)"
         echo "  get <id>                Get workflow details"
         echo "  activate <id>           Activate a workflow"
         echo "  deactivate <id>         Deactivate a workflow"
-        echo "  import <file>           Import workflow from JSON file"
+        echo "  import <file>           Import workflow from JSON file (creates new)"
+        echo "  update <id> <file>      Update existing workflow from JSON file"
         echo "  search <pattern>        Search workflows by name"
         echo "  test-webhook <path>     Test a webhook endpoint"
         echo ""

--- a/workflows/mcp/Gmail_MCP_Server_3605.json
+++ b/workflows/mcp/Gmail_MCP_Server_3605.json
@@ -498,243 +498,749 @@
       ],
       "parameters": {
         "rules": {
-          "rules": [
+          "values": [
             {
+              "outputKey": "message_get",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_get",
-                    "operation": "equals"
+                    "id": "1ffe969a-b7e0-4ef6-b945-b8336a92f0ff",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "c166a2f2-05c8-4715-8654-4ab8d9f5de49",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "get"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_getAll",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_getAll",
-                    "operation": "equals"
+                    "id": "032602bb-4e62-4b12-8e98-2ce72f75edf4",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "66743fbe-3049-4bdf-81f8-c47ba421d06d",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "getAll"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_delete",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_delete",
-                    "operation": "equals"
+                    "id": "6982333d-041e-45a7-b996-49e5adf6d6d7",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "a54673cc-e575-457e-9f0c-0b79b70c65a7",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "delete"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_reply",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_reply",
-                    "operation": "equals"
+                    "id": "502c104b-8073-4dd4-ab66-a739bf213f7d",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "d3eb1616-ddf6-488d-8d56-fdbda02f4ff0",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "reply"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_markAsRead",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_markAsRead",
-                    "operation": "equals"
+                    "id": "abe6cdd0-b3fb-426a-ad13-07e140801f51",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "205f8a36-0a48-4ca0-bc26-51fa8f297fe2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "markAsRead"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_markAsUnread",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_markAsUnread",
-                    "operation": "equals"
+                    "id": "35564b42-4573-4372-ae3b-fadb1bcd46df",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "cf282305-32f6-4cd5-8c95-f65c9a87dcdc",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "markAsUnread"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_addLabels",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_addLabels",
-                    "operation": "equals"
+                    "id": "2c7a9324-70c6-4460-837c-370f76c6aaea",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "0d1b145d-0600-4481-b81d-a7f00eff2753",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "addLabels"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "message_removeLabels",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "message_removeLabels",
-                    "operation": "equals"
+                    "id": "f167423b-631d-4b9c-a118-99718246fcf9",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "5c0c1e7e-e9e2-4e67-bc58-90de63563d96",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "removeLabels"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "label_getAll",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "label_getAll",
-                    "operation": "equals"
+                    "id": "fefd473c-b1fd-4566-9ece-c8a4d32b7438",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "label"
+                  },
+                  {
+                    "id": "ef3784f2-4eb4-4323-a72d-88ae80802247",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "getAll"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "label_get",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "label_get",
-                    "operation": "equals"
+                    "id": "b0953d5f-c82f-47f9-89e5-e093109be763",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "label"
+                  },
+                  {
+                    "id": "df29fdf0-7912-4cb7-811c-03665f14fcf2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "get"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "label_create",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "label_create",
-                    "operation": "equals"
+                    "id": "8af2d4a1-b63e-448e-b008-896428edeed6",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "label"
+                  },
+                  {
+                    "id": "bca24e25-e3ea-4823-9800-219cda37a2e7",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "create"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "label_delete",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "label_delete",
-                    "operation": "equals"
+                    "id": "8cd40263-ae2b-4305-862a-1c17b89c95cd",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "label"
+                  },
+                  {
+                    "id": "d69e3bfe-24af-4f98-8c36-b5416a95b856",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "delete"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "draft_create",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "draft_create",
-                    "operation": "equals"
+                    "id": "4fb0f8de-22ba-40e9-820c-45c40f7df581",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "draft"
+                  },
+                  {
+                    "id": "0eb6360e-b12f-4c96-82b8-b278192f0230",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "create"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "draft_get",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "draft_get",
-                    "operation": "equals"
+                    "id": "6fd64875-f158-4276-85ad-109ac5af08db",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "draft"
+                  },
+                  {
+                    "id": "659d1b06-337f-4308-85ad-fecc0bc3c0c3",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "get"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "draft_getAll",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "draft_getAll",
-                    "operation": "equals"
+                    "id": "974b10d1-3329-4c4b-8cdc-83c2434179bd",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "draft"
+                  },
+                  {
+                    "id": "6ecd5128-7739-42ce-abe1-1400b0e3ffef",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "getAll"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "draft_delete",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "draft_delete",
-                    "operation": "equals"
+                    "id": "653e39aa-1a04-4a8e-842c-110ce2fe01c1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "draft"
+                  },
+                  {
+                    "id": "b6910cbc-e291-4107-8c34-a6e7cbcfd4e1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "delete"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "thread_getAll",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "thread_getAll",
-                    "operation": "equals"
+                    "id": "cae0cb5e-4e6f-43db-91a9-49466d0eae8c",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "thread"
+                  },
+                  {
+                    "id": "fad211a1-2427-4f88-87dc-1506066b8326",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "getAll"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "thread_get",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "thread_get",
-                    "operation": "equals"
+                    "id": "4997dcea-4c81-4e11-93b4-2de3621a1a66",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "thread"
+                  },
+                  {
+                    "id": "74131011-45b7-48fa-9983-642f9a0b125d",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "get"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "thread_reply",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "thread_reply",
-                    "operation": "equals"
+                    "id": "e585abeb-a753-4f80-8099-48e3f4d7539f",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "thread"
+                  },
+                  {
+                    "id": "bf5914ad-9898-472b-9d03-801594b97bc9",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "reply"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "thread_addLabels",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "thread_addLabels",
-                    "operation": "equals"
+                    "id": "6b1f5b29-98cf-4228-a0e3-3ddd606bb53b",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "thread"
+                  },
+                  {
+                    "id": "270fd9e3-8c9d-48fb-a4ff-7e11139462ec",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "addLabels"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
+              "outputKey": "thread_removeLabels",
               "conditions": {
-                "string": [
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
                   {
-                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
-                    "value2": "thread_removeLabels",
-                    "operation": "equals"
+                    "id": "2022e6ae-14fd-4098-8c77-40e2f68ead36",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "thread"
+                  },
+                  {
+                    "id": "dc8f60ba-5a3a-476f-a1e3-776b09d167b9",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "removeLabels"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             }
           ]
         },
-        "options": {}
+        "options": {
+          "fallbackOutput": "none"
+        }
       },
-      "typeVersion": 2
+      "typeVersion": 3.2
     }
   ],
   "settings": {

--- a/workflows/mcp/Gmail_MCP_Server_3605.json
+++ b/workflows/mcp/Gmail_MCP_Server_3605.json
@@ -497,98 +497,244 @@
         40
       ],
       "parameters": {
-        "dataType": "string",
-        "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
         "rules": {
           "rules": [
             {
-              "value2": "message_get",
-              "output": 0
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_get",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_getAll",
-              "output": 1
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_getAll",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_delete",
-              "output": 2
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_delete",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_reply",
-              "output": 3
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_reply",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_markAsRead",
-              "output": 4
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_markAsRead",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_markAsUnread",
-              "output": 5
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_markAsUnread",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_addLabels",
-              "output": 6
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_addLabels",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "message_removeLabels",
-              "output": 7
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "message_removeLabels",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "label_getAll",
-              "output": 8
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "label_getAll",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "label_get",
-              "output": 9
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "label_get",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "label_create",
-              "output": 10
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "label_create",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "label_delete",
-              "output": 11
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "label_delete",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "draft_create",
-              "output": 12
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "draft_create",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "draft_get",
-              "output": 13
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "draft_get",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "draft_getAll",
-              "output": 14
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "draft_getAll",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "draft_delete",
-              "output": 15
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "draft_delete",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "thread_getAll",
-              "output": 16
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "thread_getAll",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "thread_get",
-              "output": 17
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "thread_get",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "thread_reply",
-              "output": 18
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "thread_reply",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "thread_addLabels",
-              "output": 19
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "thread_addLabels",
+                    "operation": "equals"
+                  }
+                ]
+              }
             },
             {
-              "value2": "thread_removeLabels",
-              "output": 20
+              "conditions": {
+                "string": [
+                  {
+                    "value1": "={{ $json.body.resource }}_{{ $json.body.operation }}",
+                    "value2": "thread_removeLabels",
+                    "operation": "equals"
+                  }
+                ]
+              }
             }
           ]
-        }
+        },
+        "options": {}
       },
-      "typeVersion": 3
+      "typeVersion": 2
     }
   ],
   "settings": {

--- a/workflows/mcp/Gmail_MCP_Server_3605.json
+++ b/workflows/mcp/Gmail_MCP_Server_3605.json
@@ -1233,6 +1233,41 @@
                 ]
               },
               "renameOutput": true
+            },
+            {
+              "outputKey": "message_send",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "3c45559b-7df8-4fa1-85f7-833bf15644a9",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "message"
+                  },
+                  {
+                    "id": "b9d9ae66-1202-43da-b4c9-29163c235e51",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "send"
+                  }
+                ]
+              },
+              "renameOutput": true
             }
           ]
         },
@@ -1241,6 +1276,26 @@
         }
       },
       "typeVersion": 3.2
+    },
+    {
+      "id": "9bd065c4-e883-4787-a350-8a3ec2160083",
+      "name": "sendMessage",
+      "type": "CUSTOM.gmailToolDynamic",
+      "position": [
+        400,
+        1000
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "message",
+        "operation": "send",
+        "to": "={{ $json.body.to }}",
+        "subject": "={{ $json.body.subject }}",
+        "body": "={{ $json.body.body }}",
+        "cc": "={{ $json.body.cc || '' }}",
+        "bcc": "={{ $json.body.bcc || '' }}"
+      },
+      "typeVersion": 1
     }
   ],
   "settings": {
@@ -1634,6 +1689,24 @@
         [
           {
             "node": "removeLabelThread",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "sendMessage",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "sendMessage": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- Convert all 21 Gmail nodes to use custom `CUSTOM.gmailToolDynamic` node with dynamic OAuth token support
- Add Switch node (v3.2) for routing webhook requests to the correct Gmail operation
- Add `message/send` operation for sending emails via webhook
- Fix `draft/getAll` and `thread/getAll` operations (add aliases)
- Make parameters optional in custom node to avoid validation errors

## Features
- **22 Gmail operations** supported via webhook:
  - Message: get, getAll, delete, reply, send, markAsRead, markAsUnread, addLabels, removeLabels
  - Label: getAll, get, create, delete
  - Draft: create, get, getAll, delete
  - Thread: getAll, get, reply, addLabels, removeLabels

- **Dynamic OAuth token**: Pass `access_token` in webhook body instead of using stored credentials

## Test plan
- [x] Test label/getAll routing
- [x] Test draft/getAll routing  
- [x] Test thread/get routing
- [x] Test message/send routing
- [ ] Test with valid OAuth token for full end-to-end test

🤖 Generated with [Claude Code](https://claude.com/claude-code)