### PR TITLE
feat: add Google Calendar MCP Server with dynamic OAuth

### DIFF
--- a/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts
+++ b/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts
@@ -1,0 +1,539 @@
+import {
+  IExecuteFunctions,
+  INodeType,
+  INodeTypeDescription,
+  INodeExecutionData,
+  NodeApiError,
+  JsonObject,
+  IHttpRequestOptions,
+  IDataObject,
+} from 'n8n-workflow';
+
+export class CalendarToolDynamic implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'Google Calendar Tool Dynamic',
+    name: 'calendarToolDynamic',
+    icon: 'file:calendar.svg',
+    group: ['transform'],
+    version: 1,
+    subtitle: '={{ $parameter["operation"] + " " + $parameter["resource"] }}',
+    description: 'Google Calendar API with dynamic OAuth token from input - Multi-tenant ready',
+    defaults: {
+      name: 'Calendar Dynamic',
+    },
+    inputs: ['main'],
+    outputs: ['main'],
+    credentials: [], // NO static credentials - token passed as parameter
+    properties: [
+      // === ACCESS TOKEN (DYNAMIC) ===
+      {
+        displayName: 'Access Token',
+        name: 'accessToken',
+        type: 'string',
+        typeOptions: {
+          password: true,
+        },
+        required: true,
+        default: '',
+        placeholder: '{{ $json.access_token }}',
+        description: 'OAuth 2.0 access token. Use expression to get from webhook body or previous node.',
+      },
+      // === RESOURCE ===
+      {
+        displayName: 'Resource',
+        name: 'resource',
+        type: 'options',
+        noDataExpression: true,
+        options: [
+          { name: 'Event', value: 'event' },
+          { name: 'Calendar', value: 'calendar' },
+        ],
+        default: 'event',
+      },
+      // === OPERATIONS: EVENT ===
+      {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: true,
+        displayOptions: {
+          show: { resource: ['event'] },
+        },
+        options: [
+          { name: 'Create', value: 'create', description: 'Create a new event' },
+          { name: 'Delete', value: 'delete', description: 'Delete an event' },
+          { name: 'Get', value: 'get', description: 'Get an event by ID' },
+          { name: 'Get Many', value: 'getAll', description: 'Get multiple events' },
+          { name: 'Update', value: 'update', description: 'Update an event' },
+        ],
+        default: 'getAll',
+      },
+      // === OPERATIONS: CALENDAR ===
+      {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: true,
+        displayOptions: {
+          show: { resource: ['calendar'] },
+        },
+        options: [
+          { name: 'Get Many', value: 'getAll', description: 'Get all calendars' },
+        ],
+        default: 'getAll',
+      },
+      // === PARAMETERS: CALENDAR ID ===
+      {
+        displayName: 'Calendar ID',
+        name: 'calendarId',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'] },
+        },
+        default: 'primary',
+        description: 'Calendar identifier. Use "primary" for the primary calendar of the authenticated user.',
+      },
+      // === PARAMETERS: EVENT ID ===
+      {
+        displayName: 'Event ID',
+        name: 'eventId',
+        type: 'string',
+        required: true,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['get', 'delete', 'update'] },
+        },
+        default: '',
+        description: 'The ID of the event',
+      },
+      // === PARAMETERS: EVENT CREATE/UPDATE ===
+      {
+        displayName: 'Summary',
+        name: 'summary',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        description: 'Title of the event',
+      },
+      {
+        displayName: 'Start',
+        name: 'start',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        placeholder: '2025-12-06T10:00:00Z',
+        description: 'Start date/time in ISO 8601 format (e.g., 2025-12-06T10:00:00Z or 2025-12-06 for all-day events)',
+      },
+      {
+        displayName: 'End',
+        name: 'end',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        placeholder: '2025-12-06T11:00:00Z',
+        description: 'End date/time in ISO 8601 format (e.g., 2025-12-06T11:00:00Z or 2025-12-07 for all-day events)',
+      },
+      {
+        displayName: 'Description',
+        name: 'description',
+        type: 'string',
+        typeOptions: { rows: 3 },
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        description: 'Description of the event',
+      },
+      {
+        displayName: 'Location',
+        name: 'location',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        description: 'Geographic location of the event',
+      },
+      {
+        displayName: 'Attendees',
+        name: 'attendees',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        placeholder: 'email1@example.com,email2@example.com',
+        description: 'Comma-separated list of attendee email addresses',
+      },
+      {
+        displayName: 'All Day Event',
+        name: 'allDay',
+        type: 'boolean',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: false,
+        description: 'Whether this is an all-day event',
+      },
+      {
+        displayName: 'Timezone',
+        name: 'timezone',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: '',
+        placeholder: 'Europe/Paris',
+        description: 'Timezone for the event (e.g., Europe/Paris, America/New_York)',
+      },
+      // === PARAMETERS: GET ALL EVENTS ===
+      {
+        displayName: 'Time Min',
+        name: 'timeMin',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['getAll'] },
+        },
+        default: '',
+        placeholder: '2025-12-01T00:00:00Z',
+        description: 'Lower bound (inclusive) for event start time to filter by',
+      },
+      {
+        displayName: 'Time Max',
+        name: 'timeMax',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['getAll'] },
+        },
+        default: '',
+        placeholder: '2025-12-31T23:59:59Z',
+        description: 'Upper bound (exclusive) for event start time to filter by',
+      },
+      {
+        displayName: 'Max Results',
+        name: 'maxResults',
+        type: 'number',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['getAll'] },
+        },
+        default: 10,
+        description: 'Maximum number of events to return (max 2500)',
+      },
+      {
+        displayName: 'Query',
+        name: 'query',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['getAll'] },
+        },
+        default: '',
+        description: 'Free text search terms to find events that match these terms',
+      },
+      {
+        displayName: 'Single Events',
+        name: 'singleEvents',
+        type: 'boolean',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['getAll'] },
+        },
+        default: true,
+        description: 'Whether to expand recurring events into instances',
+      },
+      {
+        displayName: 'Order By',
+        name: 'orderBy',
+        type: 'options',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['getAll'] },
+        },
+        options: [
+          { name: 'Start Time', value: 'startTime' },
+          { name: 'Updated', value: 'updated' },
+        ],
+        default: 'startTime',
+        description: 'Order of the events returned',
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const returnData: INodeExecutionData[] = [];
+
+    for (let itemIndex = 0; itemIndex < items.length; itemIndex++) {
+      try {
+        const accessToken = this.getNodeParameter('accessToken', itemIndex) as string;
+        const resource = this.getNodeParameter('resource', itemIndex) as string;
+        const operation = this.getNodeParameter('operation', itemIndex) as string;
+
+        if (!accessToken) {
+          throw new Error('Access token is required. Use expression like {{ $json.access_token }}');
+        }
+
+        let result: unknown;
+
+        if (resource === 'event') {
+          result = await executeEventOperation.call(this, accessToken, operation, itemIndex);
+        } else if (resource === 'calendar') {
+          result = await executeCalendarOperation.call(this, accessToken, operation, itemIndex);
+        }
+
+        returnData.push({
+          json: result as JsonObject,
+          pairedItem: itemIndex,
+        });
+
+      } catch (error) {
+        if (this.continueOnFail()) {
+          returnData.push({
+            json: {
+              error: (error as Error).message,
+              errorDetails: (error as JsonObject),
+            },
+            pairedItem: itemIndex,
+          });
+        } else {
+          throw new NodeApiError(this.getNode(), error as JsonObject, { itemIndex });
+        }
+      }
+    }
+
+    return [returnData];
+  }
+}
+
+// === HELPER FUNCTION: Calendar API Request ===
+async function calendarRequest(
+  this: IExecuteFunctions,
+  accessToken: string,
+  method: string,
+  endpoint: string,
+  body?: IDataObject,
+  qs?: IDataObject,
+): Promise<unknown> {
+  const options: IHttpRequestOptions = {
+    method: method as 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+    url: `https://www.googleapis.com/calendar/v3${endpoint}`,
+    headers: {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    json: true,
+  };
+
+  if (body && Object.keys(body).length > 0) {
+    options.body = body;
+  }
+  if (qs && Object.keys(qs).length > 0) {
+    options.qs = qs;
+  }
+
+  return this.helpers.httpRequest(options);
+}
+
+// === EVENT OPERATIONS ===
+async function executeEventOperation(
+  this: IExecuteFunctions,
+  accessToken: string,
+  operation: string,
+  itemIndex: number,
+): Promise<unknown> {
+  const calendarId = this.getNodeParameter('calendarId', itemIndex, 'primary') as string;
+
+  switch (operation) {
+    case 'create': {
+      const summary = this.getNodeParameter('summary', itemIndex, '') as string;
+      const start = this.getNodeParameter('start', itemIndex, '') as string;
+      const end = this.getNodeParameter('end', itemIndex, '') as string;
+      const description = this.getNodeParameter('description', itemIndex, '') as string;
+      const location = this.getNodeParameter('location', itemIndex, '') as string;
+      const attendees = this.getNodeParameter('attendees', itemIndex, '') as string;
+      const allDay = this.getNodeParameter('allDay', itemIndex, false) as boolean;
+      const timezone = this.getNodeParameter('timezone', itemIndex, '') as string;
+
+      const eventBody: IDataObject = {};
+
+      if (summary) eventBody.summary = summary;
+      if (description) eventBody.description = description;
+      if (location) eventBody.location = location;
+
+      // Handle start/end times
+      if (start) {
+        if (allDay) {
+          eventBody.start = { date: start.split('T')[0] };
+        } else {
+          const startObj: IDataObject = { dateTime: start };
+          if (timezone) startObj.timeZone = timezone;
+          eventBody.start = startObj;
+        }
+      }
+
+      if (end) {
+        if (allDay) {
+          eventBody.end = { date: end.split('T')[0] };
+        } else {
+          const endObj: IDataObject = { dateTime: end };
+          if (timezone) endObj.timeZone = timezone;
+          eventBody.end = endObj;
+        }
+      }
+
+      // Handle attendees
+      if (attendees) {
+        const attendeesList = attendees.split(',').map(email => ({ email: email.trim() }));
+        eventBody.attendees = attendeesList;
+      }
+
+      return calendarRequest.call(
+        this,
+        accessToken,
+        'POST',
+        `/calendars/${encodeURIComponent(calendarId)}/events`,
+        eventBody
+      );
+    }
+
+    case 'get': {
+      const eventId = this.getNodeParameter('eventId', itemIndex) as string;
+      return calendarRequest.call(
+        this,
+        accessToken,
+        'GET',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`
+      );
+    }
+
+    case 'getAll': {
+      const timeMin = this.getNodeParameter('timeMin', itemIndex, '') as string;
+      const timeMax = this.getNodeParameter('timeMax', itemIndex, '') as string;
+      const maxResults = this.getNodeParameter('maxResults', itemIndex, 10) as number;
+      const query = this.getNodeParameter('query', itemIndex, '') as string;
+      const singleEvents = this.getNodeParameter('singleEvents', itemIndex, true) as boolean;
+      const orderBy = this.getNodeParameter('orderBy', itemIndex, 'startTime') as string;
+
+      const qs: IDataObject = {
+        maxResults,
+        singleEvents,
+      };
+
+      if (singleEvents) {
+        qs.orderBy = orderBy;
+      }
+
+      if (timeMin) qs.timeMin = timeMin;
+      if (timeMax) qs.timeMax = timeMax;
+      if (query) qs.q = query;
+
+      return calendarRequest.call(
+        this,
+        accessToken,
+        'GET',
+        `/calendars/${encodeURIComponent(calendarId)}/events`,
+        undefined,
+        qs
+      );
+    }
+
+    case 'update': {
+      const eventId = this.getNodeParameter('eventId', itemIndex) as string;
+      const summary = this.getNodeParameter('summary', itemIndex, '') as string;
+      const start = this.getNodeParameter('start', itemIndex, '') as string;
+      const end = this.getNodeParameter('end', itemIndex, '') as string;
+      const description = this.getNodeParameter('description', itemIndex, '') as string;
+      const location = this.getNodeParameter('location', itemIndex, '') as string;
+      const attendees = this.getNodeParameter('attendees', itemIndex, '') as string;
+      const allDay = this.getNodeParameter('allDay', itemIndex, false) as boolean;
+      const timezone = this.getNodeParameter('timezone', itemIndex, '') as string;
+
+      const eventBody: IDataObject = {};
+
+      if (summary) eventBody.summary = summary;
+      if (description) eventBody.description = description;
+      if (location) eventBody.location = location;
+
+      if (start) {
+        if (allDay) {
+          eventBody.start = { date: start.split('T')[0] };
+        } else {
+          const startObj: IDataObject = { dateTime: start };
+          if (timezone) startObj.timeZone = timezone;
+          eventBody.start = startObj;
+        }
+      }
+
+      if (end) {
+        if (allDay) {
+          eventBody.end = { date: end.split('T')[0] };
+        } else {
+          const endObj: IDataObject = { dateTime: end };
+          if (timezone) endObj.timeZone = timezone;
+          eventBody.end = endObj;
+        }
+      }
+
+      if (attendees) {
+        const attendeesList = attendees.split(',').map(email => ({ email: email.trim() }));
+        eventBody.attendees = attendeesList;
+      }
+
+      return calendarRequest.call(
+        this,
+        accessToken,
+        'PATCH',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+        eventBody
+      );
+    }
+
+    case 'delete': {
+      const eventId = this.getNodeParameter('eventId', itemIndex) as string;
+      await calendarRequest.call(
+        this,
+        accessToken,
+        'DELETE',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`
+      );
+      return { success: true, eventId, calendarId, action: 'deleted' };
+    }
+
+    default:
+      throw new Error(`Unknown event operation: ${operation}`);
+  }
+}
+
+// === CALENDAR OPERATIONS ===
+async function executeCalendarOperation(
+  this: IExecuteFunctions,
+  accessToken: string,
+  operation: string,
+  _itemIndex: number,
+): Promise<unknown> {
+  switch (operation) {
+    case 'getAll': {
+      return calendarRequest.call(this, accessToken, 'GET', '/users/me/calendarList');
+    }
+
+    default:
+      throw new Error(`Unknown calendar operation: ${operation}`);
+  }
+}

--- a/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/calendar.svg
+++ b/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/calendar.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect x="20" y="40" width="160" height="140" rx="10" fill="#fff" stroke="#4285f4" stroke-width="4"/>
+  <rect x="20" y="40" width="160" height="35" rx="10" fill="#4285f4"/>
+  <rect x="20" y="65" width="160" height="10" fill="#4285f4"/>
+  <circle cx="55" cy="40" r="8" fill="#ea4335"/>
+  <circle cx="145" cy="40" r="8" fill="#ea4335"/>
+  <rect x="45" cy="20" width="6" height="30" rx="3" fill="#5f6368"/>
+  <rect x="135" cy="20" width="6" height="30" rx="3" fill="#5f6368"/>
+  <rect x="45" y="95" width="30" height="25" rx="3" fill="#34a853"/>
+  <rect x="85" y="95" width="30" height="25" rx="3" fill="#fbbc04"/>
+  <rect x="125" y="95" width="30" height="25" rx="3" fill="#ea4335"/>
+  <rect x="45" y="130" width="30" height="25" rx="3" fill="#4285f4"/>
+  <rect x="85" y="130" width="30" height="25" rx="3" fill="#34a853"/>
+  <rect x="125" y="130" width="30" height="25" rx="3" fill="#fbbc04"/>
+</svg>

--- a/custom-nodes/n8n-nodes-calendar-dynamic/package.json
+++ b/custom-nodes/n8n-nodes-calendar-dynamic/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "n8n-nodes-calendar-dynamic",
+  "version": "1.0.0",
+  "description": "Google Calendar node with dynamic OAuth token support for multi-tenant architectures",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "google-calendar",
+    "oauth",
+    "multi-tenant",
+    "dynamic-token"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/fsebbah/n8n-workflows",
+  "author": {
+    "name": "fsebbah"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fsebbah/n8n-workflows.git"
+  },
+  "main": "dist/nodes/CalendarToolDynamic/CalendarToolDynamic.node.js",
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "nodes": [
+      "dist/nodes/CalendarToolDynamic/CalendarToolDynamic.node.js"
+    ]
+  },
+  "scripts": {
+    "build": "tsc && npm run copy-assets",
+    "copy-assets": "cp -r nodes/CalendarToolDynamic/*.svg dist/nodes/CalendarToolDynamic/ 2>/dev/null || true",
+    "dev": "tsc --watch",
+    "lint": "eslint nodes --ext .ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "~5.3.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  }
+}

--- a/custom-nodes/n8n-nodes-calendar-dynamic/tsconfig.json
+++ b/custom-nodes/n8n-nodes-calendar-dynamic/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "noEmit": false,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "nodes/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/workflows/mcp/MCP_Calendar_Server.json
+++ b/workflows/mcp/MCP_Calendar_Server.json
@@ -1,0 +1,563 @@
+{
+  "name": "MCP - Google Calendar Server",
+  "nodes": [
+    {
+      "id": "webhook-calendar-001",
+      "name": "Webhook MCP Calendar",
+      "type": "n8n-nodes-base.webhook",
+      "position": [
+        300,
+        300
+      ],
+      "webhookId": "mcp-calendar",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "mcp-calendar",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "router-calendar-001",
+      "name": "Route by Operation",
+      "type": "n8n-nodes-base.switch",
+      "position": [
+        500,
+        300
+      ],
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "event_create",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-create-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-create-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "create"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_get",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-get-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-get-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "get"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_getAll",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-getAll-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-getAll-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "getAll"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_update",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-update-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-update-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "update"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_delete",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-delete-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-delete-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "delete"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "calendar_getAll",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-calendar-getAll-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "calendar"
+                  },
+                  {
+                    "id": "cond-calendar-getAll-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "getAll"
+                  }
+                ]
+              },
+              "renameOutput": true
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "none"
+        }
+      },
+      "typeVersion": 3.2
+    },
+    {
+      "id": "respond-calendar-001",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "position": [
+        900,
+        300
+      ],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: true, data: $json, error: null }) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "typeVersion": 1.1
+    },
+    {
+      "id": "event-create-001",
+      "name": "createEvent",
+      "type": "CUSTOM.calendarToolDynamic",
+      "position": [
+        700,
+        100
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "create",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "summary": "={{ $json.body.summary }}",
+        "start": "={{ $json.body.start }}",
+        "end": "={{ $json.body.end }}",
+        "description": "={{ $json.body.description || '' }}",
+        "location": "={{ $json.body.location || '' }}",
+        "attendees": "={{ Array.isArray($json.body.attendees) ? $json.body.attendees.join(',') : ($json.body.attendees || '') }}",
+        "allDay": "={{ $json.body.all_day || false }}",
+        "timezone": "={{ $json.body.timezone || '' }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-get-001",
+      "name": "getEvent",
+      "type": "CUSTOM.calendarToolDynamic",
+      "position": [
+        700,
+        200
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "get",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "eventId": "={{ $json.body.event_id }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-getAll-001",
+      "name": "getAllEvents",
+      "type": "CUSTOM.calendarToolDynamic",
+      "position": [
+        700,
+        300
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "getAll",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "timeMin": "={{ $json.body.time_min || '' }}",
+        "timeMax": "={{ $json.body.time_max || '' }}",
+        "maxResults": "={{ $json.body.max_results || 10 }}",
+        "query": "={{ $json.body.query || '' }}",
+        "singleEvents": "={{ $json.body.single_events !== false }}",
+        "orderBy": "={{ $json.body.order_by || 'startTime' }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-update-001",
+      "name": "updateEvent",
+      "type": "CUSTOM.calendarToolDynamic",
+      "position": [
+        700,
+        400
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "update",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "eventId": "={{ $json.body.event_id }}",
+        "summary": "={{ $json.body.summary || '' }}",
+        "start": "={{ $json.body.start || '' }}",
+        "end": "={{ $json.body.end || '' }}",
+        "description": "={{ $json.body.description || '' }}",
+        "location": "={{ $json.body.location || '' }}",
+        "attendees": "={{ Array.isArray($json.body.attendees) ? $json.body.attendees.join(',') : ($json.body.attendees || '') }}",
+        "allDay": "={{ $json.body.all_day || false }}",
+        "timezone": "={{ $json.body.timezone || '' }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-delete-001",
+      "name": "deleteEvent",
+      "type": "CUSTOM.calendarToolDynamic",
+      "position": [
+        700,
+        500
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "delete",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "eventId": "={{ $json.body.event_id }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "calendar-getAll-001",
+      "name": "getAllCalendars",
+      "type": "CUSTOM.calendarToolDynamic",
+      "position": [
+        700,
+        600
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "calendar",
+        "operation": "getAll"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-usage-001",
+      "name": "Sticky Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [
+        60,
+        200
+      ],
+      "parameters": {
+        "color": 6,
+        "width": 200,
+        "height": 200,
+        "content": "## USAGE\n\nOpen the Calendar MCP Server node to obtain the webhook URL.\n\nUse POST requests with:\n- `access_token`\n- `resource` (event/calendar)\n- `operation`"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-events-001",
+      "name": "Sticky Note Events",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [
+        660,
+        40
+      ],
+      "parameters": {
+        "width": 200,
+        "height": 520,
+        "content": "## Event Operations\n\n- create\n- get\n- getAll\n- update\n- delete"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-calendars-001",
+      "name": "Sticky Note Calendars",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [
+        660,
+        560
+      ],
+      "parameters": {
+        "color": 4,
+        "width": 200,
+        "height": 100,
+        "content": "## Calendar Operations\n\n- getAll"
+      },
+      "typeVersion": 1
+    }
+  ],
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "connections": {
+    "Webhook MCP Calendar": {
+      "main": [
+        [
+          {
+            "node": "Route by Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route by Operation": {
+      "main": [
+        [
+          {
+            "node": "createEvent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "getEvent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "getAllEvents",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "updateEvent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "deleteEvent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "getAllCalendars",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "createEvent": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "getEvent": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "getAllEvents": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "updateEvent": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "deleteEvent": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "getAllCalendars": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implements issue #19 - Google Calendar MCP Server
- Creates custom node `n8n-nodes-calendar-dynamic` with dynamic OAuth token support
- Adds MCP workflow with webhook endpoint `/mcp-calendar`
- Multi-tenant ready (token passed per request, no static credentials)

## Features

### Custom Node Operations

| Resource | Operation | Description |
|----------|-----------|-------------|
| event | create | Create a new calendar event |
| event | get | Get an event by ID |
| event | getAll | List events with filters (time range, query, etc.) |
| event | update | Update an existing event |
| event | delete | Delete an event |
| calendar | getAll | List all calendars |

### Event Parameters

- `calendar_id` (default: "primary")
- `summary`, `description`, `location`
- `start`, `end` (ISO 8601 datetime)
- `attendees` (comma-separated emails or array)
- `all_day` (boolean)
- `timezone` (e.g., "Europe/Paris")

## Test plan

- [ ] Restart n8n to load the new custom node
- [ ] Import the workflow `MCP_Calendar_Server.json`
- [ ] Test `calendar/getAll` operation
- [ ] Test `event/create` operation
- [ ] Test `event/getAll` operation
- [ ] Test `event/get` operation
- [ ] Test `event/update` operation
- [ ] Test `event/delete` operation

## Usage Example

```bash
# List calendars
curl -X POST http://pi6.local:5678/webhook/mcp-calendar \
  -H "Content-Type: application/json" \
  -d '{
    "access_token": "YOUR_TOKEN",
    "resource": "calendar",
    "operation": "getAll"
  }'

# Create event
curl -X POST http://pi6.local:5678/webhook/mcp-calendar \
  -H "Content-Type: application/json" \
  -d '{
    "access_token": "YOUR_TOKEN",
    "resource": "event",
    "operation": "create",
    "calendar_id": "primary",
    "summary": "Test Event",
    "start": "2025-12-10T10:00:00Z",
    "end": "2025-12-10T11:00:00Z"
  }'
```

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)