### PR TITLE
feat(calendar): add advanced calendar features and operations

### DIFF
--- a/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts
+++ b/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts
@@ -60,10 +60,12 @@ export class CalendarToolDynamic implements INodeType {
           show: { resource: ['event'] },
         },
         options: [
+          { name: 'Add Attendee', value: 'addAttendee', description: 'Add an attendee to an event' },
           { name: 'Create', value: 'create', description: 'Create a new event' },
           { name: 'Delete', value: 'delete', description: 'Delete an event' },
           { name: 'Get', value: 'get', description: 'Get an event by ID' },
           { name: 'Get Many', value: 'getAll', description: 'Get multiple events' },
+          { name: 'Remove Attendee', value: 'removeAttendee', description: 'Remove an attendee from an event' },
           { name: 'Update', value: 'update', description: 'Update an event' },
         ],
         default: 'getAll',
@@ -101,10 +103,23 @@ export class CalendarToolDynamic implements INodeType {
         type: 'string',
         required: true,
         displayOptions: {
-          show: { resource: ['event'], operation: ['get', 'delete', 'update'] },
+          show: { resource: ['event'], operation: ['get', 'delete', 'update', 'addAttendee', 'removeAttendee'] },
         },
         default: '',
         description: 'The ID of the event',
+      },
+      // === PARAMETERS: ATTENDEE EMAIL (for add/remove) ===
+      {
+        displayName: 'Attendee Email',
+        name: 'attendeeEmail',
+        type: 'string',
+        required: true,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['addAttendee', 'removeAttendee'] },
+        },
+        default: '',
+        placeholder: 'user@example.com',
+        description: 'Email address of the attendee to add or remove',
       },
       // === PARAMETERS: EVENT CREATE/UPDATE ===
       {
@@ -542,6 +557,92 @@ async function executeEventOperation(
         `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`
       );
       return { success: true, eventId, calendarId, action: 'deleted' };
+    }
+
+    case 'addAttendee': {
+      const eventId = this.getNodeParameter('eventId', itemIndex) as string;
+      const attendeeEmail = this.getNodeParameter('attendeeEmail', itemIndex) as string;
+
+      // First, get the current event to preserve existing attendees
+      const currentEvent = await calendarRequest.call(
+        this,
+        accessToken,
+        'GET',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`
+      ) as { attendees?: Array<{ email: string }> };
+
+      // Get existing attendees or empty array
+      const existingAttendees = currentEvent.attendees || [];
+
+      // Check if attendee already exists
+      const alreadyExists = existingAttendees.some(
+        (a) => a.email.toLowerCase() === attendeeEmail.toLowerCase()
+      );
+
+      if (alreadyExists) {
+        return {
+          success: false,
+          message: `Attendee ${attendeeEmail} is already in the event`,
+          eventId,
+          attendees: existingAttendees
+        };
+      }
+
+      // Add new attendee
+      const updatedAttendees = [...existingAttendees, { email: attendeeEmail.trim() }];
+
+      // Update the event with new attendee list
+      const result = await calendarRequest.call(
+        this,
+        accessToken,
+        'PATCH',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+        { attendees: updatedAttendees }
+      );
+
+      return result;
+    }
+
+    case 'removeAttendee': {
+      const eventId = this.getNodeParameter('eventId', itemIndex) as string;
+      const attendeeEmail = this.getNodeParameter('attendeeEmail', itemIndex) as string;
+
+      // First, get the current event
+      const currentEvent = await calendarRequest.call(
+        this,
+        accessToken,
+        'GET',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`
+      ) as { attendees?: Array<{ email: string }> };
+
+      // Get existing attendees
+      const existingAttendees = currentEvent.attendees || [];
+
+      // Filter out the attendee to remove
+      const updatedAttendees = existingAttendees.filter(
+        (a) => a.email.toLowerCase() !== attendeeEmail.toLowerCase()
+      );
+
+      // Check if attendee was found and removed
+      if (updatedAttendees.length === existingAttendees.length) {
+        return {
+          success: false,
+          message: `Attendee ${attendeeEmail} was not found in the event`,
+          eventId,
+          attendees: existingAttendees
+        };
+      }
+
+      // Update the event with filtered attendee list
+      const result = await calendarRequest.call(
+        this,
+        accessToken,
+        'PATCH',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}`,
+        { attendees: updatedAttendees }
+      );
+
+      return result;
     }
 
     default:

--- a/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts
+++ b/custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts
@@ -63,8 +63,11 @@ export class CalendarToolDynamic implements INodeType {
           { name: 'Add Attendee', value: 'addAttendee', description: 'Add an attendee to an event' },
           { name: 'Create', value: 'create', description: 'Create a new event' },
           { name: 'Delete', value: 'delete', description: 'Delete an event' },
+          { name: 'Free/Busy Query', value: 'freeBusy', description: 'Check availability of calendars' },
           { name: 'Get', value: 'get', description: 'Get an event by ID' },
           { name: 'Get Many', value: 'getAll', description: 'Get multiple events' },
+          { name: 'Move', value: 'move', description: 'Move an event to another calendar' },
+          { name: 'Quick Add', value: 'quickAdd', description: 'Create an event from a text string' },
           { name: 'Remove Attendee', value: 'removeAttendee', description: 'Remove an attendee from an event' },
           { name: 'Update', value: 'update', description: 'Update an event' },
         ],
@@ -103,7 +106,7 @@ export class CalendarToolDynamic implements INodeType {
         type: 'string',
         required: true,
         displayOptions: {
-          show: { resource: ['event'], operation: ['get', 'delete', 'update', 'addAttendee', 'removeAttendee'] },
+          show: { resource: ['event'], operation: ['get', 'delete', 'update', 'addAttendee', 'removeAttendee', 'move'] },
         },
         default: '',
         description: 'The ID of the event',
@@ -225,6 +228,207 @@ export class CalendarToolDynamic implements INodeType {
         },
         default: false,
         description: 'Whether to create a Google Meet conference for this event',
+      },
+      // === PARAMETERS: RECURRENCE ===
+      {
+        displayName: 'Recurrence',
+        name: 'recurrence',
+        type: 'options',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create'] },
+        },
+        options: [
+          { name: 'None', value: '' },
+          { name: 'Daily', value: 'RRULE:FREQ=DAILY' },
+          { name: 'Weekly', value: 'RRULE:FREQ=WEEKLY' },
+          { name: 'Monthly', value: 'RRULE:FREQ=MONTHLY' },
+          { name: 'Yearly', value: 'RRULE:FREQ=YEARLY' },
+          { name: 'Custom', value: 'custom' },
+        ],
+        default: '',
+        description: 'Recurrence rule for the event',
+      },
+      {
+        displayName: 'Custom Recurrence Rule',
+        name: 'customRecurrence',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create'], recurrence: ['custom'] },
+        },
+        default: '',
+        placeholder: 'RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10',
+        description: 'Custom RRULE recurrence rule (RFC 5545 format)',
+      },
+      {
+        displayName: 'Recurrence Count',
+        name: 'recurrenceCount',
+        type: 'number',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create'] },
+          hide: { recurrence: ['', 'custom'] },
+        },
+        default: 0,
+        description: 'Number of occurrences (0 = unlimited)',
+      },
+      // === PARAMETERS: REMINDERS ===
+      {
+        displayName: 'Use Default Reminders',
+        name: 'useDefaultReminders',
+        type: 'boolean',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        default: true,
+        description: 'Whether to use the default reminders of the calendar',
+      },
+      {
+        displayName: 'Email Reminder (minutes before)',
+        name: 'reminderEmail',
+        type: 'number',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'], useDefaultReminders: [false] },
+        },
+        default: 0,
+        description: 'Send email reminder X minutes before (0 = no email reminder)',
+      },
+      {
+        displayName: 'Popup Reminder (minutes before)',
+        name: 'reminderPopup',
+        type: 'number',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'], useDefaultReminders: [false] },
+        },
+        default: 10,
+        description: 'Show popup reminder X minutes before (0 = no popup reminder)',
+      },
+      // === PARAMETERS: COLOR ===
+      {
+        displayName: 'Color',
+        name: 'colorId',
+        type: 'options',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        options: [
+          { name: 'Default', value: '' },
+          { name: 'Lavender', value: '1' },
+          { name: 'Sage', value: '2' },
+          { name: 'Grape', value: '3' },
+          { name: 'Flamingo', value: '4' },
+          { name: 'Banana', value: '5' },
+          { name: 'Tangerine', value: '6' },
+          { name: 'Peacock', value: '7' },
+          { name: 'Graphite', value: '8' },
+          { name: 'Blueberry', value: '9' },
+          { name: 'Basil', value: '10' },
+          { name: 'Tomato', value: '11' },
+        ],
+        default: '',
+        description: 'Color of the event',
+      },
+      // === PARAMETERS: VISIBILITY ===
+      {
+        displayName: 'Visibility',
+        name: 'visibility',
+        type: 'options',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['create', 'update'] },
+        },
+        options: [
+          { name: 'Default', value: 'default' },
+          { name: 'Public', value: 'public' },
+          { name: 'Private', value: 'private' },
+          { name: 'Confidential', value: 'confidential' },
+        ],
+        default: 'default',
+        description: 'Visibility of the event',
+      },
+      // === PARAMETERS: STATUS ===
+      {
+        displayName: 'Status',
+        name: 'status',
+        type: 'options',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['update'] },
+        },
+        options: [
+          { name: 'Confirmed', value: 'confirmed' },
+          { name: 'Tentative', value: 'tentative' },
+          { name: 'Cancelled', value: 'cancelled' },
+        ],
+        default: 'confirmed',
+        description: 'Status of the event',
+      },
+      // === PARAMETERS: QUICK ADD ===
+      {
+        displayName: 'Quick Add Text',
+        name: 'quickAddText',
+        type: 'string',
+        required: true,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['quickAdd'] },
+        },
+        default: '',
+        placeholder: 'Meeting with John tomorrow at 3pm',
+        description: 'Text describing the event to create (Google parses this automatically)',
+      },
+      // === PARAMETERS: MOVE EVENT ===
+      {
+        displayName: 'Destination Calendar ID',
+        name: 'destinationCalendarId',
+        type: 'string',
+        required: true,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['move'] },
+        },
+        default: '',
+        description: 'ID of the destination calendar to move the event to',
+      },
+      // === PARAMETERS: FREE/BUSY ===
+      {
+        displayName: 'Calendars to Check',
+        name: 'freeBusyCalendars',
+        type: 'string',
+        required: false,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['freeBusy'] },
+        },
+        default: 'primary',
+        placeholder: 'primary,calendar2@group.calendar.google.com',
+        description: 'Comma-separated list of calendar IDs to check availability',
+      },
+      {
+        displayName: 'Free/Busy Time Min',
+        name: 'freeBusyTimeMin',
+        type: 'string',
+        required: true,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['freeBusy'] },
+        },
+        default: '',
+        placeholder: '2025-12-10T00:00:00Z',
+        description: 'Start of the interval to check (ISO 8601 format)',
+      },
+      {
+        displayName: 'Free/Busy Time Max',
+        name: 'freeBusyTimeMax',
+        type: 'string',
+        required: true,
+        displayOptions: {
+          show: { resource: ['event'], operation: ['freeBusy'] },
+        },
+        default: '',
+        placeholder: '2025-12-10T23:59:59Z',
+        description: 'End of the interval to check (ISO 8601 format)',
       },
       // === PARAMETERS: GET ALL EVENTS ===
       {
@@ -397,6 +601,14 @@ async function executeEventOperation(
       const allDay = this.getNodeParameter('allDay', itemIndex, false) as boolean;
       const timezone = this.getNodeParameter('timezone', itemIndex, '') as string;
       const addGoogleMeet = this.getNodeParameter('addGoogleMeet', itemIndex, false) as boolean;
+      const recurrence = this.getNodeParameter('recurrence', itemIndex, '') as string;
+      const customRecurrence = this.getNodeParameter('customRecurrence', itemIndex, '') as string;
+      const recurrenceCount = this.getNodeParameter('recurrenceCount', itemIndex, 0) as number;
+      const useDefaultReminders = this.getNodeParameter('useDefaultReminders', itemIndex, true) as boolean;
+      const reminderEmail = this.getNodeParameter('reminderEmail', itemIndex, 0) as number;
+      const reminderPopup = this.getNodeParameter('reminderPopup', itemIndex, 10) as number;
+      const colorId = this.getNodeParameter('colorId', itemIndex, '') as string;
+      const visibility = this.getNodeParameter('visibility', itemIndex, 'default') as string;
 
       const eventBody: IDataObject = {};
 
@@ -441,6 +653,44 @@ async function executeEventOperation(
             },
           },
         };
+      }
+
+      // Handle recurrence
+      if (recurrence) {
+        let rrule = recurrence;
+        if (recurrence === 'custom' && customRecurrence) {
+          rrule = customRecurrence;
+        } else if (recurrenceCount > 0) {
+          rrule = `${recurrence};COUNT=${recurrenceCount}`;
+        }
+        if (rrule && rrule !== 'custom') {
+          eventBody.recurrence = [rrule];
+        }
+      }
+
+      // Handle reminders
+      if (!useDefaultReminders) {
+        const overrides: Array<{ method: string; minutes: number }> = [];
+        if (reminderEmail > 0) {
+          overrides.push({ method: 'email', minutes: reminderEmail });
+        }
+        if (reminderPopup > 0) {
+          overrides.push({ method: 'popup', minutes: reminderPopup });
+        }
+        eventBody.reminders = {
+          useDefault: false,
+          overrides: overrides.length > 0 ? overrides : undefined,
+        };
+      }
+
+      // Handle color
+      if (colorId) {
+        eventBody.colorId = colorId;
+      }
+
+      // Handle visibility
+      if (visibility && visibility !== 'default') {
+        eventBody.visibility = visibility;
       }
 
       // Use conferenceDataVersion=1 if Google Meet is requested
@@ -507,6 +757,12 @@ async function executeEventOperation(
       const attendees = this.getNodeParameter('attendees', itemIndex, '') as string;
       const allDay = this.getNodeParameter('allDay', itemIndex, false) as boolean;
       const timezone = this.getNodeParameter('timezone', itemIndex, '') as string;
+      const useDefaultReminders = this.getNodeParameter('useDefaultReminders', itemIndex, true) as boolean;
+      const reminderEmail = this.getNodeParameter('reminderEmail', itemIndex, 0) as number;
+      const reminderPopup = this.getNodeParameter('reminderPopup', itemIndex, 10) as number;
+      const colorId = this.getNodeParameter('colorId', itemIndex, '') as string;
+      const visibility = this.getNodeParameter('visibility', itemIndex, 'default') as string;
+      const status = this.getNodeParameter('status', itemIndex, 'confirmed') as string;
 
       const eventBody: IDataObject = {};
 
@@ -537,6 +793,36 @@ async function executeEventOperation(
       if (attendees) {
         const attendeesList = attendees.split(',').map(email => ({ email: email.trim() }));
         eventBody.attendees = attendeesList;
+      }
+
+      // Handle reminders
+      if (!useDefaultReminders) {
+        const overrides: Array<{ method: string; minutes: number }> = [];
+        if (reminderEmail > 0) {
+          overrides.push({ method: 'email', minutes: reminderEmail });
+        }
+        if (reminderPopup > 0) {
+          overrides.push({ method: 'popup', minutes: reminderPopup });
+        }
+        eventBody.reminders = {
+          useDefault: false,
+          overrides: overrides.length > 0 ? overrides : undefined,
+        };
+      }
+
+      // Handle color
+      if (colorId) {
+        eventBody.colorId = colorId;
+      }
+
+      // Handle visibility
+      if (visibility && visibility !== 'default') {
+        eventBody.visibility = visibility;
+      }
+
+      // Handle status
+      if (status) {
+        eventBody.status = status;
       }
 
       return calendarRequest.call(
@@ -643,6 +929,62 @@ async function executeEventOperation(
       );
 
       return result;
+    }
+
+    case 'quickAdd': {
+      const quickAddText = this.getNodeParameter('quickAddText', itemIndex) as string;
+
+      return calendarRequest.call(
+        this,
+        accessToken,
+        'POST',
+        `/calendars/${encodeURIComponent(calendarId)}/events/quickAdd`,
+        undefined,
+        { text: quickAddText }
+      );
+    }
+
+    case 'move': {
+      const eventId = this.getNodeParameter('eventId', itemIndex) as string;
+      const destinationCalendarId = this.getNodeParameter('destinationCalendarId', itemIndex) as string;
+
+      return calendarRequest.call(
+        this,
+        accessToken,
+        'POST',
+        `/calendars/${encodeURIComponent(calendarId)}/events/${encodeURIComponent(eventId)}/move`,
+        undefined,
+        { destination: destinationCalendarId }
+      );
+    }
+
+    case 'freeBusy': {
+      const freeBusyCalendars = this.getNodeParameter('freeBusyCalendars', itemIndex, 'primary') as string;
+      const freeBusyTimeMin = this.getNodeParameter('freeBusyTimeMin', itemIndex) as string;
+      const freeBusyTimeMax = this.getNodeParameter('freeBusyTimeMax', itemIndex) as string;
+
+      // Parse calendar IDs
+      const calendarIds = freeBusyCalendars.split(',').map(id => ({ id: id.trim() }));
+
+      const body: IDataObject = {
+        timeMin: freeBusyTimeMin,
+        timeMax: freeBusyTimeMax,
+        items: calendarIds,
+      };
+
+      // Free/Busy uses a different endpoint
+      const options: IHttpRequestOptions = {
+        method: 'POST',
+        url: 'https://www.googleapis.com/calendar/v3/freeBusy',
+        headers: {
+          'Authorization': `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body,
+        json: true,
+      };
+
+      return this.helpers.httpRequest(options);
     }
 
     default:

--- a/docs/mcp/GOOGLE_CALENDAR_MCP_API.md
+++ b/docs/mcp/GOOGLE_CALENDAR_MCP_API.md
@@ -1,0 +1,438 @@
+# Google Calendar MCP Server - API Documentation
+
+## Overview
+
+The Google Calendar MCP Server provides a webhook-based API to interact with Google Calendar. It supports multi-tenant authentication via dynamic OAuth tokens passed in each request.
+
+**Endpoint:** `POST /webhook/mcp-calendar`
+
+## Authentication
+
+All requests must include `access_token` in the request body. This is the OAuth 2.0 access token for the user's Google account.
+
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "getAll"
+}
+```
+
+## Resources
+
+### Event Resource
+
+Operations on calendar events.
+
+---
+
+#### `create` - Create Event
+
+Creates a new calendar event.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "create",
+  "calendar_id": "primary",
+  "summary": "Meeting Title",
+  "start": "2025-12-10T10:00:00Z",
+  "end": "2025-12-10T11:00:00Z",
+  "description": "Meeting description",
+  "location": "Conference Room A",
+  "attendees": ["user1@example.com", "user2@example.com"],
+  "all_day": false,
+  "timezone": "Europe/Paris",
+  "add_google_meet": true,
+  "recurrence": "daily",
+  "recurrence_count": 5,
+  "use_default_reminders": false,
+  "reminder_email": 60,
+  "reminder_popup": 10,
+  "color_id": "1",
+  "visibility": "private"
+}
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `calendar_id` | string | No | Calendar ID (default: "primary") |
+| `summary` | string | No | Event title |
+| `start` | string | No | Start time (ISO 8601) |
+| `end` | string | No | End time (ISO 8601) |
+| `description` | string | No | Event description |
+| `location` | string | No | Location |
+| `attendees` | array/string | No | List of attendee emails |
+| `all_day` | boolean | No | All-day event (default: false) |
+| `timezone` | string | No | Timezone (e.g., "Europe/Paris") |
+| `add_google_meet` | boolean | No | Create Google Meet link (default: false) |
+| `recurrence` | string | No | "daily", "weekly", "monthly", "yearly", or custom RRULE |
+| `recurrence_count` | number | No | Number of occurrences (0 = unlimited) |
+| `use_default_reminders` | boolean | No | Use calendar default reminders (default: true) |
+| `reminder_email` | number | No | Email reminder (minutes before) |
+| `reminder_popup` | number | No | Popup reminder (minutes before) |
+| `color_id` | string | No | Color ID (1-11, see Color Reference) |
+| `visibility` | string | No | "default", "public", "private", "confidential" |
+
+---
+
+#### `get` - Get Event
+
+Retrieves a single event by ID.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "get",
+  "calendar_id": "primary",
+  "event_id": "abc123xyz"
+}
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `calendar_id` | string | No | Calendar ID (default: "primary") |
+| `event_id` | string | Yes | Event ID |
+
+---
+
+#### `getAll` - Get All Events
+
+Retrieves multiple events with optional filters.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "getAll",
+  "calendar_id": "primary",
+  "time_min": "2025-12-01T00:00:00Z",
+  "time_max": "2025-12-31T23:59:59Z",
+  "max_results": 50,
+  "query": "meeting",
+  "single_events": true,
+  "order_by": "startTime"
+}
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `calendar_id` | string | No | Calendar ID (default: "primary") |
+| `time_min` | string | No | Lower bound (ISO 8601) |
+| `time_max` | string | No | Upper bound (ISO 8601) |
+| `max_results` | number | No | Max events to return (default: 10, max: 2500) |
+| `query` | string | No | Free text search |
+| `single_events` | boolean | No | Expand recurring events (default: true) |
+| `order_by` | string | No | "startTime" or "updated" |
+
+---
+
+#### `update` - Update Event
+
+Updates an existing event.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "update",
+  "calendar_id": "primary",
+  "event_id": "abc123xyz",
+  "summary": "Updated Title",
+  "start": "2025-12-10T14:00:00Z",
+  "end": "2025-12-10T15:00:00Z",
+  "status": "tentative",
+  "color_id": "5",
+  "visibility": "public"
+}
+```
+
+**Parameters:**
+Same as `create`, plus:
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `event_id` | string | Yes | Event ID to update |
+| `status` | string | No | "confirmed", "tentative", "cancelled" |
+
+---
+
+#### `delete` - Delete Event
+
+Deletes an event.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "delete",
+  "calendar_id": "primary",
+  "event_id": "abc123xyz"
+}
+```
+
+---
+
+#### `addAttendee` - Add Attendee
+
+Adds a single attendee to an existing event.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "addAttendee",
+  "calendar_id": "primary",
+  "event_id": "abc123xyz",
+  "attendee_email": "newuser@example.com"
+}
+```
+
+---
+
+#### `removeAttendee` - Remove Attendee
+
+Removes an attendee from an event.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "removeAttendee",
+  "calendar_id": "primary",
+  "event_id": "abc123xyz",
+  "attendee_email": "user@example.com"
+}
+```
+
+---
+
+#### `quickAdd` - Quick Add Event
+
+Creates an event from a natural language text string.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "quickAdd",
+  "calendar_id": "primary",
+  "text": "Meeting with John tomorrow at 3pm"
+}
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `text` | string | Yes | Natural language event description |
+
+---
+
+#### `move` - Move Event
+
+Moves an event to a different calendar.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "move",
+  "calendar_id": "primary",
+  "event_id": "abc123xyz",
+  "destination_calendar_id": "work@group.calendar.google.com"
+}
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `event_id` | string | Yes | Event ID to move |
+| `destination_calendar_id` | string | Yes | Target calendar ID |
+
+---
+
+#### `freeBusy` - Free/Busy Query
+
+Checks availability across one or more calendars.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "freeBusy",
+  "calendars": ["primary", "work@group.calendar.google.com"],
+  "time_min": "2025-12-10T00:00:00Z",
+  "time_max": "2025-12-10T23:59:59Z"
+}
+```
+
+**Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `calendars` | array/string | No | Calendar IDs to check (default: "primary") |
+| `time_min` | string | Yes | Start of interval (ISO 8601) |
+| `time_max` | string | Yes | End of interval (ISO 8601) |
+
+**Response:**
+```json
+{
+  "kind": "calendar#freeBusy",
+  "timeMin": "2025-12-10T00:00:00.000Z",
+  "timeMax": "2025-12-10T23:59:59.000Z",
+  "calendars": {
+    "primary": {
+      "busy": [
+        {
+          "start": "2025-12-10T10:00:00Z",
+          "end": "2025-12-10T11:00:00Z"
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+### Calendar Resource
+
+Operations on calendars.
+
+#### `getAll` - Get All Calendars
+
+Retrieves all calendars accessible by the user.
+
+**Request:**
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "calendar",
+  "operation": "getAll"
+}
+```
+
+---
+
+## Color Reference
+
+| ID | Name |
+|----|------|
+| 1 | Lavender |
+| 2 | Sage |
+| 3 | Grape |
+| 4 | Flamingo |
+| 5 | Banana |
+| 6 | Tangerine |
+| 7 | Peacock |
+| 8 | Graphite |
+| 9 | Blueberry |
+| 10 | Basil |
+| 11 | Tomato |
+
+---
+
+## Recurrence Rules
+
+### Preset Values
+- `daily` - Repeat every day
+- `weekly` - Repeat every week
+- `monthly` - Repeat every month
+- `yearly` - Repeat every year
+
+### Custom RRULE
+For advanced recurrence patterns, use RFC 5545 RRULE format:
+
+```
+RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10
+```
+
+Examples:
+- Every weekday: `RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR`
+- Every 2 weeks on Tuesday: `RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TU`
+- Monthly on the 15th: `RRULE:FREQ=MONTHLY;BYMONTHDAY=15`
+
+---
+
+## Response Format
+
+All responses follow this structure:
+
+```json
+{
+  "success": true,
+  "data": { ... },
+  "error": null
+}
+```
+
+On error:
+```json
+{
+  "success": true,
+  "data": {
+    "error": "Error message",
+    "errorDetails": { ... }
+  },
+  "error": null
+}
+```
+
+---
+
+## Usage Examples
+
+### Create a recurring meeting with Google Meet
+
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "create",
+  "summary": "Weekly Team Standup",
+  "start": "2025-12-09T09:00:00",
+  "end": "2025-12-09T09:30:00",
+  "timezone": "Europe/Paris",
+  "attendees": ["team@company.com"],
+  "add_google_meet": true,
+  "recurrence": "weekly",
+  "reminder_popup": 5
+}
+```
+
+### Check team availability
+
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "freeBusy",
+  "calendars": ["alice@company.com", "bob@company.com"],
+  "time_min": "2025-12-10T08:00:00Z",
+  "time_max": "2025-12-10T18:00:00Z"
+}
+```
+
+### Quick schedule from natural language
+
+```json
+{
+  "access_token": "ya29.xxx...",
+  "resource": "event",
+  "operation": "quickAdd",
+  "text": "Lunch with Sarah next Friday at noon"
+}
+```

--- a/workflows/mcp/MCP_Calendar_Server.json
+++ b/workflows/mcp/MCP_Calendar_Server.json
@@ -238,6 +238,76 @@
                 ]
               },
               "renameOutput": true
+            },
+            {
+              "outputKey": "event_addAttendee",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-addAttendee-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-addAttendee-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "addAttendee"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_removeAttendee",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-removeAttendee-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-removeAttendee-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "removeAttendee"
+                  }
+                ]
+              },
+              "renameOutput": true
             }
           ]
         },
@@ -385,6 +455,42 @@
       "typeVersion": 1
     },
     {
+      "id": "event-addAttendee-001",
+      "name": "addAttendee",
+      "type": "n8n-nodes-calendar-dynamic.calendarToolDynamic",
+      "position": [
+        700,
+        700
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "addAttendee",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "eventId": "={{ $json.body.event_id }}",
+        "attendeeEmail": "={{ $json.body.attendee_email }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-removeAttendee-001",
+      "name": "removeAttendee",
+      "type": "n8n-nodes-calendar-dynamic.calendarToolDynamic",
+      "position": [
+        700,
+        800
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "removeAttendee",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "eventId": "={{ $json.body.event_id }}",
+        "attendeeEmail": "={{ $json.body.attendee_email }}"
+      },
+      "typeVersion": 1
+    },
+    {
       "id": "sticky-usage-001",
       "name": "Sticky Note",
       "type": "n8n-nodes-base.stickyNote",
@@ -411,7 +517,7 @@
       "parameters": {
         "width": 200,
         "height": 520,
-        "content": "## Event Operations\n\n- create\n- get\n- getAll\n- update\n- delete"
+        "content": "## Event Operations\n\n- create\n- get\n- getAll\n- update\n- delete\n- addAttendee\n- removeAttendee"
       },
       "typeVersion": 1
     },
@@ -490,6 +596,20 @@
             "type": "main",
             "index": 0
           }
+        ],
+        [
+          {
+            "node": "addAttendee",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "removeAttendee",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     },
@@ -549,6 +669,28 @@
       ]
     },
     "getAllCalendars": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "addAttendee": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "removeAttendee": {
       "main": [
         [
           {

--- a/workflows/mcp/MCP_Calendar_Server.json
+++ b/workflows/mcp/MCP_Calendar_Server.json
@@ -308,6 +308,111 @@
                 ]
               },
               "renameOutput": true
+            },
+            {
+              "outputKey": "event_quickAdd",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-quickAdd-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-quickAdd-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "quickAdd"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_move",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-move-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-move-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "move"
+                  }
+                ]
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "event_freeBusy",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-event-freeBusy-1",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.resource }}",
+                    "rightValue": "event"
+                  },
+                  {
+                    "id": "cond-event-freeBusy-2",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "freeBusy"
+                  }
+                ]
+              },
+              "renameOutput": true
             }
           ]
         },
@@ -491,6 +596,59 @@
       "typeVersion": 1
     },
     {
+      "id": "event-quickAdd-001",
+      "name": "quickAdd",
+      "type": "n8n-nodes-calendar-dynamic.calendarToolDynamic",
+      "position": [
+        700,
+        900
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "quickAdd",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "quickAddText": "={{ $json.body.text }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-move-001",
+      "name": "moveEvent",
+      "type": "n8n-nodes-calendar-dynamic.calendarToolDynamic",
+      "position": [
+        700,
+        1000
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "move",
+        "calendarId": "={{ $json.body.calendar_id || 'primary' }}",
+        "eventId": "={{ $json.body.event_id }}",
+        "destinationCalendarId": "={{ $json.body.destination_calendar_id }}"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "event-freeBusy-001",
+      "name": "freeBusy",
+      "type": "n8n-nodes-calendar-dynamic.calendarToolDynamic",
+      "position": [
+        700,
+        1100
+      ],
+      "parameters": {
+        "accessToken": "={{ $json.body.access_token }}",
+        "resource": "event",
+        "operation": "freeBusy",
+        "freeBusyCalendars": "={{ Array.isArray($json.body.calendars) ? $json.body.calendars.join(',') : ($json.body.calendars || 'primary') }}",
+        "freeBusyTimeMin": "={{ $json.body.time_min }}",
+        "freeBusyTimeMax": "={{ $json.body.time_max }}"
+      },
+      "typeVersion": 1
+    },
+    {
       "id": "sticky-usage-001",
       "name": "Sticky Note",
       "type": "n8n-nodes-base.stickyNote",
@@ -516,8 +674,8 @@
       ],
       "parameters": {
         "width": 200,
-        "height": 520,
-        "content": "## Event Operations\n\n- create\n- get\n- getAll\n- update\n- delete\n- addAttendee\n- removeAttendee"
+        "height": 620,
+        "content": "## Event Operations\n\n- create\n- get\n- getAll\n- update\n- delete\n- addAttendee\n- removeAttendee\n- quickAdd\n- move\n- freeBusy"
       },
       "typeVersion": 1
     },
@@ -610,6 +768,27 @@
             "type": "main",
             "index": 0
           }
+        ],
+        [
+          {
+            "node": "quickAdd",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "moveEvent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "freeBusy",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     },
@@ -691,6 +870,39 @@
       ]
     },
     "removeAttendee": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "quickAdd": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "moveEvent": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "freeBusy": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary

- **Attendee management**: Add/remove individual attendees from events
- **Google Meet integration**: Auto-create Meet links for events
- **Recurrence support**: Daily, weekly, monthly, yearly, and custom RRULE patterns
- **Reminders**: Configurable email and popup reminders (minutes before)
- **Event colors**: 11 color options (Lavender, Sage, Grape, etc.)
- **Visibility settings**: Default, public, private, confidential
- **Event status**: Confirmed, tentative, cancelled (for updates)
- **Quick Add**: Create events from natural language text
- **Move Event**: Move events between calendars
- **Free/Busy Query**: Check availability across multiple calendars

## New Operations

| Operation | Description |
|-----------|-------------|
| `addAttendee` | Add a single attendee to an existing event |
| `removeAttendee` | Remove an attendee from an event |
| `quickAdd` | Create event from natural language (e.g., "Meeting tomorrow at 3pm") |
| `move` | Move event to a different calendar |
| `freeBusy` | Query availability for one or more calendars |

## Files Changed

- `custom-nodes/n8n-nodes-calendar-dynamic/nodes/CalendarToolDynamic/CalendarToolDynamic.node.ts` - All new features
- `workflows/mcp/MCP_Calendar_Server.json` - New routes and operation nodes
- `docs/mcp/GOOGLE_CALENDAR_MCP_API.md` - Complete API documentation for MCP server team

## Test plan

- [ ] Build custom node: `cd custom-nodes/n8n-nodes-calendar-dynamic && npm run build`
- [ ] Deploy to n8n: copy to `~/.n8n/nodes/` and restart
- [ ] Test create event with recurrence
- [ ] Test create event with reminders
- [ ] Test create event with color and visibility
- [ ] Test quickAdd with natural language
- [ ] Test move event between calendars
- [ ] Test freeBusy query
- [ ] Test addAttendee / removeAttendee

🤖 Generated with [Claude Code](https://claude.com/claude-code)