### PR TITLE
feat(knowledge-graph): add Knowledge Graph extraction node

### DIFF
--- a/custom-nodes/n8n-nodes-google-genai-core/shared/GenAiClient.ts
+++ b/custom-nodes/n8n-nodes-google-genai-core/shared/GenAiClient.ts
@@ -220,10 +220,71 @@ export class GenAiClient {
 
     const result = await this.generateText(prompt, opts);
 
-    // Parser le JSON depuis la réponse
+    return this.parseJsonResponse<T>(result.text);
+  }
+
+  /**
+   * Génère du texte au format JSON à partir d'un document (multimodal)
+   */
+  async generateJsonFromDocument<T>(
+    prompt: string,
+    document: { mimeType: string; data: string },
+    options?: TextGenerationOptions
+  ): Promise<T> {
+    const opts = {
+      ...DEFAULT_TEXT_OPTIONS,
+      ...options,
+      temperature: 0, // Déterministe pour JSON
+    };
+
+    return withErrorHandling(async () => {
+      const endpoint = this.getTextEndpoint(opts.model!);
+
+      const body = {
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              {
+                inlineData: {
+                  mimeType: document.mimeType,
+                  data: document.data,
+                },
+              },
+              { text: prompt },
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: opts.temperature,
+          topP: opts.topP,
+          topK: opts.topK,
+          maxOutputTokens: opts.maxOutputTokens,
+          ...(opts.seed !== undefined && { seed: opts.seed }),
+        },
+        ...(opts.systemInstruction && {
+          systemInstruction: {
+            parts: [{ text: opts.systemInstruction }],
+          },
+        }),
+      };
+
+      const response = await this.request<GeminiTextResponse>(endpoint, body);
+
+      const candidate = response.candidates?.[0];
+      const text = candidate?.content?.parts?.[0]?.text || '';
+
+      return this.parseJsonResponse<T>(text);
+    });
+  }
+
+  /**
+   * Parse une réponse JSON depuis du texte
+   */
+  private parseJsonResponse<T>(text: string): T {
     try {
       // Nettoyer les markdown code blocks si présents
-      let jsonText = result.text.trim();
+      let jsonText = text.trim();
       if (jsonText.startsWith('```json')) {
         jsonText = jsonText.slice(7);
       }
@@ -237,7 +298,7 @@ export class GenAiClient {
       return JSON.parse(jsonText.trim()) as T;
     } catch (error) {
       throw new GenAiNodeError(parseGoogleApiError(
-        new Error(`Failed to parse JSON response: ${result.text}`)
+        new Error(`Failed to parse JSON response: ${text}`)
       ));
     }
   }

--- a/custom-nodes/n8n-nodes-knowledge-graph/nodes/KnowledgeGraph/KnowledgeGraph.node.ts
+++ b/custom-nodes/n8n-nodes-knowledge-graph/nodes/KnowledgeGraph/KnowledgeGraph.node.ts
@@ -1,0 +1,562 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	NodeOperationError,
+	IBinaryData,
+} from 'n8n-workflow';
+
+import {
+	createVertexAiClientWithAdc,
+	createVertexAiClient,
+	GenAiClient,
+} from 'n8n-nodes-google-genai-core';
+
+import {
+	ENTITY_EXTRACTION_PROMPT,
+	RELATIONSHIP_EXTRACTION_PROMPT,
+	FULL_GRAPH_EXTRACTION_PROMPT,
+	buildPromptWithConfig,
+	buildRelationshipPromptWithEntities,
+	buildExtractionConfig,
+	ExtractionConfig,
+} from '../../prompts/knowledgeGraphPrompts';
+
+// Types pour les résultats
+interface Entity {
+	id: number;
+	name: string;
+	type: string;
+}
+
+interface Relationship {
+	source: number;
+	target: number;
+	links: string[];
+}
+
+interface EntityExtractionResult {
+	entities: Entity[];
+	metadata: {
+		source_length: number;
+		language_detected: string;
+		entity_count: number;
+	};
+}
+
+interface RelationshipExtractionResult {
+	relationships: Relationship[];
+	metadata: {
+		relationship_count: number;
+	};
+}
+
+interface GraphResult {
+	graph: {
+		nodes: Entity[];
+		edges: Array<{ source: number; target: number; type: string }>;
+	};
+	metadata: {
+		node_count: number;
+		edge_count: number;
+		language_detected: string;
+	};
+}
+
+export class KnowledgeGraph implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Knowledge Graph',
+		name: 'knowledgeGraph',
+		icon: 'file:knowledge-graph.svg',
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{$parameter["operation"]}}',
+		description: 'Extract knowledge graphs from text using Google Gemini',
+		defaults: {
+			name: 'Knowledge Graph',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'googleVertexAiApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Build Graph',
+						value: 'buildGraph',
+						description: 'Extract entities and relationships to build a complete graph',
+						action: 'Build a complete knowledge graph',
+					},
+					{
+						name: 'Extract Entities',
+						value: 'extractEntities',
+						description: 'Extract entities (characters, locations, organizations) from text',
+						action: 'Extract entities from text',
+					},
+					{
+						name: 'Extract Relationships',
+						value: 'extractRelationships',
+						description: 'Extract relationships between entities',
+						action: 'Extract relationships between entities',
+					},
+				],
+				default: 'buildGraph',
+			},
+			{
+				displayName: 'Input Type',
+				name: 'inputType',
+				type: 'options',
+				options: [
+					{
+						name: 'Text',
+						value: 'text',
+						description: 'Analyze text directly',
+					},
+					{
+						name: 'Document',
+						value: 'document',
+						description: 'Analyze a document file (PDF, TXT, DOCX, etc.)',
+					},
+				],
+				default: 'text',
+				description: 'Choose whether to analyze text or a document file',
+			},
+			{
+				displayName: 'Text',
+				name: 'text',
+				type: 'string',
+				typeOptions: {
+					rows: 10,
+				},
+				default: '',
+				required: true,
+				description: 'The text to analyze for knowledge extraction',
+				displayOptions: {
+					show: {
+						inputType: ['text'],
+					},
+				},
+			},
+			{
+				displayName: 'Binary Property',
+				name: 'binaryPropertyName',
+				type: 'string',
+				default: 'data',
+				required: true,
+				description: 'Name of the binary property containing the document to analyze',
+				displayOptions: {
+					show: {
+						inputType: ['document'],
+					},
+				},
+			},
+			{
+				displayName: 'Configuration Mode',
+				name: 'configMode',
+				type: 'options',
+				options: [
+					{
+						name: 'Preset',
+						value: 'preset',
+						description: 'Use a predefined configuration for common document types',
+					},
+					{
+						name: 'Custom',
+						value: 'custom',
+						description: 'Define your own entity types and relation types',
+					},
+					{
+						name: 'JSON Config',
+						value: 'jsonConfig',
+						description: 'Pass a complete configuration as JSON',
+					},
+				],
+				default: 'preset',
+				description: 'How to configure the extraction parameters',
+			},
+			{
+				displayName: 'Preset',
+				name: 'preset',
+				type: 'options',
+				options: [
+					{
+						name: 'Narrative (Stories, Books)',
+						value: 'narrative',
+						description: 'Characters, locations, events, relationships',
+					},
+					{
+						name: 'Business / Market Research',
+						value: 'business',
+						description: 'Organizations, people, metrics, strategies, risks',
+					},
+					{
+						name: 'Technical Documentation',
+						value: 'technical',
+						description: 'APIs, services, components, dependencies',
+					},
+					{
+						name: 'Scientific / Academic',
+						value: 'scientific',
+						description: 'Researchers, theories, studies, findings',
+					},
+					{
+						name: 'Legal / Compliance',
+						value: 'legal',
+						description: 'Laws, regulations, parties, obligations',
+					},
+				],
+				default: 'narrative',
+				description: 'Predefined configuration for common document types',
+				displayOptions: {
+					show: {
+						configMode: ['preset'],
+						operation: ['extractEntities', 'buildGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Entity Types',
+				name: 'entityTypes',
+				type: 'multiOptions',
+				options: [
+					{
+						name: 'Characters/People',
+						value: 'characters',
+					},
+					{
+						name: 'Concepts',
+						value: 'concepts',
+					},
+					{
+						name: 'Events',
+						value: 'events',
+					},
+					{
+						name: 'Locations',
+						value: 'locations',
+					},
+					{
+						name: 'Metrics/KPIs',
+						value: 'metrics',
+					},
+					{
+						name: 'Organizations',
+						value: 'organizations',
+					},
+					{
+						name: 'Products/Services',
+						value: 'products',
+					},
+					{
+						name: 'Risks/Concerns',
+						value: 'risks',
+					},
+					{
+						name: 'Technologies',
+						value: 'technologies',
+					},
+				],
+				default: ['characters'],
+				description: 'Types of entities to extract',
+				displayOptions: {
+					show: {
+						configMode: ['custom'],
+						operation: ['extractEntities', 'buildGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Relation Types',
+				name: 'relationTypes',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., works_at, manages, influences, measures',
+				description: 'Comma-separated list of relation types to extract. Leave empty for automatic detection.',
+				displayOptions: {
+					show: {
+						configMode: ['custom'],
+						operation: ['extractRelationships', 'buildGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Configuration JSON',
+				name: 'configJson',
+				type: 'json',
+				default: '{}',
+				description: 'Complete configuration as JSON. Expected format: { "entityTypes": [...], "relationTypes": [...], "customInstructions": "..." }',
+				displayOptions: {
+					show: {
+						configMode: ['jsonConfig'],
+					},
+				},
+			},
+			{
+				displayName: 'Custom Instructions',
+				name: 'customInstructions',
+				type: 'string',
+				typeOptions: {
+					rows: 3,
+				},
+				default: '',
+				placeholder: 'e.g., Focus on financial metrics and their relationships to company performance',
+				description: 'Additional instructions to guide the extraction',
+				displayOptions: {
+					show: {
+						configMode: ['custom'],
+					},
+				},
+			},
+			{
+				displayName: 'Entities JSON',
+				name: 'entitiesJson',
+				type: 'string',
+				typeOptions: {
+					rows: 5,
+				},
+				default: '',
+				description: 'Optional: Pre-defined entities JSON array. If empty, entities will be extracted automatically.',
+				displayOptions: {
+					show: {
+						operation: ['extractRelationships'],
+					},
+				},
+			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				placeholder: 'Add Option',
+				default: {},
+				options: [
+					{
+						displayName: 'Model',
+						name: 'model',
+						type: 'options',
+						options: [
+							{
+								name: 'Gemini 2.5 Flash (Fast)',
+								value: 'gemini-2.5-flash',
+							},
+							{
+								name: 'Gemini 2.5 Pro (Accurate)',
+								value: 'gemini-2.5-pro',
+							},
+						],
+						default: 'gemini-2.5-flash',
+						description: 'The Gemini model to use',
+					},
+					{
+						displayName: 'Temperature',
+						name: 'temperature',
+						type: 'number',
+						typeOptions: {
+							minValue: 0,
+							maxValue: 1,
+							numberStepSize: 0.1,
+						},
+						default: 0,
+						description: 'Controls randomness. 0 = deterministic, 1 = creative.',
+					},
+					{
+						displayName: 'Max Output Tokens',
+						name: 'maxOutputTokens',
+						type: 'number',
+						typeOptions: {
+							minValue: 100,
+							maxValue: 65536,
+						},
+						default: 8192,
+						description: 'Maximum number of tokens in the response',
+					},
+				],
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const returnData: INodeExecutionData[] = [];
+
+		// Get credentials
+		const credentials = await this.getCredentials('googleVertexAiApi');
+		const projectId = credentials.projectId as string;
+		const location = credentials.location as string;
+		const authMethod = credentials.authMethod as string;
+		const serviceAccountKey = credentials.serviceAccountKey as string | undefined;
+
+		// Create GenAI client
+		let client: GenAiClient;
+		if (authMethod === 'adc' || !serviceAccountKey) {
+			client = createVertexAiClientWithAdc(projectId, location);
+		} else {
+			client = createVertexAiClient(projectId, serviceAccountKey, location);
+		}
+
+		for (let i = 0; i < items.length; i++) {
+			try {
+				const operation = this.getNodeParameter('operation', i) as string;
+				const inputType = this.getNodeParameter('inputType', i, 'text') as string;
+				const options = this.getNodeParameter('options', i, {}) as {
+					model?: string;
+					temperature?: number;
+					maxOutputTokens?: number;
+				};
+
+				let text: string;
+				let documentData: { mimeType: string; data: string } | undefined;
+
+				if (inputType === 'document') {
+					// Handle document input
+					const binaryPropertyName = this.getNodeParameter('binaryPropertyName', i, 'data') as string;
+					const binaryData = items[i].binary?.[binaryPropertyName] as IBinaryData | undefined;
+
+					if (!binaryData) {
+						throw new NodeOperationError(
+							this.getNode(),
+							`No binary data found in property "${binaryPropertyName}"`,
+							{ itemIndex: i }
+						);
+					}
+
+					const mimeType = binaryData.mimeType;
+					const supportedMimeTypes = [
+						'application/pdf',
+						'text/plain',
+						'text/html',
+						'text/csv',
+						'text/markdown',
+						'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+						'application/msword',
+					];
+
+					// For text-based documents, extract text content
+					if (mimeType.startsWith('text/')) {
+						const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+						text = buffer.toString('utf-8');
+					} else if (supportedMimeTypes.includes(mimeType)) {
+						// For PDF and other binary documents, send as base64 to Gemini
+						const buffer = await this.helpers.getBinaryDataBuffer(i, binaryPropertyName);
+						documentData = {
+							mimeType: mimeType,
+							data: buffer.toString('base64'),
+						};
+						text = ''; // Will use document instead
+					} else {
+						throw new NodeOperationError(
+							this.getNode(),
+							`Unsupported document type: ${mimeType}. Supported types: PDF, TXT, HTML, CSV, Markdown, DOCX`,
+							{ itemIndex: i }
+						);
+					}
+				} else {
+					// Handle text input
+					text = this.getNodeParameter('text', i) as string;
+				}
+
+				if (!documentData && (!text || text.trim().length === 0)) {
+					throw new NodeOperationError(this.getNode(), 'Text or document input is required', { itemIndex: i });
+				}
+
+				const genOptions = {
+					model: (options.model || 'gemini-2.5-flash') as any,
+					temperature: options.temperature ?? 0,
+					maxOutputTokens: options.maxOutputTokens ?? 8192,
+				};
+
+				let result: EntityExtractionResult | RelationshipExtractionResult | GraphResult;
+
+				// Helper function to call the appropriate API method
+				const callGemini = async <T>(prompt: string): Promise<T> => {
+					if (documentData) {
+						return client.generateJsonFromDocument<T>(prompt, documentData, genOptions);
+					} else {
+						return client.generateJson<T>(prompt, genOptions);
+					}
+				};
+
+				// Build extraction configuration
+				const configMode = this.getNodeParameter('configMode', i, 'preset') as 'preset' | 'custom' | 'jsonConfig';
+				const preset = this.getNodeParameter('preset', i, 'narrative') as string;
+				const entityTypes = this.getNodeParameter('entityTypes', i, ['characters']) as string[];
+				const relationTypes = this.getNodeParameter('relationTypes', i, '') as string;
+				const customInstructions = this.getNodeParameter('customInstructions', i, '') as string;
+				const configJson = this.getNodeParameter('configJson', i, '{}') as string;
+
+				const extractionConfig: ExtractionConfig = buildExtractionConfig(
+					configMode,
+					preset,
+					entityTypes,
+					relationTypes,
+					customInstructions,
+					configJson
+				);
+
+				const presetName = configMode === 'preset' ? preset : undefined;
+				const textContent = text || 'Analyze the provided document.';
+
+				switch (operation) {
+					case 'extractEntities': {
+						const prompt = buildPromptWithConfig(ENTITY_EXTRACTION_PROMPT, textContent, extractionConfig, presetName);
+						result = await callGemini<EntityExtractionResult>(prompt);
+						break;
+					}
+
+					case 'extractRelationships': {
+						const entitiesJson = this.getNodeParameter('entitiesJson', i, '') as string;
+						let prompt: string;
+
+						if (entitiesJson && entitiesJson.trim()) {
+							// Use provided entities
+							const entities = JSON.parse(entitiesJson) as Entity[];
+							prompt = buildRelationshipPromptWithEntities(textContent, entities, extractionConfig);
+						} else {
+							// Extract entities first, then relationships
+							prompt = buildPromptWithConfig(RELATIONSHIP_EXTRACTION_PROMPT, textContent, extractionConfig, presetName);
+						}
+
+						result = await callGemini<RelationshipExtractionResult>(prompt);
+						break;
+					}
+
+					case 'buildGraph': {
+						const prompt = buildPromptWithConfig(FULL_GRAPH_EXTRACTION_PROMPT, textContent, extractionConfig, presetName);
+						result = await callGemini<GraphResult>(prompt);
+						break;
+					}
+
+					default:
+						throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, { itemIndex: i });
+				}
+
+				returnData.push({
+					json: result as any,
+					pairedItem: { item: i },
+				});
+			} catch (error) {
+				if (this.continueOnFail()) {
+					returnData.push({
+						json: {
+							error: (error as Error).message,
+						},
+						pairedItem: { item: i },
+					});
+					continue;
+				}
+				throw error;
+			}
+		}
+
+		return [returnData];
+	}
+}

--- a/custom-nodes/n8n-nodes-knowledge-graph/nodes/KnowledgeGraph/knowledge-graph.svg
+++ b/custom-nodes/n8n-nodes-knowledge-graph/nodes/KnowledgeGraph/knowledge-graph.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60">
+  <!-- Background circle -->
+  <circle cx="30" cy="30" r="28" fill="#4285F4" opacity="0.1"/>
+
+  <!-- Main nodes -->
+  <circle cx="30" cy="15" r="6" fill="#4285F4"/>
+  <circle cx="15" cy="35" r="6" fill="#34A853"/>
+  <circle cx="45" cy="35" r="6" fill="#EA4335"/>
+  <circle cx="30" cy="50" r="5" fill="#FBBC04"/>
+
+  <!-- Connection lines -->
+  <line x1="30" y1="21" x2="18" y2="30" stroke="#666" stroke-width="2"/>
+  <line x1="30" y1="21" x2="42" y2="30" stroke="#666" stroke-width="2"/>
+  <line x1="21" y1="35" x2="39" y2="35" stroke="#666" stroke-width="2"/>
+  <line x1="18" y1="40" x2="27" y2="47" stroke="#666" stroke-width="1.5"/>
+  <line x1="42" y1="40" x2="33" y2="47" stroke="#666" stroke-width="1.5"/>
+
+  <!-- Inner dots on main nodes -->
+  <circle cx="30" cy="15" r="2.5" fill="white"/>
+  <circle cx="15" cy="35" r="2.5" fill="white"/>
+  <circle cx="45" cy="35" r="2.5" fill="white"/>
+  <circle cx="30" cy="50" r="2" fill="white"/>
+</svg>

--- a/custom-nodes/n8n-nodes-knowledge-graph/package.json
+++ b/custom-nodes/n8n-nodes-knowledge-graph/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "n8n-nodes-knowledge-graph",
+  "version": "1.0.0",
+  "description": "n8n node for extracting knowledge graphs from text using Google Gemini",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "knowledge-graph",
+    "entity-extraction",
+    "gemini",
+    "nlp"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/fsebbah/n8n-workflows",
+  "author": {
+    "name": "fsebbah"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fsebbah/n8n-workflows.git"
+  },
+  "main": "dist/nodes/KnowledgeGraph/KnowledgeGraph.node.js",
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "nodes": [
+      "dist/nodes/KnowledgeGraph/KnowledgeGraph.node.js"
+    ],
+    "credentials": []
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "eslint . --ext .ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "n8n-nodes-google-genai-core": "file:../n8n-nodes-google-genai-core"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "~5.3.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  }
+}

--- a/custom-nodes/n8n-nodes-knowledge-graph/prompts/knowledgeGraphPrompts.ts
+++ b/custom-nodes/n8n-nodes-knowledge-graph/prompts/knowledgeGraphPrompts.ts
@@ -1,0 +1,294 @@
+/**
+ * Prompts pour l'extraction de graphes de connaissances
+ * Basé sur le Colab knowledge_graph_generation.ipynb
+ *
+ * Supports multiple presets and custom configurations
+ */
+
+// ============================================================================
+// PRESET CONFIGURATIONS
+// ============================================================================
+
+export interface PresetConfig {
+	entityTypes: string[];
+	relationTypes: string[];
+	entityDefinition: string;
+	relationDefinition: string;
+}
+
+export const PRESETS: Record<string, PresetConfig> = {
+	narrative: {
+		entityTypes: ['character', 'location', 'event', 'object'],
+		relationTypes: ['friend_of', 'enemy_of', 'family_of', 'lives_in', 'works_at', 'travels_to', 'owns', 'participates_in'],
+		entityDefinition: 'A "key entity" is a named individual (person, animal), place, significant event, or important object that is central to the story.',
+		relationDefinition: 'A "key relationship" is an explicitly stated or directly implied relationship between two entities that affects the plot or understanding.',
+	},
+	business: {
+		entityTypes: ['organization', 'person', 'metric', 'concept', 'risk', 'event', 'region', 'industry'],
+		relationTypes: ['works_at', 'manages', 'owns', 'influences', 'measures', 'concerns', 'operates_in', 'competes_with', 'partners_with', 'invests_in', 'authored_by', 'conducted_in'],
+		entityDefinition: 'A "key entity" is an organization, person, financial metric (e.g., EBITDA, ROIC), business concept, risk factor, event, geographic region, or industry sector mentioned in the document.',
+		relationDefinition: 'A "key relationship" describes how entities interact: employment, ownership, measurement, influence, concern, competition, partnership, or investment relationships.',
+	},
+	technical: {
+		entityTypes: ['service', 'api', 'database', 'component', 'protocol', 'technology', 'pattern', 'configuration'],
+		relationTypes: ['depends_on', 'calls', 'implements', 'extends', 'contains', 'configures', 'stores_in', 'communicates_with', 'inherits_from', 'uses'],
+		entityDefinition: 'A "key entity" is a technical component: service, API endpoint, database, software component, protocol, technology, design pattern, or configuration element.',
+		relationDefinition: 'A "key relationship" describes technical interactions: dependencies, API calls, implementations, inheritance, data storage, or communication patterns.',
+	},
+	scientific: {
+		entityTypes: ['researcher', 'theory', 'study', 'finding', 'method', 'dataset', 'institution', 'publication'],
+		relationTypes: ['authored_by', 'cites', 'supports', 'contradicts', 'uses_method', 'affiliated_with', 'published_in', 'discovers', 'proposes', 'validates'],
+		entityDefinition: 'A "key entity" is a researcher, scientific theory, study, finding, methodology, dataset, research institution, or publication.',
+		relationDefinition: 'A "key relationship" describes academic interactions: authorship, citations, support or contradiction of theories, methodological choices, affiliations, or discoveries.',
+	},
+	legal: {
+		entityTypes: ['law', 'regulation', 'party', 'obligation', 'right', 'court', 'contract', 'clause'],
+		relationTypes: ['governs', 'obligates', 'grants_right', 'party_to', 'references', 'amends', 'enforces', 'violates', 'complies_with', 'interprets'],
+		entityDefinition: 'A "key entity" is a law, regulation, legal party, obligation, right, court, contract, or contract clause.',
+		relationDefinition: 'A "key relationship" describes legal interactions: governance, obligations, rights, references between laws, amendments, enforcement, or compliance.',
+	},
+};
+
+// ============================================================================
+// BASE PROMPTS
+// ============================================================================
+
+export const ENTITY_EXTRACTION_PROMPT = `
+Using only the provided text, complete the following task.
+
+**Task - Extract Entities**
+
+- Definition: {{ENTITY_DEFINITION}}
+- Entity types to extract: {{ENTITY_TYPES}}
+- Task:
+  - Extract the distinct key entities found in the provided text.
+  - For each one:
+    - Assign a unique integer identifier (\`id\`=0, 1, 2...).
+    - Determine their most complete \`name\` from the text, spelled in title case.
+    - Determine their \`type\` from the allowed types above.
+
+{{CUSTOM_INSTRUCTIONS}}
+
+Output a JSON object with the following structure:
+{
+  "entities": [
+    {"id": 0, "name": "Entity Name", "type": "entity_type"},
+    ...
+  ],
+  "metadata": {
+    "source_length": <number of characters in source>,
+    "language_detected": "<detected language code>",
+    "entity_count": <number of entities>
+  }
+}
+`;
+
+export const RELATIONSHIP_EXTRACTION_PROMPT = `
+Using only the provided text, complete the following task.
+
+**Task - Extract Relationships**
+
+- Definition: {{RELATION_DEFINITION}}
+- Relation types to use: {{RELATION_TYPES}}
+- Task:
+  - Extract the distinct key relationships between entity pairs.
+  - Use the relation types provided, or infer appropriate types in snake_case if not listed.
+  - For symmetrical relationships (e.g., "friend_of"), create two entries to represent the relationship in both directions.
+  - For asymmetrical relationships (e.g., "manages"), create entries for both directions (e.g., "manages" and "managed_by").
+
+If entities are provided, use them. Otherwise, first extract entities then find relationships.
+
+{{CUSTOM_INSTRUCTIONS}}
+
+Output a JSON object with the following structure:
+{
+  "relationships": [
+    {"source": 0, "target": 1, "links": ["relationship_type_1", "relationship_type_2"]},
+    ...
+  ],
+  "metadata": {
+    "relationship_count": <number of relationship pairs>
+  }
+}
+`;
+
+export const FULL_GRAPH_EXTRACTION_PROMPT = `
+Using only the provided text, complete the following tasks.
+
+**Task 1 - Extract Entities**
+
+- Definition: {{ENTITY_DEFINITION}}
+- Entity types to extract: {{ENTITY_TYPES}}
+- Task:
+  - Extract the distinct key entities found in the provided text.
+  - For each one:
+    - Assign a unique integer identifier (\`id\`=0, 1, 2...).
+    - Determine their most complete \`name\` from the text, spelled in title case.
+    - Determine their \`type\` from the allowed types above.
+
+**Task 2 - Extract Relationships**
+
+- Definition: {{RELATION_DEFINITION}}
+- Relation types to use: {{RELATION_TYPES}}
+- Task:
+  - Extract the distinct key relationships between the entity pairs from Task 1.
+  - Use the relation types provided, or infer appropriate types in snake_case if not listed.
+  - For symmetrical relationships, create two entries to represent both directions.
+  - For asymmetrical relationships, create entries for both directions.
+
+{{CUSTOM_INSTRUCTIONS}}
+
+Output a JSON object with the following structure:
+{
+  "graph": {
+    "nodes": [
+      {"id": 0, "name": "Entity Name", "type": "entity_type"},
+      ...
+    ],
+    "edges": [
+      {"source": 0, "target": 1, "type": "relationship_type"},
+      ...
+    ]
+  },
+  "metadata": {
+    "node_count": <number of nodes>,
+    "edge_count": <number of edges>,
+    "language_detected": "<detected language code>"
+  }
+}
+`;
+
+// ============================================================================
+// CONFIGURATION INTERFACE
+// ============================================================================
+
+export interface ExtractionConfig {
+	entityTypes: string[];
+	relationTypes: string[];
+	customInstructions?: string;
+}
+
+// ============================================================================
+// PROMPT BUILDERS
+// ============================================================================
+
+/**
+ * Get configuration from preset name
+ */
+export function getPresetConfig(presetName: string): PresetConfig {
+	return PRESETS[presetName] || PRESETS.narrative;
+}
+
+/**
+ * Build extraction config from various sources
+ */
+export function buildExtractionConfig(
+	configMode: 'preset' | 'custom' | 'jsonConfig',
+	preset?: string,
+	entityTypes?: string[],
+	relationTypes?: string,
+	customInstructions?: string,
+	configJson?: string
+): ExtractionConfig {
+	if (configMode === 'jsonConfig' && configJson) {
+		try {
+			const parsed = JSON.parse(configJson);
+			return {
+				entityTypes: parsed.entityTypes || ['character'],
+				relationTypes: parsed.relationTypes || [],
+				customInstructions: parsed.customInstructions || '',
+			};
+		} catch {
+			// Fall back to narrative preset
+			const presetConfig = getPresetConfig('narrative');
+			return {
+				entityTypes: presetConfig.entityTypes,
+				relationTypes: presetConfig.relationTypes,
+			};
+		}
+	}
+
+	if (configMode === 'preset' && preset) {
+		const presetConfig = getPresetConfig(preset);
+		return {
+			entityTypes: presetConfig.entityTypes,
+			relationTypes: presetConfig.relationTypes,
+		};
+	}
+
+	// Custom mode
+	return {
+		entityTypes: entityTypes || ['character'],
+		relationTypes: relationTypes ? relationTypes.split(',').map(s => s.trim()).filter(Boolean) : [],
+		customInstructions: customInstructions || '',
+	};
+}
+
+/**
+ * Build the complete prompt with configuration
+ */
+export function buildPromptWithConfig(
+	basePrompt: string,
+	text: string,
+	config: ExtractionConfig,
+	presetName?: string
+): string {
+	const preset = presetName ? getPresetConfig(presetName) : null;
+
+	// Replace placeholders
+	let prompt = basePrompt
+		.replace('{{ENTITY_DEFINITION}}', preset?.entityDefinition || 'A key entity is a significant named item in the text.')
+		.replace('{{ENTITY_TYPES}}', config.entityTypes.join(', '))
+		.replace('{{RELATION_DEFINITION}}', preset?.relationDefinition || 'A key relationship describes how entities interact.')
+		.replace('{{RELATION_TYPES}}', config.relationTypes.length > 0 ? config.relationTypes.join(', ') : 'Infer appropriate relation types in snake_case');
+
+	// Add custom instructions
+	if (config.customInstructions) {
+		prompt = prompt.replace('{{CUSTOM_INSTRUCTIONS}}', `\n**Additional Instructions:**\n${config.customInstructions}\n`);
+	} else {
+		prompt = prompt.replace('{{CUSTOM_INSTRUCTIONS}}', '');
+	}
+
+	// Wrap with text
+	return '<TEXT>\n' + text + '\n</TEXT>\n\n<INSTRUCTIONS>\n' + prompt.trim() + '\n</INSTRUCTIONS>';
+}
+
+/**
+ * Legacy function for backward compatibility
+ */
+export function buildPrompt(basePrompt: string, text: string, entityTypes?: string[]): string {
+	// Use narrative preset as default for legacy calls
+	const config: ExtractionConfig = {
+		entityTypes: entityTypes || ['character'],
+		relationTypes: [],
+	};
+	return buildPromptWithConfig(basePrompt, text, config, 'narrative');
+}
+
+/**
+ * Construit le prompt pour l'extraction de relations avec des entités pré-définies
+ */
+export function buildRelationshipPromptWithEntities(
+	text: string,
+	entities: Array<{ id: number; name: string; type: string }>,
+	config?: ExtractionConfig
+): string {
+	const effectiveConfig = config || {
+		entityTypes: [],
+		relationTypes: [],
+	};
+
+	let prompt = '<TEXT>\n' + text + '\n</TEXT>\n\n';
+	prompt += '<ENTITIES>\n' + JSON.stringify(entities, null, 2) + '\n</ENTITIES>\n\n';
+
+	let instructions = RELATIONSHIP_EXTRACTION_PROMPT
+		.replace('{{RELATION_DEFINITION}}', 'A key relationship describes how entities interact.')
+		.replace('{{RELATION_TYPES}}', effectiveConfig.relationTypes.length > 0 ? effectiveConfig.relationTypes.join(', ') : 'Infer appropriate relation types in snake_case')
+		.replace('{{CUSTOM_INSTRUCTIONS}}', effectiveConfig.customInstructions ? `\n**Additional Instructions:**\n${effectiveConfig.customInstructions}\n` : '');
+
+	prompt += '<INSTRUCTIONS>\n' + instructions.trim();
+	prompt += '\n\nUse the provided entities list above. Find relationships between these entities only.';
+	prompt += '\n</INSTRUCTIONS>';
+
+	return prompt;
+}

--- a/custom-nodes/n8n-nodes-knowledge-graph/tsconfig.json
+++ b/custom-nodes/n8n-nodes-knowledge-graph/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "nodes/**/*.ts",
+    "prompts/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/workflows/knowledge-graph-workflow.json
+++ b/workflows/knowledge-graph-workflow.json
@@ -1,0 +1,361 @@
+{
+  "name": "Knowledge Graph Extraction",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "knowledge-graph",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "knowledge-graph-webhook"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-path",
+              "leftValue": "={{ $json.body.documentPath }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-document-path",
+      "name": "Has documentPath?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-url",
+              "leftValue": "={{ $json.body.documentUrl }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-document-url",
+      "name": "Has documentUrl?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [680, 420]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-base64",
+              "leftValue": "={{ $json.body.document?.data }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-document-base64",
+      "name": "Has document.data?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [900, 540]
+    },
+    {
+      "parameters": {
+        "fileSelector": "={{ $json.body.documentPath }}",
+        "options": {}
+      },
+      "id": "read-local-file",
+      "name": "Read Local File",
+      "type": "n8n-nodes-base.readBinaryFiles",
+      "typeVersion": 1,
+      "position": [680, 180]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $json.body.documentUrl }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          }
+        }
+      },
+      "id": "download-from-url",
+      "name": "Download from URL",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "operation": "toJson",
+        "sourceProperty": "data",
+        "options": {}
+      },
+      "id": "convert-base64",
+      "name": "Convert Base64 to Binary",
+      "type": "n8n-nodes-base.moveBinaryData",
+      "typeVersion": 1.1,
+      "position": [1120, 420]
+    },
+    {
+      "parameters": {
+        "errorMessage": "={{ \"No document provided. Please send documentPath, documentUrl, or document.data (base64)\" }}"
+      },
+      "id": "error-no-document",
+      "name": "Error: No Document",
+      "type": "n8n-nodes-base.stopAndError",
+      "typeVersion": 1,
+      "position": [1120, 660]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineAll",
+        "options": {}
+      },
+      "id": "merge-sources",
+      "name": "Merge Sources",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare data for Knowledge Graph node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get config from request\nconst configMode = body.configMode || 'preset';\nconst preset = body.preset || 'business';\nconst configJson = body.configJson ? JSON.stringify(body.configJson) : '{}';\n\n// Pass through binary data and add config\nconst items = $input.all();\n\nreturn items.map(item => ({\n  json: {\n    configMode,\n    preset,\n    configJson,\n    originalRequest: body\n  },\n  binary: item.binary\n}));"
+      },
+      "id": "prepare-config",
+      "name": "Prepare Config",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "operation": "buildGraph",
+        "inputType": "document",
+        "binaryPropertyName": "data",
+        "configMode": "={{ $json.configMode }}",
+        "preset": "={{ $json.preset }}",
+        "configJson": "={{ $json.configJson }}",
+        "options": {
+          "model": "gemini-2.5-flash"
+        }
+      },
+      "id": "knowledge-graph",
+      "name": "Knowledge Graph",
+      "type": "n8n-nodes-knowledge-graph.knowledgeGraph",
+      "typeVersion": 1,
+      "position": [1780, 300],
+      "credentials": {
+        "googleVertexAiApi": {
+          "id": "google-vertex-ai",
+          "name": "Google Vertex AI account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2000, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Convert base64 to binary\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\nconst base64Data = body.document?.data;\nconst mimeType = body.document?.mimeType || 'application/pdf';\n\nif (!base64Data) {\n  throw new Error('No base64 data found in document.data');\n}\n\n// Create binary data from base64\nconst binaryData = Buffer.from(base64Data, 'base64');\n\nreturn [{\n  json: body,\n  binary: {\n    data: {\n      data: base64Data,\n      mimeType: mimeType,\n      fileName: 'document.pdf'\n    }\n  }\n}];"
+      },
+      "id": "base64-to-binary",
+      "name": "Base64 to Binary",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 420]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Has documentPath?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has documentPath?": {
+      "main": [
+        [
+          {
+            "node": "Read Local File",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Has documentUrl?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has documentUrl?": {
+      "main": [
+        [
+          {
+            "node": "Download from URL",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Has document.data?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has document.data?": {
+      "main": [
+        [
+          {
+            "node": "Base64 to Binary",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: No Document",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Local File": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download from URL": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Base64 to Binary": {
+      "main": [
+        [
+          {
+            "node": "Merge Sources",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Sources": {
+      "main": [
+        [
+          {
+            "node": "Prepare Config",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Config": {
+      "main": [
+        [
+          {
+            "node": "Knowledge Graph",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Knowledge Graph": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

- New **n8n-nodes-knowledge-graph** package with KnowledgeGraph node
- Extract entities and relationships from text or documents using Google Gemini
- Support for multiple document types (PDF, TXT, HTML, etc.)

## Features

### Operations
- **Build Graph**: Extract complete knowledge graph (nodes + edges)
- **Extract Entities**: Extract entities only (characters, organizations, metrics, etc.)
- **Extract Relationships**: Extract relationships between entities

### Configuration Modes
- **Preset**: Pre-configured for common document types
  - `narrative`: Stories, books (characters, locations, events)
  - `business`: Market research, reports (organizations, metrics, risks)
  - `technical`: Documentation (APIs, services, dependencies)
  - `scientific`: Academic papers (researchers, theories, studies)
  - `legal`: Contracts, regulations (laws, parties, obligations)
- **Custom**: Define your own entity types, relation types, and instructions
- **JSON Config**: Pass complete configuration programmatically

### Input Types
- **Text**: Direct text input
- **Document**: Binary file input (PDF, TXT, HTML, CSV, Markdown, DOCX)

## Files Changed

- `custom-nodes/n8n-nodes-knowledge-graph/` - New package
- `custom-nodes/n8n-nodes-google-genai-core/shared/GenAiClient.ts` - Added `generateJsonFromDocument` for multimodal support
- `workflows/knowledge-graph-workflow.json` - Example workflow with webhook trigger
- `docs/test/mckinsey-config.json` - Example configuration for business documents

## Test Plan

- [ ] Build the package: `cd custom-nodes/n8n-nodes-knowledge-graph && npm install && npm run build`
- [ ] Link to n8n nodes directory
- [ ] Test with text input using "narrative" preset
- [ ] Test with PDF document using "business" preset
- [ ] Test JSON config mode with custom entity/relation types
- [ ] Verify webhook workflow accepts documentPath, documentUrl, and base64 document

🤖 Generated with [Claude Code](https://claude.ai/claude-code)