### PR TITLE
feat(knowledge-graph): implement Phase 2 enhancements

### DIFF
--- a/custom-nodes/n8n-nodes-graph-exporter/nodes/GraphExporter/GraphExporter.node.ts
+++ b/custom-nodes/n8n-nodes-graph-exporter/nodes/GraphExporter/GraphExporter.node.ts
@@ -1,0 +1,715 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+// Types for graph data
+interface GraphNode {
+	id: number;
+	name: string;
+	type: string;
+	[key: string]: any;
+}
+
+interface GraphEdge {
+	source: number;
+	target: number;
+	type: string;
+	[key: string]: any;
+}
+
+interface GraphData {
+	nodes: GraphNode[];
+	edges: GraphEdge[];
+}
+
+function parseGraphJson(jsonInput: string | object): GraphData {
+	let data: any;
+	if (typeof jsonInput === 'string') {
+		data = JSON.parse(jsonInput);
+	} else {
+		data = jsonInput;
+	}
+
+	if (data.graph) {
+		return data.graph as GraphData;
+	}
+	if (data.nodes && data.edges) {
+		return data as GraphData;
+	}
+	throw new Error('Invalid graph JSON structure. Expected "graph" or "nodes"/"edges" keys.');
+}
+
+function sanitizeUri(name: string): string {
+	let sanitized = name.replace(/[^a-zA-Z0-9_-]/g, '_');
+	sanitized = sanitized.replace(/_+/g, '_');
+	sanitized = sanitized.replace(/^_|_$/g, '');
+	return sanitized || 'unknown';
+}
+
+function sanitizeCypherString(value: string): string {
+	return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
+}
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;');
+}
+
+export class GraphExporter implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Graph Exporter',
+		name: 'graphExporter',
+		icon: 'file:graph-exporter.svg',
+		group: ['output'],
+		version: 1,
+		subtitle: '={{$parameter["format"]}}',
+		description: 'Export knowledge graphs to RDF, Cypher, GraphML, GEXF, and JSON-LD formats',
+		defaults: {
+			name: 'Graph Exporter',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [
+			{
+				displayName: 'Graph JSON',
+				name: 'graphJson',
+				type: 'json',
+				default: '',
+				required: true,
+				description: 'The knowledge graph JSON to export',
+			},
+			{
+				displayName: 'Export Format',
+				name: 'format',
+				type: 'options',
+				options: [
+					{
+						name: 'RDF (Turtle)',
+						value: 'rdf',
+						description: 'Export as RDF Turtle format (.ttl)',
+					},
+					{
+						name: 'Cypher (Neo4j)',
+						value: 'cypher',
+						description: 'Export as Cypher statements for Neo4j',
+					},
+					{
+						name: 'Cypher Batch (Neo4j)',
+						value: 'cypherBatch',
+						description: 'Export as optimized batch Cypher using UNWIND',
+					},
+					{
+						name: 'GraphML',
+						value: 'graphml',
+						description: 'Export as GraphML format (Gephi, yEd compatible)',
+					},
+					{
+						name: 'GEXF',
+						value: 'gexf',
+						description: 'Export as GEXF format (Gephi native)',
+					},
+					{
+						name: 'JSON-LD',
+						value: 'jsonld',
+						description: 'Export as JSON-LD linked data format',
+					},
+					{
+						name: 'CSV (Nodes + Edges)',
+						value: 'csv',
+						description: 'Export as two CSV strings (nodes and edges)',
+					},
+					{
+						name: 'DOT (Graphviz)',
+						value: 'dot',
+						description: 'Export as DOT format for Graphviz',
+					},
+				],
+				default: 'cypher',
+			},
+			{
+				displayName: 'Base URI',
+				name: 'baseUri',
+				type: 'string',
+				default: 'http://example.org/kg/',
+				description: 'Base URI for RDF and JSON-LD exports',
+				displayOptions: {
+					show: {
+						format: ['rdf', 'jsonld'],
+					},
+				},
+			},
+			{
+				displayName: 'Include Comments',
+				name: 'includeComments',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to include comments and metadata in the output',
+			},
+			{
+				displayName: 'Output As',
+				name: 'outputAs',
+				type: 'options',
+				options: [
+					{
+						name: 'String',
+						value: 'string',
+						description: 'Return the export as a string in JSON',
+					},
+					{
+						name: 'Binary File',
+						value: 'binary',
+						description: 'Return as a downloadable binary file',
+					},
+				],
+				default: 'string',
+			},
+			{
+				displayName: 'File Name',
+				name: 'fileName',
+				type: 'string',
+				default: 'graph_export',
+				description: 'Name of the output file (without extension)',
+				displayOptions: {
+					show: {
+						outputAs: ['binary'],
+					},
+				},
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const returnData: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			try {
+				const graphJson = this.getNodeParameter('graphJson', i) as string | object;
+				const format = this.getNodeParameter('format', i) as string;
+				const includeComments = this.getNodeParameter('includeComments', i) as boolean;
+				const outputAs = this.getNodeParameter('outputAs', i) as string;
+
+				const graph = parseGraphJson(graphJson);
+
+				let exportedContent: string;
+				let fileExtension: string;
+				let mimeType: string;
+
+				switch (format) {
+					case 'rdf': {
+						const baseUri = this.getNodeParameter('baseUri', i) as string;
+						exportedContent = exportToRdf(graph, baseUri, includeComments);
+						fileExtension = '.ttl';
+						mimeType = 'text/turtle';
+						break;
+					}
+					case 'cypher': {
+						exportedContent = exportToCypher(graph, includeComments);
+						fileExtension = '.cypher';
+						mimeType = 'application/x-cypher-query';
+						break;
+					}
+					case 'cypherBatch': {
+						exportedContent = exportToCypherBatch(graph, includeComments);
+						fileExtension = '.cypher';
+						mimeType = 'application/x-cypher-query';
+						break;
+					}
+					case 'graphml': {
+						exportedContent = exportToGraphML(graph);
+						fileExtension = '.graphml';
+						mimeType = 'application/graphml+xml';
+						break;
+					}
+					case 'gexf': {
+						exportedContent = exportToGexf(graph);
+						fileExtension = '.gexf';
+						mimeType = 'application/gexf+xml';
+						break;
+					}
+					case 'jsonld': {
+						const baseUri = this.getNodeParameter('baseUri', i) as string;
+						exportedContent = exportToJsonLd(graph, baseUri);
+						fileExtension = '.jsonld';
+						mimeType = 'application/ld+json';
+						break;
+					}
+					case 'csv': {
+						exportedContent = exportToCsv(graph);
+						fileExtension = '.csv';
+						mimeType = 'text/csv';
+						break;
+					}
+					case 'dot': {
+						exportedContent = exportToDot(graph, includeComments);
+						fileExtension = '.dot';
+						mimeType = 'text/vnd.graphviz';
+						break;
+					}
+					default:
+						throw new NodeOperationError(this.getNode(), `Unknown format: ${format}`);
+				}
+
+				if (outputAs === 'binary') {
+					const fileName = this.getNodeParameter('fileName', i) as string;
+					const binaryData = await this.helpers.prepareBinaryData(
+						Buffer.from(exportedContent, 'utf-8'),
+						`${fileName}${fileExtension}`,
+						mimeType
+					);
+
+					returnData.push({
+						json: {
+							format,
+							nodeCount: graph.nodes.length,
+							edgeCount: graph.edges.length,
+							fileName: `${fileName}${fileExtension}`,
+						},
+						binary: {
+							data: binaryData,
+						},
+						pairedItem: { item: i },
+					});
+				} else {
+					returnData.push({
+						json: {
+							format,
+							nodeCount: graph.nodes.length,
+							edgeCount: graph.edges.length,
+							content: exportedContent,
+						},
+						pairedItem: { item: i },
+					});
+				}
+			} catch (error) {
+				if (this.continueOnFail()) {
+					returnData.push({
+						json: { error: (error as Error).message },
+						pairedItem: { item: i },
+					});
+				} else {
+					throw error;
+				}
+			}
+		}
+
+		return [returnData];
+	}
+}
+
+// Export functions
+
+function exportToRdf(graph: GraphData, baseUri: string, includeComments: boolean): string {
+	const lines: string[] = [];
+	const nodeMap: Map<number, { name: string; type: string; uriName: string }> = new Map();
+
+	// Build node map
+	for (const node of graph.nodes) {
+		nodeMap.set(node.id, {
+			name: node.name,
+			type: node.type,
+			uriName: sanitizeUri(node.name),
+		});
+	}
+
+	// Collect unique types
+	const entityTypes = new Set<string>();
+	const relationTypes = new Set<string>();
+	for (const node of graph.nodes) entityTypes.add(node.type);
+	for (const edge of graph.edges) relationTypes.add(edge.type);
+
+	// Prefixes
+	lines.push('@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .');
+	lines.push('@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .');
+	lines.push('@prefix owl: <http://www.w3.org/2002/07/owl#> .');
+	lines.push('@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .');
+	lines.push(`@prefix kg: <${baseUri}> .`);
+	lines.push(`@prefix entity: <${baseUri}entity/> .`);
+	lines.push(`@prefix rel: <${baseUri}relation/> .`);
+	lines.push('');
+
+	if (includeComments) {
+		lines.push(`<${baseUri}> a owl:Ontology ;`);
+		lines.push('    rdfs:label "Knowledge Graph Export" ;');
+		lines.push(`    rdfs:comment "Exported from n8n Graph Exporter" .`);
+		lines.push('');
+	}
+
+	// Entity classes
+	if (includeComments) lines.push('# Entity Classes');
+	for (const etype of Array.from(entityTypes).sort()) {
+		const classUri = sanitizeUri(etype.charAt(0).toUpperCase() + etype.slice(1));
+		lines.push(`kg:${classUri} a owl:Class ;`);
+		lines.push(`    rdfs:label "${etype}" .`);
+	}
+	lines.push('');
+
+	// Relation properties
+	if (includeComments) lines.push('# Relation Properties');
+	for (const rtype of Array.from(relationTypes).sort()) {
+		const propUri = sanitizeUri(rtype);
+		lines.push(`rel:${propUri} a owl:ObjectProperty ;`);
+		lines.push(`    rdfs:label "${rtype}" .`);
+	}
+	lines.push('');
+
+	// Entities
+	if (includeComments) lines.push('# Entity Instances');
+	for (const node of graph.nodes) {
+		const info = nodeMap.get(node.id)!;
+		const entityUri = info.uriName;
+		const entityType = sanitizeUri(info.type.charAt(0).toUpperCase() + info.type.slice(1));
+		const entityName = info.name.replace(/"/g, '\\"');
+
+		lines.push(`entity:${entityUri} a kg:${entityType} ;`);
+		lines.push(`    rdfs:label "${entityName}" ;`);
+		lines.push(`    kg:nodeId ${node.id} .`);
+	}
+	lines.push('');
+
+	// Relationships
+	if (includeComments) lines.push('# Relationships');
+	for (const edge of graph.edges) {
+		const sourceInfo = nodeMap.get(edge.source);
+		const targetInfo = nodeMap.get(edge.target);
+		if (sourceInfo && targetInfo) {
+			const relProp = sanitizeUri(edge.type);
+			lines.push(`entity:${sourceInfo.uriName} rel:${relProp} entity:${targetInfo.uriName} .`);
+		}
+	}
+
+	return lines.join('\n');
+}
+
+function exportToCypher(graph: GraphData, includeComments: boolean): string {
+	const lines: string[] = [];
+
+	if (includeComments) {
+		lines.push('// Knowledge Graph Import Script');
+		lines.push(`// Nodes: ${graph.nodes.length}, Edges: ${graph.edges.length}`);
+		lines.push('');
+	}
+
+	// Create constraints
+	const entityTypes = new Set(graph.nodes.map(n => n.type));
+	if (includeComments) lines.push('// Create constraints for better performance');
+	for (const etype of Array.from(entityTypes).sort()) {
+		const label = sanitizeUri(etype.charAt(0).toUpperCase() + etype.slice(1));
+		lines.push(`CREATE CONSTRAINT IF NOT EXISTS FOR (n:${label}) REQUIRE n.id IS UNIQUE;`);
+	}
+	lines.push('');
+
+	// Create nodes
+	if (includeComments) lines.push('// Create nodes');
+	for (const node of graph.nodes) {
+		const nodeName = sanitizeCypherString(node.name);
+		const nodeType = node.type;
+		const label = sanitizeUri(nodeType.charAt(0).toUpperCase() + nodeType.slice(1));
+		lines.push(`CREATE (n${node.id}:${label} {id: ${node.id}, name: '${nodeName}', type: '${nodeType}'});`);
+	}
+	lines.push('');
+
+	// Create relationships
+	if (includeComments) lines.push('// Create relationships');
+	for (const edge of graph.edges) {
+		const relLabel = sanitizeUri(edge.type).toUpperCase();
+		lines.push(`MATCH (a {id: ${edge.source}}), (b {id: ${edge.target}}) CREATE (a)-[:${relLabel}]->(b);`);
+	}
+
+	return lines.join('\n');
+}
+
+function exportToCypherBatch(graph: GraphData, includeComments: boolean): string {
+	const lines: string[] = [];
+
+	if (includeComments) {
+		lines.push('// Knowledge Graph Batch Import Script');
+		lines.push(`// Nodes: ${graph.nodes.length}, Edges: ${graph.edges.length}`);
+		lines.push('');
+	}
+
+	// Group nodes by type
+	const nodesByType: Map<string, any[]> = new Map();
+	for (const node of graph.nodes) {
+		if (!nodesByType.has(node.type)) {
+			nodesByType.set(node.type, []);
+		}
+		nodesByType.get(node.type)!.push({
+			id: node.id,
+			name: node.name,
+			type: node.type,
+		});
+	}
+
+	// Create constraints
+	if (includeComments) lines.push('// Create constraints');
+	for (const nodeType of Array.from(nodesByType.keys()).sort()) {
+		const label = sanitizeUri(nodeType.charAt(0).toUpperCase() + nodeType.slice(1));
+		lines.push(`CREATE CONSTRAINT IF NOT EXISTS FOR (n:${label}) REQUIRE n.id IS UNIQUE;`);
+	}
+	lines.push('');
+
+	// Batch create nodes
+	if (includeComments) lines.push('// Batch create nodes');
+	for (const [nodeType, typeNodes] of nodesByType) {
+		const label = sanitizeUri(nodeType.charAt(0).toUpperCase() + nodeType.slice(1));
+		const nodesJson = JSON.stringify(typeNodes);
+		lines.push(`UNWIND ${nodesJson} AS node`);
+		lines.push(`CREATE (n:${label} {id: node.id, name: node.name, type: node.type});`);
+		lines.push('');
+	}
+
+	// Group edges by type
+	const edgesByType: Map<string, any[]> = new Map();
+	for (const edge of graph.edges) {
+		if (!edgesByType.has(edge.type)) {
+			edgesByType.set(edge.type, []);
+		}
+		edgesByType.get(edge.type)!.push({
+			source: edge.source,
+			target: edge.target,
+		});
+	}
+
+	// Batch create relationships
+	if (includeComments) lines.push('// Batch create relationships');
+	for (const [relType, typeEdges] of edgesByType) {
+		const relLabel = sanitizeUri(relType).toUpperCase();
+		const edgesJson = JSON.stringify(typeEdges);
+		lines.push(`UNWIND ${edgesJson} AS rel`);
+		lines.push(`MATCH (a {id: rel.source}), (b {id: rel.target})`);
+		lines.push(`CREATE (a)-[:${relLabel}]->(b);`);
+		lines.push('');
+	}
+
+	return lines.join('\n');
+}
+
+function exportToGraphML(graph: GraphData): string {
+	const lines: string[] = [];
+
+	lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+	lines.push('<graphml xmlns="http://graphml.graphdrawing.org/xmlns"');
+	lines.push('         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"');
+	lines.push('         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns');
+	lines.push('         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">');
+	lines.push('');
+	lines.push('  <!-- Node attributes -->');
+	lines.push('  <key id="name" for="node" attr.name="name" attr.type="string"/>');
+	lines.push('  <key id="type" for="node" attr.name="type" attr.type="string"/>');
+	lines.push('  <!-- Edge attributes -->');
+	lines.push('  <key id="rel_type" for="edge" attr.name="type" attr.type="string"/>');
+	lines.push('');
+	lines.push('  <graph id="KnowledgeGraph" edgedefault="directed">');
+	lines.push('');
+
+	// Nodes
+	lines.push('    <!-- Nodes -->');
+	for (const node of graph.nodes) {
+		const nodeName = escapeXml(node.name);
+		lines.push(`    <node id="n${node.id}">`);
+		lines.push(`      <data key="name">${nodeName}</data>`);
+		lines.push(`      <data key="type">${node.type}</data>`);
+		lines.push('    </node>');
+	}
+	lines.push('');
+
+	// Edges
+	lines.push('    <!-- Edges -->');
+	for (let i = 0; i < graph.edges.length; i++) {
+		const edge = graph.edges[i];
+		lines.push(`    <edge id="e${i}" source="n${edge.source}" target="n${edge.target}">`);
+		lines.push(`      <data key="rel_type">${edge.type}</data>`);
+		lines.push('    </edge>');
+	}
+
+	lines.push('');
+	lines.push('  </graph>');
+	lines.push('</graphml>');
+
+	return lines.join('\n');
+}
+
+function exportToGexf(graph: GraphData): string {
+	const lines: string[] = [];
+	const today = new Date().toISOString().split('T')[0];
+
+	lines.push('<?xml version="1.0" encoding="UTF-8"?>');
+	lines.push('<gexf xmlns="http://www.gexf.net/1.3"');
+	lines.push('      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"');
+	lines.push('      xsi:schemaLocation="http://www.gexf.net/1.3 http://www.gexf.net/1.3/gexf.xsd"');
+	lines.push('      version="1.3">');
+	lines.push('');
+	lines.push(`  <meta lastmodifieddate="${today}">`);
+	lines.push('    <creator>n8n Graph Exporter</creator>');
+	lines.push('    <description>Knowledge Graph Export</description>');
+	lines.push('  </meta>');
+	lines.push('');
+	lines.push('  <graph defaultedgetype="directed">');
+	lines.push('');
+	lines.push('    <attributes class="node">');
+	lines.push('      <attribute id="0" title="type" type="string"/>');
+	lines.push('    </attributes>');
+	lines.push('');
+	lines.push('    <attributes class="edge">');
+	lines.push('      <attribute id="0" title="type" type="string"/>');
+	lines.push('    </attributes>');
+	lines.push('');
+
+	// Nodes
+	lines.push('    <nodes>');
+	for (const node of graph.nodes) {
+		const nodeName = escapeXml(node.name);
+		lines.push(`      <node id="${node.id}" label="${nodeName}">`);
+		lines.push('        <attvalues>');
+		lines.push(`          <attvalue for="0" value="${node.type}"/>`);
+		lines.push('        </attvalues>');
+		lines.push('      </node>');
+	}
+	lines.push('    </nodes>');
+	lines.push('');
+
+	// Edges
+	lines.push('    <edges>');
+	for (let i = 0; i < graph.edges.length; i++) {
+		const edge = graph.edges[i];
+		lines.push(`      <edge id="${i}" source="${edge.source}" target="${edge.target}" label="${edge.type}">`);
+		lines.push('        <attvalues>');
+		lines.push(`          <attvalue for="0" value="${edge.type}"/>`);
+		lines.push('        </attvalues>');
+		lines.push('      </edge>');
+	}
+	lines.push('    </edges>');
+	lines.push('');
+
+	lines.push('  </graph>');
+	lines.push('</gexf>');
+
+	return lines.join('\n');
+}
+
+function exportToJsonLd(graph: GraphData, baseUri: string): string {
+	const nodeMap = new Map<number, GraphNode>();
+	for (const node of graph.nodes) {
+		nodeMap.set(node.id, node);
+	}
+
+	const jsonld: any = {
+		'@context': {
+			'@base': baseUri,
+			kg: baseUri,
+			name: 'kg:name',
+			type: '@type',
+			id: '@id',
+		},
+		'@graph': [],
+	};
+
+	// Add nodes
+	for (const node of graph.nodes) {
+		const nodeObj: any = {
+			'@id': `entity/${sanitizeUri(node.name)}`,
+			'@type': `kg:${sanitizeUri(node.type.charAt(0).toUpperCase() + node.type.slice(1))}`,
+			'kg:nodeId': node.id,
+			name: node.name,
+		};
+		jsonld['@graph'].push(nodeObj);
+	}
+
+	// Add relationships to nodes
+	for (const edge of graph.edges) {
+		const sourceNode = nodeMap.get(edge.source);
+		const targetNode = nodeMap.get(edge.target);
+
+		if (sourceNode && targetNode) {
+			for (const nodeObj of jsonld['@graph']) {
+				if (nodeObj['kg:nodeId'] === edge.source) {
+					const relKey = `kg:${sanitizeUri(edge.type)}`;
+					if (!nodeObj[relKey]) {
+						nodeObj[relKey] = [];
+					}
+					nodeObj[relKey].push({
+						'@id': `entity/${sanitizeUri(targetNode.name)}`,
+					});
+					break;
+				}
+			}
+		}
+	}
+
+	return JSON.stringify(jsonld, null, 2);
+}
+
+function exportToCsv(graph: GraphData): string {
+	const lines: string[] = [];
+
+	// Nodes CSV
+	lines.push('=== NODES ===');
+	lines.push('id,name,type');
+	for (const node of graph.nodes) {
+		const name = node.name.includes(',') || node.name.includes('"')
+			? `"${node.name.replace(/"/g, '""')}"`
+			: node.name;
+		lines.push(`${node.id},${name},${node.type}`);
+	}
+
+	lines.push('');
+	lines.push('=== EDGES ===');
+	lines.push('source,target,type');
+	for (const edge of graph.edges) {
+		lines.push(`${edge.source},${edge.target},${edge.type}`);
+	}
+
+	return lines.join('\n');
+}
+
+function exportToDot(graph: GraphData, includeComments: boolean): string {
+	const lines: string[] = [];
+
+	lines.push('digraph KnowledgeGraph {');
+	lines.push('  rankdir=LR;');
+	lines.push('  node [shape=box, style=filled];');
+
+	if (includeComments) {
+		lines.push('');
+		lines.push(`  // Nodes: ${graph.nodes.length}`);
+		lines.push(`  // Edges: ${graph.edges.length}`);
+	}
+	lines.push('');
+
+	// Define node colors by type
+	const typeColors: Record<string, string> = {
+		person: '#4CAF50',
+		organization: '#2196F3',
+		location: '#FF9800',
+		event: '#9C27B0',
+		concept: '#00BCD4',
+		metric: '#F44336',
+		default: '#9E9E9E',
+	};
+
+	// Nodes
+	for (const node of graph.nodes) {
+		const color = typeColors[node.type.toLowerCase()] || typeColors.default;
+		const label = node.name.replace(/"/g, '\\"');
+		lines.push(`  n${node.id} [label="${label}", fillcolor="${color}"];`);
+	}
+	lines.push('');
+
+	// Edges
+	for (const edge of graph.edges) {
+		const label = edge.type.replace(/_/g, ' ');
+		lines.push(`  n${edge.source} -> n${edge.target} [label="${label}"];`);
+	}
+
+	lines.push('}');
+
+	return lines.join('\n');
+}

--- a/custom-nodes/n8n-nodes-graph-exporter/nodes/GraphExporter/graph-exporter.svg
+++ b/custom-nodes/n8n-nodes-graph-exporter/nodes/GraphExporter/graph-exporter.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" fill="#E3F2FD"/>
+  <polyline points="14 2 14 8 20 8"/>
+  <circle cx="9" cy="13" r="2" fill="#4CAF50"/>
+  <circle cx="15" cy="13" r="2" fill="#2196F3"/>
+  <circle cx="12" cy="17" r="2" fill="#FF9800"/>
+  <line x1="10.5" y1="14" x2="13.5" y2="14" stroke="#666" stroke-width="1"/>
+  <line x1="9.5" y1="14.5" x2="11.5" y2="16.5" stroke="#666" stroke-width="1"/>
+  <line x1="14.5" y1="14.5" x2="12.5" y2="16.5" stroke="#666" stroke-width="1"/>
+</svg>

--- a/custom-nodes/n8n-nodes-graph-exporter/package.json
+++ b/custom-nodes/n8n-nodes-graph-exporter/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "n8n-nodes-graph-exporter",
+  "version": "1.0.0",
+  "description": "n8n node for exporting knowledge graphs to various formats (RDF, Cypher, GraphML, GEXF, JSON-LD)",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "knowledge-graph",
+    "rdf",
+    "cypher",
+    "neo4j",
+    "graphml",
+    "export"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/fsebbah/n8n-workflows",
+  "author": {
+    "name": "fsebbah"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fsebbah/n8n-workflows.git"
+  },
+  "main": "dist/nodes/GraphExporter/GraphExporter.node.js",
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "nodes": [
+      "dist/nodes/GraphExporter/GraphExporter.node.js"
+    ],
+    "credentials": []
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "eslint . --ext .ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "~5.3.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  }
+}

--- a/custom-nodes/n8n-nodes-graph-exporter/tsconfig.json
+++ b/custom-nodes/n8n-nodes-graph-exporter/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "nodes/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/custom-nodes/n8n-nodes-graph-transformer/nodes/GraphTransformer/GraphTransformer.node.ts
+++ b/custom-nodes/n8n-nodes-graph-transformer/nodes/GraphTransformer/GraphTransformer.node.ts
@@ -1,0 +1,1150 @@
+import {
+	IExecuteFunctions,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	NodeOperationError,
+} from 'n8n-workflow';
+
+// Types for graph data
+interface GraphNode {
+	id: number;
+	name: string;
+	type: string;
+	[key: string]: any;
+}
+
+interface GraphEdge {
+	source: number;
+	target: number;
+	type: string;
+	[key: string]: any;
+}
+
+interface GraphData {
+	nodes: GraphNode[];
+	edges: GraphEdge[];
+}
+
+function parseGraphJson(jsonInput: string | object): GraphData {
+	let data: any;
+	if (typeof jsonInput === 'string') {
+		data = JSON.parse(jsonInput);
+	} else {
+		data = jsonInput;
+	}
+
+	// Handle nested graph structure
+	if (data.graph) {
+		return data.graph as GraphData;
+	}
+	if (data.nodes && data.edges) {
+		return data as GraphData;
+	}
+	throw new Error('Invalid graph JSON structure. Expected "graph" or "nodes"/"edges" keys.');
+}
+
+export class GraphTransformer implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Graph Transformer',
+		name: 'graphTransformer',
+		icon: 'file:graph-transformer.svg',
+		group: ['transform'],
+		version: 1,
+		subtitle: '={{$parameter["operation"]}}',
+		description: 'Transform, merge, filter and manipulate knowledge graphs',
+		defaults: {
+			name: 'Graph Transformer',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Merge Graphs',
+						value: 'merge',
+						description: 'Merge multiple graphs into one',
+						action: 'Merge multiple graphs',
+					},
+					{
+						name: 'Filter Nodes',
+						value: 'filterNodes',
+						description: 'Filter nodes by type or property',
+						action: 'Filter nodes from graph',
+					},
+					{
+						name: 'Filter Edges',
+						value: 'filterEdges',
+						description: 'Filter edges by type or property',
+						action: 'Filter edges from graph',
+					},
+					{
+						name: 'Rename Types',
+						value: 'renameTypes',
+						description: 'Rename node or edge types',
+						action: 'Rename types in graph',
+					},
+					{
+						name: 'Add Properties',
+						value: 'addProperties',
+						description: 'Add computed properties to nodes or edges',
+						action: 'Add properties to graph elements',
+					},
+					{
+						name: 'Remove Duplicates',
+						value: 'deduplicate',
+						description: 'Remove duplicate nodes and edges',
+						action: 'Remove duplicates from graph',
+					},
+					{
+						name: 'Extract Subgraph',
+						value: 'extractSubgraph',
+						description: 'Extract a subgraph around specific nodes',
+						action: 'Extract subgraph',
+					},
+					{
+						name: 'Compute Statistics',
+						value: 'statistics',
+						description: 'Compute graph statistics (degree, centrality, etc.)',
+						action: 'Compute graph statistics',
+					},
+				],
+				default: 'merge',
+			},
+			// Graph JSON input (for single graph operations)
+			{
+				displayName: 'Graph JSON',
+				name: 'graphJson',
+				type: 'json',
+				default: '',
+				description: 'The knowledge graph JSON to transform',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges', 'renameTypes', 'addProperties', 'deduplicate', 'extractSubgraph', 'statistics'],
+					},
+				},
+			},
+			// Merge operation parameters
+			{
+				displayName: 'Merge Mode',
+				name: 'mergeMode',
+				type: 'options',
+				options: [
+					{
+						name: 'From Items',
+						value: 'fromItems',
+						description: 'Merge graphs from input items (each item has a graph)',
+					},
+					{
+						name: 'Two Graphs',
+						value: 'twoGraphs',
+						description: 'Merge two specific graphs',
+					},
+				],
+				default: 'fromItems',
+				displayOptions: {
+					show: {
+						operation: ['merge'],
+					},
+				},
+			},
+			{
+				displayName: 'Graph 1 JSON',
+				name: 'graph1Json',
+				type: 'json',
+				default: '',
+				description: 'First graph to merge',
+				displayOptions: {
+					show: {
+						operation: ['merge'],
+						mergeMode: ['twoGraphs'],
+					},
+				},
+			},
+			{
+				displayName: 'Graph 2 JSON',
+				name: 'graph2Json',
+				type: 'json',
+				default: '',
+				description: 'Second graph to merge',
+				displayOptions: {
+					show: {
+						operation: ['merge'],
+						mergeMode: ['twoGraphs'],
+					},
+				},
+			},
+			{
+				displayName: 'Graph Property Name',
+				name: 'graphPropertyName',
+				type: 'string',
+				default: 'graph',
+				description: 'Property name containing the graph in each input item',
+				displayOptions: {
+					show: {
+						operation: ['merge'],
+						mergeMode: ['fromItems'],
+					},
+				},
+			},
+			{
+				displayName: 'Deduplication Strategy',
+				name: 'deduplicationStrategy',
+				type: 'options',
+				options: [
+					{
+						name: 'By Name',
+						value: 'byName',
+						description: 'Merge nodes with the same name',
+					},
+					{
+						name: 'By Name and Type',
+						value: 'byNameAndType',
+						description: 'Merge nodes with the same name and type',
+					},
+					{
+						name: 'Keep All',
+						value: 'keepAll',
+						description: 'Keep all nodes (reassign IDs)',
+					},
+				],
+				default: 'byNameAndType',
+				displayOptions: {
+					show: {
+						operation: ['merge', 'deduplicate'],
+					},
+				},
+			},
+			// Filter parameters
+			{
+				displayName: 'Filter Mode',
+				name: 'filterMode',
+				type: 'options',
+				options: [
+					{
+						name: 'Include',
+						value: 'include',
+						description: 'Keep only matching elements',
+					},
+					{
+						name: 'Exclude',
+						value: 'exclude',
+						description: 'Remove matching elements',
+					},
+				],
+				default: 'include',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges'],
+					},
+				},
+			},
+			{
+				displayName: 'Filter By',
+				name: 'filterBy',
+				type: 'options',
+				options: [
+					{
+						name: 'Type',
+						value: 'type',
+						description: 'Filter by element type',
+					},
+					{
+						name: 'Property',
+						value: 'property',
+						description: 'Filter by property value',
+					},
+					{
+						name: 'Expression',
+						value: 'expression',
+						description: 'Filter using a JavaScript expression',
+					},
+				],
+				default: 'type',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges'],
+					},
+				},
+			},
+			{
+				displayName: 'Types',
+				name: 'filterTypes',
+				type: 'string',
+				default: '',
+				placeholder: 'person, organization',
+				description: 'Comma-separated list of types to filter',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges'],
+						filterBy: ['type'],
+					},
+				},
+			},
+			{
+				displayName: 'Property Name',
+				name: 'filterPropertyName',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., importance',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges'],
+						filterBy: ['property'],
+					},
+				},
+			},
+			{
+				displayName: 'Property Value',
+				name: 'filterPropertyValue',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., high',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges'],
+						filterBy: ['property'],
+					},
+				},
+			},
+			{
+				displayName: 'Filter Expression',
+				name: 'filterExpression',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., item.name.length > 10',
+				description: 'JavaScript expression. Use "item" to reference the current node/edge.',
+				displayOptions: {
+					show: {
+						operation: ['filterNodes', 'filterEdges'],
+						filterBy: ['expression'],
+					},
+				},
+			},
+			// Rename types parameters
+			{
+				displayName: 'Rename Target',
+				name: 'renameTarget',
+				type: 'options',
+				options: [
+					{
+						name: 'Node Types',
+						value: 'nodes',
+					},
+					{
+						name: 'Edge Types',
+						value: 'edges',
+					},
+					{
+						name: 'Both',
+						value: 'both',
+					},
+				],
+				default: 'nodes',
+				displayOptions: {
+					show: {
+						operation: ['renameTypes'],
+					},
+				},
+			},
+			{
+				displayName: 'Type Mappings',
+				name: 'typeMappings',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				description: 'Mappings from old type to new type',
+				displayOptions: {
+					show: {
+						operation: ['renameTypes'],
+					},
+				},
+				options: [
+					{
+						name: 'mappings',
+						displayName: 'Mappings',
+						values: [
+							{
+								displayName: 'Old Type',
+								name: 'oldType',
+								type: 'string',
+								default: '',
+								placeholder: 'e.g., person',
+							},
+							{
+								displayName: 'New Type',
+								name: 'newType',
+								type: 'string',
+								default: '',
+								placeholder: 'e.g., individual',
+							},
+						],
+					},
+				],
+			},
+			// Add properties parameters
+			{
+				displayName: 'Target',
+				name: 'addPropertiesTarget',
+				type: 'options',
+				options: [
+					{
+						name: 'Nodes',
+						value: 'nodes',
+					},
+					{
+						name: 'Edges',
+						value: 'edges',
+					},
+				],
+				default: 'nodes',
+				displayOptions: {
+					show: {
+						operation: ['addProperties'],
+					},
+				},
+			},
+			{
+				displayName: 'Properties',
+				name: 'propertiesToAdd',
+				type: 'fixedCollection',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				displayOptions: {
+					show: {
+						operation: ['addProperties'],
+					},
+				},
+				options: [
+					{
+						name: 'properties',
+						displayName: 'Properties',
+						values: [
+							{
+								displayName: 'Property Name',
+								name: 'name',
+								type: 'string',
+								default: '',
+								placeholder: 'e.g., label',
+							},
+							{
+								displayName: 'Value Expression',
+								name: 'expression',
+								type: 'string',
+								default: '',
+								placeholder: 'e.g., item.name.toUpperCase()',
+								description: 'JavaScript expression. Use "item" for current element, "graph" for full graph.',
+							},
+						],
+					},
+				],
+			},
+			// Extract subgraph parameters
+			{
+				displayName: 'Center Nodes',
+				name: 'centerNodes',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., 0, 5, 10 or "John Doe", "Acme Corp"',
+				description: 'Node IDs or names to center the subgraph on',
+				displayOptions: {
+					show: {
+						operation: ['extractSubgraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Depth',
+				name: 'subgraphDepth',
+				type: 'number',
+				default: 1,
+				description: 'How many hops from center nodes to include',
+				displayOptions: {
+					show: {
+						operation: ['extractSubgraph'],
+					},
+				},
+			},
+			// Statistics output
+			{
+				displayName: 'Include in Output',
+				name: 'statisticsOutput',
+				type: 'multiOptions',
+				options: [
+					{
+						name: 'Basic Counts',
+						value: 'basicCounts',
+					},
+					{
+						name: 'Degree Statistics',
+						value: 'degreeStats',
+					},
+					{
+						name: 'Type Distribution',
+						value: 'typeDistribution',
+					},
+					{
+						name: 'Connected Components',
+						value: 'connectedComponents',
+					},
+					{
+						name: 'Top Nodes by Degree',
+						value: 'topNodes',
+					},
+				],
+				default: ['basicCounts', 'degreeStats', 'typeDistribution'],
+				displayOptions: {
+					show: {
+						operation: ['statistics'],
+					},
+				},
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const returnData: INodeExecutionData[] = [];
+
+		const operation = this.getNodeParameter('operation', 0) as string;
+
+		try {
+			switch (operation) {
+				case 'merge': {
+					const result = mergeGraphs(this, items);
+					returnData.push({ json: result });
+					break;
+				}
+
+				case 'filterNodes':
+				case 'filterEdges': {
+					for (let i = 0; i < items.length; i++) {
+						const result = filterGraph(this, i, operation === 'filterNodes');
+						returnData.push({ json: result, pairedItem: { item: i } });
+					}
+					break;
+				}
+
+				case 'renameTypes': {
+					for (let i = 0; i < items.length; i++) {
+						const result = renameTypes(this, i);
+						returnData.push({ json: result, pairedItem: { item: i } });
+					}
+					break;
+				}
+
+				case 'addProperties': {
+					for (let i = 0; i < items.length; i++) {
+						const result = addProperties(this, i);
+						returnData.push({ json: result, pairedItem: { item: i } });
+					}
+					break;
+				}
+
+				case 'deduplicate': {
+					for (let i = 0; i < items.length; i++) {
+						const result = deduplicateGraph(this, i);
+						returnData.push({ json: result, pairedItem: { item: i } });
+					}
+					break;
+				}
+
+				case 'extractSubgraph': {
+					for (let i = 0; i < items.length; i++) {
+						const result = extractSubgraph(this, i);
+						returnData.push({ json: result, pairedItem: { item: i } });
+					}
+					break;
+				}
+
+				case 'statistics': {
+					for (let i = 0; i < items.length; i++) {
+						const result = computeStatistics(this, i);
+						returnData.push({ json: result, pairedItem: { item: i } });
+					}
+					break;
+				}
+
+				default:
+					throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`);
+			}
+		} catch (error) {
+			if (this.continueOnFail()) {
+				returnData.push({
+					json: { error: (error as Error).message },
+				});
+			} else {
+				throw error;
+			}
+		}
+
+		return [returnData];
+	}
+}
+
+// Helper functions
+
+function mergeGraphs(context: IExecuteFunctions, items: INodeExecutionData[]): any {
+	const mergeMode = context.getNodeParameter('mergeMode', 0) as string;
+	const deduplicationStrategy = context.getNodeParameter('deduplicationStrategy', 0) as string;
+
+	let graphs: GraphData[] = [];
+
+	if (mergeMode === 'twoGraphs') {
+		const graph1Json = context.getNodeParameter('graph1Json', 0) as string | object;
+		const graph2Json = context.getNodeParameter('graph2Json', 0) as string | object;
+		graphs.push(parseGraphJson(graph1Json));
+		graphs.push(parseGraphJson(graph2Json));
+	} else {
+		const graphPropertyName = context.getNodeParameter('graphPropertyName', 0) as string;
+		for (const item of items) {
+			const graphData = item.json[graphPropertyName];
+			if (graphData) {
+				graphs.push(parseGraphJson(graphData as string | object));
+			}
+		}
+	}
+
+	if (graphs.length === 0) {
+		throw new NodeOperationError(context.getNode(), 'No graphs to merge');
+	}
+
+	// Merge nodes
+	const mergedNodes: GraphNode[] = [];
+	const nodeMapping: Map<string, number> = new Map(); // originalKey -> newId
+	let nextId = 0;
+
+	for (const graph of graphs) {
+		for (const node of graph.nodes) {
+			let key: string;
+			if (deduplicationStrategy === 'byName') {
+				key = node.name.toLowerCase();
+			} else if (deduplicationStrategy === 'byNameAndType') {
+				key = `${node.name.toLowerCase()}:${node.type.toLowerCase()}`;
+			} else {
+				// keepAll - each node gets unique key
+				key = `graph${graphs.indexOf(graph)}_node${node.id}`;
+			}
+
+			if (!nodeMapping.has(key)) {
+				nodeMapping.set(key, nextId);
+				mergedNodes.push({
+					...node,
+					id: nextId,
+				});
+				nextId++;
+			}
+
+			// Store mapping for edge remapping
+			const originalKey = `graph${graphs.indexOf(graph)}_${node.id}`;
+			nodeMapping.set(originalKey, nodeMapping.get(key)!);
+		}
+	}
+
+	// Merge edges
+	const mergedEdges: GraphEdge[] = [];
+	const edgeSet = new Set<string>();
+
+	for (let graphIdx = 0; graphIdx < graphs.length; graphIdx++) {
+		const graph = graphs[graphIdx];
+		for (const edge of graph.edges) {
+			const sourceKey = `graph${graphIdx}_${edge.source}`;
+			const targetKey = `graph${graphIdx}_${edge.target}`;
+
+			const newSource = nodeMapping.get(sourceKey);
+			const newTarget = nodeMapping.get(targetKey);
+
+			if (newSource !== undefined && newTarget !== undefined) {
+				const edgeKey = `${newSource}-${newTarget}-${edge.type}`;
+				if (!edgeSet.has(edgeKey)) {
+					edgeSet.add(edgeKey);
+					mergedEdges.push({
+						...edge,
+						source: newSource,
+						target: newTarget,
+					});
+				}
+			}
+		}
+	}
+
+	return {
+		graph: {
+			nodes: mergedNodes,
+			edges: mergedEdges,
+		},
+		metadata: {
+			source_graphs: graphs.length,
+			merged_node_count: mergedNodes.length,
+			merged_edge_count: mergedEdges.length,
+			deduplication_strategy: deduplicationStrategy,
+		},
+	};
+}
+
+function filterGraph(context: IExecuteFunctions, itemIndex: number, filterNodes: boolean): any {
+	const graphJson = context.getNodeParameter('graphJson', itemIndex) as string | object;
+	const filterMode = context.getNodeParameter('filterMode', itemIndex) as string;
+	const filterBy = context.getNodeParameter('filterBy', itemIndex) as string;
+
+	const graph = parseGraphJson(graphJson);
+	const include = filterMode === 'include';
+
+	let filterFn: (item: any) => boolean;
+
+	if (filterBy === 'type') {
+		const types = (context.getNodeParameter('filterTypes', itemIndex) as string)
+			.split(',')
+			.map(t => t.trim().toLowerCase())
+			.filter(Boolean);
+
+		filterFn = (item) => {
+			const matches = types.includes((item.type || '').toLowerCase());
+			return include ? matches : !matches;
+		};
+	} else if (filterBy === 'property') {
+		const propName = context.getNodeParameter('filterPropertyName', itemIndex) as string;
+		const propValue = context.getNodeParameter('filterPropertyValue', itemIndex) as string;
+
+		filterFn = (item) => {
+			const matches = String(item[propName]) === propValue;
+			return include ? matches : !matches;
+		};
+	} else {
+		// expression
+		const expression = context.getNodeParameter('filterExpression', itemIndex) as string;
+		filterFn = (item) => {
+			try {
+				const fn = new Function('item', 'graph', `return ${expression}`);
+				const matches = fn(item, graph);
+				return include ? matches : !matches;
+			} catch {
+				return false;
+			}
+		};
+	}
+
+	let filteredNodes: GraphNode[];
+	let filteredEdges: GraphEdge[];
+
+	if (filterNodes) {
+		filteredNodes = graph.nodes.filter(filterFn);
+		const nodeIds = new Set(filteredNodes.map(n => n.id));
+		filteredEdges = graph.edges.filter(e =>
+			nodeIds.has(e.source) && nodeIds.has(e.target)
+		);
+	} else {
+		filteredEdges = graph.edges.filter(filterFn);
+		const usedNodeIds = new Set<number>();
+		filteredEdges.forEach(e => {
+			usedNodeIds.add(e.source);
+			usedNodeIds.add(e.target);
+		});
+		filteredNodes = graph.nodes.filter(n => usedNodeIds.has(n.id));
+	}
+
+	return {
+		graph: {
+			nodes: filteredNodes,
+			edges: filteredEdges,
+		},
+		metadata: {
+			original_node_count: graph.nodes.length,
+			original_edge_count: graph.edges.length,
+			filtered_node_count: filteredNodes.length,
+			filtered_edge_count: filteredEdges.length,
+			filter_mode: filterMode,
+			filter_by: filterBy,
+		},
+	};
+}
+
+function renameTypes(context: IExecuteFunctions, itemIndex: number): any {
+	const graphJson = context.getNodeParameter('graphJson', itemIndex) as string | object;
+	const renameTarget = context.getNodeParameter('renameTarget', itemIndex) as string;
+	const typeMappings = context.getNodeParameter('typeMappings', itemIndex) as {
+		mappings?: Array<{ oldType: string; newType: string }>;
+	};
+
+	const graph = parseGraphJson(graphJson);
+	const mappings = new Map<string, string>();
+
+	if (typeMappings.mappings) {
+		for (const mapping of typeMappings.mappings) {
+			mappings.set(mapping.oldType.toLowerCase(), mapping.newType);
+		}
+	}
+
+	const renameType = (type: string): string => {
+		return mappings.get(type.toLowerCase()) || type;
+	};
+
+	const renamedNodes = graph.nodes.map(node => ({
+		...node,
+		type: (renameTarget === 'nodes' || renameTarget === 'both')
+			? renameType(node.type)
+			: node.type,
+	}));
+
+	const renamedEdges = graph.edges.map(edge => ({
+		...edge,
+		type: (renameTarget === 'edges' || renameTarget === 'both')
+			? renameType(edge.type)
+			: edge.type,
+	}));
+
+	return {
+		graph: {
+			nodes: renamedNodes,
+			edges: renamedEdges,
+		},
+		metadata: {
+			node_count: renamedNodes.length,
+			edge_count: renamedEdges.length,
+			rename_target: renameTarget,
+			mappings_applied: mappings.size,
+		},
+	};
+}
+
+function addProperties(context: IExecuteFunctions, itemIndex: number): any {
+	const graphJson = context.getNodeParameter('graphJson', itemIndex) as string | object;
+	const target = context.getNodeParameter('addPropertiesTarget', itemIndex) as string;
+	const propertiesToAdd = context.getNodeParameter('propertiesToAdd', itemIndex) as {
+		properties?: Array<{ name: string; expression: string }>;
+	};
+
+	const graph = parseGraphJson(graphJson);
+
+	const addPropsToItem = (item: any): any => {
+		const newItem = { ...item };
+		if (propertiesToAdd.properties) {
+			for (const prop of propertiesToAdd.properties) {
+				try {
+					const fn = new Function('item', 'graph', `return ${prop.expression}`);
+					newItem[prop.name] = fn(item, graph);
+				} catch (e) {
+					newItem[prop.name] = null;
+				}
+			}
+		}
+		return newItem;
+	};
+
+	const updatedNodes = target === 'nodes'
+		? graph.nodes.map(addPropsToItem)
+		: graph.nodes;
+
+	const updatedEdges = target === 'edges'
+		? graph.edges.map(addPropsToItem)
+		: graph.edges;
+
+	return {
+		graph: {
+			nodes: updatedNodes,
+			edges: updatedEdges,
+		},
+		metadata: {
+			node_count: updatedNodes.length,
+			edge_count: updatedEdges.length,
+			properties_added: propertiesToAdd.properties?.length || 0,
+			target,
+		},
+	};
+}
+
+function deduplicateGraph(context: IExecuteFunctions, itemIndex: number): any {
+	const graphJson = context.getNodeParameter('graphJson', itemIndex) as string | object;
+	const strategy = context.getNodeParameter('deduplicationStrategy', itemIndex) as string;
+
+	const graph = parseGraphJson(graphJson);
+	const nodeMapping = new Map<number, number>(); // oldId -> newId
+	const seenNodes = new Map<string, number>(); // key -> newId
+	const dedupedNodes: GraphNode[] = [];
+	let nextId = 0;
+
+	for (const node of graph.nodes) {
+		let key: string;
+		if (strategy === 'byName') {
+			key = node.name.toLowerCase();
+		} else {
+			key = `${node.name.toLowerCase()}:${node.type.toLowerCase()}`;
+		}
+
+		if (seenNodes.has(key)) {
+			nodeMapping.set(node.id, seenNodes.get(key)!);
+		} else {
+			seenNodes.set(key, nextId);
+			nodeMapping.set(node.id, nextId);
+			dedupedNodes.push({ ...node, id: nextId });
+			nextId++;
+		}
+	}
+
+	const edgeSet = new Set<string>();
+	const dedupedEdges: GraphEdge[] = [];
+
+	for (const edge of graph.edges) {
+		const newSource = nodeMapping.get(edge.source);
+		const newTarget = nodeMapping.get(edge.target);
+
+		if (newSource !== undefined && newTarget !== undefined) {
+			const edgeKey = `${newSource}-${newTarget}-${edge.type}`;
+			if (!edgeSet.has(edgeKey)) {
+				edgeSet.add(edgeKey);
+				dedupedEdges.push({
+					...edge,
+					source: newSource,
+					target: newTarget,
+				});
+			}
+		}
+	}
+
+	return {
+		graph: {
+			nodes: dedupedNodes,
+			edges: dedupedEdges,
+		},
+		metadata: {
+			original_node_count: graph.nodes.length,
+			original_edge_count: graph.edges.length,
+			deduplicated_node_count: dedupedNodes.length,
+			deduplicated_edge_count: dedupedEdges.length,
+			nodes_removed: graph.nodes.length - dedupedNodes.length,
+			edges_removed: graph.edges.length - dedupedEdges.length,
+			strategy,
+		},
+	};
+}
+
+function extractSubgraph(context: IExecuteFunctions, itemIndex: number): any {
+	const graphJson = context.getNodeParameter('graphJson', itemIndex) as string | object;
+	const centerNodesInput = context.getNodeParameter('centerNodes', itemIndex) as string;
+	const depth = context.getNodeParameter('subgraphDepth', itemIndex) as number;
+
+	const graph = parseGraphJson(graphJson);
+
+	// Parse center nodes (can be IDs or names)
+	const centerNodeIds = new Set<number>();
+	const parts = centerNodesInput.split(',').map(s => s.trim()).filter(Boolean);
+
+	for (const part of parts) {
+		// Try as number first
+		const numId = parseInt(part, 10);
+		if (!isNaN(numId)) {
+			centerNodeIds.add(numId);
+		} else {
+			// Try as name (remove quotes)
+			const name = part.replace(/^["']|["']$/g, '').toLowerCase();
+			const node = graph.nodes.find(n => n.name.toLowerCase() === name);
+			if (node) {
+				centerNodeIds.add(node.id);
+			}
+		}
+	}
+
+	if (centerNodeIds.size === 0) {
+		throw new NodeOperationError(context.getNode(), 'No valid center nodes found');
+	}
+
+	// Build adjacency list
+	const adjacency = new Map<number, Set<number>>();
+	for (const node of graph.nodes) {
+		adjacency.set(node.id, new Set());
+	}
+	for (const edge of graph.edges) {
+		adjacency.get(edge.source)?.add(edge.target);
+		adjacency.get(edge.target)?.add(edge.source);
+	}
+
+	// BFS to find nodes within depth
+	const includedNodeIds = new Set<number>(centerNodeIds);
+	let frontier = new Set<number>(centerNodeIds);
+
+	for (let d = 0; d < depth; d++) {
+		const newFrontier = new Set<number>();
+		for (const nodeId of frontier) {
+			const neighbors = adjacency.get(nodeId) || new Set();
+			for (const neighbor of neighbors) {
+				if (!includedNodeIds.has(neighbor)) {
+					includedNodeIds.add(neighbor);
+					newFrontier.add(neighbor);
+				}
+			}
+		}
+		frontier = newFrontier;
+	}
+
+	// Filter nodes and edges
+	const subgraphNodes = graph.nodes.filter(n => includedNodeIds.has(n.id));
+	const subgraphEdges = graph.edges.filter(e =>
+		includedNodeIds.has(e.source) && includedNodeIds.has(e.target)
+	);
+
+	return {
+		graph: {
+			nodes: subgraphNodes,
+			edges: subgraphEdges,
+		},
+		metadata: {
+			original_node_count: graph.nodes.length,
+			original_edge_count: graph.edges.length,
+			subgraph_node_count: subgraphNodes.length,
+			subgraph_edge_count: subgraphEdges.length,
+			center_nodes: Array.from(centerNodeIds),
+			depth,
+		},
+	};
+}
+
+function computeStatistics(context: IExecuteFunctions, itemIndex: number): any {
+	const graphJson = context.getNodeParameter('graphJson', itemIndex) as string | object;
+	const outputOptions = context.getNodeParameter('statisticsOutput', itemIndex) as string[];
+
+	const graph = parseGraphJson(graphJson);
+	const result: any = {};
+
+	// Basic counts
+	if (outputOptions.includes('basicCounts')) {
+		result.basicCounts = {
+			nodeCount: graph.nodes.length,
+			edgeCount: graph.edges.length,
+			density: graph.nodes.length > 1
+				? (2 * graph.edges.length) / (graph.nodes.length * (graph.nodes.length - 1))
+				: 0,
+		};
+	}
+
+	// Degree statistics
+	if (outputOptions.includes('degreeStats')) {
+		const degrees = new Map<number, { in: number; out: number }>();
+		for (const node of graph.nodes) {
+			degrees.set(node.id, { in: 0, out: 0 });
+		}
+		for (const edge of graph.edges) {
+			const source = degrees.get(edge.source);
+			const target = degrees.get(edge.target);
+			if (source) source.out++;
+			if (target) target.in++;
+		}
+
+		const totalDegrees = Array.from(degrees.values()).map(d => d.in + d.out);
+		const avgDegree = totalDegrees.length > 0
+			? totalDegrees.reduce((a, b) => a + b, 0) / totalDegrees.length
+			: 0;
+		const maxDegree = totalDegrees.length > 0 ? Math.max(...totalDegrees) : 0;
+		const minDegree = totalDegrees.length > 0 ? Math.min(...totalDegrees) : 0;
+
+		result.degreeStats = {
+			averageDegree: avgDegree,
+			maxDegree,
+			minDegree,
+			isolatedNodes: totalDegrees.filter(d => d === 0).length,
+		};
+	}
+
+	// Type distribution
+	if (outputOptions.includes('typeDistribution')) {
+		const nodeTypes: Record<string, number> = {};
+		const edgeTypes: Record<string, number> = {};
+
+		for (const node of graph.nodes) {
+			nodeTypes[node.type] = (nodeTypes[node.type] || 0) + 1;
+		}
+		for (const edge of graph.edges) {
+			edgeTypes[edge.type] = (edgeTypes[edge.type] || 0) + 1;
+		}
+
+		result.typeDistribution = {
+			nodeTypes,
+			edgeTypes,
+			uniqueNodeTypes: Object.keys(nodeTypes).length,
+			uniqueEdgeTypes: Object.keys(edgeTypes).length,
+		};
+	}
+
+	// Connected components (simple BFS)
+	if (outputOptions.includes('connectedComponents')) {
+		const visited = new Set<number>();
+		const components: number[][] = [];
+
+		const adjacency = new Map<number, Set<number>>();
+		for (const node of graph.nodes) {
+			adjacency.set(node.id, new Set());
+		}
+		for (const edge of graph.edges) {
+			adjacency.get(edge.source)?.add(edge.target);
+			adjacency.get(edge.target)?.add(edge.source);
+		}
+
+		for (const node of graph.nodes) {
+			if (!visited.has(node.id)) {
+				const component: number[] = [];
+				const queue = [node.id];
+				while (queue.length > 0) {
+					const current = queue.shift()!;
+					if (!visited.has(current)) {
+						visited.add(current);
+						component.push(current);
+						const neighbors = adjacency.get(current) || new Set();
+						for (const neighbor of neighbors) {
+							if (!visited.has(neighbor)) {
+								queue.push(neighbor);
+							}
+						}
+					}
+				}
+				components.push(component);
+			}
+		}
+
+		result.connectedComponents = {
+			count: components.length,
+			sizes: components.map(c => c.length).sort((a, b) => b - a),
+			largestComponent: components.length > 0 ? Math.max(...components.map(c => c.length)) : 0,
+		};
+	}
+
+	// Top nodes by degree
+	if (outputOptions.includes('topNodes')) {
+		const degrees = new Map<number, number>();
+		for (const node of graph.nodes) {
+			degrees.set(node.id, 0);
+		}
+		for (const edge of graph.edges) {
+			degrees.set(edge.source, (degrees.get(edge.source) || 0) + 1);
+			degrees.set(edge.target, (degrees.get(edge.target) || 0) + 1);
+		}
+
+		const nodeDegreePairs = Array.from(degrees.entries())
+			.map(([id, degree]) => ({
+				id,
+				name: graph.nodes.find(n => n.id === id)?.name || `Node ${id}`,
+				type: graph.nodes.find(n => n.id === id)?.type || 'unknown',
+				degree,
+			}))
+			.sort((a, b) => b.degree - a.degree)
+			.slice(0, 10);
+
+		result.topNodes = nodeDegreePairs;
+	}
+
+	return {
+		statistics: result,
+		metadata: {
+			node_count: graph.nodes.length,
+			edge_count: graph.edges.length,
+			computed_statistics: outputOptions,
+		},
+	};
+}

--- a/custom-nodes/n8n-nodes-graph-transformer/nodes/GraphTransformer/graph-transformer.svg
+++ b/custom-nodes/n8n-nodes-graph-transformer/nodes/GraphTransformer/graph-transformer.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="6" cy="6" r="3" fill="#4CAF50"/>
+  <circle cx="18" cy="6" r="3" fill="#2196F3"/>
+  <circle cx="6" cy="18" r="3" fill="#FF9800"/>
+  <circle cx="18" cy="18" r="3" fill="#9C27B0"/>
+  <line x1="9" y1="6" x2="15" y2="6" stroke="#666"/>
+  <line x1="6" y1="9" x2="6" y2="15" stroke="#666"/>
+  <line x1="18" y1="9" x2="18" y2="15" stroke="#666"/>
+  <line x1="9" y1="18" x2="15" y2="18" stroke="#666"/>
+  <line x1="8" y1="8" x2="16" y2="16" stroke="#666"/>
+  <line x1="16" y1="8" x2="8" y2="16" stroke="#666"/>
+</svg>

--- a/custom-nodes/n8n-nodes-graph-transformer/package.json
+++ b/custom-nodes/n8n-nodes-graph-transformer/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "n8n-nodes-graph-transformer",
+  "version": "1.0.0",
+  "description": "n8n node for transforming, merging, and manipulating knowledge graphs",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "knowledge-graph",
+    "graph-transformation",
+    "graph-merge",
+    "graph-filter"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/fsebbah/n8n-workflows",
+  "author": {
+    "name": "fsebbah"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fsebbah/n8n-workflows.git"
+  },
+  "main": "dist/nodes/GraphTransformer/GraphTransformer.node.js",
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "nodes": [
+      "dist/nodes/GraphTransformer/GraphTransformer.node.js"
+    ],
+    "credentials": []
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "eslint . --ext .ts",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "~5.3.0"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  }
+}

--- a/custom-nodes/n8n-nodes-graph-transformer/tsconfig.json
+++ b/custom-nodes/n8n-nodes-graph-transformer/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "nodes/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/custom-nodes/n8n-nodes-knowledge-graph/nodes/KnowledgeGraph/KnowledgeGraph.node.ts
+++ b/custom-nodes/n8n-nodes-knowledge-graph/nodes/KnowledgeGraph/KnowledgeGraph.node.ts
@@ -17,6 +17,8 @@ import {
 	ENTITY_EXTRACTION_PROMPT,
 	RELATIONSHIP_EXTRACTION_PROMPT,
 	FULL_GRAPH_EXTRACTION_PROMPT,
+	SIMPLIFY_GRAPH_PROMPT,
+	ANALYZE_GRAPH_PROMPT,
 	buildPromptWithConfig,
 	buildRelationshipPromptWithEntities,
 	buildExtractionConfig,
@@ -64,6 +66,42 @@ interface GraphResult {
 	};
 }
 
+interface SimplifiedGraphResult {
+	graph: {
+		nodes: Entity[];
+		edges: Array<{ source: number; target: number; type: string }>;
+	};
+	metadata: {
+		original_node_count: number;
+		original_edge_count: number;
+		simplified_node_count: number;
+		simplified_edge_count: number;
+		simplification_method: string;
+	};
+	key_entities: Array<{ id: number; name: string; type: string; importance: string }>;
+}
+
+interface GraphAnalysisResult {
+	summary: string;
+	key_findings: string[];
+	entity_statistics: {
+		total_entities: number;
+		by_type: Record<string, number>;
+		most_connected: Array<{ name: string; connections: number }>;
+	};
+	relationship_statistics: {
+		total_relationships: number;
+		by_type: Record<string, number>;
+	};
+	clusters: Array<{
+		name: string;
+		description: string;
+		entities: string[];
+	}>;
+	insights: string[];
+	recommendations: string[];
+}
+
 export class KnowledgeGraph implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'Knowledge Graph',
@@ -108,6 +146,18 @@ export class KnowledgeGraph implements INodeType {
 						value: 'extractRelationships',
 						description: 'Extract relationships between entities',
 						action: 'Extract relationships between entities',
+					},
+					{
+						name: 'Simplify Graph',
+						value: 'simplifyGraph',
+						description: 'Reduce a graph to its most important entities and relationships',
+						action: 'Simplify a knowledge graph',
+					},
+					{
+						name: 'Analyze Graph',
+						value: 'analyzeGraph',
+						description: 'Generate insights and analysis from a knowledge graph',
+						action: 'Analyze a knowledge graph',
 					},
 				],
 				default: 'buildGraph',
@@ -333,6 +383,103 @@ export class KnowledgeGraph implements INodeType {
 				},
 			},
 			{
+				displayName: 'Graph JSON',
+				name: 'graphJson',
+				type: 'json',
+				default: '',
+				description: 'The knowledge graph JSON to process (from a previous Build Graph operation)',
+				displayOptions: {
+					show: {
+						operation: ['simplifyGraph', 'analyzeGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Max Nodes',
+				name: 'maxNodes',
+				type: 'number',
+				default: 30,
+				description: 'Maximum number of nodes to keep in the simplified graph',
+				displayOptions: {
+					show: {
+						operation: ['simplifyGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Keep Entity Types',
+				name: 'keepEntityTypes',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., person, organization',
+				description: 'Comma-separated list of entity types to always keep (leave empty for automatic selection)',
+				displayOptions: {
+					show: {
+						operation: ['simplifyGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Simplification Method',
+				name: 'simplificationMethod',
+				type: 'options',
+				options: [
+					{
+						name: 'By Importance (Connections)',
+						value: 'importance',
+						description: 'Keep nodes with the most connections',
+					},
+					{
+						name: 'By Centrality',
+						value: 'centrality',
+						description: 'Keep nodes that are central to the graph',
+					},
+					{
+						name: 'By Type Priority',
+						value: 'typePriority',
+						description: 'Prioritize certain entity types',
+					},
+				],
+				default: 'importance',
+				description: 'Method to use for selecting which nodes to keep',
+				displayOptions: {
+					show: {
+						operation: ['simplifyGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Analysis Language',
+				name: 'analysisLanguage',
+				type: 'options',
+				options: [
+					{ name: 'English', value: 'en' },
+					{ name: 'French', value: 'fr' },
+					{ name: 'Spanish', value: 'es' },
+					{ name: 'German', value: 'de' },
+				],
+				default: 'en',
+				description: 'Language for the analysis output',
+				displayOptions: {
+					show: {
+						operation: ['analyzeGraph'],
+					},
+				},
+			},
+			{
+				displayName: 'Analysis Focus',
+				name: 'analysisFocus',
+				type: 'string',
+				default: '',
+				placeholder: 'e.g., Focus on financial risks and investment strategies',
+				description: 'Optional focus area for the analysis',
+				displayOptions: {
+					show: {
+						operation: ['analyzeGraph'],
+					},
+				},
+			},
+			{
 				displayName: 'Options',
 				name: 'options',
 				type: 'collection',
@@ -474,7 +621,7 @@ export class KnowledgeGraph implements INodeType {
 					maxOutputTokens: options.maxOutputTokens ?? 8192,
 				};
 
-				let result: EntityExtractionResult | RelationshipExtractionResult | GraphResult;
+				let result: EntityExtractionResult | RelationshipExtractionResult | GraphResult | SimplifiedGraphResult | GraphAnalysisResult;
 
 				// Helper function to call the appropriate API method
 				const callGemini = async <T>(prompt: string): Promise<T> => {
@@ -532,6 +679,53 @@ export class KnowledgeGraph implements INodeType {
 					case 'buildGraph': {
 						const prompt = buildPromptWithConfig(FULL_GRAPH_EXTRACTION_PROMPT, textContent, extractionConfig, presetName);
 						result = await callGemini<GraphResult>(prompt);
+						break;
+					}
+
+					case 'simplifyGraph': {
+						const graphJson = this.getNodeParameter('graphJson', i, '') as string;
+						if (!graphJson) {
+							throw new NodeOperationError(this.getNode(), 'Graph JSON is required for simplifyGraph operation', { itemIndex: i });
+						}
+
+						const maxNodes = this.getNodeParameter('maxNodes', i, 30) as number;
+						const keepEntityTypes = this.getNodeParameter('keepEntityTypes', i, '') as string;
+						const simplificationMethod = this.getNodeParameter('simplificationMethod', i, 'importance') as string;
+
+						const graphData = typeof graphJson === 'string' ? JSON.parse(graphJson) : graphJson;
+						const prompt = SIMPLIFY_GRAPH_PROMPT
+							.replace('{{GRAPH_JSON}}', JSON.stringify(graphData, null, 2))
+							.replace('{{MAX_NODES}}', maxNodes.toString())
+							.replace('{{KEEP_TYPES}}', keepEntityTypes || 'auto-detect based on importance')
+							.replace('{{METHOD}}', simplificationMethod);
+
+						result = await client.generateJson<SimplifiedGraphResult>(prompt, genOptions);
+						break;
+					}
+
+					case 'analyzeGraph': {
+						const graphJson = this.getNodeParameter('graphJson', i, '') as string;
+						if (!graphJson) {
+							throw new NodeOperationError(this.getNode(), 'Graph JSON is required for analyzeGraph operation', { itemIndex: i });
+						}
+
+						const analysisLanguage = this.getNodeParameter('analysisLanguage', i, 'en') as string;
+						const analysisFocus = this.getNodeParameter('analysisFocus', i, '') as string;
+
+						const graphData = typeof graphJson === 'string' ? JSON.parse(graphJson) : graphJson;
+						const languageMap: Record<string, string> = {
+							'en': 'English',
+							'fr': 'French',
+							'es': 'Spanish',
+							'de': 'German',
+						};
+
+						const prompt = ANALYZE_GRAPH_PROMPT
+							.replace('{{GRAPH_JSON}}', JSON.stringify(graphData, null, 2))
+							.replace('{{LANGUAGE}}', languageMap[analysisLanguage] || 'English')
+							.replace('{{FOCUS}}', analysisFocus || 'general analysis of all aspects');
+
+						result = await client.generateJson<GraphAnalysisResult>(prompt, genOptions);
 						break;
 					}
 

--- a/custom-nodes/n8n-nodes-knowledge-graph/prompts/knowledgeGraphPrompts.ts
+++ b/custom-nodes/n8n-nodes-knowledge-graph/prompts/knowledgeGraphPrompts.ts
@@ -159,6 +159,129 @@ Output a JSON object with the following structure:
 `;
 
 // ============================================================================
+// SIMPLIFY GRAPH PROMPT
+// ============================================================================
+
+export const SIMPLIFY_GRAPH_PROMPT = `
+You are given a knowledge graph in JSON format. Your task is to simplify it by keeping only the most important entities and relationships.
+
+**Input Graph:**
+{{GRAPH_JSON}}
+
+**Simplification Parameters:**
+- Maximum nodes to keep: {{MAX_NODES}}
+- Entity types to prioritize: {{KEEP_TYPES}}
+- Simplification method: {{METHOD}}
+
+**Task:**
+1. Analyze the graph to identify the most important nodes based on:
+   - Number of connections (degree centrality)
+   - Position in the network (betweenness centrality)
+   - Type priority if specified
+2. Keep the top {{MAX_NODES}} most important nodes
+3. Keep only edges that connect the retained nodes
+4. For each kept node, explain why it's important
+
+Output a JSON object with the following structure:
+{
+  "graph": {
+    "nodes": [
+      {"id": 0, "name": "Entity Name", "type": "entity_type"},
+      ...
+    ],
+    "edges": [
+      {"source": 0, "target": 1, "type": "relationship_type"},
+      ...
+    ]
+  },
+  "metadata": {
+    "original_node_count": <original number of nodes>,
+    "original_edge_count": <original number of edges>,
+    "simplified_node_count": <number of nodes after simplification>,
+    "simplified_edge_count": <number of edges after simplification>,
+    "simplification_method": "{{METHOD}}"
+  },
+  "key_entities": [
+    {"id": 0, "name": "Entity Name", "type": "entity_type", "importance": "Explanation of why this entity is key"},
+    ...
+  ]
+}
+`;
+
+// ============================================================================
+// ANALYZE GRAPH PROMPT
+// ============================================================================
+
+export const ANALYZE_GRAPH_PROMPT = `
+You are an expert analyst. Analyze the following knowledge graph and provide comprehensive insights.
+
+**Input Graph:**
+{{GRAPH_JSON}}
+
+**Analysis Parameters:**
+- Output language: {{LANGUAGE}}
+- Focus area: {{FOCUS}}
+
+**Task:**
+Provide a detailed analysis including:
+1. **Summary**: A brief overview of what the graph represents
+2. **Key Findings**: Main insights from the graph structure
+3. **Entity Statistics**: Breakdown of entities by type and most connected nodes
+4. **Relationship Statistics**: Breakdown of relationships by type
+5. **Clusters**: Identify groups of related entities and describe them
+6. **Insights**: Deep insights about patterns, anomalies, or important connections
+7. **Recommendations**: Actionable recommendations based on the analysis
+
+Output a JSON object with the following structure (all text in {{LANGUAGE}}):
+{
+  "summary": "A comprehensive summary of the knowledge graph...",
+  "key_findings": [
+    "Finding 1...",
+    "Finding 2...",
+    ...
+  ],
+  "entity_statistics": {
+    "total_entities": <number>,
+    "by_type": {
+      "type1": <count>,
+      "type2": <count>,
+      ...
+    },
+    "most_connected": [
+      {"name": "Entity Name", "connections": <number>},
+      ...
+    ]
+  },
+  "relationship_statistics": {
+    "total_relationships": <number>,
+    "by_type": {
+      "type1": <count>,
+      "type2": <count>,
+      ...
+    }
+  },
+  "clusters": [
+    {
+      "name": "Cluster Name",
+      "description": "Description of what this cluster represents",
+      "entities": ["Entity1", "Entity2", ...]
+    },
+    ...
+  ],
+  "insights": [
+    "Deep insight 1...",
+    "Deep insight 2...",
+    ...
+  ],
+  "recommendations": [
+    "Recommendation 1...",
+    "Recommendation 2...",
+    ...
+  ]
+}
+`;
+
+// ============================================================================
 // CONFIGURATION INTERFACE
 // ============================================================================
 

--- a/scripts/graph_exporter.py
+++ b/scripts/graph_exporter.py
@@ -1,0 +1,577 @@
+#!/usr/bin/env python3
+"""
+Knowledge Graph Exporter
+Exports knowledge graph JSON to RDF (Turtle), Cypher (Neo4j), and other formats.
+
+Usage:
+    python graph_exporter.py <input.json> --format rdf|cypher|graphml|gexf [--output output_file]
+
+Examples:
+    python graph_exporter.py graph.json --format rdf
+    python graph_exporter.py graph.json --format cypher --output import.cypher
+    python graph_exporter.py graph.json --format graphml --output graph.graphml
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List, Any
+from datetime import datetime
+import re
+
+
+def sanitize_uri(name: str) -> str:
+    """Sanitize a string to be used as a URI component."""
+    # Replace spaces and special characters
+    sanitized = re.sub(r'[^a-zA-Z0-9_-]', '_', name)
+    # Remove consecutive underscores
+    sanitized = re.sub(r'_+', '_', sanitized)
+    # Remove leading/trailing underscores
+    sanitized = sanitized.strip('_')
+    return sanitized or 'unknown'
+
+
+def sanitize_cypher_string(value: str) -> str:
+    """Escape special characters for Cypher strings."""
+    return value.replace('\\', '\\\\').replace("'", "\\'").replace('"', '\\"')
+
+
+def load_graph_json(filepath: str) -> dict:
+    """Load and parse the knowledge graph JSON file."""
+    with open(filepath, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    # Handle different JSON structures
+    if "graph" in data:
+        return data["graph"]
+    elif "nodes" in data and "edges" in data:
+        return data
+    else:
+        raise ValueError("Invalid JSON structure. Expected 'graph' or 'nodes'/'edges' keys.")
+
+
+def export_to_rdf(graph_data: dict, output_path: str, base_uri: str = "http://example.org/kg/"):
+    """
+    Export graph to RDF Turtle format.
+
+    Args:
+        graph_data: Dictionary with 'nodes' and 'edges'
+        output_path: Path to output .ttl file
+        base_uri: Base URI for the ontology
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    # Build node ID to info mapping
+    node_map = {}
+    for node in nodes:
+        node_map[node.get("id")] = {
+            "name": node.get("name", f"Node_{node.get('id')}"),
+            "type": node.get("type", "Entity"),
+            "uri_name": sanitize_uri(node.get("name", f"Node_{node.get('id')}"))
+        }
+
+    # Collect unique types for ontology
+    entity_types = set()
+    relation_types = set()
+
+    for node in nodes:
+        entity_types.add(node.get("type", "Entity"))
+    for edge in edges:
+        relation_types.add(edge.get("type", "related_to"))
+
+    lines = []
+
+    # Prefixes
+    lines.append("@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .")
+    lines.append("@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .")
+    lines.append("@prefix owl: <http://www.w3.org/2002/07/owl#> .")
+    lines.append("@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .")
+    lines.append(f"@prefix kg: <{base_uri}> .")
+    lines.append(f"@prefix entity: <{base_uri}entity/> .")
+    lines.append(f"@prefix rel: <{base_uri}relation/> .")
+    lines.append("")
+
+    # Ontology header
+    lines.append(f"<{base_uri}> a owl:Ontology ;")
+    lines.append(f'    rdfs:label "Knowledge Graph Export" ;')
+    lines.append(f'    rdfs:comment "Exported from n8n Knowledge Graph node on {datetime.now().isoformat()}" .')
+    lines.append("")
+
+    # Define entity classes
+    lines.append("# Entity Classes")
+    for etype in sorted(entity_types):
+        class_uri = sanitize_uri(etype.capitalize())
+        lines.append(f"kg:{class_uri} a owl:Class ;")
+        lines.append(f'    rdfs:label "{etype}" .')
+    lines.append("")
+
+    # Define relation properties
+    lines.append("# Relation Properties")
+    for rtype in sorted(relation_types):
+        prop_uri = sanitize_uri(rtype)
+        lines.append(f"rel:{prop_uri} a owl:ObjectProperty ;")
+        lines.append(f'    rdfs:label "{rtype}" .')
+    lines.append("")
+
+    # Entity instances
+    lines.append("# Entity Instances")
+    for node in nodes:
+        node_id = node.get("id")
+        info = node_map[node_id]
+        entity_uri = info["uri_name"]
+        entity_type = sanitize_uri(info["type"].capitalize())
+        entity_name = info["name"].replace('"', '\\"')
+
+        lines.append(f"entity:{entity_uri} a kg:{entity_type} ;")
+        lines.append(f'    rdfs:label "{entity_name}" ;')
+        lines.append(f'    kg:nodeId {node_id} .')
+    lines.append("")
+
+    # Relationships
+    lines.append("# Relationships")
+    for edge in edges:
+        source_id = edge.get("source")
+        target_id = edge.get("target")
+        rel_type = edge.get("type", "related_to")
+
+        if source_id in node_map and target_id in node_map:
+            source_uri = node_map[source_id]["uri_name"]
+            target_uri = node_map[target_id]["uri_name"]
+            rel_prop = sanitize_uri(rel_type)
+
+            lines.append(f"entity:{source_uri} rel:{rel_prop} entity:{target_uri} .")
+
+    # Write output
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+
+    print(f"RDF (Turtle) exported: {output_path}")
+    print(f"  - {len(nodes)} entities")
+    print(f"  - {len(edges)} relationships")
+    print(f"  - {len(entity_types)} entity types")
+    print(f"  - {len(relation_types)} relation types")
+    return output_path
+
+
+def export_to_cypher(graph_data: dict, output_path: str):
+    """
+    Export graph to Cypher format for Neo4j import.
+
+    Args:
+        graph_data: Dictionary with 'nodes' and 'edges'
+        output_path: Path to output .cypher file
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    lines = []
+
+    # Header
+    lines.append("// Knowledge Graph Import Script")
+    lines.append(f"// Generated on {datetime.now().isoformat()}")
+    lines.append(f"// Nodes: {len(nodes)}, Edges: {len(edges)}")
+    lines.append("")
+
+    # Create constraints (optional, for performance)
+    lines.append("// Create constraints for better performance")
+    entity_types = set(node.get("type", "Entity") for node in nodes)
+    for etype in sorted(entity_types):
+        label = sanitize_uri(etype.capitalize())
+        lines.append(f"CREATE CONSTRAINT IF NOT EXISTS FOR (n:{label}) REQUIRE n.id IS UNIQUE;")
+    lines.append("")
+
+    # Create nodes
+    lines.append("// Create nodes")
+    for node in nodes:
+        node_id = node.get("id")
+        node_name = sanitize_cypher_string(node.get("name", f"Node_{node_id}"))
+        node_type = node.get("type", "Entity")
+        label = sanitize_uri(node_type.capitalize())
+
+        lines.append(f"CREATE (n{node_id}:{label} {{id: {node_id}, name: '{node_name}', type: '{node_type}'}});")
+    lines.append("")
+
+    # Create relationships
+    lines.append("// Create relationships")
+    for i, edge in enumerate(edges):
+        source_id = edge.get("source")
+        target_id = edge.get("target")
+        rel_type = edge.get("type", "RELATED_TO")
+
+        # Convert relation type to Neo4j format (uppercase, underscores)
+        rel_label = sanitize_uri(rel_type).upper()
+
+        lines.append(f"MATCH (a {{id: {source_id}}}), (b {{id: {target_id}}}) CREATE (a)-[:{rel_label}]->(b);")
+
+    # Write output
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+
+    print(f"Cypher exported: {output_path}")
+    print(f"  - {len(nodes)} CREATE node statements")
+    print(f"  - {len(edges)} CREATE relationship statements")
+    return output_path
+
+
+def export_to_cypher_batch(graph_data: dict, output_path: str):
+    """
+    Export graph to optimized Cypher format using UNWIND for batch import.
+    Better for large graphs in Neo4j.
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    lines = []
+
+    # Header
+    lines.append("// Knowledge Graph Batch Import Script")
+    lines.append(f"// Generated on {datetime.now().isoformat()}")
+    lines.append(f"// Nodes: {len(nodes)}, Edges: {len(edges)}")
+    lines.append("")
+
+    # Create constraints
+    lines.append("// Create constraints")
+    entity_types = set(node.get("type", "Entity") for node in nodes)
+    for etype in sorted(entity_types):
+        label = sanitize_uri(etype.capitalize())
+        lines.append(f"CREATE CONSTRAINT IF NOT EXISTS FOR (n:{label}) REQUIRE n.id IS UNIQUE;")
+    lines.append("")
+
+    # Batch create nodes by type
+    lines.append("// Batch create nodes")
+    nodes_by_type: Dict[str, List[dict]] = {}
+    for node in nodes:
+        node_type = node.get("type", "Entity")
+        if node_type not in nodes_by_type:
+            nodes_by_type[node_type] = []
+        nodes_by_type[node_type].append({
+            "id": node.get("id"),
+            "name": node.get("name", f"Node_{node.get('id')}"),
+            "type": node_type
+        })
+
+    for node_type, type_nodes in nodes_by_type.items():
+        label = sanitize_uri(node_type.capitalize())
+        nodes_json = json.dumps(type_nodes, ensure_ascii=False)
+        lines.append(f"UNWIND {nodes_json} AS node")
+        lines.append(f"CREATE (n:{label} {{id: node.id, name: node.name, type: node.type}});")
+        lines.append("")
+
+    # Batch create relationships by type
+    lines.append("// Batch create relationships")
+    edges_by_type: Dict[str, List[dict]] = {}
+    for edge in edges:
+        rel_type = edge.get("type", "related_to")
+        if rel_type not in edges_by_type:
+            edges_by_type[rel_type] = []
+        edges_by_type[rel_type].append({
+            "source": edge.get("source"),
+            "target": edge.get("target")
+        })
+
+    for rel_type, type_edges in edges_by_type.items():
+        rel_label = sanitize_uri(rel_type).upper()
+        edges_json = json.dumps(type_edges, ensure_ascii=False)
+        lines.append(f"UNWIND {edges_json} AS rel")
+        lines.append(f"MATCH (a {{id: rel.source}}), (b {{id: rel.target}})")
+        lines.append(f"CREATE (a)-[:{rel_label}]->(b);")
+        lines.append("")
+
+    # Write output
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+
+    print(f"Cypher (batch) exported: {output_path}")
+    print(f"  - {len(nodes)} nodes in {len(nodes_by_type)} type batches")
+    print(f"  - {len(edges)} relationships in {len(edges_by_type)} type batches")
+    return output_path
+
+
+def export_to_graphml(graph_data: dict, output_path: str):
+    """
+    Export graph to GraphML format.
+    GraphML is supported by many graph tools including Gephi, yEd, NetworkX.
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    lines = []
+
+    # XML header
+    lines.append('<?xml version="1.0" encoding="UTF-8"?>')
+    lines.append('<graphml xmlns="http://graphml.graphdrawing.org/xmlns"')
+    lines.append('         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"')
+    lines.append('         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns')
+    lines.append('         http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">')
+    lines.append('')
+
+    # Define attributes
+    lines.append('  <!-- Node attributes -->')
+    lines.append('  <key id="name" for="node" attr.name="name" attr.type="string"/>')
+    lines.append('  <key id="type" for="node" attr.name="type" attr.type="string"/>')
+    lines.append('  <!-- Edge attributes -->')
+    lines.append('  <key id="rel_type" for="edge" attr.name="type" attr.type="string"/>')
+    lines.append('')
+
+    # Graph
+    lines.append('  <graph id="KnowledgeGraph" edgedefault="directed">')
+    lines.append('')
+
+    # Nodes
+    lines.append('    <!-- Nodes -->')
+    for node in nodes:
+        node_id = node.get("id")
+        node_name = node.get("name", f"Node_{node_id}").replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
+        node_type = node.get("type", "Entity")
+
+        lines.append(f'    <node id="n{node_id}">')
+        lines.append(f'      <data key="name">{node_name}</data>')
+        lines.append(f'      <data key="type">{node_type}</data>')
+        lines.append('    </node>')
+    lines.append('')
+
+    # Edges
+    lines.append('    <!-- Edges -->')
+    for i, edge in enumerate(edges):
+        source_id = edge.get("source")
+        target_id = edge.get("target")
+        rel_type = edge.get("type", "related_to")
+
+        lines.append(f'    <edge id="e{i}" source="n{source_id}" target="n{target_id}">')
+        lines.append(f'      <data key="rel_type">{rel_type}</data>')
+        lines.append('    </edge>')
+
+    lines.append('')
+    lines.append('  </graph>')
+    lines.append('</graphml>')
+
+    # Write output
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+
+    print(f"GraphML exported: {output_path}")
+    print(f"  - {len(nodes)} nodes")
+    print(f"  - {len(edges)} edges")
+    return output_path
+
+
+def export_to_gexf(graph_data: dict, output_path: str):
+    """
+    Export graph to GEXF format (Gephi Exchange Format).
+    Native format for Gephi with support for dynamic graphs.
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    lines = []
+
+    # XML header
+    lines.append('<?xml version="1.0" encoding="UTF-8"?>')
+    lines.append('<gexf xmlns="http://www.gexf.net/1.3"')
+    lines.append('      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"')
+    lines.append('      xsi:schemaLocation="http://www.gexf.net/1.3 http://www.gexf.net/1.3/gexf.xsd"')
+    lines.append('      version="1.3">')
+    lines.append('')
+
+    # Meta
+    lines.append('  <meta lastmodifieddate="' + datetime.now().strftime('%Y-%m-%d') + '">')
+    lines.append('    <creator>n8n Knowledge Graph Exporter</creator>')
+    lines.append('    <description>Knowledge Graph Export</description>')
+    lines.append('  </meta>')
+    lines.append('')
+
+    # Graph
+    lines.append('  <graph defaultedgetype="directed">')
+    lines.append('')
+
+    # Node attributes
+    lines.append('    <attributes class="node">')
+    lines.append('      <attribute id="0" title="type" type="string"/>')
+    lines.append('    </attributes>')
+    lines.append('')
+
+    # Edge attributes
+    lines.append('    <attributes class="edge">')
+    lines.append('      <attribute id="0" title="type" type="string"/>')
+    lines.append('    </attributes>')
+    lines.append('')
+
+    # Nodes
+    lines.append('    <nodes>')
+    for node in nodes:
+        node_id = node.get("id")
+        node_name = node.get("name", f"Node_{node_id}").replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
+        node_type = node.get("type", "Entity")
+
+        lines.append(f'      <node id="{node_id}" label="{node_name}">')
+        lines.append('        <attvalues>')
+        lines.append(f'          <attvalue for="0" value="{node_type}"/>')
+        lines.append('        </attvalues>')
+        lines.append('      </node>')
+    lines.append('    </nodes>')
+    lines.append('')
+
+    # Edges
+    lines.append('    <edges>')
+    for i, edge in enumerate(edges):
+        source_id = edge.get("source")
+        target_id = edge.get("target")
+        rel_type = edge.get("type", "related_to")
+
+        lines.append(f'      <edge id="{i}" source="{source_id}" target="{target_id}" label="{rel_type}">')
+        lines.append('        <attvalues>')
+        lines.append(f'          <attvalue for="0" value="{rel_type}"/>')
+        lines.append('        </attvalues>')
+        lines.append('      </edge>')
+    lines.append('    </edges>')
+    lines.append('')
+
+    lines.append('  </graph>')
+    lines.append('</gexf>')
+
+    # Write output
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(lines))
+
+    print(f"GEXF exported: {output_path}")
+    print(f"  - {len(nodes)} nodes")
+    print(f"  - {len(edges)} edges")
+    return output_path
+
+
+def export_to_json_ld(graph_data: dict, output_path: str, base_uri: str = "http://example.org/kg/"):
+    """
+    Export graph to JSON-LD format.
+    JSON-LD is a JSON-based format for linked data.
+    """
+    nodes = graph_data.get("nodes", [])
+    edges = graph_data.get("edges", [])
+
+    # Build node map
+    node_map = {node.get("id"): node for node in nodes}
+
+    # Create JSON-LD document
+    jsonld = {
+        "@context": {
+            "@base": base_uri,
+            "kg": base_uri,
+            "name": "kg:name",
+            "type": "@type",
+            "id": "@id"
+        },
+        "@graph": []
+    }
+
+    # Add nodes
+    for node in nodes:
+        node_id = node.get("id")
+        node_name = node.get("name", f"Node_{node_id}")
+        node_type = node.get("type", "Entity")
+
+        node_obj = {
+            "@id": f"entity/{sanitize_uri(node_name)}",
+            "@type": f"kg:{sanitize_uri(node_type.capitalize())}",
+            "kg:nodeId": node_id,
+            "name": node_name
+        }
+        jsonld["@graph"].append(node_obj)
+
+    # Add relationships to nodes
+    for edge in edges:
+        source_id = edge.get("source")
+        target_id = edge.get("target")
+        rel_type = edge.get("type", "related_to")
+
+        if source_id in node_map and target_id in node_map:
+            source_name = node_map[source_id].get("name", f"Node_{source_id}")
+            target_name = node_map[target_id].get("name", f"Node_{target_id}")
+
+            # Find source node and add relationship
+            for node_obj in jsonld["@graph"]:
+                if node_obj.get("kg:nodeId") == source_id:
+                    rel_key = f"kg:{sanitize_uri(rel_type)}"
+                    if rel_key not in node_obj:
+                        node_obj[rel_key] = []
+                    node_obj[rel_key].append({
+                        "@id": f"entity/{sanitize_uri(target_name)}"
+                    })
+                    break
+
+    # Write output
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(jsonld, f, indent=2, ensure_ascii=False)
+
+    print(f"JSON-LD exported: {output_path}")
+    print(f"  - {len(nodes)} entities")
+    print(f"  - {len(edges)} relationships")
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export Knowledge Graph to various formats",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    parser.add_argument("input", help="Input JSON file from Knowledge Graph workflow")
+    parser.add_argument("-f", "--format",
+                        choices=["rdf", "cypher", "cypher-batch", "graphml", "gexf", "jsonld"],
+                        default="cypher",
+                        help="Output format (default: cypher)")
+    parser.add_argument("-o", "--output", help="Output file path")
+    parser.add_argument("--base-uri", default="http://example.org/kg/",
+                        help="Base URI for RDF/JSON-LD export (default: http://example.org/kg/)")
+
+    args = parser.parse_args()
+
+    # Validate input
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: Input file not found: {args.input}")
+        sys.exit(1)
+
+    # Determine output path and extension
+    format_extensions = {
+        "rdf": ".ttl",
+        "cypher": ".cypher",
+        "cypher-batch": ".cypher",
+        "graphml": ".graphml",
+        "gexf": ".gexf",
+        "jsonld": ".jsonld"
+    }
+
+    if args.output:
+        output_path = args.output
+    else:
+        output_path = str(input_path.with_suffix(format_extensions[args.format]))
+
+    # Load graph data
+    print(f"Loading graph from: {args.input}")
+    graph_data = load_graph_json(args.input)
+
+    nodes_count = len(graph_data.get("nodes", []))
+    edges_count = len(graph_data.get("edges", []))
+    print(f"Found {nodes_count} nodes and {edges_count} edges")
+    print("")
+
+    # Export based on format
+    if args.format == "rdf":
+        export_to_rdf(graph_data, output_path, args.base_uri)
+    elif args.format == "cypher":
+        export_to_cypher(graph_data, output_path)
+    elif args.format == "cypher-batch":
+        export_to_cypher_batch(graph_data, output_path)
+    elif args.format == "graphml":
+        export_to_graphml(graph_data, output_path)
+    elif args.format == "gexf":
+        export_to_gexf(graph_data, output_path)
+    elif args.format == "jsonld":
+        export_to_json_ld(graph_data, output_path, args.base_uri)
+
+    print("\nDone!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the Knowledge Graph enhancements as specified in issue #53.

### Phase 2.1 - Knowledge Graph Node Enhancements
- **simplifyGraph operation**: Reduces a complex graph to its most important entities using LLM-powered analysis (by connections, centrality, or type priority)
- **analyzeGraph operation**: Generates comprehensive insights including summary, statistics, clusters, key findings, and recommendations
- **New prompts**: `SIMPLIFY_GRAPH_PROMPT` and `ANALYZE_GRAPH_PROMPT` added to knowledgeGraphPrompts.ts
- **graph_exporter.py script**: Python script for exporting graphs to RDF (Turtle), Cypher (Neo4j), GraphML, GEXF, and JSON-LD formats

### Phase 2.2 - New Custom Nodes
- **n8n-nodes-graph-transformer**: Graph manipulation node with operations:
  - Merge Graphs (combine multiple graphs with deduplication)
  - Filter Nodes/Edges (by type, property, or expression)
  - Rename Types
  - Add Properties (computed via expressions)
  - Remove Duplicates
  - Extract Subgraph (BFS from center nodes)
  - Compute Statistics (degree, centrality, components)

- **n8n-nodes-graph-exporter**: Export node supporting:
  - RDF (Turtle)
  - Cypher (Neo4j) - standard and batch mode
  - GraphML (Gephi/yEd)
  - GEXF (Gephi native)
  - JSON-LD
  - CSV (nodes + edges)
  - DOT (Graphviz)
  - Output as string or binary file

## Test Plan
- [ ] Test simplifyGraph operation with existing knowledge graph output
- [ ] Test analyzeGraph operation with various graph sizes
- [ ] Test graph_exporter.py script with sample JSON
- [ ] Test Graph Transformer merge operation
- [ ] Test Graph Exporter with each format
- [ ] Verify binary file download works correctly

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)