### PR TITLE
feat: add context caching support for video transcription

### DIFF
--- a/custom-nodes/n8n-nodes-video-transcription/nodes/VideoTranscription/VideoTranscription.node.ts
+++ b/custom-nodes/n8n-nodes-video-transcription/nodes/VideoTranscription/VideoTranscription.node.ts
@@ -16,8 +16,14 @@ import {
   calculateChunks,
   mergeTranscriptionResults,
   timeToSeconds,
+  createVideoCache,
+  queryVideoCache,
+  deleteVideoCache,
+  listVideoCaches,
   GeminiCredentials,
   VideoInfo,
+  CacheInfo,
+  CreateCacheResult,
 } from '../../shared/VideoClient';
 
 import { getPromptForOperation } from '../../shared/videoTranscriptionPrompts';
@@ -104,8 +110,90 @@ export class VideoTranscription implements INodeType {
             description: 'Full video analysis: transcription, speakers, OCR, and scene description',
             action: 'Analyze video scene completely',
           },
+          {
+            name: 'Create Cache',
+            value: 'createCache',
+            description: 'Upload video and create cache for multiple queries (saves ~70% on costs)',
+            action: 'Create video cache',
+          },
+          {
+            name: 'Query Cache',
+            value: 'queryCache',
+            description: 'Query an existing cached video with a custom prompt',
+            action: 'Query cached video',
+          },
+          {
+            name: 'Delete Cache',
+            value: 'deleteCache',
+            description: 'Delete a video cache to stop billing',
+            action: 'Delete video cache',
+          },
+          {
+            name: 'List Caches',
+            value: 'listCaches',
+            description: 'List all active video caches',
+            action: 'List video caches',
+          },
         ],
         default: 'transcribe',
+      },
+      // Cache ID for cache operations
+      {
+        displayName: 'Cache ID',
+        name: 'cacheId',
+        type: 'string',
+        default: '',
+        placeholder: 'projects/.../locations/.../cachedContents/...',
+        description: 'The cache ID returned from Create Cache operation',
+        displayOptions: {
+          show: {
+            operation: ['queryCache', 'deleteCache'],
+          },
+        },
+      },
+      // Cache display name
+      {
+        displayName: 'Cache Name',
+        name: 'cacheName',
+        type: 'string',
+        default: '',
+        placeholder: 'my-video-cache',
+        description: 'A friendly name for the cache (for identification)',
+        displayOptions: {
+          show: {
+            operation: ['createCache'],
+          },
+        },
+      },
+      // Cache TTL
+      {
+        displayName: 'Cache TTL (minutes)',
+        name: 'cacheTtl',
+        type: 'number',
+        default: 60,
+        description: 'How long to keep the cache (billing applies). Minimum 1 minute.',
+        displayOptions: {
+          show: {
+            operation: ['createCache'],
+          },
+        },
+      },
+      // Custom prompt for queryCache
+      {
+        displayName: 'Prompt',
+        name: 'cachePrompt',
+        type: 'string',
+        typeOptions: {
+          rows: 4,
+        },
+        default: '',
+        placeholder: 'Summarize this video in 3 bullet points...',
+        description: 'The prompt to send to the cached video',
+        displayOptions: {
+          show: {
+            operation: ['queryCache'],
+          },
+        },
       },
       // Video source options
       {
@@ -131,6 +219,11 @@ export class VideoTranscription implements INodeType {
         ],
         default: 'url',
         description: 'Source of the video to process',
+        displayOptions: {
+          show: {
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene', 'createCache'],
+          },
+        },
       },
       {
         displayName: 'Video URL',
@@ -299,11 +392,6 @@ export class VideoTranscription implements INodeType {
       try {
         const operation = this.getNodeParameter('operation', i) as string;
         const credentialType = this.getNodeParameter('credentialType', i) as string;
-        const videoSource = this.getNodeParameter('videoSource', i) as string;
-        const outputLanguage = this.getNodeParameter('outputLanguage', i) as string;
-        const enableChunking = this.getNodeParameter('enableChunking', i) as boolean;
-        const startTime = this.getNodeParameter('startTime', i, '') as string;
-        const endTime = this.getNodeParameter('endTime', i, '') as string;
         const options = this.getNodeParameter('options', i, {}) as {
           model?: string;
           maxOutputTokens?: number;
@@ -328,7 +416,84 @@ export class VideoTranscription implements INodeType {
               apiKey: credentials.apiKey as string,
             };
 
-        // Get video content
+        // Handle cache operations that don't require video input
+        if (operation === 'listCaches') {
+          const caches = await listVideoCaches(geminiCredentials);
+          returnData.push({
+            json: {
+              caches,
+              count: caches.length,
+              metadata: {
+                operation,
+                processedAt: new Date().toISOString(),
+              },
+            },
+          });
+          continue;
+        }
+
+        if (operation === 'deleteCache') {
+          const cacheId = this.getNodeParameter('cacheId', i) as string;
+          if (!cacheId) {
+            throw new NodeOperationError(this.getNode(), 'Cache ID is required', { itemIndex: i });
+          }
+          const deleteResult = await deleteVideoCache(geminiCredentials, cacheId);
+          returnData.push({
+            json: {
+              ...deleteResult,
+              cacheId,
+              metadata: {
+                operation,
+                processedAt: new Date().toISOString(),
+              },
+            },
+          });
+          continue;
+        }
+
+        if (operation === 'queryCache') {
+          const cacheId = this.getNodeParameter('cacheId', i) as string;
+          const cachePrompt = this.getNodeParameter('cachePrompt', i) as string;
+
+          if (!cacheId) {
+            throw new NodeOperationError(this.getNode(), 'Cache ID is required', { itemIndex: i });
+          }
+          if (!cachePrompt) {
+            throw new NodeOperationError(this.getNode(), 'Prompt is required for cache query', { itemIndex: i });
+          }
+
+          const queryResult = await queryVideoCache(
+            geminiCredentials,
+            cacheId,
+            cachePrompt,
+            {
+              model: options.model,
+              maxOutputTokens: options.maxOutputTokens,
+            }
+          );
+
+          returnData.push({
+            json: {
+              ...queryResult,
+              metadata: {
+                operation,
+                cacheId,
+                prompt: cachePrompt,
+                model: options.model || 'gemini-2.5-flash',
+                processedAt: new Date().toISOString(),
+              },
+            },
+          });
+          continue;
+        }
+
+        // For video-based operations, get video content
+        const videoSource = this.getNodeParameter('videoSource', i) as string;
+        const outputLanguage = this.getNodeParameter('outputLanguage', i) as string;
+        const enableChunking = this.getNodeParameter('enableChunking', i) as boolean;
+        const startTime = this.getNodeParameter('startTime', i, '') as string;
+        const endTime = this.getNodeParameter('endTime', i, '') as string;
+
         let videoInfo: VideoInfo;
 
         if (videoSource === 'url') {
@@ -385,7 +550,38 @@ export class VideoTranscription implements INodeType {
           };
         }
 
-        // Process video
+        // Handle createCache operation
+        if (operation === 'createCache') {
+          const cacheName = this.getNodeParameter('cacheName', i, '') as string;
+          const cacheTtl = this.getNodeParameter('cacheTtl', i, 60) as number;
+
+          const videoContent = prepareVideoContent(videoInfo);
+          const cacheResult = await createVideoCache(
+            geminiCredentials,
+            videoContent,
+            {
+              displayName: cacheName || `video-cache-${Date.now()}`,
+              ttlMinutes: cacheTtl,
+              model: options.model,
+            }
+          );
+
+          returnData.push({
+            json: {
+              ...cacheResult,
+              metadata: {
+                operation,
+                source: videoInfo.source,
+                title: videoInfo.title,
+                model: options.model || 'gemini-2.5-flash',
+                processedAt: new Date().toISOString(),
+              },
+            },
+          });
+          continue;
+        }
+
+        // Standard video processing operations
         let result: any;
 
         if (enableChunking && videoInfo.data) {

--- a/custom-nodes/n8n-nodes-video-transcription/nodes/VideoTranscription/VideoTranscription.node.ts
+++ b/custom-nodes/n8n-nodes-video-transcription/nodes/VideoTranscription/VideoTranscription.node.ts
@@ -291,6 +291,45 @@ export class VideoTranscription implements INodeType {
         default: 'auto',
         description: 'Language for the transcription output',
       },
+      // Cache options for standard operations
+      {
+        displayName: 'Use Cache',
+        name: 'useCache',
+        type: 'boolean',
+        default: false,
+        description: 'Use context caching for ~70% cost savings on repeated queries. Creates a cache, processes the video, then optionally keeps the cache.',
+        displayOptions: {
+          show: {
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene'],
+          },
+        },
+      },
+      {
+        displayName: 'Cache TTL (Minutes)',
+        name: 'useCacheTtl',
+        type: 'number',
+        default: 60,
+        description: 'How long to keep the cache after processing',
+        displayOptions: {
+          show: {
+            useCache: [true],
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene'],
+          },
+        },
+      },
+      {
+        displayName: 'Keep Cache After Processing',
+        name: 'keepCache',
+        type: 'boolean',
+        default: false,
+        description: 'Keep the cache for future queries. If true, returns cacheId in metadata for reuse.',
+        displayOptions: {
+          show: {
+            useCache: [true],
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene'],
+          },
+        },
+      },
       // Chunking options
       {
         displayName: 'Enable Chunking',
@@ -581,10 +620,62 @@ export class VideoTranscription implements INodeType {
           continue;
         }
 
+        // Check if useCache is enabled for standard operations
+        const useCache = this.getNodeParameter('useCache', i, false) as boolean;
+
         // Standard video processing operations
         let result: any;
+        let cacheId: string | null = null;
 
-        if (enableChunking && videoInfo.data) {
+        if (useCache) {
+          // Use context caching for cost savings
+          const useCacheTtl = this.getNodeParameter('useCacheTtl', i, 60) as number;
+          const keepCache = this.getNodeParameter('keepCache', i, false) as boolean;
+
+          // Step 1: Create cache for the video
+          const videoContent = prepareVideoContent(videoInfo);
+          const cacheResult = await createVideoCache(
+            geminiCredentials,
+            videoContent,
+            {
+              displayName: `auto-cache-${operation}-${Date.now()}`,
+              ttlMinutes: useCacheTtl,
+              model: options.model,
+            }
+          );
+          cacheId = cacheResult.cacheId;
+
+          // Step 2: Query the cache with the operation prompt
+          const prompt = getPromptForOperation(
+            operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene',
+            {
+              language: outputLanguage,
+              customInstructions: options.customInstructions,
+              startTime,
+              endTime,
+            }
+          );
+
+          result = await queryVideoCache(
+            geminiCredentials,
+            cacheId,
+            prompt,
+            {
+              model: options.model,
+              maxOutputTokens: options.maxOutputTokens,
+            }
+          );
+
+          // Step 3: Delete cache if not keeping it
+          if (!keepCache) {
+            try {
+              await deleteVideoCache(geminiCredentials, cacheId);
+              cacheId = null;
+            } catch {
+              // Ignore deletion errors, cache will expire anyway
+            }
+          }
+        } else if (enableChunking && videoInfo.data) {
           // Chunked processing for long videos
           const chunkDuration = this.getNodeParameter('chunkDuration', i) as number;
           const videoDuration = this.getNodeParameter('videoDuration', i) as number;
@@ -640,7 +731,7 @@ export class VideoTranscription implements INodeType {
           // Merge chunk results
           result = mergeTranscriptionResults(chunkResults);
         } else {
-          // Single video processing
+          // Single video processing (direct, no cache)
           const prompt = getPromptForOperation(
             operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene',
             {
@@ -676,6 +767,8 @@ export class VideoTranscription implements INodeType {
               start: startTime || null,
               end: endTime || null,
             } : null,
+            useCache,
+            cacheId: cacheId || undefined,
           },
         };
 

--- a/custom-nodes/n8n-nodes-video-transcription/shared/VideoClient.ts
+++ b/custom-nodes/n8n-nodes-video-transcription/shared/VideoClient.ts
@@ -34,6 +34,26 @@ export interface GeminiCredentials {
   authMethod?: string;
 }
 
+export interface CacheInfo {
+  name: string;  // Full cache ID/name
+  displayName?: string;
+  model: string;
+  createTime: string;
+  updateTime: string;
+  expireTime: string;
+  usageMetadata?: {
+    totalTokenCount: number;
+  };
+}
+
+export interface CreateCacheResult {
+  cacheId: string;
+  displayName?: string;
+  expireTime: string;
+  model: string;
+  tokenCount?: number;
+}
+
 /**
  * Extract YouTube video ID from various URL formats
  */
@@ -570,6 +590,355 @@ export async function callGeminiWithVideo(
     });
 
     req.write(JSON.stringify(requestBody));
+    req.end();
+  });
+}
+
+/**
+ * Create a video cache for repeated queries (saves ~70% costs)
+ */
+export async function createVideoCache(
+  credentials: GeminiCredentials,
+  videoContent: ReturnType<typeof prepareVideoContent>,
+  options: {
+    displayName?: string;
+    ttlMinutes?: number;
+    model?: string;
+    systemInstruction?: string;
+  } = {}
+): Promise<CreateCacheResult> {
+  const model = options.model || 'gemini-2.5-flash';
+  const ttlMinutes = options.ttlMinutes || 60;
+  const ttlSeconds = ttlMinutes * 60;
+
+  const requestBody: any = {
+    model: credentials.type === 'vertexai'
+      ? `projects/${credentials.projectId}/locations/${credentials.location}/publishers/google/models/${model}`
+      : `models/${model}`,
+    displayName: options.displayName || `video-cache-${Date.now()}`,
+    contents: [{
+      role: 'user',
+      parts: [
+        videoContent.inlineData
+          ? { inlineData: videoContent.inlineData }
+          : { fileData: videoContent.fileData }
+      ]
+    }],
+    ttl: `${ttlSeconds}s`
+  };
+
+  if (options.systemInstruction) {
+    requestBody.systemInstruction = {
+      parts: [{ text: options.systemInstruction }]
+    };
+  }
+
+  let endpoint: string;
+  let headers: Record<string, string>;
+
+  if (credentials.type === 'vertexai') {
+    const accessToken = await getAccessToken(credentials);
+    endpoint = `https://${credentials.location}-aiplatform.googleapis.com/v1beta1/projects/${credentials.projectId}/locations/${credentials.location}/cachedContents`;
+    headers = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    };
+  } else {
+    endpoint = `https://generativelanguage.googleapis.com/v1beta/cachedContents?key=${credentials.apiKey}`;
+    headers = {
+      'Content-Type': 'application/json'
+    };
+  }
+
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(endpoint);
+    const bodyStr = JSON.stringify(requestBody);
+
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Length': Buffer.byteLength(bodyStr)
+      }
+    };
+
+    const req = https.request(requestOptions, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const response = JSON.parse(data);
+
+          if (response.error) {
+            reject(new Error(`Cache creation error: ${response.error.message}`));
+            return;
+          }
+
+          resolve({
+            cacheId: response.name,
+            displayName: response.displayName,
+            expireTime: response.expireTime,
+            model: response.model,
+            tokenCount: response.usageMetadata?.totalTokenCount
+          });
+        } catch (e) {
+          reject(new Error(`Failed to parse cache response: ${e}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(600000, () => {
+      req.destroy();
+      reject(new Error('Cache creation timeout'));
+    });
+
+    req.write(bodyStr);
+    req.end();
+  });
+}
+
+/**
+ * Query a cached video with a prompt
+ */
+export async function queryVideoCache(
+  credentials: GeminiCredentials,
+  cacheId: string,
+  prompt: string,
+  options: {
+    model?: string;
+    maxOutputTokens?: number;
+  } = {}
+): Promise<any> {
+  const model = options.model || 'gemini-2.5-flash';
+  const maxOutputTokens = options.maxOutputTokens || 8192;
+
+  const requestBody = {
+    cachedContent: cacheId,
+    contents: [{
+      role: 'user',
+      parts: [{ text: prompt }]
+    }],
+    generationConfig: {
+      temperature: 0.1,
+      maxOutputTokens,
+      responseMimeType: 'application/json'
+    }
+  };
+
+  let endpoint: string;
+  let headers: Record<string, string>;
+
+  if (credentials.type === 'vertexai') {
+    const accessToken = await getAccessToken(credentials);
+    endpoint = `https://${credentials.location}-aiplatform.googleapis.com/v1beta1/projects/${credentials.projectId}/locations/${credentials.location}/publishers/google/models/${model}:generateContent`;
+    headers = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    };
+  } else {
+    endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${credentials.apiKey}`;
+    headers = {
+      'Content-Type': 'application/json'
+    };
+  }
+
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(endpoint);
+    const bodyStr = JSON.stringify(requestBody);
+
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'POST',
+      headers: {
+        ...headers,
+        'Content-Length': Buffer.byteLength(bodyStr)
+      }
+    };
+
+    const req = https.request(requestOptions, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const response = JSON.parse(data);
+
+          if (response.error) {
+            reject(new Error(`Cache query error: ${response.error.message}`));
+            return;
+          }
+
+          const content = response.candidates?.[0]?.content?.parts?.[0]?.text;
+          if (!content) {
+            reject(new Error('No content in cache query response'));
+            return;
+          }
+
+          try {
+            resolve(JSON.parse(content));
+          } catch {
+            resolve({ raw: content });
+          }
+        } catch (e) {
+          reject(new Error(`Failed to parse cache query response: ${e}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(600000, () => {
+      req.destroy();
+      reject(new Error('Cache query timeout'));
+    });
+
+    req.write(bodyStr);
+    req.end();
+  });
+}
+
+/**
+ * Delete a video cache
+ */
+export async function deleteVideoCache(
+  credentials: GeminiCredentials,
+  cacheId: string
+): Promise<{ success: boolean; message: string }> {
+  let endpoint: string;
+  let headers: Record<string, string>;
+
+  if (credentials.type === 'vertexai') {
+    const accessToken = await getAccessToken(credentials);
+    // cacheId should be full path like: projects/.../locations/.../cachedContents/...
+    endpoint = `https://${credentials.location}-aiplatform.googleapis.com/v1beta1/${cacheId}`;
+    headers = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    };
+  } else {
+    // For AI Studio, cacheId format: cachedContents/xxx
+    endpoint = `https://generativelanguage.googleapis.com/v1beta/${cacheId}?key=${credentials.apiKey}`;
+    headers = {
+      'Content-Type': 'application/json'
+    };
+  }
+
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(endpoint);
+
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'DELETE',
+      headers
+    };
+
+    const req = https.request(requestOptions, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        if (res.statusCode === 200 || res.statusCode === 204) {
+          resolve({ success: true, message: 'Cache deleted successfully' });
+          return;
+        }
+
+        try {
+          const response = JSON.parse(data);
+          if (response.error) {
+            reject(new Error(`Cache deletion error: ${response.error.message}`));
+            return;
+          }
+          resolve({ success: true, message: 'Cache deleted' });
+        } catch {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            resolve({ success: true, message: 'Cache deleted' });
+          } else {
+            reject(new Error(`Cache deletion failed: HTTP ${res.statusCode}`));
+          }
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(30000, () => {
+      req.destroy();
+      reject(new Error('Cache deletion timeout'));
+    });
+
+    req.end();
+  });
+}
+
+/**
+ * List all video caches
+ */
+export async function listVideoCaches(
+  credentials: GeminiCredentials
+): Promise<CacheInfo[]> {
+  let endpoint: string;
+  let headers: Record<string, string>;
+
+  if (credentials.type === 'vertexai') {
+    const accessToken = await getAccessToken(credentials);
+    endpoint = `https://${credentials.location}-aiplatform.googleapis.com/v1beta1/projects/${credentials.projectId}/locations/${credentials.location}/cachedContents`;
+    headers = {
+      'Authorization': `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    };
+  } else {
+    endpoint = `https://generativelanguage.googleapis.com/v1beta/cachedContents?key=${credentials.apiKey}`;
+    headers = {
+      'Content-Type': 'application/json'
+    };
+  }
+
+  return new Promise((resolve, reject) => {
+    const parsedUrl = new URL(endpoint);
+
+    const requestOptions = {
+      hostname: parsedUrl.hostname,
+      path: parsedUrl.pathname + parsedUrl.search,
+      method: 'GET',
+      headers
+    };
+
+    const req = https.request(requestOptions, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          const response = JSON.parse(data);
+
+          if (response.error) {
+            reject(new Error(`List caches error: ${response.error.message}`));
+            return;
+          }
+
+          const caches: CacheInfo[] = (response.cachedContents || []).map((cache: any) => ({
+            name: cache.name,
+            displayName: cache.displayName,
+            model: cache.model,
+            createTime: cache.createTime,
+            updateTime: cache.updateTime,
+            expireTime: cache.expireTime,
+            usageMetadata: cache.usageMetadata
+          }));
+
+          resolve(caches);
+        } catch (e) {
+          reject(new Error(`Failed to parse list caches response: ${e}`));
+        }
+      });
+    });
+
+    req.on('error', reject);
+    req.setTimeout(30000, () => {
+      req.destroy();
+      reject(new Error('List caches timeout'));
+    });
+
     req.end();
   });
 }

--- a/docs/n8n/video-transcription-mcp-server.md
+++ b/docs/n8n/video-transcription-mcp-server.md
@@ -24,7 +24,7 @@ Ce workflow transcrit et analyse des vidéos (YouTube, URL directes) en utilisan
 
 | Paramètre | Type | Défaut | Description |
 |-----------|------|--------|-------------|
-| `operation` | string | `"transcribe"` | Opération à effectuer (voir ci-dessous) |
+| `operation` | string | `"transcribe"` | Opération à effectuer (voir ci-dessous): `transcribe`, `identifySpeakers`, `extractOcr`, `analyzeScene`, `createCache`, `queryCache`, `deleteCache`, `listCaches` |
 | `language` | string | `"auto"` | Langue de sortie: `"auto"`, `"en"`, `"fr"`, `"es"`, `"de"`, `"it"`, `"pt"` |
 
 ### Options de chunking (pour vidéos longues)
@@ -41,6 +41,17 @@ Ce workflow transcrit et analyse des vidéos (YouTube, URL directes) en utilisan
 |-----------|------|--------|-------------|
 | `startTime` | string | `""` | Temps de début (format `MM:SS` ou `HH:MM:SS`, ex: `"1:30"` ou `"0:01:30"`) |
 | `endTime` | string | `""` | Temps de fin (format `MM:SS` ou `HH:MM:SS`, ex: `"5:00"` ou `"0:05:00"`) |
+
+### Options de cache (pour requêtes multiples)
+
+Le caching permet de réduire les coûts de ~70% pour plusieurs requêtes sur la même vidéo.
+
+| Paramètre | Type | Défaut | Description |
+|-----------|------|--------|-------------|
+| `cacheId` | string | `""` | ID du cache (retourné par `createCache`, requis pour `queryCache`/`deleteCache`) |
+| `cacheName` | string | `""` | Nom convivial pour le cache (pour `createCache`) |
+| `cacheTtl` | number | `60` | Durée de vie du cache en minutes (pour `createCache`) |
+| `cachePrompt` | string | `""` | Prompt pour interroger le cache (pour `queryCache`) |
 
 ### Options avancées
 
@@ -174,6 +185,102 @@ Analyse complète : transcription, locuteurs, OCR et description des scènes.
 }
 ```
 
+## Opérations de cache
+
+Les opérations de cache permettent de stocker une vidéo côté serveur et de l'interroger plusieurs fois sans la renvoyer. Cela réduit les coûts de ~70%.
+
+### `createCache`
+Crée un cache pour une vidéo. La vidéo est uploadée et stockée pour des requêtes ultérieures.
+
+**Paramètres requis:** `videoUrl` ou `videoBase64`
+**Paramètres optionnels:** `cacheName`, `cacheTtl`, `model`
+
+**Sortie:**
+```json
+{
+  "cacheId": "projects/xxx/locations/us-central1/cachedContents/xxx",
+  "displayName": "my-video-cache",
+  "expireTime": "2025-12-12T10:00:00Z",
+  "model": "projects/xxx/locations/us-central1/publishers/google/models/gemini-2.5-flash",
+  "tokenCount": 150000,
+  "metadata": {
+    "operation": "createCache",
+    "source": "url",
+    "title": "Video Title",
+    "model": "gemini-2.5-flash",
+    "processedAt": "2025-12-12T09:00:00Z"
+  }
+}
+```
+
+### `queryCache`
+Interroge une vidéo en cache avec un prompt personnalisé.
+
+**Paramètres requis:** `cacheId`, `cachePrompt`
+**Paramètres optionnels:** `model`, `maxOutputTokens`
+
+**Sortie:** Dépend du prompt. Exemple avec prompt de résumé:
+```json
+{
+  "summary": "This video discusses...",
+  "key_points": ["point 1", "point 2"],
+  "metadata": {
+    "operation": "queryCache",
+    "cacheId": "projects/xxx/locations/us-central1/cachedContents/xxx",
+    "prompt": "Summarize this video in 3 bullet points",
+    "model": "gemini-2.5-flash",
+    "processedAt": "2025-12-12T09:05:00Z"
+  }
+}
+```
+
+### `deleteCache`
+Supprime un cache pour arrêter la facturation.
+
+**Paramètres requis:** `cacheId`
+
+**Sortie:**
+```json
+{
+  "success": true,
+  "message": "Cache deleted successfully",
+  "cacheId": "projects/xxx/locations/us-central1/cachedContents/xxx",
+  "metadata": {
+    "operation": "deleteCache",
+    "processedAt": "2025-12-12T10:00:00Z"
+  }
+}
+```
+
+### `listCaches`
+Liste tous les caches actifs.
+
+**Paramètres:** Aucun requis
+
+**Sortie:**
+```json
+{
+  "caches": [
+    {
+      "name": "projects/xxx/locations/us-central1/cachedContents/xxx",
+      "displayName": "my-video-cache",
+      "model": "projects/xxx/locations/us-central1/publishers/google/models/gemini-2.5-flash",
+      "createTime": "2025-12-12T09:00:00Z",
+      "updateTime": "2025-12-12T09:00:00Z",
+      "expireTime": "2025-12-12T10:00:00Z",
+      "usageMetadata": {
+        "totalTokenCount": 150000
+      }
+    }
+  ],
+  "count": 1,
+  "metadata": {
+    "operation": "listCaches",
+    "processedAt": "2025-12-12T09:10:00Z"
+  }
+}
+```
+
 ## Exemples de requêtes
 
 ### Transcription basique YouTube
@@ -276,6 +383,52 @@ curl -X POST http://localhost:5678/webhook/video-transcription \
   }'
 ```
 
+### Créer un cache pour une vidéo
+
+```bash
+curl -X POST http://localhost:5678/webhook/video-cache \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "createCache",
+    "videoUrl": "https://example.com/long-video.mp4",
+    "cacheName": "presentation-cache",
+    "cacheTtl": 120
+  }'
+```
+
+### Interroger un cache
+
+```bash
+curl -X POST http://localhost:5678/webhook/video-cache \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "queryCache",
+    "cacheId": "projects/xxx/locations/us-central1/cachedContents/xxx",
+    "prompt": "What are the 3 main topics discussed in this video?"
+  }'
+```
+
+### Lister les caches actifs
+
+```bash
+curl -X POST http://localhost:5678/webhook/video-cache \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "listCaches"
+  }'
+```
+
+### Supprimer un cache
+
+```bash
+curl -X POST http://localhost:5678/webhook/video-cache \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "deleteCache",
+    "cacheId": "projects/xxx/locations/us-central1/cachedContents/xxx"
+  }'
+```
+
 ## Sources vidéo supportées
 
 ### YouTube
@@ -298,6 +451,32 @@ curl -X POST http://localhost:5678/webhook/video-transcription \
 | `gemini-2.0-flash` | Dernière génération rapide | Vidéos courtes |
 | `gemini-1.5-pro` | Contexte long (jusqu'à 1M tokens) | Vidéos très longues |
 | `gemini-1.5-flash` | Rapide, bon contexte | Équilibre performance/coût |
+
+## Context Caching (économie de coûts)
+
+Le Context Caching permet de stocker une vidéo sur les serveurs Gemini et de l'interroger plusieurs fois sans la renvoyer. Cela offre des économies significatives :
+
+**Avantages:**
+- **~70% d'économie** sur les coûts par requête après la première
+- **Latence réduite** : pas besoin de re-transférer la vidéo
+- **Requêtes multiples** : poser plusieurs questions sur la même vidéo
+
+**Quand utiliser:**
+- Analyse détaillée nécessitant plusieurs passes
+- Questions interactives sur une vidéo
+- Extraction de différentes informations (transcription + OCR + résumé)
+- Vidéos longues avec plusieurs requêtes prévues
+
+**Workflow recommandé:**
+1. `createCache` : upload de la vidéo (coût initial)
+2. `queryCache` : requêtes multiples (coût réduit de ~70%)
+3. `deleteCache` : suppression pour arrêter la facturation
+
+**Important:**
+- Le cache est facturé tant qu'il existe (TTL)
+- Minimum TTL : 1 minute
+- Les caches expirent automatiquement après le TTL
+- Toujours supprimer les caches inutilisés
 
 ## Chunking pour vidéos longues
 
@@ -359,7 +538,7 @@ Les paramètres `startTime` et `endTime` permettent de limiter la transcription 
 
 ## Intégration avec MCP Server
 
-Exemple d'outil MCP pour appeler ce workflow:
+### Outil de transcription vidéo
 
 ```typescript
 {
@@ -394,6 +573,51 @@ Exemple d'outil MCP pour appeler ce workflow:
       customInstructions: { type: "string" }
     },
     required: ["videoUrl"]
+  }
+}
+```
+
+### Outil de gestion du cache vidéo
+
+```typescript
+{
+  name: "manage_video_cache",
+  description: "Create, query, list, and delete video caches for cost-effective repeated queries",
+  inputSchema: {
+    type: "object",
+    properties: {
+      operation: {
+        type: "string",
+        enum: ["createCache", "queryCache", "listCaches", "deleteCache"],
+        description: "Cache operation to perform"
+      },
+      videoUrl: {
+        type: "string",
+        description: "Video URL (required for createCache)"
+      },
+      cacheId: {
+        type: "string",
+        description: "Cache ID (required for queryCache and deleteCache)"
+      },
+      cacheName: {
+        type: "string",
+        description: "Friendly name for the cache (optional for createCache)"
+      },
+      cacheTtl: {
+        type: "number",
+        default: 60,
+        description: "Cache TTL in minutes (for createCache)"
+      },
+      prompt: {
+        type: "string",
+        description: "Prompt to query the cached video (required for queryCache)"
+      },
+      model: {
+        type: "string",
+        default: "gemini-2.5-flash"
+      }
+    },
+    required: ["operation"]
   }
 }
 ```

--- a/workflows/video-cache-workflow.json
+++ b/workflows/video-cache-workflow.json
@@ -1,0 +1,165 @@
+{
+  "name": "Video Cache Management",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "video-cache",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "video-cache-webhook"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-operation",
+              "leftValue": "={{ $json.body.operation }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-operation",
+      "name": "Has operation?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "errorMessage": "={{ \"No operation specified. Use: createCache, queryCache, deleteCache, or listCaches\" }}"
+      },
+      "id": "error-no-operation",
+      "name": "Error: No Operation",
+      "type": "n8n-nodes-base.stopAndError",
+      "typeVersion": 1,
+      "position": [680, 420]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare data for Video Cache operations\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request\nconst operation = body.operation;\n\n// Prepare result based on operation\nconst result = {\n  operation,\n  originalRequest: { ...body }\n};\n\n// Operation-specific parameters\nswitch (operation) {\n  case 'createCache':\n    result.videoSource = body.videoBase64 ? 'base64' : 'url';\n    result.videoUrl = body.videoUrl || '';\n    result.videoBase64 = body.videoBase64 || '';\n    result.videoMimeType = body.videoMimeType || 'video/mp4';\n    result.cacheName = body.cacheName || '';\n    result.cacheTtl = body.cacheTtl || 60;\n    result.model = body.model || 'gemini-2.5-flash';\n    break;\n  case 'queryCache':\n    result.cacheId = body.cacheId;\n    result.cachePrompt = body.prompt || body.cachePrompt;\n    result.model = body.model || 'gemini-2.5-flash';\n    break;\n  case 'deleteCache':\n    result.cacheId = body.cacheId;\n    break;\n  case 'listCaches':\n    // No additional parameters needed\n    break;\n  default:\n    throw new Error(`Unknown operation: ${operation}`);\n}\n\nreturn [{ json: result }];"
+      },
+      "id": "prepare-config",
+      "name": "Prepare Config",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 180]
+    },
+    {
+      "parameters": {
+        "operation": "={{ $json.operation }}",
+        "credentialType": "vertexai",
+        "videoSource": "={{ $json.videoSource }}",
+        "videoUrl": "={{ $json.videoUrl }}",
+        "videoBase64": "={{ $json.videoBase64 }}",
+        "videoMimeType": "={{ $json.videoMimeType }}",
+        "cacheId": "={{ $json.cacheId }}",
+        "cacheName": "={{ $json.cacheName }}",
+        "cacheTtl": "={{ $json.cacheTtl }}",
+        "cachePrompt": "={{ $json.cachePrompt }}",
+        "options": {
+          "model": "={{ $json.model }}",
+          "maxOutputTokens": 16384
+        }
+      },
+      "id": "video-cache",
+      "name": "Video Cache",
+      "type": "n8n-nodes-video-transcription.videoTranscription",
+      "typeVersion": 1,
+      "position": [900, 180],
+      "credentials": {
+        "googleVertexAiApi": {
+          "id": "google-vertex-ai",
+          "name": "Google Vertex AI account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 180]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Has operation?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has operation?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Config",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: No Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Config": {
+      "main": [
+        [
+          {
+            "node": "Video Cache",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Video Cache": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/video-transcription-workflow.json
+++ b/workflows/video-transcription-workflow.json
@@ -56,7 +56,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Prepare data for Video Transcription node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: transcribe)\nconst operation = body.operation || 'transcribe';\n\n// Determine video source type\nconst hasBase64 = !!body.videoBase64;\nconst videoSource = hasBase64 ? 'base64' : 'url';\n\n// Get optional parameters\nconst outputLanguage = body.language || 'auto';\nconst enableChunking = body.enableChunking === true || body.enableChunking === 'true';\nconst chunkDuration = body.chunkDuration || 10;\nconst videoDuration = body.videoDuration || 0;\nconst model = body.model || 'gemini-2.5-flash';\nconst customInstructions = body.customInstructions || '';\nconst startTime = body.startTime || '';\nconst endTime = body.endTime || '';\n\nconst result = {\n  videoSource,\n  operation,\n  outputLanguage,\n  enableChunking,\n  chunkDuration,\n  videoDuration,\n  model,\n  customInstructions,\n  startTime,\n  endTime,\n  originalRequest: { ...body, videoBase64: body.videoBase64 ? '<base64_data>' : undefined }\n};\n\nif (hasBase64) {\n  result.videoBase64 = body.videoBase64;\n  result.videoMimeType = body.videoMimeType || 'video/mp4';\n} else {\n  result.videoUrl = body.videoUrl;\n}\n\nreturn [{ json: result }];"
+        "jsCode": "// Prepare data for Video Transcription node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: transcribe)\nconst operation = body.operation || 'transcribe';\n\n// Determine video source type\nconst hasBase64 = !!body.videoBase64;\nconst videoSource = hasBase64 ? 'base64' : 'url';\n\n// Get optional parameters\nconst outputLanguage = body.language || 'auto';\nconst enableChunking = body.enableChunking === true || body.enableChunking === 'true';\nconst chunkDuration = body.chunkDuration || 10;\nconst videoDuration = body.videoDuration || 0;\nconst model = body.model || 'gemini-2.5-flash';\nconst customInstructions = body.customInstructions || '';\nconst startTime = body.startTime || '';\nconst endTime = body.endTime || '';\n\n// Cache parameters\nconst useCache = body.useCache === true || body.useCache === 'true';\nconst useCacheTtl = body.cacheTtl || body.useCacheTtl || 60;\nconst keepCache = body.keepCache === true || body.keepCache === 'true';\n\nconst result = {\n  videoSource,\n  operation,\n  outputLanguage,\n  enableChunking,\n  chunkDuration,\n  videoDuration,\n  model,\n  customInstructions,\n  startTime,\n  endTime,\n  useCache,\n  useCacheTtl,\n  keepCache,\n  originalRequest: { ...body, videoBase64: body.videoBase64 ? '<base64_data>' : undefined }\n};\n\nif (hasBase64) {\n  result.videoBase64 = body.videoBase64;\n  result.videoMimeType = body.videoMimeType || 'video/mp4';\n} else {\n  result.videoUrl = body.videoUrl;\n}\n\nreturn [{ json: result }];"
       },
       "id": "prepare-config",
       "name": "Prepare Config",
@@ -73,6 +73,9 @@
         "videoBase64": "={{ $json.videoBase64 }}",
         "videoMimeType": "={{ $json.videoMimeType }}",
         "outputLanguage": "={{ $json.outputLanguage }}",
+        "useCache": "={{ $json.useCache }}",
+        "useCacheTtl": "={{ $json.useCacheTtl }}",
+        "keepCache": "={{ $json.keepCache }}",
         "enableChunking": "={{ $json.enableChunking }}",
         "chunkDuration": "={{ $json.chunkDuration }}",
         "videoDuration": "={{ $json.videoDuration }}",


### PR DESCRIPTION
## Summary

Adds context caching operations to the Video Transcription node to reduce API costs by ~70% for repeated video queries.

### New Operations
- **createCache**: Upload video and create a cache for multiple queries
- **queryCache**: Query a cached video with custom prompts (reduced cost)
- **deleteCache**: Delete a cache to stop billing
- **listCaches**: List all active video caches

### Changes
- Add cache functions in `VideoClient.ts`:
  - `createVideoCache()` - Creates a cached context for a video
  - `queryVideoCache()` - Queries a cached video
  - `deleteVideoCache()` - Deletes a cached video
  - `listVideoCaches()` - Lists all active caches
- Add cache parameters to `VideoTranscription.node.ts`:
  - `cacheId` - Cache identifier for query/delete operations
  - `cacheName` - Display name for cache identification
  - `cacheTtl` - Cache TTL in minutes
  - `cachePrompt` - Prompt for querying cached videos
- Add execution logic for all cache operations
- Create `video-cache-workflow.json` for cache management via webhook
- Update MCP documentation with cache operations and examples

### Cost Savings
Context caching reduces costs by ~70% for subsequent queries on the same video. Ideal for:
- Detailed analysis requiring multiple passes
- Interactive Q&A on video content
- Extracting different information types (transcription + OCR + summary)

### API Endpoints
- POST `/webhook/video-cache` - Cache management endpoint
- Operations: createCache, queryCache, listCaches, deleteCache

## Test plan
- [ ] Build the node: `npm run build` in custom-nodes directory
- [ ] Deploy to n8n
- [ ] Test createCache with a video URL
- [ ] Test queryCache with the returned cacheId
- [ ] Test listCaches to verify cache exists
- [ ] Test deleteCache to remove the cache
- [ ] Verify listCaches shows empty after deletion

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)