### PR TITLE
feat: add extractSlides operation and GCP Cloud Function

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,6 @@
+# Configuration pour extract_slides_remote.sh
+# Copier ce fichier vers .env.local et adapter les valeurs
+
+EXTRACT_SERVER="user@your-server.com"
+SSH_PORT="2222"
+REMOTE_DIR="~/extract-slides"

--- a/cloud-functions/extract-slides/deploy.sh
+++ b/cloud-functions/extract-slides/deploy.sh
@@ -7,8 +7,8 @@ set -e
 PROJECT_ID="${GCP_PROJECT_ID:-your-project-id}"
 REGION="${GCP_REGION:-europe-west1}"
 FUNCTION_NAME="extract-slides"
-MEMORY="512MB"
-TIMEOUT="300s"
+MEMORY="1GB"
+TIMEOUT="540s"
 MIN_INSTANCES="0"
 MAX_INSTANCES="10"
 

--- a/cloud-functions/extract-slides/deploy.sh
+++ b/cloud-functions/extract-slides/deploy.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# Deploy extract-slides Cloud Function to GCP
+
+set -e
+
+# Configuration - Update these values
+PROJECT_ID="${GCP_PROJECT_ID:-your-project-id}"
+REGION="${GCP_REGION:-europe-west1}"
+FUNCTION_NAME="extract-slides"
+MEMORY="512MB"
+TIMEOUT="300s"
+MIN_INSTANCES="0"
+MAX_INSTANCES="10"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${YELLOW}Deploying ${FUNCTION_NAME} to GCP...${NC}"
+echo "Project: ${PROJECT_ID}"
+echo "Region: ${REGION}"
+echo ""
+
+# Check if gcloud is installed
+if ! command -v gcloud &> /dev/null; then
+    echo -e "${RED}Error: gcloud CLI is not installed${NC}"
+    echo "Install from: https://cloud.google.com/sdk/docs/install"
+    exit 1
+fi
+
+# Check if logged in
+if ! gcloud auth list --filter=status:ACTIVE --format="value(account)" &> /dev/null; then
+    echo -e "${RED}Error: Not logged in to gcloud${NC}"
+    echo "Run: gcloud auth login"
+    exit 1
+fi
+
+# Set project
+echo "Setting project..."
+gcloud config set project "${PROJECT_ID}"
+
+# Enable required APIs
+echo -e "${YELLOW}Enabling required APIs...${NC}"
+gcloud services enable cloudfunctions.googleapis.com --quiet
+gcloud services enable cloudbuild.googleapis.com --quiet
+gcloud services enable run.googleapis.com --quiet
+gcloud services enable artifactregistry.googleapis.com --quiet
+gcloud services enable storage.googleapis.com --quiet
+
+# Deploy the function
+echo -e "${YELLOW}Deploying function...${NC}"
+gcloud functions deploy "${FUNCTION_NAME}" \
+    --gen2 \
+    --runtime=python311 \
+    --region="${REGION}" \
+    --source=. \
+    --entry-point=extract_slides \
+    --trigger-http \
+    --allow-unauthenticated \
+    --memory="${MEMORY}" \
+    --timeout="${TIMEOUT}" \
+    --min-instances="${MIN_INSTANCES}" \
+    --max-instances="${MAX_INSTANCES}" \
+    --set-env-vars="GCP_PROJECT=${PROJECT_ID}"
+
+# Get the function URL
+FUNCTION_URL=$(gcloud functions describe "${FUNCTION_NAME}" \
+    --region="${REGION}" \
+    --format="value(serviceConfig.uri)" 2>/dev/null || echo "")
+
+if [ -n "${FUNCTION_URL}" ]; then
+    echo ""
+    echo -e "${GREEN}Deployment successful!${NC}"
+    echo ""
+    echo "Function URL: ${FUNCTION_URL}"
+    echo ""
+    echo "Test with:"
+    echo "curl -X POST ${FUNCTION_URL} \\"
+    echo "  -H 'Content-Type: application/json' \\"
+    echo "  -d '{"
+    echo "    \"video_url\": \"https://example.com/video.mp4\","
+    echo "    \"slides\": [{\"id\": 1, \"timestamp_ms\": 15000, \"title\": \"Test\"}],"
+    echo "    \"output\": {\"type\": \"base64\"}"
+    echo "  }'"
+else
+    echo -e "${RED}Warning: Could not retrieve function URL${NC}"
+    echo "Check the GCP Console for the function URL"
+fi
+
+echo ""
+echo -e "${GREEN}Done!${NC}"

--- a/cloud-functions/extract-slides/main.py
+++ b/cloud-functions/extract-slides/main.py
@@ -4,10 +4,14 @@ GCP Cloud Function for extracting slide images from videos.
 This function takes timestamps from the extractSlides operation and
 extracts the corresponding frames from the video using OpenCV.
 
+Supports:
+- Direct video URLs (.mp4, .webm, etc.)
+- YouTube URLs (via yt-dlp)
+
 Usage:
     POST /extract-slides
     {
-        "video_url": "https://example.com/video.mp4",
+        "video_url": "https://www.youtube.com/watch?v=VIDEO_ID",
         "slides": [
             {"id": 1, "timestamp_ms": 15000, "title": "Introduction"},
             {"id": 2, "timestamp_ms": 145000, "title": "Results"}
@@ -27,8 +31,17 @@ import requests
 import base64
 import os
 import re
+import subprocess
+from urllib.parse import urlparse
 from flask import jsonify
 from google.cloud import storage
+
+
+def is_youtube_url(url: str) -> bool:
+    """Check if URL is a YouTube video."""
+    parsed = urlparse(url)
+    youtube_domains = ['youtube.com', 'www.youtube.com', 'youtu.be', 'm.youtube.com']
+    return parsed.netloc in youtube_domains
 
 
 def sanitize_filename(title: str, max_length: int = 50) -> str:
@@ -43,14 +56,57 @@ def sanitize_filename(title: str, max_length: int = 50) -> str:
     return safe[:max_length]
 
 
-def download_video(url: str, tmp_path: str) -> None:
-    """Download video from URL to temporary file."""
+def download_youtube_video(url: str, tmp_path: str) -> None:
+    """Download YouTube video using yt-dlp."""
+    try:
+        # Use yt-dlp to download video
+        # -f: format selector (best quality up to 720p to save bandwidth)
+        # -o: output path
+        # --no-playlist: don't download playlists
+        # --quiet: minimal output
+        result = subprocess.run(
+            [
+                'yt-dlp',
+                '-f', 'best[height<=720]/best',
+                '-o', tmp_path,
+                '--no-playlist',
+                '--quiet',
+                '--no-warnings',
+                url
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300  # 5 minutes timeout
+        )
+
+        if result.returncode != 0:
+            raise RuntimeError(f"yt-dlp failed: {result.stderr}")
+
+        if not os.path.exists(tmp_path):
+            raise RuntimeError("yt-dlp did not create output file")
+
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("YouTube download timed out")
+    except FileNotFoundError:
+        raise RuntimeError("yt-dlp not installed in Cloud Function")
+
+
+def download_direct_video(url: str, tmp_path: str) -> None:
+    """Download video from direct URL."""
     response = requests.get(url, stream=True, timeout=300)
     response.raise_for_status()
 
     with open(tmp_path, 'wb') as f:
         for chunk in response.iter_content(chunk_size=8192):
             f.write(chunk)
+
+
+def download_video(url: str, tmp_path: str) -> None:
+    """Download video from URL (supports YouTube and direct URLs)."""
+    if is_youtube_url(url):
+        download_youtube_video(url, tmp_path)
+    else:
+        download_direct_video(url, tmp_path)
 
 
 def extract_frame(video_path: str, timestamp_ms: int, bounding_box: list = None) -> bytes:
@@ -141,12 +197,31 @@ def extract_slides(request):
         if output_type == 'gcs' and not bucket_name:
             return jsonify({'error': 'bucket is required for GCS output'}), 400, headers
 
+        # Determine file extension based on source
+        suffix = '.mp4'
+        if is_youtube_url(video_url):
+            # yt-dlp may download as different format
+            suffix = '.%(ext)s'
+
         # Download video to temp file
         with tempfile.NamedTemporaryFile(suffix='.mp4', delete=False) as tmp:
             tmp_path = tmp.name
 
         try:
-            download_video(video_url, tmp_path)
+            # For YouTube, yt-dlp handles the extension
+            if is_youtube_url(video_url):
+                # Remove the .mp4 suffix and let yt-dlp add correct extension
+                tmp_base = tmp_path.rsplit('.', 1)[0]
+                download_video(video_url, tmp_base + '.%(ext)s')
+                # Find the actual downloaded file
+                import glob
+                downloaded_files = glob.glob(tmp_base + '.*')
+                if downloaded_files:
+                    tmp_path = downloaded_files[0]
+                else:
+                    raise RuntimeError("YouTube video download failed - no file created")
+            else:
+                download_video(video_url, tmp_path)
 
             results = []
             for slide in slides:
@@ -198,8 +273,14 @@ def extract_slides(request):
             }), 200, headers
 
         finally:
-            # Clean up temp file
-            if os.path.exists(tmp_path):
+            # Clean up temp file(s)
+            if is_youtube_url(video_url):
+                import glob
+                tmp_base = tmp_path.rsplit('.', 1)[0]
+                for f in glob.glob(tmp_base + '.*'):
+                    if os.path.exists(f):
+                        os.unlink(f)
+            elif os.path.exists(tmp_path):
                 os.unlink(tmp_path)
 
     except requests.exceptions.RequestException as e:

--- a/cloud-functions/extract-slides/main.py
+++ b/cloud-functions/extract-slides/main.py
@@ -1,0 +1,215 @@
+"""
+GCP Cloud Function for extracting slide images from videos.
+
+This function takes timestamps from the extractSlides operation and
+extracts the corresponding frames from the video using OpenCV.
+
+Usage:
+    POST /extract-slides
+    {
+        "video_url": "https://example.com/video.mp4",
+        "slides": [
+            {"id": 1, "timestamp_ms": 15000, "title": "Introduction"},
+            {"id": 2, "timestamp_ms": 145000, "title": "Results"}
+        ],
+        "output": {
+            "type": "base64" | "gcs",
+            "bucket": "my-bucket",  // required if type is "gcs"
+            "prefix": "slides/"     // optional prefix for GCS
+        }
+    }
+"""
+
+import functions_framework
+import cv2
+import tempfile
+import requests
+import base64
+import os
+import re
+from flask import jsonify
+from google.cloud import storage
+
+
+def sanitize_filename(title: str, max_length: int = 50) -> str:
+    """Convert title to a safe filename."""
+    if not title:
+        return "slide"
+    # Remove non-alphanumeric characters except spaces and hyphens
+    safe = re.sub(r'[^\w\s-]', '', title)
+    # Replace spaces with underscores
+    safe = re.sub(r'\s+', '_', safe)
+    # Truncate if too long
+    return safe[:max_length]
+
+
+def download_video(url: str, tmp_path: str) -> None:
+    """Download video from URL to temporary file."""
+    response = requests.get(url, stream=True, timeout=300)
+    response.raise_for_status()
+
+    with open(tmp_path, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+
+def extract_frame(video_path: str, timestamp_ms: int, bounding_box: list = None) -> bytes:
+    """Extract a single frame from video at given timestamp."""
+    cap = cv2.VideoCapture(video_path)
+
+    try:
+        # Seek to timestamp
+        cap.set(cv2.CAP_PROP_POS_MSEC, timestamp_ms)
+        success, frame = cap.read()
+
+        if not success:
+            raise ValueError(f"Failed to read frame at {timestamp_ms}ms")
+
+        # Crop if bounding box provided
+        if bounding_box and len(bounding_box) == 4:
+            height, width = frame.shape[:2]
+            # Convert from 0-1000 scale to actual pixels
+            ymin = int(bounding_box[0] * height / 1000)
+            xmin = int(bounding_box[1] * width / 1000)
+            ymax = int(bounding_box[2] * height / 1000)
+            xmax = int(bounding_box[3] * width / 1000)
+            frame = frame[ymin:ymax, xmin:xmax]
+
+        # Encode as JPEG
+        _, buffer = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 90])
+        return buffer.tobytes()
+
+    finally:
+        cap.release()
+
+
+def upload_to_gcs(bucket_name: str, blob_name: str, data: bytes, content_type: str = 'image/jpeg') -> str:
+    """Upload data to Google Cloud Storage and return the public URL."""
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+
+    blob.upload_from_string(data, content_type=content_type)
+
+    # Return gs:// URL
+    return f"gs://{bucket_name}/{blob_name}"
+
+
+@functions_framework.http
+def extract_slides(request):
+    """
+    HTTP Cloud Function to extract slide images from video.
+
+    Args:
+        request: Flask Request object
+
+    Returns:
+        JSON response with extracted images
+    """
+    # Handle CORS preflight
+    if request.method == 'OPTIONS':
+        headers = {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'POST',
+            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Max-Age': '3600'
+        }
+        return ('', 204, headers)
+
+    headers = {'Access-Control-Allow-Origin': '*'}
+
+    try:
+        data = request.get_json()
+
+        if not data:
+            return jsonify({'error': 'No JSON data provided'}), 400, headers
+
+        video_url = data.get('video_url')
+        slides = data.get('slides', [])
+        output_config = data.get('output', {'type': 'base64'})
+
+        if not video_url:
+            return jsonify({'error': 'video_url is required'}), 400, headers
+
+        if not slides:
+            return jsonify({'error': 'slides array is required'}), 400, headers
+
+        output_type = output_config.get('type', 'base64')
+        bucket_name = output_config.get('bucket')
+        prefix = output_config.get('prefix', '')
+
+        if output_type == 'gcs' and not bucket_name:
+            return jsonify({'error': 'bucket is required for GCS output'}), 400, headers
+
+        # Download video to temp file
+        with tempfile.NamedTemporaryFile(suffix='.mp4', delete=False) as tmp:
+            tmp_path = tmp.name
+
+        try:
+            download_video(video_url, tmp_path)
+
+            results = []
+            for slide in slides:
+                slide_id = slide.get('id', len(results) + 1)
+                timestamp_ms = slide.get('timestamp_ms', 0)
+                title = slide.get('title', f'slide_{slide_id}')
+                bounding_box = slide.get('bounding_box')
+
+                try:
+                    # Extract frame
+                    image_data = extract_frame(tmp_path, timestamp_ms, bounding_box)
+
+                    if output_type == 'gcs':
+                        # Upload to GCS
+                        filename = f"{prefix}slide_{slide_id:03d}_{sanitize_filename(title)}.jpg"
+                        url = upload_to_gcs(bucket_name, filename, image_data)
+                        results.append({
+                            'slide_id': slide_id,
+                            'title': title,
+                            'timestamp_ms': timestamp_ms,
+                            'url': url,
+                            'status': 'success'
+                        })
+                    else:
+                        # Return base64
+                        results.append({
+                            'slide_id': slide_id,
+                            'title': title,
+                            'timestamp_ms': timestamp_ms,
+                            'image_base64': base64.b64encode(image_data).decode('utf-8'),
+                            'status': 'success'
+                        })
+
+                except Exception as e:
+                    results.append({
+                        'slide_id': slide_id,
+                        'title': title,
+                        'timestamp_ms': timestamp_ms,
+                        'status': 'error',
+                        'error': str(e)
+                    })
+
+            return jsonify({
+                'success': True,
+                'total_slides': len(slides),
+                'extracted': sum(1 for r in results if r['status'] == 'success'),
+                'failed': sum(1 for r in results if r['status'] == 'error'),
+                'images': results
+            }), 200, headers
+
+        finally:
+            # Clean up temp file
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+    except requests.exceptions.RequestException as e:
+        return jsonify({
+            'success': False,
+            'error': f'Failed to download video: {str(e)}'
+        }), 500, headers
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500, headers

--- a/cloud-functions/extract-slides/requirements.txt
+++ b/cloud-functions/extract-slides/requirements.txt
@@ -3,3 +3,4 @@ opencv-python-headless==4.*
 google-cloud-storage==2.*
 requests==2.*
 flask>=2.0.0
+yt-dlp>=2024.0.0

--- a/cloud-functions/extract-slides/requirements.txt
+++ b/cloud-functions/extract-slides/requirements.txt
@@ -1,0 +1,5 @@
+functions-framework==3.*
+opencv-python-headless==4.*
+google-cloud-storage==2.*
+requests==2.*
+flask>=2.0.0

--- a/custom-nodes/n8n-nodes-video-transcription/nodes/VideoTranscription/VideoTranscription.node.ts
+++ b/custom-nodes/n8n-nodes-video-transcription/nodes/VideoTranscription/VideoTranscription.node.ts
@@ -111,6 +111,12 @@ export class VideoTranscription implements INodeType {
             action: 'Analyze video scene completely',
           },
           {
+            name: 'Extract Slides',
+            value: 'extractSlides',
+            description: 'Detect and extract slide/presentation metadata with timestamps',
+            action: 'Extract slides from video',
+          },
+          {
             name: 'Create Cache',
             value: 'createCache',
             description: 'Upload video and create cache for multiple queries (saves ~70% on costs)',
@@ -221,7 +227,7 @@ export class VideoTranscription implements INodeType {
         description: 'Source of the video to process',
         displayOptions: {
           show: {
-            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene', 'createCache'],
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene', 'extractSlides', 'createCache'],
           },
         },
       },
@@ -300,7 +306,7 @@ export class VideoTranscription implements INodeType {
         description: 'Use context caching for ~70% cost savings on repeated queries. Creates a cache, processes the video, then optionally keeps the cache.',
         displayOptions: {
           show: {
-            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene'],
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene', 'extractSlides'],
           },
         },
       },
@@ -313,7 +319,7 @@ export class VideoTranscription implements INodeType {
         displayOptions: {
           show: {
             useCache: [true],
-            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene'],
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene', 'extractSlides'],
           },
         },
       },
@@ -326,7 +332,7 @@ export class VideoTranscription implements INodeType {
         displayOptions: {
           show: {
             useCache: [true],
-            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene'],
+            operation: ['transcribe', 'identifySpeakers', 'extractOcr', 'analyzeScene', 'extractSlides'],
           },
         },
       },
@@ -647,7 +653,7 @@ export class VideoTranscription implements INodeType {
 
           // Step 2: Query the cache with the operation prompt
           const prompt = getPromptForOperation(
-            operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene',
+            operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene' | 'extractSlides',
             {
               language: outputLanguage,
               customInstructions: options.customInstructions,
@@ -696,7 +702,7 @@ export class VideoTranscription implements INodeType {
 
             // Build prompt with chunking instructions
             const prompt = getPromptForOperation(
-              operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene',
+              operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene' | 'extractSlides',
               {
                 language: outputLanguage,
                 chunkIndex,
@@ -733,7 +739,7 @@ export class VideoTranscription implements INodeType {
         } else {
           // Single video processing (direct, no cache)
           const prompt = getPromptForOperation(
-            operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene',
+            operation as 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene' | 'extractSlides',
             {
               language: outputLanguage,
               customInstructions: options.customInstructions,

--- a/custom-nodes/n8n-nodes-video-transcription/shared/videoTranscriptionPrompts.ts
+++ b/custom-nodes/n8n-nodes-video-transcription/shared/videoTranscriptionPrompts.ts
@@ -162,6 +162,69 @@ Return a JSON object with this structure:
 }`;
 
 /**
+ * Slide extraction prompt - detects and extracts slide/presentation metadata
+ */
+export const EXTRACT_SLIDES_PROMPT = `**Task - Slide/Presentation Detection**
+
+Analyze this video to identify each distinct slide or presentation screen change.
+
+**Instructions:**
+- Detect every slide transition or significant presentation change
+- Do NOT include minor animations within the same slide
+- For each slide, extract metadata including title and key points
+- Provide precise timestamps in milliseconds for frame extraction
+- If the slide/presentation is not fullscreen, provide bounding box coordinates
+
+**Output Format:**
+Return a JSON object with this structure:
+{
+  "slides": [
+    {
+      "id": 1,
+      "timestamp_ms": 15000,
+      "timestamp": "00:00:15",
+      "title": "Main title or heading visible on the slide",
+      "key_points": ["Bullet point 1", "Bullet point 2", "Key text visible"],
+      "type": "slide",
+      "description": "Brief description of slide content",
+      "bounding_box": null
+    },
+    {
+      "id": 2,
+      "timestamp_ms": 145000,
+      "timestamp": "00:02:25",
+      "title": "Next Slide Title",
+      "key_points": ["Point A", "Point B"],
+      "type": "chart",
+      "description": "Bar chart showing Q4 results",
+      "bounding_box": [100, 50, 900, 700]
+    }
+  ],
+  "metadata": {
+    "total_slides": 10,
+    "video_duration": "45:00",
+    "slide_types_found": ["slide", "chart", "diagram", "demo"],
+    "presentation_title": "Detected presentation title if visible",
+    "presenter": "Name if identified or null"
+  }
+}
+
+**Field Definitions:**
+- id: Sequential slide number (1, 2, 3, ...)
+- timestamp_ms: Milliseconds from video start when slide FIRST appears
+- timestamp: Same time in HH:MM:SS format
+- title: Main heading/title text on the slide
+- key_points: Array of bullet points or key text visible
+- type: One of: "slide", "title_slide", "chart", "diagram", "table", "demo", "code", "image", "video", "other"
+- description: Brief description of the visual content
+- bounding_box: [ymin, xmin, ymax, xmax] in 0-1000 scale if slide is NOT fullscreen, null if fullscreen
+
+**Important:**
+- Only include actual slide CHANGES, not every frame
+- Be precise with timestamps - they will be used for frame extraction
+- If no slides/presentation content is found, return empty slides array`;
+
+/**
  * Chunking instructions - appended when processing long videos
  */
 export const CHUNKING_INSTRUCTIONS = (chunkIndex: number, totalChunks: number, startTime: string) => `
@@ -212,7 +275,7 @@ export const LANGUAGE_INSTRUCTIONS: Record<string, string> = {
  * Get the appropriate prompt for an operation
  */
 export function getPromptForOperation(
-  operation: 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene',
+  operation: 'transcribe' | 'identifySpeakers' | 'extractOcr' | 'analyzeScene' | 'extractSlides',
   options: {
     language?: string;
     chunkIndex?: number;
@@ -237,6 +300,9 @@ export function getPromptForOperation(
       break;
     case 'analyzeScene':
       basePrompt = SCENE_ANALYSIS_PROMPT;
+      break;
+    case 'extractSlides':
+      basePrompt = EXTRACT_SLIDES_PROMPT;
       break;
     default:
       throw new Error(`Unknown operation: ${operation}`);

--- a/docs/n8n/video-transcription-mcp-server.md
+++ b/docs/n8n/video-transcription-mcp-server.md
@@ -24,7 +24,7 @@ Ce workflow transcrit et analyse des vidéos (YouTube, URL directes) en utilisan
 
 | Paramètre | Type | Défaut | Description |
 |-----------|------|--------|-------------|
-| `operation` | string | `"transcribe"` | Opération à effectuer (voir ci-dessous): `transcribe`, `identifySpeakers`, `extractOcr`, `analyzeScene`, `createCache`, `queryCache`, `deleteCache`, `listCaches` |
+| `operation` | string | `"transcribe"` | Opération à effectuer: `transcribe`, `identifySpeakers`, `extractOcr`, `analyzeScene`, `extractSlides`, `createCache`, `queryCache`, `deleteCache`, `listCaches` |
 | `language` | string | `"auto"` | Langue de sortie: `"auto"`, `"en"`, `"fr"`, `"es"`, `"de"`, `"it"`, `"pt"` |
 
 ### Options de chunking (pour vidéos longues)
@@ -184,6 +184,57 @@ Analyse complète : transcription, locuteurs, OCR et description des scènes.
   }
 }
 ```
+
+### `extractSlides`
+Détecte et extrait les métadonnées des slides/présentations avec timestamps précis.
+
+**Sortie:**
+```json
+{
+  "slides": [
+    {
+      "id": 1,
+      "timestamp_ms": 15000,
+      "timestamp": "00:00:15",
+      "title": "Introduction",
+      "key_points": ["Point 1", "Point 2"],
+      "type": "slide",
+      "description": "Title slide with company logo",
+      "bounding_box": null
+    },
+    {
+      "id": 2,
+      "timestamp_ms": 145000,
+      "timestamp": "00:02:25",
+      "title": "Résultats Q4",
+      "key_points": ["CA +15%", "Marge 12%"],
+      "type": "chart",
+      "description": "Bar chart showing quarterly results",
+      "bounding_box": [100, 50, 900, 700]
+    }
+  ],
+  "metadata": {
+    "total_slides": 10,
+    "video_duration": "45:00",
+    "slide_types_found": ["slide", "chart", "diagram"],
+    "presentation_title": "Rapport Annuel 2025",
+    "presenter": "Jean Dupont"
+  }
+}
+```
+
+**Types de slides détectés:**
+- `slide` - Slide de présentation classique
+- `title_slide` - Slide de titre
+- `chart` - Graphique
+- `diagram` - Diagramme
+- `table` - Tableau
+- `demo` - Démonstration
+- `code` - Code source
+- `image` - Image plein écran
+- `video` - Vidéo intégrée
+
+**Note:** Les timestamps en millisecondes (`timestamp_ms`) peuvent être utilisés avec la Cloud Function `extract-slides` pour extraire les images des slides.
 
 ## Opérations de cache
 
@@ -381,6 +432,38 @@ curl -X POST http://localhost:5678/webhook/video-transcription \
     "operation": "transcribe",
     "endTime": "3:00"
   }'
+```
+
+### Extraire les slides d'une présentation
+
+```bash
+curl -X POST http://localhost:5678/webhook/video-transcription \
+  -H "Content-Type: application/json" \
+  -d '{
+    "videoUrl": "https://example.com/presentation.mp4",
+    "operation": "extractSlides"
+  }'
+```
+
+### Extraire les slides puis les images (avec Cloud Function)
+
+```bash
+# Étape 1: Extraire les métadonnées des slides
+SLIDES=$(curl -s -X POST http://localhost:5678/webhook/video-transcription \
+  -H "Content-Type: application/json" \
+  -d '{
+    "videoUrl": "https://example.com/presentation.mp4",
+    "operation": "extractSlides"
+  }')
+
+# Étape 2: Extraire les images via Cloud Function
+curl -X POST https://REGION-PROJECT_ID.cloudfunctions.net/extract-slides \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"video_url\": \"https://example.com/presentation.mp4\",
+    \"slides\": $(echo $SLIDES | jq '.slides'),
+    \"output\": {\"type\": \"base64\"}
+  }"
 ```
 
 ### Créer un cache pour une vidéo
@@ -622,6 +705,78 @@ Les paramètres `startTime` et `endTime` permettent de limiter la transcription 
 }
 ```
 
+## Cloud Function: extract-slides
+
+Une Cloud Function GCP est disponible pour extraire les images des slides à partir des timestamps retournés par `extractSlides`.
+
+### Architecture
+
+```
+┌─────────────────┐      JSON        ┌─────────────────────┐      Images
+│  n8n + Gemini   │  ─────────────►  │  GCP Cloud Function │  ─────────►  Base64 / GCS
+│  (extractSlides)│   timestamps     │  (ffmpeg/OpenCV)    │
+└─────────────────┘                  └─────────────────────┘
+```
+
+### Endpoint
+
+```
+POST https://REGION-PROJECT_ID.cloudfunctions.net/extract-slides
+```
+
+### Input
+
+```json
+{
+  "video_url": "https://example.com/video.mp4",
+  "slides": [
+    {"id": 1, "timestamp_ms": 15000, "title": "Introduction"},
+    {"id": 2, "timestamp_ms": 145000, "title": "Résultats"}
+  ],
+  "output": {
+    "type": "base64",
+    "bucket": "my-bucket",
+    "prefix": "slides/"
+  }
+}
+```
+
+### Output
+
+```json
+{
+  "success": true,
+  "total_slides": 2,
+  "extracted": 2,
+  "failed": 0,
+  "images": [
+    {
+      "slide_id": 1,
+      "title": "Introduction",
+      "timestamp_ms": 15000,
+      "image_base64": "...",
+      "status": "success"
+    }
+  ]
+}
+```
+
+### Déploiement
+
+```bash
+cd cloud-functions/extract-slides
+export GCP_PROJECT_ID=your-project-id
+export GCP_REGION=europe-west1
+./deploy.sh
+```
+
+### Coût estimé
+
+| Usage | Coût |
+|-------|------|
+| Cloud Function (512MB, 120s) | ~$0.000005/invocation |
+| 100 vidéos/mois | < $1 |
+
 ## Limitations
 
 - Les vidéos protégées par DRM ne sont pas supportées
@@ -629,8 +784,10 @@ Les paramètres `startTime` et `endTime` permettent de limiter la transcription 
 - La qualité de la transcription dépend de la qualité audio
 - L'identification des locuteurs fonctionne mieux avec des voix distinctes
 - L'OCR nécessite un texte suffisamment lisible à l'écran
+- `extractSlides` fonctionne mieux avec des présentations claires (PowerPoint, Keynote, Google Slides)
 
 ## Voir aussi
 
 - [Knowledge Graph MCP Server API](./knowledge-graph-mcp-server.md)
 - [Guide de Test](./TESTING_GUIDE.md)
+- [Cloud Function extract-slides](../../cloud-functions/extract-slides/)

--- a/scripts/test/extract_presentation.sh
+++ b/scripts/test/extract_presentation.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# =============================================================================
+# Extract Presentation - Complete extraction pipeline
+# =============================================================================
+#
+# This script performs a complete extraction from a video:
+#   1. Transcribes the video (via n8n webhook)
+#   2. Extracts slides metadata (via n8n webhook)
+#   3. Extracts slide images (via remote server)
+#
+# Usage:
+#   ./scripts/test/extract_presentation.sh <video_url> [output_dir] [save_video_dir]
+#
+# Examples:
+#   ./scripts/test/extract_presentation.sh "https://youtube.com/watch?v=abc123"
+#   ./scripts/test/extract_presentation.sh "https://youtube.com/watch?v=abc123" docs/test/my_presentation
+#   ./scripts/test/extract_presentation.sh "https://youtube.com/watch?v=abc123" docs/test/my_presentation docs/test/videos
+#
+# =============================================================================
+
+set -e
+
+# === CONFIGURATION ===
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Load from .env.local at project root if exists
+if [ -f "${PROJECT_ROOT}/.env.local" ]; then
+    source "${PROJECT_ROOT}/.env.local"
+fi
+
+# Defaults
+N8N_WEBHOOK_URL="${N8N_WEBHOOK_URL:-http://localhost:5678/webhook/video-transcription}"
+EXTRACT_SERVER="${EXTRACT_SERVER:-user@your-server.com}"
+SSH_PORT="${SSH_PORT:-2222}"
+REMOTE_DIR="${REMOTE_DIR:-~/extract-slides}"
+DEFAULT_OUTPUT_DIR="docs/test"
+
+# SSH/SCP options
+SSH_OPTS="-p ${SSH_PORT}"
+SCP_OPTS="-P ${SSH_PORT}"
+# =====================
+
+# === FUNCTIONS ===
+
+extract_video_id() {
+    local url="$1"
+    # Extract video ID from various YouTube URL formats
+    if [[ "$url" =~ youtube\.com.*v=([a-zA-Z0-9_-]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    elif [[ "$url" =~ youtu\.be/([a-zA-Z0-9_-]+) ]]; then
+        echo "${BASH_REMATCH[1]}"
+    else
+        # Return hash of URL for non-YouTube videos
+        echo "$url" | md5sum | cut -c1-11
+    fi
+}
+
+call_n8n_webhook() {
+    local operation="$1"
+    local video_url="$2"
+    local output_file="$3"
+
+    echo "Calling n8n webhook: $operation"
+
+    local response=$(curl -s -X POST "$N8N_WEBHOOK_URL" \
+        -H "Content-Type: application/json" \
+        -d "{\"operation\": \"$operation\", \"videoUrl\": \"$video_url\"}" \
+        --max-time 600)
+
+    if [ -z "$response" ]; then
+        echo "Error: Empty response from n8n webhook"
+        return 1
+    fi
+
+    echo "$response" > "$output_file"
+    echo "  -> Saved to: $output_file"
+}
+
+extract_slides_remote() {
+    local metadata_file="$1"
+    local video_url="$2"
+    local output_dir="$3"
+    local save_video_dir="$4"
+
+    local metadata_filename=$(basename "$metadata_file")
+    local remote_metadata="${REMOTE_DIR}/${metadata_filename}"
+    local remote_output="${REMOTE_DIR}/output"
+
+    # Step 1: Copy metadata to server
+    echo "  Copying metadata to server..."
+    scp ${SCP_OPTS} "$metadata_file" "${EXTRACT_SERVER}:${remote_metadata}"
+
+    # Step 2: Run extraction on server
+    echo "  Running extraction on server..."
+    local save_video_opt=""
+    if [ -n "$save_video_dir" ]; then
+        save_video_opt="--save-video video/"
+    fi
+    ssh ${SSH_OPTS} "$EXTRACT_SERVER" "cd ${REMOTE_DIR} && source .venv/bin/activate && python extract_frames.py --metadata '${metadata_filename}' --video '${video_url}' -o output/ ${save_video_opt}"
+
+    # Step 3: Copy images back
+    echo "  Copying images back..."
+    mkdir -p "$output_dir"
+    scp ${SCP_OPTS} -r "${EXTRACT_SERVER}:${remote_output}/*.jpg" "$output_dir/" 2>/dev/null || echo "  No images found"
+
+    # Step 4: Copy video if requested
+    if [ -n "$save_video_dir" ]; then
+        echo "  Copying video back..."
+        mkdir -p "$save_video_dir"
+        scp ${SCP_OPTS} -r "${EXTRACT_SERVER}:${REMOTE_DIR}/video/*" "$save_video_dir/" 2>/dev/null || echo "  No video found"
+    fi
+
+    # Cleanup remote
+    ssh ${SSH_OPTS} "$EXTRACT_SERVER" "rm -rf ${remote_output}/* ${remote_metadata} ${REMOTE_DIR}/video/* 2>/dev/null || true"
+}
+
+# === MAIN ===
+
+VIDEO_URL="$1"
+OUTPUT_DIR="${2:-}"
+SAVE_VIDEO_DIR="${3:-}"
+
+if [ -z "$VIDEO_URL" ]; then
+    echo "Usage: $0 <video_url> [output_dir] [save_video_dir]"
+    echo ""
+    echo "This script performs a complete presentation extraction:"
+    echo "  1. Transcribes the video"
+    echo "  2. Extracts slides metadata (timestamps, titles, bounding boxes)"
+    echo "  3. Extracts slide images via remote server"
+    echo ""
+    echo "Arguments:"
+    echo "  video_url       - YouTube or direct video URL"
+    echo "  output_dir      - Output directory (default: docs/test/<video_id>)"
+    echo "  save_video_dir  - Directory to save video (optional)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 'https://youtube.com/watch?v=abc123'"
+    echo "  $0 'https://youtube.com/watch?v=abc123' docs/test/my_presentation"
+    echo "  $0 'https://youtube.com/watch?v=abc123' docs/test/my_presentation docs/test/videos"
+    exit 1
+fi
+
+# Extract video ID
+VIDEO_ID=$(extract_video_id "$VIDEO_URL")
+echo "Video ID: $VIDEO_ID"
+
+# Set output directory
+if [ -z "$OUTPUT_DIR" ]; then
+    OUTPUT_DIR="${DEFAULT_OUTPUT_DIR}/${VIDEO_ID}"
+fi
+mkdir -p "$OUTPUT_DIR"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+TRANSCRIPT_FILE="${OUTPUT_DIR}/transcript_${VIDEO_ID}_${TIMESTAMP}.json"
+SLIDES_FILE="${OUTPUT_DIR}/slides_${VIDEO_ID}_${TIMESTAMP}.json"
+IMAGES_DIR="${OUTPUT_DIR}/images"
+
+echo ""
+echo "=============================================="
+echo "  PRESENTATION EXTRACTION PIPELINE"
+echo "=============================================="
+echo "Video URL:    $VIDEO_URL"
+echo "Video ID:     $VIDEO_ID"
+echo "Output:       $OUTPUT_DIR"
+if [ -n "$SAVE_VIDEO_DIR" ]; then
+    echo "Save video:   $SAVE_VIDEO_DIR"
+fi
+echo "=============================================="
+echo ""
+
+# === STEP 1: TRANSCRIPT ===
+echo "[1/3] Extracting transcript..."
+START_TIME=$(date +%s)
+call_n8n_webhook "transcribe" "$VIDEO_URL" "$TRANSCRIPT_FILE"
+END_TIME=$(date +%s)
+echo "  -> Completed in $((END_TIME - START_TIME))s"
+echo ""
+
+# === STEP 2: SLIDES METADATA ===
+echo "[2/3] Extracting slides metadata..."
+START_TIME=$(date +%s)
+call_n8n_webhook "extractSlides" "$VIDEO_URL" "$SLIDES_FILE"
+END_TIME=$(date +%s)
+echo "  -> Completed in $((END_TIME - START_TIME))s"
+
+# Check if slides were found
+SLIDES_COUNT=$(cat "$SLIDES_FILE" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('slides', [])))" 2>/dev/null || echo "0")
+echo "  -> Found $SLIDES_COUNT slides"
+echo ""
+
+# === STEP 3: SLIDE IMAGES ===
+if [ "$SLIDES_COUNT" -gt 0 ]; then
+    echo "[3/3] Extracting slide images via remote server..."
+    START_TIME=$(date +%s)
+    mkdir -p "$IMAGES_DIR"
+    extract_slides_remote "$SLIDES_FILE" "$VIDEO_URL" "$IMAGES_DIR" "$SAVE_VIDEO_DIR"
+    END_TIME=$(date +%s)
+    echo "  -> Completed in $((END_TIME - START_TIME))s"
+
+    IMAGES_COUNT=$(ls -1 "$IMAGES_DIR"/*.jpg 2>/dev/null | wc -l || echo "0")
+    echo "  -> Extracted $IMAGES_COUNT images"
+else
+    echo "[3/3] Skipping image extraction (no slides found)"
+fi
+echo ""
+
+# === SUMMARY ===
+echo "=============================================="
+echo "  EXTRACTION COMPLETE"
+echo "=============================================="
+echo "Transcript:   $TRANSCRIPT_FILE"
+echo "Slides meta:  $SLIDES_FILE"
+echo "Images:       $IMAGES_DIR/ ($IMAGES_COUNT files)"
+if [ -n "$SAVE_VIDEO_DIR" ]; then
+    echo "Video:        $SAVE_VIDEO_DIR/"
+fi
+echo ""
+echo "Total files:"
+ls -la "$OUTPUT_DIR"/ 2>/dev/null | tail -n +2
+echo "=============================================="

--- a/scripts/test/extract_slides_remote.sh
+++ b/scripts/test/extract_slides_remote.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Extract slide images via remote server
+#
+# Usage:
+#   ./extract_slides_remote.sh <metadata_json> <video_url> [output_dir]
+#
+# Example:
+#   ./extract_slides_remote.sh docs/test/slides_VIDEO_ID.json "https://youtube.com/..." docs/test/presentation/
+#
+# Configuration:
+#   Set EXTRACT_SERVER environment variable or edit below
+
+# === CONFIGURATION ===
+# Load from .env.local at project root if exists
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+if [ -f "${PROJECT_ROOT}/.env.local" ]; then
+    source "${PROJECT_ROOT}/.env.local"
+fi
+
+EXTRACT_SERVER="${EXTRACT_SERVER:-user@your-server.com}"
+REMOTE_DIR="${REMOTE_DIR:-~/extract-slides}"
+SSH_PORT="${SSH_PORT:-2222}"
+# =====================
+
+# SSH/SCP options with port
+SSH_OPTS="-p ${SSH_PORT}"
+SCP_OPTS="-P ${SSH_PORT}"
+
+set -e
+
+# Arguments
+METADATA_JSON="$1"
+VIDEO_URL="$2"
+OUTPUT_DIR="${3:-docs/test/slide_images}"
+SAVE_VIDEO_DIR="${4:-}"
+
+if [ -z "$METADATA_JSON" ] || [ -z "$VIDEO_URL" ]; then
+    echo "Usage: $0 <metadata_json> <video_url> [output_dir] [save_video_dir]"
+    echo ""
+    echo "Arguments:"
+    echo "  metadata_json   - Path to slides metadata JSON"
+    echo "  video_url       - YouTube or direct video URL"
+    echo "  output_dir      - Local directory for extracted images (default: docs/test/slide_images)"
+    echo "  save_video_dir  - Local directory to save downloaded video (optional)"
+    echo ""
+    echo "Example:"
+    echo "  $0 docs/test/slides_abc123.json 'https://youtube.com/watch?v=abc123'"
+    echo "  $0 docs/test/slides_abc123.json 'https://youtube.com/watch?v=abc123' docs/test/slides/ docs/test/videos/"
+    echo ""
+    echo "Environment variables:"
+    echo "  EXTRACT_SERVER  - SSH server (default: user@your-server.com)"
+    echo "  SSH_PORT        - SSH port (default: 2222)"
+    echo "  REMOTE_DIR      - Remote working directory (default: ~/extract-slides)"
+    exit 1
+fi
+
+# Check if metadata file exists
+if [ ! -f "$METADATA_JSON" ]; then
+    echo "Error: Metadata file not found: $METADATA_JSON"
+    exit 1
+fi
+
+METADATA_FILENAME=$(basename "$METADATA_JSON")
+REMOTE_METADATA="${REMOTE_DIR}/${METADATA_FILENAME}"
+REMOTE_OUTPUT="${REMOTE_DIR}/output"
+
+echo "=== Extract Slides Remote ==="
+echo "Server: $EXTRACT_SERVER (port $SSH_PORT)"
+echo "Metadata: $METADATA_JSON"
+echo "Video: $VIDEO_URL"
+echo "Output: $OUTPUT_DIR"
+if [ -n "$SAVE_VIDEO_DIR" ]; then
+    echo "Save video: $SAVE_VIDEO_DIR"
+fi
+echo "============================="
+echo ""
+
+# Step 1: Copy metadata to server
+echo "[1/4] Copying metadata to server..."
+scp ${SCP_OPTS} "$METADATA_JSON" "${EXTRACT_SERVER}:${REMOTE_METADATA}"
+
+# Step 2: Run extraction on server
+echo "[2/4] Running extraction on server..."
+SAVE_VIDEO_OPT=""
+if [ -n "$SAVE_VIDEO_DIR" ]; then
+    SAVE_VIDEO_OPT="--save-video video/"
+fi
+ssh ${SSH_OPTS} "$EXTRACT_SERVER" "cd ${REMOTE_DIR} && source .venv/bin/activate && python extract_frames.py --metadata '${METADATA_FILENAME}' --video '${VIDEO_URL}' -o output/ ${SAVE_VIDEO_OPT}"
+
+# Step 3: Create local output directory
+echo "[3/4] Creating output directory..."
+mkdir -p "$OUTPUT_DIR"
+
+# Step 4: Copy results back
+echo "[4/5] Copying images back..."
+scp ${SCP_OPTS} -r "${EXTRACT_SERVER}:${REMOTE_OUTPUT}/*.jpg" "$OUTPUT_DIR/"
+
+# Step 5: Copy video if requested
+if [ -n "$SAVE_VIDEO_DIR" ]; then
+    echo "[5/5] Copying video back..."
+    mkdir -p "$SAVE_VIDEO_DIR"
+    scp ${SCP_OPTS} -r "${EXTRACT_SERVER}:${REMOTE_DIR}/video/*" "$SAVE_VIDEO_DIR/"
+fi
+
+# Cleanup remote
+echo "Cleaning up remote..."
+ssh ${SSH_OPTS} "$EXTRACT_SERVER" "rm -rf ${REMOTE_OUTPUT}/* ${REMOTE_METADATA} ${REMOTE_DIR}/video/* 2>/dev/null || true"
+
+# Summary
+echo ""
+echo "=== Done ==="
+echo "Images saved to: $OUTPUT_DIR"
+ls -la "$OUTPUT_DIR"/*.jpg 2>/dev/null | wc -l | xargs echo "Total images:"
+if [ -n "$SAVE_VIDEO_DIR" ]; then
+    echo "Video saved to: $SAVE_VIDEO_DIR"
+    ls -la "$SAVE_VIDEO_DIR"/* 2>/dev/null
+fi

--- a/scripts/test/test_extract_slide_images.py
+++ b/scripts/test/test_extract_slide_images.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Extract actual slide images using the GCP Cloud Function.
+
+This script takes the metadata output from test_extract_slides.py and
+calls the Cloud Function to extract the actual frames from the video.
+
+Usage:
+    python scripts/test/test_extract_slide_images.py <metadata_json> <video_url>
+
+Examples:
+    # Extract images from metadata file
+    python scripts/test/test_extract_slide_images.py docs/test/slides_VIDEO_ID_20251212.json "https://..."
+
+    # Save images to specific directory
+    python scripts/test/test_extract_slide_images.py metadata.json "https://..." -o docs/test/slides/
+
+    # Get base64 output instead of saving files
+    python scripts/test/test_extract_slide_images.py metadata.json "https://..." --base64
+"""
+
+import argparse
+import json
+import requests
+import os
+import base64
+import time
+from pathlib import Path
+from datetime import datetime
+
+# Configuration
+CLOUD_FUNCTION_URL = os.getenv(
+    'EXTRACT_SLIDES_FUNCTION_URL',
+    'https://europe-west1-n8n-genai-480909.cloudfunctions.net/extract-slides'
+)
+
+
+def get_auth_token() -> str:
+    """Get GCP identity token for authenticated Cloud Function calls."""
+    import subprocess
+    try:
+        result = subprocess.run(
+            ['gcloud', 'auth', 'print-identity-token'],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to get auth token: {e.stderr}")
+    except FileNotFoundError:
+        raise RuntimeError("gcloud CLI not found. Please install Google Cloud SDK.")
+
+
+def load_metadata(json_path: str) -> dict:
+    """Load slides metadata from JSON file."""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def call_cloud_function(video_url: str, slides: list, output_type: str = 'base64',
+                        bucket: str = None, prefix: str = '') -> dict:
+    """Call the extract-slides Cloud Function."""
+
+    # Get auth token
+    token = get_auth_token()
+
+    # Build payload
+    payload = {
+        'video_url': video_url,
+        'slides': slides,
+        'output': {
+            'type': output_type
+        }
+    }
+
+    if output_type == 'gcs' and bucket:
+        payload['output']['bucket'] = bucket
+        payload['output']['prefix'] = prefix
+
+    print(f"Calling Cloud Function: {CLOUD_FUNCTION_URL}")
+    print(f"Slides to extract: {len(slides)}")
+    print("-" * 50)
+
+    response = requests.post(
+        CLOUD_FUNCTION_URL,
+        json=payload,
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {token}'
+        },
+        timeout=300  # 5 minutes
+    )
+
+    response.raise_for_status()
+    return response.json()
+
+
+def save_images(images: list, output_dir: str) -> list:
+    """Save base64 images to files."""
+    os.makedirs(output_dir, exist_ok=True)
+    saved_files = []
+
+    for img in images:
+        if img.get('status') != 'success' or 'image_base64' not in img:
+            continue
+
+        slide_id = img.get('slide_id', 0)
+        title = img.get('title', f'slide_{slide_id}')
+        # Sanitize filename
+        safe_title = "".join(c if c.isalnum() or c in ' -_' else '_' for c in title)[:50]
+
+        filename = f"slide_{slide_id:03d}_{safe_title}.jpg"
+        filepath = os.path.join(output_dir, filename)
+
+        # Decode and save
+        image_data = base64.b64decode(img['image_base64'])
+        with open(filepath, 'wb') as f:
+            f.write(image_data)
+
+        saved_files.append({
+            'slide_id': slide_id,
+            'title': title,
+            'file': filepath,
+            'size_kb': len(image_data) / 1024
+        })
+        print(f"  Saved: {filename} ({len(image_data) / 1024:.1f} KB)")
+
+    return saved_files
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Extract slide images using GCP Cloud Function',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument(
+        'metadata_json',
+        help='Path to slides metadata JSON (output from test_extract_slides.py)'
+    )
+
+    parser.add_argument(
+        'video_url',
+        nargs='?',
+        help='Video URL (if not in metadata, or to override)'
+    )
+
+    parser.add_argument(
+        '-o', '--output',
+        dest='output_dir',
+        default='docs/test/slide_images',
+        help='Output directory for images (default: docs/test/slide_images)'
+    )
+
+    parser.add_argument(
+        '--base64',
+        action='store_true',
+        help='Return base64 data instead of saving files'
+    )
+
+    parser.add_argument(
+        '--gcs',
+        metavar='BUCKET',
+        help='Upload to GCS bucket instead of returning base64'
+    )
+
+    parser.add_argument(
+        '--prefix',
+        default='slides/',
+        help='GCS prefix for uploaded files (default: slides/)'
+    )
+
+    parser.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        help='Quiet mode - minimal output'
+    )
+
+    args = parser.parse_args()
+
+    # Load metadata
+    if not os.path.exists(args.metadata_json):
+        print(f"Error: Metadata file not found: {args.metadata_json}")
+        return 1
+
+    metadata = load_metadata(args.metadata_json)
+
+    # Get slides
+    slides = metadata.get('slides', [])
+    if not slides:
+        print("Error: No slides found in metadata")
+        return 1
+
+    # Get video URL
+    video_url = args.video_url
+    if not video_url:
+        # Try to get from metadata
+        video_url = metadata.get('_execution', {}).get('video_source')
+        if not video_url:
+            video_url = metadata.get('metadata', {}).get('source')
+
+    if not video_url:
+        print("Error: No video URL provided and not found in metadata")
+        print("Please provide the video URL as second argument")
+        return 1
+
+    if not args.quiet:
+        print(f"Metadata file: {args.metadata_json}")
+        print(f"Video URL: {video_url}")
+        print(f"Slides to extract: {len(slides)}")
+
+    # Prepare slides data for Cloud Function
+    slides_data = []
+    for slide in slides:
+        slides_data.append({
+            'id': slide.get('id'),
+            'timestamp_ms': slide.get('timestamp_ms', 0),
+            'title': slide.get('title', ''),
+            'bounding_box': slide.get('bounding_box')
+        })
+
+    try:
+        # Track time
+        start_time = time.time()
+
+        # Determine output type
+        if args.gcs:
+            output_type = 'gcs'
+        else:
+            output_type = 'base64'
+
+        # Call Cloud Function
+        result = call_cloud_function(
+            video_url=video_url,
+            slides=slides_data,
+            output_type=output_type,
+            bucket=args.gcs,
+            prefix=args.prefix
+        )
+
+        elapsed_time = time.time() - start_time
+
+        if not args.quiet:
+            print(f"\nCloud Function response:")
+            print(f"  Success: {result.get('success')}")
+            print(f"  Extracted: {result.get('extracted', 0)}/{result.get('total_slides', 0)}")
+            if result.get('failed', 0) > 0:
+                print(f"  Failed: {result.get('failed')}")
+
+        # Handle output
+        images = result.get('images', [])
+
+        if args.base64:
+            # Just output JSON
+            print(json.dumps(result, indent=2))
+        elif args.gcs:
+            # Show GCS URLs
+            print("\nUploaded to GCS:")
+            for img in images:
+                if img.get('status') == 'success':
+                    print(f"  Slide {img.get('slide_id')}: {img.get('url')}")
+        else:
+            # Save images locally
+            print(f"\nSaving images to: {args.output_dir}")
+            saved = save_images(images, args.output_dir)
+            print(f"\nSaved {len(saved)} images")
+
+        # Summary
+        if not args.quiet:
+            print(f"\nExecution time: {int(elapsed_time // 60)}m {int(elapsed_time % 60)}s ({elapsed_time:.2f}s)")
+
+        return 0
+
+    except requests.exceptions.HTTPError as e:
+        print(f"Error: HTTP {e.response.status_code}")
+        try:
+            error_detail = e.response.json()
+            print(json.dumps(error_detail, indent=2))
+        except:
+            print(e.response.text)
+        return 1
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/scripts/test/test_extract_slides.py
+++ b/scripts/test/test_extract_slides.py
@@ -2,29 +2,33 @@
 """
 Test script for extractSlides operation.
 
-Usage:
-    python scripts/test/test_extract_slides.py <video_url>
-    python scripts/test/test_extract_slides.py https://www.youtube.com/watch?v=VIDEO_ID
-    python scripts/test/test_extract_slides.py /path/to/local/presentation.mp4
-
 Examples:
-    # YouTube presentation
-    python scripts/test/test_extract_slides.py "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    # Extract slides metadata from YouTube presentation
+    python scripts/test/test_extract_slides.py "https://www.youtube.com/watch?v=VIDEO_ID"
 
-    # Local file
-    python scripts/test/test_extract_slides.py "/home/user/presentation.mp4"
+    # Extract slides from local file
+    python scripts/test/test_extract_slides.py /path/to/presentation.mp4
+
+    # Custom output file
+    python scripts/test/test_extract_slides.py "https://youtu.be/VIDEO_ID" -f docs/test/my_slides.json
+
+    # Quiet mode (JSON only)
+    python scripts/test/test_extract_slides.py "https://youtu.be/VIDEO_ID" -q
 """
 
-import sys
+import argparse
 import json
 import requests
 import os
 import base64
+import time
 from pathlib import Path
 from urllib.parse import urlparse
+from datetime import datetime
 
 # Configuration
-N8N_WEBHOOK_URL = os.getenv('N8N_WEBHOOK_URL', 'http://localhost:5678/webhook/video-transcription')
+DEFAULT_WEBHOOK_URL = 'http://localhost:5678/webhook/video-transcription'
+DEFAULT_OUTPUT_DIR = 'docs/test'
 
 
 def is_local_file(path: str) -> bool:
@@ -40,6 +44,21 @@ def is_valid_video_source(source: str) -> bool:
     if parsed.scheme in ('http', 'https') and parsed.netloc:
         return True
     return False
+
+
+def get_video_id(url: str) -> str:
+    """Extract video ID from YouTube URL or return filename."""
+    if is_local_file(url):
+        return Path(url).stem
+
+    parsed = urlparse(url)
+    if 'youtube.com' in parsed.netloc:
+        from urllib.parse import parse_qs
+        params = parse_qs(parsed.query)
+        return params.get('v', ['unknown'])[0]
+    elif 'youtu.be' in parsed.netloc:
+        return parsed.path.strip('/')
+    return 'video'
 
 
 def load_video_as_base64(file_path: str) -> tuple[str, str]:
@@ -63,30 +82,33 @@ def load_video_as_base64(file_path: str) -> tuple[str, str]:
     return data, mime_type
 
 
-def call_extract_slides(video_source: str) -> dict:
+def call_extract_slides(video_source: str, webhook_url: str, quiet: bool = False) -> dict:
     """Call the extractSlides operation via n8n webhook."""
 
     if is_local_file(video_source):
-        print(f"Loading local file: {video_source}")
+        if not quiet:
+            print(f"Loading local file: {video_source}")
         video_base64, mime_type = load_video_as_base64(video_source)
         payload = {
             'operation': 'extractSlides',
             'videoBase64': video_base64,
             'videoMimeType': mime_type,
         }
-        print(f"File size: {len(video_base64) / 1024 / 1024:.2f} MB (base64)")
+        if not quiet:
+            print(f"File size: {len(video_base64) / 1024 / 1024:.2f} MB (base64)")
     else:
         payload = {
             'operation': 'extractSlides',
             'videoUrl': video_source,
         }
 
-    print(f"Calling n8n webhook: {N8N_WEBHOOK_URL}")
-    print(f"Operation: extractSlides")
-    print("-" * 50)
+    if not quiet:
+        print(f"Calling n8n webhook: {webhook_url}")
+        print(f"Operation: extractSlides")
+        print("-" * 50)
 
     response = requests.post(
-        N8N_WEBHOOK_URL,
+        webhook_url,
         json=payload,
         headers={'Content-Type': 'application/json'},
         timeout=600  # 10 minutes for video processing
@@ -111,7 +133,9 @@ def print_slides_summary(result: dict):
         print(f"Presenter: {metadata.get('presenter', 'N/A')}")
         print(f"Duration: {metadata.get('video_duration', 'N/A')}")
         print(f"Total slides: {metadata.get('total_slides', len(slides))}")
-        print(f"Types found: {', '.join(metadata.get('slide_types_found', []))}")
+        slide_types = metadata.get('slide_types_found', [])
+        if slide_types:
+            print(f"Types found: {', '.join(slide_types)}")
 
     print("\n" + "-" * 60)
     print("SLIDES")
@@ -126,12 +150,15 @@ def print_slides_summary(result: dict):
         if key_points:
             print(f"  Key points:")
             for point in key_points[:5]:  # Limit to 5 points
-                print(f"    • {point}")
+                print(f"    - {point}")
             if len(key_points) > 5:
                 print(f"    ... and {len(key_points) - 5} more")
 
         if slide.get('description'):
-            print(f"  Description: {slide.get('description')}")
+            desc = slide.get('description')
+            if len(desc) > 100:
+                desc = desc[:100] + "..."
+            print(f"  Description: {desc}")
 
         if slide.get('bounding_box'):
             print(f"  Bounding box: {slide.get('bounding_box')}")
@@ -140,54 +167,113 @@ def print_slides_summary(result: dict):
 
 
 def main():
-    if len(sys.argv) < 2:
-        print(__doc__)
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description='Test extractSlides operation via n8n webhook',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
 
-    video_source = sys.argv[1]
+    parser.add_argument(
+        'video_source',
+        help='Video URL (YouTube, direct URL) or local file path'
+    )
 
-    if not is_valid_video_source(video_source):
-        print(f"Error: Invalid video source: {video_source}")
+    parser.add_argument(
+        '-f', '--file',
+        dest='output_file',
+        help=f'Output file path (default: {DEFAULT_OUTPUT_DIR}/slides_<video_id>_<timestamp>.json)'
+    )
+
+    parser.add_argument(
+        '-w', '--webhook',
+        default=os.getenv('N8N_WEBHOOK_URL', DEFAULT_WEBHOOK_URL),
+        help=f'n8n webhook URL (default: {DEFAULT_WEBHOOK_URL})'
+    )
+
+    parser.add_argument(
+        '-q', '--quiet',
+        action='store_true',
+        help='Quiet mode - only output JSON result'
+    )
+
+    args = parser.parse_args()
+
+    # Validate video source
+    if not is_valid_video_source(args.video_source):
+        print(f"Error: Invalid video source: {args.video_source}")
         print("Provide a valid URL (http/https) or local file path")
-        sys.exit(1)
+        return 1
 
-    print(f"Video source: {video_source}")
+    if not args.quiet:
+        print(f"Video source: {args.video_source}")
 
     try:
-        result = call_extract_slides(video_source)
+        # Track execution time
+        start_time = time.time()
+
+        result = call_extract_slides(args.video_source, args.webhook, args.quiet)
+
+        # Calculate elapsed time
+        elapsed_time = time.time() - start_time
+
+        # Add execution metadata to result
+        result['_execution'] = {
+            'elapsed_seconds': round(elapsed_time, 2),
+            'elapsed_formatted': f"{int(elapsed_time // 60)}m {int(elapsed_time % 60)}s",
+            'timestamp': datetime.now().isoformat(),
+            'video_source': args.video_source
+        }
+
+        # Generate output filename if not provided
+        if not args.output_file:
+            os.makedirs(DEFAULT_OUTPUT_DIR, exist_ok=True)
+            video_id = get_video_id(args.video_source)
+            timestamp_str = datetime.now().strftime('%Y%m%d_%H%M%S')
+            args.output_file = f'{DEFAULT_OUTPUT_DIR}/slides_{video_id}_{timestamp_str}.json'
 
         # Save full result to file
-        output_file = 'extract_slides_result.json'
-        with open(output_file, 'w', encoding='utf-8') as f:
+        with open(args.output_file, 'w', encoding='utf-8') as f:
             json.dump(result, f, indent=2, ensure_ascii=False)
-        print(f"\nFull result saved to: {output_file}")
 
-        # Print summary
-        print_slides_summary(result)
+        if args.quiet:
+            # Just print JSON
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        else:
+            print(f"\nFull result saved to: {args.output_file}")
 
-        # Print metadata
-        if 'metadata' in result:
-            meta = result.get('metadata', {})
-            print(f"\nProcessing metadata:")
-            print(f"  Operation: {meta.get('operation', 'N/A')}")
-            print(f"  Model: {meta.get('model', 'N/A')}")
-            print(f"  Processed at: {meta.get('processedAt', 'N/A')}")
+            # Print summary
+            print_slides_summary(result)
+
+            # Print processing metadata
+            if 'metadata' in result:
+                meta = result.get('metadata', {})
+                print(f"\nProcessing metadata:")
+                print(f"  Operation: {meta.get('operation', 'N/A')}")
+                print(f"  Model: {meta.get('model', 'N/A')}")
+                print(f"  Processed at: {meta.get('processedAt', 'N/A')}")
+
+            # Print execution time
+            print(f"\nExecution time: {result['_execution']['elapsed_formatted']} ({elapsed_time:.2f}s)")
+
+        return 0
 
     except requests.exceptions.ConnectionError:
-        print(f"Error: Cannot connect to {N8N_WEBHOOK_URL}")
+        print(f"Error: Cannot connect to {args.webhook}")
         print("Make sure n8n is running and the workflow is active")
-        sys.exit(1)
+        return 1
     except requests.exceptions.Timeout:
         print("Error: Request timed out (video processing took too long)")
-        sys.exit(1)
+        return 1
     except requests.exceptions.HTTPError as e:
         print(f"Error: HTTP {e.response.status_code}")
         print(e.response.text)
-        sys.exit(1)
+        return 1
     except Exception as e:
         print(f"Error: {e}")
-        sys.exit(1)
+        import traceback
+        traceback.print_exc()
+        return 1
 
 
 if __name__ == '__main__':
-    main()
+    exit(main())

--- a/scripts/test/test_extract_slides.py
+++ b/scripts/test/test_extract_slides.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""
+Test script for extractSlides operation.
+
+Usage:
+    python scripts/test/test_extract_slides.py <video_url>
+    python scripts/test/test_extract_slides.py https://www.youtube.com/watch?v=VIDEO_ID
+    python scripts/test/test_extract_slides.py /path/to/local/presentation.mp4
+
+Examples:
+    # YouTube presentation
+    python scripts/test/test_extract_slides.py "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    # Local file
+    python scripts/test/test_extract_slides.py "/home/user/presentation.mp4"
+"""
+
+import sys
+import json
+import requests
+import os
+import base64
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Configuration
+N8N_WEBHOOK_URL = os.getenv('N8N_WEBHOOK_URL', 'http://localhost:5678/webhook/video-transcription')
+
+
+def is_local_file(path: str) -> bool:
+    """Check if path is a local file."""
+    return os.path.isfile(path)
+
+
+def is_valid_video_source(source: str) -> bool:
+    """Check if source is a valid video URL or local file."""
+    if is_local_file(source):
+        return True
+    parsed = urlparse(source)
+    if parsed.scheme in ('http', 'https') and parsed.netloc:
+        return True
+    return False
+
+
+def load_video_as_base64(file_path: str) -> tuple[str, str]:
+    """Load a local video file and return base64 data with mime type."""
+    path = Path(file_path)
+
+    mime_types = {
+        '.mp4': 'video/mp4',
+        '.webm': 'video/webm',
+        '.avi': 'video/avi',
+        '.mov': 'video/quicktime',
+        '.mkv': 'video/x-matroska',
+        '.m4v': 'video/x-m4v',
+    }
+
+    mime_type = mime_types.get(path.suffix.lower(), 'video/mp4')
+
+    with open(path, 'rb') as f:
+        data = base64.b64encode(f.read()).decode('utf-8')
+
+    return data, mime_type
+
+
+def call_extract_slides(video_source: str) -> dict:
+    """Call the extractSlides operation via n8n webhook."""
+
+    if is_local_file(video_source):
+        print(f"Loading local file: {video_source}")
+        video_base64, mime_type = load_video_as_base64(video_source)
+        payload = {
+            'operation': 'extractSlides',
+            'videoBase64': video_base64,
+            'videoMimeType': mime_type,
+        }
+        print(f"File size: {len(video_base64) / 1024 / 1024:.2f} MB (base64)")
+    else:
+        payload = {
+            'operation': 'extractSlides',
+            'videoUrl': video_source,
+        }
+
+    print(f"Calling n8n webhook: {N8N_WEBHOOK_URL}")
+    print(f"Operation: extractSlides")
+    print("-" * 50)
+
+    response = requests.post(
+        N8N_WEBHOOK_URL,
+        json=payload,
+        headers={'Content-Type': 'application/json'},
+        timeout=600  # 10 minutes for video processing
+    )
+
+    response.raise_for_status()
+    return response.json()
+
+
+def print_slides_summary(result: dict):
+    """Print a formatted summary of extracted slides."""
+
+    slides = result.get('slides', [])
+    metadata = result.get('metadata', {})
+
+    print("\n" + "=" * 60)
+    print("EXTRACTION RESULTS")
+    print("=" * 60)
+
+    if metadata:
+        print(f"\nPresentation: {metadata.get('presentation_title', 'N/A')}")
+        print(f"Presenter: {metadata.get('presenter', 'N/A')}")
+        print(f"Duration: {metadata.get('video_duration', 'N/A')}")
+        print(f"Total slides: {metadata.get('total_slides', len(slides))}")
+        print(f"Types found: {', '.join(metadata.get('slide_types_found', []))}")
+
+    print("\n" + "-" * 60)
+    print("SLIDES")
+    print("-" * 60)
+
+    for slide in slides:
+        print(f"\n[Slide {slide.get('id', '?')}] @ {slide.get('timestamp', 'N/A')} ({slide.get('timestamp_ms', 0)}ms)")
+        print(f"  Type: {slide.get('type', 'N/A')}")
+        print(f"  Title: {slide.get('title', 'N/A')}")
+
+        key_points = slide.get('key_points', [])
+        if key_points:
+            print(f"  Key points:")
+            for point in key_points[:5]:  # Limit to 5 points
+                print(f"    • {point}")
+            if len(key_points) > 5:
+                print(f"    ... and {len(key_points) - 5} more")
+
+        if slide.get('description'):
+            print(f"  Description: {slide.get('description')}")
+
+        if slide.get('bounding_box'):
+            print(f"  Bounding box: {slide.get('bounding_box')}")
+
+    print("\n" + "=" * 60)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    video_source = sys.argv[1]
+
+    if not is_valid_video_source(video_source):
+        print(f"Error: Invalid video source: {video_source}")
+        print("Provide a valid URL (http/https) or local file path")
+        sys.exit(1)
+
+    print(f"Video source: {video_source}")
+
+    try:
+        result = call_extract_slides(video_source)
+
+        # Save full result to file
+        output_file = 'extract_slides_result.json'
+        with open(output_file, 'w', encoding='utf-8') as f:
+            json.dump(result, f, indent=2, ensure_ascii=False)
+        print(f"\nFull result saved to: {output_file}")
+
+        # Print summary
+        print_slides_summary(result)
+
+        # Print metadata
+        if 'metadata' in result:
+            meta = result.get('metadata', {})
+            print(f"\nProcessing metadata:")
+            print(f"  Operation: {meta.get('operation', 'N/A')}")
+            print(f"  Model: {meta.get('model', 'N/A')}")
+            print(f"  Processed at: {meta.get('processedAt', 'N/A')}")
+
+    except requests.exceptions.ConnectionError:
+        print(f"Error: Cannot connect to {N8N_WEBHOOK_URL}")
+        print("Make sure n8n is running and the workflow is active")
+        sys.exit(1)
+    except requests.exceptions.Timeout:
+        print("Error: Request timed out (video processing took too long)")
+        sys.exit(1)
+    except requests.exceptions.HTTPError as e:
+        print(f"Error: HTTP {e.response.status_code}")
+        print(e.response.text)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/server-scripts/extract-slides/README.md
+++ b/server-scripts/extract-slides/README.md
@@ -1,0 +1,112 @@
+# Extract Slides Server
+
+Script pour extraire les frames de slides depuis des vidéos YouTube.
+
+## Installation sur le serveur
+
+### 1. Cloner ou copier les fichiers
+
+```bash
+# Option A: Créer le dossier et copier les fichiers
+mkdir -p ~/extract-slides
+cd ~/extract-slides
+
+# Option B: Cloner depuis le repo (si disponible)
+# git clone <repo_url> ~/extract-slides
+```
+
+### 2. Créer un environnement virtuel
+
+```bash
+cd ~/extract-slides
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 3. Installer les dépendances
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 4. Vérifier l'installation
+
+```bash
+# Vérifier yt-dlp
+yt-dlp --version
+
+# Vérifier OpenCV
+python3 -c "import cv2; print(cv2.__version__)"
+```
+
+## Utilisation
+
+### Depuis un fichier metadata (recommandé)
+
+```bash
+# Activer l'environnement
+source ~/extract-slides/.venv/bin/activate
+
+# Extraire les slides
+python extract_frames.py \
+    --metadata slides.json \
+    --video "https://www.youtube.com/watch?v=VIDEO_ID" \
+    --output ./output_slides/
+```
+
+### Avec timestamps directs
+
+```bash
+python extract_frames.py \
+    --video "https://www.youtube.com/watch?v=VIDEO_ID" \
+    --timestamps "15000,45000,120000,180000" \
+    --output ./output_slides/
+```
+
+### Avec cookies navigateur (si YouTube bloque)
+
+```bash
+python extract_frames.py \
+    --metadata slides.json \
+    --video "https://www.youtube.com/watch?v=VIDEO_ID" \
+    --cookies-from-browser firefox \
+    --output ./output_slides/
+```
+
+### Output en base64 (pour API)
+
+```bash
+python extract_frames.py \
+    --metadata slides.json \
+    --video "https://www.youtube.com/watch?v=VIDEO_ID" \
+    --base64
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--video, -v` | URL vidéo (YouTube ou directe) ou fichier local |
+| `--metadata, -m` | Fichier JSON avec metadata des slides |
+| `--timestamps, -t` | Timestamps en ms séparés par virgules |
+| `--output, -o` | Dossier de sortie (défaut: ./slides) |
+| `--cookies-from-browser, -c` | Navigateur pour cookies (chrome, firefox, etc.) |
+| `--keep-video, -k` | Garder la vidéo téléchargée |
+| `--base64` | Sortie JSON avec images en base64 |
+| `--quiet, -q` | Mode silencieux |
+
+## Appel distant via SSH
+
+Depuis le Pi :
+
+```bash
+# Copier le fichier metadata
+scp docs/test/slides_VIDEO_ID.json user@server:~/extract-slides/
+
+# Exécuter l'extraction
+ssh user@server "cd ~/extract-slides && source venv/bin/activate && python extract_frames.py --metadata slides_VIDEO_ID.json --video 'https://youtube.com/...' -o output/"
+
+# Récupérer les images
+scp -r user@server:~/extract-slides/output/*.jpg docs/test/presentation/
+```

--- a/server-scripts/extract-slides/extract_frames.py
+++ b/server-scripts/extract-slides/extract_frames.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+Extract slide frames from YouTube videos.
+
+Usage:
+    # From metadata JSON file
+    python extract_frames.py --metadata slides.json --video "https://youtube.com/..." -o output/
+
+    # From direct timestamps
+    python extract_frames.py --video "https://youtube.com/..." --timestamps 15000,45000,120000 -o output/
+
+    # Keep downloaded video
+    python extract_frames.py --metadata slides.json --video "https://youtube.com/..." -o output/ --keep-video
+"""
+
+import argparse
+import json
+import os
+import sys
+import subprocess
+import tempfile
+import base64
+import cv2
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+def is_youtube_url(url: str) -> bool:
+    """Check if URL is a YouTube video."""
+    parsed = urlparse(url)
+    youtube_domains = ['youtube.com', 'www.youtube.com', 'youtu.be', 'm.youtube.com']
+    return parsed.netloc in youtube_domains
+
+
+def download_youtube_video(url: str, output_path: str, cookies_from_browser: str = None) -> str:
+    """Download YouTube video using yt-dlp."""
+    cmd = [
+        'yt-dlp',
+        '-f', 'best[height<=720]/best',
+        '-o', output_path,
+        '--no-playlist',
+        '--progress',
+    ]
+
+    # Use browser cookies if specified
+    if cookies_from_browser:
+        cmd.extend(['--cookies-from-browser', cookies_from_browser])
+
+    cmd.append(url)
+
+    print(f"Downloading video: {url}")
+    result = subprocess.run(cmd, capture_output=False, text=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(f"yt-dlp failed with code {result.returncode}")
+
+    # Find the actual downloaded file (extension may vary)
+    base = output_path.rsplit('.', 1)[0] if '.' in output_path else output_path
+    for ext in ['.mp4', '.webm', '.mkv', '.m4v']:
+        candidate = base + ext
+        if os.path.exists(candidate):
+            return candidate
+
+    # Check if file exists as-is
+    if os.path.exists(output_path):
+        return output_path
+
+    raise RuntimeError(f"Downloaded file not found at {output_path}")
+
+
+def download_direct_video(url: str, output_path: str) -> str:
+    """Download video from direct URL."""
+    import requests
+
+    print(f"Downloading video: {url}")
+    response = requests.get(url, stream=True, timeout=300)
+    response.raise_for_status()
+
+    total_size = int(response.headers.get('content-length', 0))
+    downloaded = 0
+
+    with open(output_path, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+            downloaded += len(chunk)
+            if total_size:
+                pct = (downloaded / total_size) * 100
+                print(f"\rProgress: {pct:.1f}%", end='', flush=True)
+
+    print()  # newline
+    return output_path
+
+
+def extract_frame(video_path: str, timestamp_ms: int, bounding_box: list = None) -> bytes:
+    """Extract a single frame from video at given timestamp."""
+    cap = cv2.VideoCapture(video_path)
+
+    try:
+        # Seek to timestamp
+        cap.set(cv2.CAP_PROP_POS_MSEC, timestamp_ms)
+        success, frame = cap.read()
+
+        if not success:
+            raise ValueError(f"Failed to read frame at {timestamp_ms}ms")
+
+        # Crop if bounding box provided [ymin, xmin, ymax, xmax] on 0-1000 scale
+        if bounding_box and len(bounding_box) == 4:
+            height, width = frame.shape[:2]
+            ymin = int(bounding_box[0] * height / 1000)
+            xmin = int(bounding_box[1] * width / 1000)
+            ymax = int(bounding_box[2] * height / 1000)
+            xmax = int(bounding_box[3] * width / 1000)
+            frame = frame[ymin:ymax, xmin:xmax]
+
+        # Encode as JPEG
+        _, buffer = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, 90])
+        return buffer.tobytes()
+
+    finally:
+        cap.release()
+
+
+def sanitize_filename(title: str, max_length: int = 50) -> str:
+    """Convert title to a safe filename."""
+    if not title:
+        return "slide"
+    import re
+    safe = re.sub(r'[^\w\s-]', '', title)
+    safe = re.sub(r'\s+', '_', safe)
+    return safe[:max_length]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Extract slide frames from videos (supports YouTube)',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument(
+        '--video', '-v',
+        required=True,
+        help='Video URL (YouTube or direct) or local file path'
+    )
+
+    parser.add_argument(
+        '--metadata', '-m',
+        help='Path to slides metadata JSON (from extractSlides operation)'
+    )
+
+    parser.add_argument(
+        '--timestamps', '-t',
+        help='Comma-separated timestamps in ms (e.g., 15000,45000,120000)'
+    )
+
+    parser.add_argument(
+        '--output', '-o',
+        default='./slides',
+        help='Output directory for extracted frames (default: ./slides)'
+    )
+
+    parser.add_argument(
+        '--cookies-from-browser', '-c',
+        choices=['chrome', 'firefox', 'edge', 'safari', 'opera', 'brave'],
+        help='Browser to get cookies from (for YouTube authentication)'
+    )
+
+    parser.add_argument(
+        '--keep-video', '-k',
+        action='store_true',
+        help='Keep downloaded video file in temp location'
+    )
+
+    parser.add_argument(
+        '--save-video', '-s',
+        metavar='DIR',
+        help='Save downloaded video to specified directory (created if not exists)'
+    )
+
+    parser.add_argument(
+        '--base64',
+        action='store_true',
+        help='Output base64 JSON instead of files'
+    )
+
+    parser.add_argument(
+        '--quiet', '-q',
+        action='store_true',
+        help='Minimal output'
+    )
+
+    args = parser.parse_args()
+
+    # Load slides from metadata or timestamps
+    slides = []
+    if args.metadata:
+        with open(args.metadata, 'r') as f:
+            data = json.load(f)
+            slides = data.get('slides', [])
+    elif args.timestamps:
+        for i, ts in enumerate(args.timestamps.split(','), 1):
+            slides.append({
+                'id': i,
+                'timestamp_ms': int(ts.strip()),
+                'title': f'slide_{i}'
+            })
+    else:
+        print("Error: Either --metadata or --timestamps is required")
+        return 1
+
+    if not slides:
+        print("Error: No slides found")
+        return 1
+
+    if not args.quiet:
+        print(f"Slides to extract: {len(slides)}")
+
+    # Download video if needed
+    video_path = args.video
+    temp_video = None
+
+    if args.video.startswith('http://') or args.video.startswith('https://'):
+        temp_video = tempfile.mktemp(suffix='.mp4')
+
+        if is_youtube_url(args.video):
+            video_path = download_youtube_video(
+                args.video,
+                temp_video,
+                args.cookies_from_browser
+            )
+        else:
+            video_path = download_direct_video(args.video, temp_video)
+
+        if not args.quiet:
+            print(f"Video downloaded: {video_path}")
+
+    try:
+        # Create output directory
+        os.makedirs(args.output, exist_ok=True)
+
+        results = []
+
+        for slide in slides:
+            slide_id = slide.get('id', len(results) + 1)
+            timestamp_ms = slide.get('timestamp_ms', 0)
+            title = slide.get('title', f'slide_{slide_id}')
+            bounding_box = slide.get('bounding_box')
+
+            if not args.quiet:
+                print(f"Extracting slide {slide_id} @ {timestamp_ms}ms: {title}")
+
+            try:
+                image_data = extract_frame(video_path, timestamp_ms, bounding_box)
+
+                if args.base64:
+                    results.append({
+                        'slide_id': slide_id,
+                        'title': title,
+                        'timestamp_ms': timestamp_ms,
+                        'image_base64': base64.b64encode(image_data).decode('utf-8'),
+                        'status': 'success'
+                    })
+                else:
+                    filename = f"slide_{slide_id:03d}_{sanitize_filename(title)}.jpg"
+                    filepath = os.path.join(args.output, filename)
+
+                    with open(filepath, 'wb') as f:
+                        f.write(image_data)
+
+                    results.append({
+                        'slide_id': slide_id,
+                        'title': title,
+                        'timestamp_ms': timestamp_ms,
+                        'file': filepath,
+                        'size_kb': len(image_data) / 1024,
+                        'status': 'success'
+                    })
+
+                    if not args.quiet:
+                        print(f"  -> Saved: {filename} ({len(image_data) / 1024:.1f} KB)")
+
+            except Exception as e:
+                results.append({
+                    'slide_id': slide_id,
+                    'title': title,
+                    'timestamp_ms': timestamp_ms,
+                    'status': 'error',
+                    'error': str(e)
+                })
+                print(f"  -> Error: {e}")
+
+        # Summary
+        success_count = sum(1 for r in results if r['status'] == 'success')
+        failed_count = sum(1 for r in results if r['status'] == 'error')
+
+        if args.base64:
+            output = {
+                'success': True,
+                'total_slides': len(slides),
+                'extracted': success_count,
+                'failed': failed_count,
+                'images': results
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            if not args.quiet:
+                print(f"\nExtracted: {success_count}/{len(slides)}")
+                if failed_count:
+                    print(f"Failed: {failed_count}")
+                print(f"Output: {args.output}/")
+
+        return 0 if failed_count == 0 else 1
+
+    finally:
+        # Handle video file: save, keep, or cleanup
+        if temp_video:
+            if args.save_video:
+                # Save video to specified directory
+                import shutil
+                os.makedirs(args.save_video, exist_ok=True)
+
+                # Get video filename from URL or use default
+                if is_youtube_url(args.video):
+                    video_filename = f"video_{Path(args.video).name.split('=')[-1].split('&')[0]}"
+                else:
+                    video_filename = Path(args.video).stem or "video"
+
+                # Get extension from downloaded file
+                ext = Path(video_path).suffix or '.mp4'
+                dest_path = os.path.join(args.save_video, f"{video_filename}{ext}")
+
+                shutil.copy2(video_path, dest_path)
+                if not args.quiet:
+                    print(f"Video saved to: {dest_path}")
+
+                # Cleanup temp
+                base = temp_video.rsplit('.', 1)[0]
+                import glob
+                for f in glob.glob(base + '.*'):
+                    if os.path.exists(f):
+                        os.unlink(f)
+
+            elif args.keep_video:
+                if not args.quiet:
+                    print(f"Video kept at: {video_path}")
+            else:
+                # Cleanup temp video
+                base = temp_video.rsplit('.', 1)[0]
+                import glob
+                for f in glob.glob(base + '.*'):
+                    if os.path.exists(f):
+                        os.unlink(f)
+                        if not args.quiet:
+                            print(f"Cleaned up: {f}")
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/server-scripts/extract-slides/requirements.txt
+++ b/server-scripts/extract-slides/requirements.txt
@@ -1,0 +1,3 @@
+yt-dlp>=2024.0.0
+opencv-python-headless>=4.8.0
+requests>=2.28.0


### PR DESCRIPTION
## Summary

Adds a new `extractSlides` operation to detect and extract slide/presentation metadata from videos, plus a GCP Cloud Function for extracting the actual images.

### Issue #57: extractSlides operation
- New operation in VideoTranscription node
- Detects slide transitions with precise timestamps (milliseconds)
- Extracts: title, key points, type (slide/chart/diagram/etc.), bounding box
- Optimized prompt for slide detection

### Issue #58: GCP Cloud Function
- Python Cloud Function using OpenCV
- Takes timestamps from extractSlides output
- Extracts frames and returns as base64 or uploads to GCS
- Includes deployment script

## Files Changed

### Node Changes
- `VideoTranscription.node.ts` - Added extractSlides operation
- `videoTranscriptionPrompts.ts` - Added EXTRACT_SLIDES_PROMPT

### Cloud Function
- `cloud-functions/extract-slides/main.py` - Main function code
- `cloud-functions/extract-slides/requirements.txt` - Dependencies
- `cloud-functions/extract-slides/deploy.sh` - Deployment script

### Documentation
- `docs/n8n/video-transcription-mcp-server.md` - Updated with extractSlides and Cloud Function docs

## Usage

### Extract slide metadata
```bash
curl -X POST http://localhost:5678/webhook/video-transcription \
  -d '{"videoUrl": "https://example.com/presentation.mp4", "operation": "extractSlides"}'
```

### Extract images (with Cloud Function)
```bash
curl -X POST https://REGION-PROJECT.cloudfunctions.net/extract-slides \
  -d '{"video_url": "...", "slides": [...], "output": {"type": "base64"}}'
```

## Test plan
- [ ] Build node: `npm run build`
- [ ] Test extractSlides with a presentation video
- [ ] Deploy Cloud Function: `cd cloud-functions/extract-slides && ./deploy.sh`
- [ ] Test Cloud Function with extracted timestamps

Closes #57
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)