### PR TITLE
feat(mcp): add text_classifier_tool workflow (P1-14)

### DIFF
--- a/workflows/mcp-tools/text_classifier_tool.json
+++ b/workflows/mcp-tools/text_classifier_tool.json
@@ -1,0 +1,318 @@
+{
+  "name": "MCP - Text Classifier",
+  "nodes": [
+    {
+      "id": "webhook-classifier",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "text-classifier-webhook",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "text-classifier",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [460, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.body.text }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isNotEmpty"
+              }
+            },
+            {
+              "leftValue": "={{ $json.body.categories }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "isNotEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "error-missing-params",
+      "name": "Error: Missing Params",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [700, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameters: text and categories (array)\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    },
+    {
+      "id": "route-mode",
+      "name": "Route Classification Mode",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [700, 200],
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "multi_label",
+              "conditions": {
+                "options": {
+                  "caseSensitive": false,
+                  "leftValue": "",
+                  "typeValidation": "loose"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.body.multi_label }}",
+                    "rightValue": true,
+                    "operator": {
+                      "type": "boolean",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "extra"
+        }
+      }
+    },
+    {
+      "id": "single-label-classify",
+      "name": "Single Label Classification",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1.8,
+      "position": [940, 300],
+      "parameters": {
+        "resource": "chat",
+        "operation": "message",
+        "model": "gpt-4o-mini",
+        "messages": {
+          "values": [
+            {
+              "content": "You are a precise text classifier. Classify the given text into exactly ONE of the provided categories. Return a JSON object with 'category' (the chosen category) and 'confidence' (a number between 0 and 1). Only respond with valid JSON, no explanation.",
+              "role": "system"
+            },
+            {
+              "content": "={{ 'Classify the following text into one of these categories: ' + $json.body.categories.join(', ') + '\\n\\nText to classify:\\n' + $json.body.text }}",
+              "role": "user"
+            }
+          ]
+        },
+        "options": {
+          "temperature": 0.1,
+          "responseFormat": "json_object"
+        }
+      },
+      "credentials": {
+        "openAiApi": {
+          "id": "openai-credentials",
+          "name": "OpenAI account"
+        }
+      }
+    },
+    {
+      "id": "multi-label-classify",
+      "name": "Multi Label Classification",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1.8,
+      "position": [940, 100],
+      "parameters": {
+        "resource": "chat",
+        "operation": "message",
+        "model": "gpt-4o-mini",
+        "messages": {
+          "values": [
+            {
+              "content": "You are a precise text classifier. Classify the given text into ALL applicable categories from the provided list. Return a JSON object with 'categories' (array of objects, each with 'category' and 'confidence' between 0 and 1). Only include categories with confidence > 0.3. Only respond with valid JSON, no explanation.",
+              "role": "system"
+            },
+            {
+              "content": "={{ 'Classify the following text into applicable categories from this list: ' + $json.body.categories.join(', ') + '\\n\\nText to classify:\\n' + $json.body.text }}",
+              "role": "user"
+            }
+          ]
+        },
+        "options": {
+          "temperature": 0.1,
+          "responseFormat": "json_object"
+        }
+      },
+      "credentials": {
+        "openAiApi": {
+          "id": "openai-credentials",
+          "name": "OpenAI account"
+        }
+      }
+    },
+    {
+      "id": "format-single",
+      "name": "Format Single Label",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1160, 300],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ (() => { try { const result = JSON.parse($json.message.content); return { \"success\": true, \"data\": { \"classification\": { \"category\": result.category, \"confidence\": result.confidence }, \"mode\": \"single_label\", \"input_categories\": $('Webhook').first().json.body.categories, \"text_length\": $('Webhook').first().json.body.text.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } }; } catch(e) { return { \"success\": false, \"error\": { \"code\": 500, \"message\": \"Failed to parse classification result\", \"status\": \"PARSE_ERROR\" } }; } })() }}"
+      }
+    },
+    {
+      "id": "format-multi",
+      "name": "Format Multi Label",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1160, 100],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ (() => { try { const result = JSON.parse($json.message.content); return { \"success\": true, \"data\": { \"classifications\": result.categories || [], \"mode\": \"multi_label\", \"input_categories\": $('Webhook').first().json.body.categories, \"text_length\": $('Webhook').first().json.body.text.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } }; } catch(e) { return { \"success\": false, \"error\": { \"code\": 500, \"message\": \"Failed to parse classification result\", \"status\": \"PARSE_ERROR\" } }; } })() }}"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1380, 200],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "sticky-note-doc",
+      "name": "API Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [240, 80],
+      "parameters": {
+        "color": 4,
+        "width": 550,
+        "height": 220,
+        "content": "## MCP - Text Classifier\n\n**Endpoint:** POST /webhook/text-classifier\n\n**Parameters:**\n- `text` (required): Text to classify\n- `categories` (required): Array of category labels\n- `multi_label` (optional): true for multi-label classification (default: false)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Classification result with category/confidence scores"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Route Classification Mode",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: Missing Params",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route Classification Mode": {
+      "main": [
+        [
+          {
+            "node": "Multi Label Classification",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Single Label Classification",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Single Label Classification": {
+      "main": [
+        [
+          {
+            "node": "Format Single Label",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Multi Label Classification": {
+      "main": [
+        [
+          {
+            "node": "Format Multi Label",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Single Label": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Multi Label": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Add text classification workflow with single-label and multi-label support
- Uses OpenAI GPT-4o-mini for classification with JSON response format
- Returns category with confidence scores

## Features
- **Endpoint:** `POST /webhook/text-classifier`
- **Parameters:**
  - `text` (required): Text to classify
  - `categories` (required): Array of category labels
  - `multi_label` (optional): Enable multi-label classification
  - `execution_mode` (optional): online | offline

## Test plan
- [ ] Test single-label classification with sample text
- [ ] Test multi-label classification with `multi_label: true`
- [ ] Verify error handling for missing parameters
- [ ] Confirm confidence scores are returned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)