### PR TITLE
feat(mcp): add linkedin_tool workflow (P1-03)

### DIFF
--- a/workflows/mcp-tools/linkedin_tool.json
+++ b/workflows/mcp-tools/linkedin_tool.json
@@ -1,0 +1,264 @@
+{
+  "name": "MCP - LinkedIn",
+  "nodes": [
+    {
+      "id": "webhook-linkedin",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "linkedin-webhook",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "linkedin",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "route-action",
+      "name": "Route Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [460, 300],
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "post",
+              "conditions": {
+                "options": {
+                  "caseSensitive": false,
+                  "leftValue": "",
+                  "typeValidation": "loose"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.body.action }}",
+                    "rightValue": "post",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "post_with_image",
+              "conditions": {
+                "options": {
+                  "caseSensitive": false,
+                  "leftValue": "",
+                  "typeValidation": "loose"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.body.action }}",
+                    "rightValue": "post_with_image",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "extra"
+        }
+      }
+    },
+    {
+      "id": "linkedin-post-text",
+      "name": "Post Text",
+      "type": "n8n-nodes-base.linkedIn",
+      "typeVersion": 1,
+      "position": [700, 200],
+      "parameters": {
+        "operation": "post",
+        "text": "={{ $json.body.text }}",
+        "additionalFields": {}
+      },
+      "credentials": {
+        "linkedInOAuth2Api": {
+          "id": "linkedin-oauth",
+          "name": "LinkedIn account"
+        }
+      }
+    },
+    {
+      "id": "linkedin-post-image",
+      "name": "Post with Image",
+      "type": "n8n-nodes-base.linkedIn",
+      "typeVersion": 1,
+      "position": [700, 400],
+      "parameters": {
+        "operation": "post",
+        "text": "={{ $json.body.text }}",
+        "additionalFields": {
+          "mediaCategory": "IMAGE",
+          "media": "={{ $json.body.image_url }}"
+        }
+      },
+      "credentials": {
+        "linkedInOAuth2Api": {
+          "id": "linkedin-oauth",
+          "name": "LinkedIn account"
+        }
+      }
+    },
+    {
+      "id": "error-invalid-action",
+      "name": "Error: Invalid Action",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [700, 560],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Invalid action. Use: post, post_with_image\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"linkedin\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    },
+    {
+      "id": "format-output-text",
+      "name": "Format Output (Text)",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [920, 200],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"post_id\": $json.id || $json.updateKey, \"urn\": $json.activity || $json.updateUrl, \"text\": $('Webhook').first().json.body.text }, \"meta\": { \"provider\": \"linkedin\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"action\": \"post\" } } }}"
+      }
+    },
+    {
+      "id": "format-output-image",
+      "name": "Format Output (Image)",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [920, 400],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"post_id\": $json.id || $json.updateKey, \"urn\": $json.activity || $json.updateUrl, \"text\": $('Webhook').first().json.body.text, \"image_url\": $('Webhook').first().json.body.image_url }, \"meta\": { \"provider\": \"linkedin\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"action\": \"post_with_image\" } } }}"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1140, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "sticky-note-doc",
+      "name": "API Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [240, 80],
+      "parameters": {
+        "color": 6,
+        "width": 450,
+        "height": 180,
+        "content": "## MCP - LinkedIn\n\n**Endpoint:** POST /webhook/linkedin\n\n**Parameters:**\n- `action`: post | post_with_image\n- `text` (required): Post content\n- `image_url` (for post_with_image): URL of image\n\n**Note:** Requires LinkedIn OAuth credentials configured"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Route Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route Action": {
+      "main": [
+        [
+          {
+            "node": "Post Text",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Post with Image",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: Invalid Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Post Text": {
+      "main": [
+        [
+          {
+            "node": "Format Output (Text)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Post with Image": {
+      "main": [
+        [
+          {
+            "node": "Format Output (Image)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Output (Text)": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Output (Image)": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Add linkedin_tool workflow for LinkedIn interactions
- Standardized MCP output format

## Phase 1 - Tool 3/14

**Order:** Merge after P1-02

## Test plan
- [ ] Test LinkedIn API integration
- [ ] Verify response format

🤖 Generated with [Claude Code](https://claude.com/claude-code)