### PR TITLE
feat(mcp): add text_generator_tool workflow (P1-07)

### DIFF
--- a/workflows/mcp-tools/text_generator_tool.json
+++ b/workflows/mcp-tools/text_generator_tool.json
@@ -1,0 +1,187 @@
+{
+  "name": "MCP - Text Generator",
+  "nodes": [
+    {
+      "id": "webhook-textgen",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "text-generator-webhook",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "text-generator",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [460, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.body.prompt }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isNotEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "error-no-prompt",
+      "name": "Error: No Prompt",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [700, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: prompt\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    },
+    {
+      "id": "openai-generate",
+      "name": "OpenAI Generate Text",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1.8,
+      "position": [700, 200],
+      "parameters": {
+        "resource": "chat",
+        "operation": "message",
+        "model": "={{ $json.body.model || 'gpt-4o' }}",
+        "messages": {
+          "values": [
+            {
+              "content": "={{ $json.body.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.' }}",
+              "role": "system"
+            },
+            {
+              "content": "={{ $json.body.prompt }}",
+              "role": "user"
+            }
+          ]
+        },
+        "options": {
+          "temperature": "={{ $json.body.temperature || 0.7 }}",
+          "maxTokens": "={{ $json.body.max_tokens || 2048 }}"
+        }
+      },
+      "credentials": {
+        "openAiApi": {
+          "id": "openai-credentials",
+          "name": "OpenAI account"
+        }
+      }
+    },
+    {
+      "id": "format-output",
+      "name": "Format Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [920, 200],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.message.content, \"model\": $json.model || $('Webhook').first().json.body.model || 'gpt-4o', \"finish_reason\": $json.finish_reason || 'stop' }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0, \"total_tokens\": $json.usage?.total_tokens || 0 } } } }}"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1140, 200],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "sticky-note-doc",
+      "name": "API Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [240, 80],
+      "parameters": {
+        "color": 6,
+        "width": 550,
+        "height": 220,
+        "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Parameters:**\n- `prompt` (required): Text generation prompt\n- `system_prompt` (optional): System instructions\n- `model` (optional): gpt-4o, gpt-4o-mini, gpt-4-turbo (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.7)\n- `max_tokens` (optional): Max output tokens (default: 2048)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Generated text with usage stats"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "OpenAI Generate Text",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: No Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Generate Text": {
+      "main": [
+        [
+          {
+            "node": "Format Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Output": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Add text_generator_tool workflow for AI text generation
- Uses OpenAI GPT-4o for content generation
- Configurable prompts and parameters
- Standardized MCP output format

## Phase 1 - Tool 7/14

**Order:** Merge after P1-06

## Test plan
- [ ] Test text generation with various prompts
- [ ] Test different output formats
- [ ] Verify response structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)