### PR TITLE
feat(mcp): add speaker_identifier_tool workflow (P2-01)

### DIFF
--- a/workflows/mcp-tools/speaker_identifier_tool.json
+++ b/workflows/mcp-tools/speaker_identifier_tool.json
@@ -1,0 +1,552 @@
+{
+  "name": "MCP - Speaker Identifier",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "speaker-identifier",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "speaker-identifier-webhook"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-data",
+              "leftValue": "={{ $json.body.data }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: 'Missing required field: data (URL or base64 audio)' } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "error-invalid-input",
+      "name": "Error Invalid Input",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [680, 480]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-source",
+              "leftValue": "={{ $json.body.source }}",
+              "rightValue": "base64",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-source-type",
+      "name": "Is Base64?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// For base64 input, we need to upload to a temporary storage\n// In production, this would upload to S3/MinIO and return a URL\n// For now, we'll use AssemblyAI's upload endpoint\n\nconst base64Data = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\n\n// Remove data URL prefix if present\nconst cleanBase64 = base64Data.replace(/^data:audio\\/[a-z]+;base64,/, '');\n\nreturn {\n  json: {\n    audioBase64: cleanBase64,\n    options: options,\n    needsUpload: true\n  }\n};"
+      },
+      "id": "prepare-base64",
+      "name": "Prepare Base64",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.assemblyai.com/v2/upload",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "contentType": "raw",
+        "body": "={{ Buffer.from($json.audioBase64, 'base64') }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "upload-to-assemblyai",
+      "name": "Upload to AssemblyAI",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "assemblyai-auth",
+          "name": "AssemblyAI API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare URL audio input\nconst audioUrl = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\n\nreturn {\n  json: {\n    audioUrl: audioUrl,\n    options: options,\n    needsUpload: false\n  }\n};"
+      },
+      "id": "prepare-url",
+      "name": "Prepare URL",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Merge uploaded URL with options\nconst uploadResponse = $input.first().json;\nconst previousData = $('Prepare Base64').first().json;\n\nreturn {\n  json: {\n    audioUrl: uploadResponse.upload_url,\n    options: previousData.options\n  }\n};"
+      },
+      "id": "merge-upload-result",
+      "name": "Merge Upload Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare AssemblyAI transcription request\nconst input = $input.first().json;\nconst options = input.options || {};\n\nconst requestBody = {\n  audio_url: input.audioUrl,\n  speaker_labels: true\n};\n\n// Add optional parameters\nif (options.speakers_expected) {\n  requestBody.speakers_expected = options.speakers_expected;\n}\n\nif (options.language && options.language !== 'auto') {\n  requestBody.language_code = options.language;\n}\n\nif (options.language === 'auto') {\n  requestBody.language_detection = true;\n}\n\nreturn {\n  json: {\n    requestBody: requestBody,\n    options: options\n  }\n};"
+      },
+      "id": "prepare-transcription-request",
+      "name": "Prepare Transcription Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.assemblyai.com/v2/transcript",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.requestBody) }}",
+        "options": {}
+      },
+      "id": "start-transcription",
+      "name": "Start Transcription",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1780, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "assemblyai-auth",
+          "name": "AssemblyAI API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Store transcript ID and options for polling\nconst response = $input.first().json;\nconst previousData = $('Prepare Transcription Request').first().json;\n\nreturn {\n  json: {\n    transcriptId: response.id,\n    status: response.status,\n    options: previousData.options,\n    pollCount: 0,\n    startTime: Date.now()\n  }\n};"
+      },
+      "id": "store-transcript-id",
+      "name": "Store Transcript ID",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2000, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.assemblyai.com/v2/transcript/{{ $json.transcriptId }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "poll-status",
+      "name": "Poll Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2220, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "assemblyai-auth",
+          "name": "AssemblyAI API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-completed",
+              "leftValue": "={{ $json.status }}",
+              "rightValue": "completed",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-completed",
+      "name": "Is Completed?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2440, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-error",
+              "leftValue": "={{ $json.status }}",
+              "rightValue": "error",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-error",
+      "name": "Is Error?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'TRANSCRIPTION_ERROR', message: $json.error || 'Transcription failed' } }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "error-transcription",
+      "name": "Error Transcription",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2880, 500]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Increment poll count and prepare for next poll\nconst response = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\n\nconst pollCount = storedData.pollCount + 1;\nconst elapsedMs = Date.now() - storedData.startTime;\n\n// Timeout after 30 minutes\nif (elapsedMs > 30 * 60 * 1000) {\n  throw new Error('Transcription timeout after 30 minutes');\n}\n\nreturn {\n  json: {\n    transcriptId: storedData.transcriptId,\n    status: response.status,\n    options: storedData.options,\n    pollCount: pollCount,\n    startTime: storedData.startTime\n  }\n};"
+      },
+      "id": "prepare-next-poll",
+      "name": "Prepare Next Poll",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2880, 300]
+    },
+    {
+      "parameters": {
+        "amount": 5,
+        "unit": "seconds"
+      },
+      "id": "wait-before-poll",
+      "name": "Wait 5s",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [3100, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format the final response with speaker identification\nconst transcript = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\nconst options = storedData.options || {};\nconst startTime = storedData.startTime;\n\n// Group utterances by speaker\nconst speakerStats = {};\nconst utterances = transcript.utterances || [];\n\nutterances.forEach(u => {\n  if (!speakerStats[u.speaker]) {\n    speakerStats[u.speaker] = {\n      id: u.speaker,\n      label: `Speaker ${u.speaker.replace('speaker_', '').toUpperCase()}`,\n      total_speaking_time_ms: 0,\n      utterance_count: 0\n    };\n  }\n  speakerStats[u.speaker].total_speaking_time_ms += (u.end - u.start);\n  speakerStats[u.speaker].utterance_count++;\n});\n\n// Calculate percentages\nconst totalSpeakingTime = Object.values(speakerStats).reduce((sum, s) => sum + s.total_speaking_time_ms, 0);\nconst speakers = Object.values(speakerStats).map(s => ({\n  ...s,\n  percentage: totalSpeakingTime > 0 ? Math.round((s.total_speaking_time_ms / totalSpeakingTime) * 100) : 0\n}));\n\n// Format utterances\nconst formattedUtterances = utterances.map(u => ({\n  speaker: u.speaker,\n  text: u.text,\n  start_ms: u.start,\n  end_ms: u.end,\n  confidence: u.confidence\n}));\n\n// Build full transcript with speaker labels\nconst transcriptFull = utterances.map(u => {\n  const label = speakerStats[u.speaker]?.label || u.speaker;\n  return `${label}: ${u.text}`;\n}).join('\\n');\n\nconst response = {\n  success: true,\n  data: {\n    speakers: speakers,\n    utterances: options.include_transcription !== false ? formattedUtterances : undefined,\n    transcript_full: options.include_transcription !== false ? transcriptFull : undefined,\n    audio_duration_ms: transcript.audio_duration * 1000,\n    num_speakers_detected: speakers.length,\n    language_detected: transcript.language_code\n  },\n  meta: {\n    provider: 'assemblyai',\n    execution_mode: 'online',\n    processing_time_ms: Date.now() - startTime,\n    transcript_id: transcript.id\n  }\n};\n\nreturn { json: response };"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2660, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2880, 200]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is Base64?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error Invalid Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Base64?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Base64",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare URL",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Base64": {
+      "main": [
+        [
+          {
+            "node": "Upload to AssemblyAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Upload to AssemblyAI": {
+      "main": [
+        [
+          {
+            "node": "Merge Upload Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Upload Result": {
+      "main": [
+        [
+          {
+            "node": "Prepare Transcription Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare URL": {
+      "main": [
+        [
+          {
+            "node": "Prepare Transcription Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Transcription Request": {
+      "main": [
+        [
+          {
+            "node": "Start Transcription",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Start Transcription": {
+      "main": [
+        [
+          {
+            "node": "Store Transcript ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Store Transcript ID": {
+      "main": [
+        [
+          {
+            "node": "Poll Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Poll Status": {
+      "main": [
+        [
+          {
+            "node": "Is Completed?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Completed?": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Is Error?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Error?": {
+      "main": [
+        [
+          {
+            "node": "Error Transcription",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Next Poll",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Next Poll": {
+      "main": [
+        [
+          {
+            "node": "Wait 5s",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Wait 5s": {
+      "main": [
+        [
+          {
+            "node": "Poll Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 0,
+  "updatedAt": "2025-12-17T00:00:00.000Z",
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary
- Add speaker identification/diarization workflow using AssemblyAI
- Endpoint: `POST /webhook/speaker-identifier`
- Support URL and base64 audio input
- Speaker diarization with labels (Speaker A, B, C...)
- Full transcription with speaker attribution
- Multi-language support (FR, EN, auto-detect)

## Phase 2 - Tool 1/13

## Provider
**AssemblyAI** - $0.00025/sec (~$0.90/h), speaker labels included

## Test plan
- [ ] Test with 2-speaker interview
- [ ] Test with 3+ speakers meeting
- [ ] Test mono-speaker podcast
- [ ] Test long audio (> 30 min) with polling
- [ ] Test different languages (FR, EN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)