### PR TITLE
feat(mcp): add html_extractor_tool workflow (P2-03)

### DIFF
--- a/workflows/mcp-tools/html_extractor_tool.json
+++ b/workflows/mcp-tools/html_extractor_tool.json
@@ -1,0 +1,270 @@
+{
+  "name": "MCP - HTML Extractor",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "html-extractor",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "html-extractor-webhook"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-data",
+              "leftValue": "={{ $json.body.data }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            },
+            {
+              "id": "condition-selectors",
+              "leftValue": "={{ $json.body.selectors }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: 'Missing required fields: data (URL or HTML) and selectors (array)' } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "error-invalid-input",
+      "name": "Error Invalid Input",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [680, 480]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-source",
+              "leftValue": "={{ $json.body.source }}",
+              "rightValue": "url",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-source-type",
+      "name": "Is URL?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.body.data }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "text"
+            }
+          }
+        }
+      },
+      "id": "fetch-html-url",
+      "name": "Fetch HTML URL",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare fetched HTML data\nconst body = $('Webhook').first().json.body;\nconst htmlContent = $input.first().json;\nconst selectors = body.selectors || [];\nconst options = body.options || {};\n\nlet content = '';\nif (typeof htmlContent === 'string') {\n  content = htmlContent;\n} else if (htmlContent.data) {\n  content = htmlContent.data;\n} else {\n  content = String(htmlContent);\n}\n\nreturn {\n  json: {\n    htmlContent: content,\n    selectors: selectors,\n    options: options,\n    sourceUrl: body.data,\n    startTime: Date.now()\n  }\n};"
+      },
+      "id": "prepare-url-html",
+      "name": "Prepare URL HTML",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare raw HTML data\nconst body = $input.first().json.body;\nconst htmlContent = body.data;\nconst selectors = body.selectors || [];\nconst options = body.options || {};\n\nreturn {\n  json: {\n    htmlContent: htmlContent,\n    selectors: selectors,\n    options: options,\n    sourceUrl: null,\n    startTime: Date.now()\n  }\n};"
+      },
+      "id": "prepare-raw-html",
+      "name": "Prepare Raw HTML",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// HTML Extraction using CSS selectors (Cheerio-like)\nconst input = $input.first().json;\nconst htmlContent = input.htmlContent;\nconst selectors = input.selectors;\nconst options = input.options || {};\nconst sourceUrl = input.sourceUrl;\nconst startTime = input.startTime;\n\n// Simple HTML parser functions\nfunction parseHTML(html) {\n  return html;\n}\n\n// Clean whitespace\nfunction cleanText(text) {\n  if (!text) return '';\n  if (options.clean_whitespace !== false) {\n    return text.replace(/[\\n\\t\\r]+/g, ' ').replace(/\\s+/g, ' ').trim();\n  }\n  return text.trim();\n}\n\n// Extract text content from HTML element string\nfunction extractText(html) {\n  if (!html) return '';\n  // Remove script and style content\n  let text = html.replace(/<script[^>]*>[\\s\\S]*?<\\/script>/gi, '');\n  text = text.replace(/<style[^>]*>[\\s\\S]*?<\\/style>/gi, '');\n  // Remove HTML tags\n  text = text.replace(/<[^>]+>/g, ' ');\n  // Decode HTML entities\n  text = text.replace(/&nbsp;/g, ' ');\n  text = text.replace(/&amp;/g, '&');\n  text = text.replace(/&lt;/g, '<');\n  text = text.replace(/&gt;/g, '>');\n  text = text.replace(/&quot;/g, '\"');\n  text = text.replace(/&#39;/g, \"'\");\n  return cleanText(text);\n}\n\n// Extract attribute from element\nfunction extractAttribute(elementHtml, attrName) {\n  if (!elementHtml || !attrName) return null;\n  \n  // Match attribute value\n  const regex = new RegExp(`${attrName}\\\\s*=\\\\s*[\"']([^\"']*)[\"']`, 'i');\n  const match = elementHtml.match(regex);\n  return match ? match[1] : null;\n}\n\n// Find elements by CSS selector (simplified)\nfunction querySelectorAll(html, selector) {\n  const results = [];\n  \n  // Parse selector\n  let tagName = '*';\n  let className = null;\n  let idName = null;\n  let attrMatch = null;\n  \n  // ID selector\n  const idMatch = selector.match(/#([\\w-]+)/);\n  if (idMatch) idName = idMatch[1];\n  \n  // Class selector\n  const classMatch = selector.match(/\\.([\\w-]+)/);\n  if (classMatch) className = classMatch[1];\n  \n  // Tag selector\n  const tagMatch = selector.match(/^([\\w]+)/);\n  if (tagMatch) tagName = tagMatch[1].toLowerCase();\n  \n  // Attribute selector [attr=\"value\"]\n  const attrSelectorMatch = selector.match(/\\[([\\w-]+)(?:=[\"']([^\"']*)[\"'])?\\]/);\n  if (attrSelectorMatch) {\n    attrMatch = { name: attrSelectorMatch[1], value: attrSelectorMatch[2] };\n  }\n  \n  // Build regex to find matching elements\n  let pattern;\n  if (tagName !== '*') {\n    pattern = new RegExp(`<${tagName}[^>]*>([\\\\s\\\\S]*?)<\\/${tagName}>`, 'gi');\n  } else {\n    pattern = /<([a-z][a-z0-9]*)\\b[^>]*>([\\s\\S]*?)<\\/\\1>/gi;\n  }\n  \n  let match;\n  while ((match = pattern.exec(html)) !== null) {\n    const fullMatch = match[0];\n    const openTag = fullMatch.match(/<[^>]+>/)?.[0] || '';\n    \n    let include = true;\n    \n    // Check ID\n    if (idName) {\n      const hasId = new RegExp(`id\\\\s*=\\\\s*[\"']${idName}[\"']`, 'i').test(openTag);\n      if (!hasId) include = false;\n    }\n    \n    // Check class\n    if (className && include) {\n      const classAttr = extractAttribute(openTag, 'class') || '';\n      const classes = classAttr.split(/\\s+/);\n      if (!classes.includes(className)) include = false;\n    }\n    \n    // Check attribute\n    if (attrMatch && include) {\n      const attrValue = extractAttribute(openTag, attrMatch.name);\n      if (attrMatch.value !== undefined) {\n        if (attrValue !== attrMatch.value) include = false;\n      } else {\n        if (attrValue === null) include = false;\n      }\n    }\n    \n    if (include) {\n      results.push({\n        html: fullMatch,\n        openTag: openTag,\n        text: extractText(fullMatch)\n      });\n    }\n  }\n  \n  return results;\n}\n\n// Process each selector\nconst extractions = {};\nlet selectorsMatched = 0;\nlet selectorsFailed = 0;\nconst selectorErrors = [];\n\nfor (const sel of selectors) {\n  const name = sel.name;\n  const selector = sel.selector;\n  const type = sel.type || 'css';\n  const attribute = sel.attribute || 'text';\n  const multiple = sel.multiple || false;\n  \n  try {\n    let elements = [];\n    \n    if (type === 'css') {\n      elements = querySelectorAll(htmlContent, selector);\n    } else if (type === 'xpath') {\n      // XPath support is limited in pure JS, use simplified approach\n      // Extract tag name and basic conditions from xpath\n      const xpathMatch = selector.match(/\\/\\/([\\w]+)(?:\\[@([\\w-]+)(?:=[\"']([^\"']*)[\"'])?\\])?/);\n      if (xpathMatch) {\n        const tag = xpathMatch[1];\n        const attr = xpathMatch[2];\n        const attrVal = xpathMatch[3];\n        let cssSelector = tag;\n        if (attr && attrVal) {\n          cssSelector = `${tag}[${attr}=\"${attrVal}\"]`;\n        } else if (attr) {\n          cssSelector = `${tag}[${attr}]`;\n        }\n        elements = querySelectorAll(htmlContent, cssSelector);\n      }\n    }\n    \n    if (elements.length > 0) {\n      selectorsMatched++;\n      \n      const extractValue = (el) => {\n        if (attribute === 'text') {\n          return el.text;\n        } else if (attribute === 'html') {\n          return el.html;\n        } else {\n          return extractAttribute(el.openTag, attribute);\n        }\n      };\n      \n      if (multiple) {\n        extractions[name] = elements.map(el => {\n          if (attribute === 'text') {\n            return el.text;\n          } else if (sel.attributes) {\n            // Return multiple attributes as object\n            const obj = { text: el.text };\n            for (const attr of sel.attributes || ['href']) {\n              obj[attr] = extractAttribute(el.openTag, attr);\n            }\n            return obj;\n          } else {\n            const value = extractValue(el);\n            if (attribute !== 'text' && el.text) {\n              return { text: el.text, [attribute]: value };\n            }\n            return value;\n          }\n        });\n      } else {\n        extractions[name] = extractValue(elements[0]);\n      }\n    } else {\n      selectorsFailed++;\n      selectorErrors.push({ name, selector, error: 'No elements found' });\n      extractions[name] = multiple ? [] : null;\n    }\n  } catch (error) {\n    selectorsFailed++;\n    selectorErrors.push({ name, selector, error: error.message });\n    extractions[name] = multiple ? [] : null;\n  }\n}\n\nconst response = {\n  success: true,\n  data: {\n    extractions: extractions,\n    source_url: sourceUrl,\n    selectors_matched: selectorsMatched,\n    selectors_failed: selectorsFailed\n  },\n  meta: {\n    provider: 'cheerio-like',\n    execution_mode: 'online',\n    processing_time_ms: Date.now() - startTime\n  }\n};\n\nif (selectorErrors.length > 0 && options.include_errors) {\n  response.data.selector_errors = selectorErrors;\n}\n\nreturn { json: response };"
+      },
+      "id": "extract-html",
+      "name": "Extract HTML",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is URL?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error Invalid Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is URL?": {
+      "main": [
+        [
+          {
+            "node": "Fetch HTML URL",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Raw HTML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch HTML URL": {
+      "main": [
+        [
+          {
+            "node": "Prepare URL HTML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare URL HTML": {
+      "main": [
+        [
+          {
+            "node": "Extract HTML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Raw HTML": {
+      "main": [
+        [
+          {
+            "node": "Extract HTML",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract HTML": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [],
+  "triggerCount": 0,
+  "updatedAt": "2025-12-17T00:00:00.000Z",
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary
- Add HTML extraction workflow using Cheerio-like parsing
- Endpoint: `POST /webhook/html-extractor`
- Support URL and raw HTML input
- CSS and basic XPath selectors

## Phase 2 - Tool 3/13

## Features
- CSS selectors (tag, class, id, attributes)
- Basic XPath support (converted to CSS)
- Multi-select with array results (`multiple: true`)
- Extract text or specific attributes (href, src, data-*)
- Automatic whitespace cleaning
- HTML entity decoding
- Error tracking for failed selectors

## Provider
**cheerio-like** - Native JS implementation (no external API)

## Test plan
- [ ] Test CSS selector `h1.title`
- [ ] Test CSS selector `a[href]` with attribute extraction
- [ ] Test multiple elements `li.item`
- [ ] Test XPath `//div[@id='main']`
- [ ] Test with URL source
- [ ] Test with raw HTML source

🤖 Generated with [Claude Code](https://claude.com/claude-code)