### PR TITLE
feat(mcp-tools): add multi-intent support and API key parameters

### DIFF
--- a/docs/n8n/CONVERSATIONAL_ANALYSIS_TOOLS_REQUEST.md
+++ b/docs/n8n/CONVERSATIONAL_ANALYSIS_TOOLS_REQUEST.md
@@ -1,0 +1,354 @@
+# Demande d'outils d'analyse conversationnelle pour n8n
+
+**Date**: 2025-12-17
+**Issue liée**: #422 - LangGraph Checkpointing
+**Auteur**: Équipe MCP Server
+
+## Contexte
+
+Lorsqu'un utilisateur envoie un message **sans contexte expert**, le MCP Server doit analyser le message pour :
+
+1. Comprendre l'intention de l'utilisateur
+2. Adapter le ton de la réponse
+3. Extraire les entités mentionnées
+4. Prioriser les actions
+
+Actuellement, ces analyses sont faites uniquement par le LLM, ce qui peut être :
+
+- Lent (appel LLM complet)
+- Coûteux (tokens)
+- Incohérent (pas de structure)
+
+## Outils demandés
+
+### 1. Sentiment Analyzer (Priorité: HAUTE)
+
+**Objectif**: Détecter l'état émotionnel de l'utilisateur
+
+**Input**:
+```json
+{
+  "text": "Je suis frustré, ça fait 3 fois que je demande !",
+  "language": "fr"
+}
+```
+
+**Output**:
+```json
+{
+  "sentiment": "negative",
+  "score": -0.8,
+  "emotions": {
+    "frustration": 0.9,
+    "anger": 0.3,
+    "sadness": 0.1
+  },
+  "confidence": 0.92
+}
+```
+
+**Cas d'usage**:
+
+- Adapter le ton de la réponse (empathie si frustré)
+- Prioriser les demandes urgentes
+- Alerter si escalade nécessaire
+
+**Outils externes existants**:
+
+| Service | Avantages | Inconvénients |
+|---------|-----------|---------------|
+| AWS Comprehend | Multilingue, fiable | Coût par requête |
+| Google Cloud NLP | Très précis | Coût |
+| Azure Text Analytics | Multilingue | Coût |
+| Hugging Face (cardiffnlp/twitter-roberta-base-sentiment) | Gratuit, auto-hébergeable | Moins précis |
+| spaCy + TextBlob | Gratuit, local | Anglais principalement |
+
+---
+
+### 2. Intent Classifier (Priorité: HAUTE)
+
+**Objectif**: Classifier l'intention de l'utilisateur
+
+**Input**:
+```json
+{
+  "text": "Envoie un email à Guy pour confirmer le RDV",
+  "language": "fr"
+}
+```
+
+**Output**:
+```json
+{
+  "intent": "action_request",
+  "sub_intent": "send_email",
+  "confidence": 0.95,
+  "requires_confirmation": true,
+  "detected_actions": ["send_email", "schedule_meeting"]
+}
+```
+
+**Intents suggérés**:
+
+| Intent | Description | Exemple |
+|--------|-------------|---------|
+| `action_request` | Demande d'exécution | "Envoie un email" |
+| `question` | Demande d'information | "Quel est mon prochain RDV ?" |
+| `feedback` | Retour utilisateur | "Merci, c'était parfait" |
+| `complaint` | Plainte/problème | "Ça ne marche pas" |
+| `clarification` | Réponse à une question | "Son email est <guy@test.com>" |
+| `greeting` | Salutation | "Bonjour" |
+| `cancel` | Annulation | "Non, laisse tomber" |
+
+**Outils externes existants**:
+
+| Service | Avantages | Inconvénients |
+|---------|-----------|---------------|
+| Dialogflow (Google) | Très puissant, NLU complet | Complexe à configurer |
+| Amazon Lex | Intégration AWS | Coût |
+| Rasa NLU | Open source, auto-hébergeable | Nécessite entraînement |
+| Wit.ai (Meta) | Gratuit, facile | Moins précis |
+| Hugging Face Zero-Shot | Flexible, gratuit | Performance variable |
+
+---
+
+### 3. Entity Extractor (Priorité: MOYENNE)
+
+**Note**: Un outil `entity_extractor_tool` existe déjà dans le MCP Server, mais une version n8n centralisée serait utile.
+
+**Objectif**: Extraire les entités nommées du message
+
+**Input**:
+```json
+{
+  "text": "Envoie un email à Guy Martin demain à 14h au café de la Paix",
+  "language": "fr"
+}
+```
+
+**Output**:
+```json
+{
+  "entities": [
+    {"type": "PERSON", "value": "Guy Martin", "start": 19, "end": 29},
+    {"type": "DATE", "value": "demain", "normalized": "2025-12-18", "start": 30, "end": 36},
+    {"type": "TIME", "value": "14h", "normalized": "14:00", "start": 39, "end": 42},
+    {"type": "LOCATION", "value": "café de la Paix", "start": 46, "end": 61}
+  ]
+}
+```
+
+**Types d'entités suggérés**:
+
+- `PERSON` - Noms de personnes
+- `EMAIL` - Adresses email
+- `PHONE` - Numéros de téléphone
+- `DATE` - Dates (avec normalisation)
+- `TIME` - Heures (avec normalisation)
+- `LOCATION` - Lieux
+- `ORGANIZATION` - Entreprises
+- `MONEY` - Montants
+
+**Outils externes existants**:
+
+| Service | Avantages | Inconvénients |
+|---------|-----------|---------------|
+| spaCy | Gratuit, rapide, multilingue | Installation locale |
+| AWS Comprehend | API simple | Coût |
+| Google Cloud NLP | Très précis | Coût |
+| Duckling (Meta) | Excellent pour dates/heures | Limité aux types temporels |
+| dateparser (Python) | Excellent pour dates | Dates uniquement |
+
+---
+
+### 4. Priority/Urgency Scorer (Priorité: BASSE)
+
+**Objectif**: Évaluer l'urgence d'un message
+
+**Input**:
+```json
+{
+  "text": "URGENT ! Il faut envoyer ce document maintenant !",
+  "language": "fr"
+}
+```
+
+**Output**:
+```json
+{
+  "priority": "critical",
+  "score": 0.95,
+  "indicators": ["URGENT", "maintenant"],
+  "suggested_deadline": "immediate"
+}
+```
+
+**Niveaux de priorité**:
+
+| Niveau | Score | Indicateurs |
+|--------|-------|-------------|
+| `critical` | 0.9-1.0 | URGENT, maintenant, immédiatement |
+| `high` | 0.7-0.9 | aujourd'hui, dès que possible |
+| `medium` | 0.4-0.7 | cette semaine, bientôt |
+| `low` | 0.0-0.4 | quand tu peux, à l'occasion |
+
+---
+
+### 5. Language Detector (Priorité: BASSE)
+
+**Note**: Un outil `language_detector_tool` existe déjà, mais une version n8n serait utile pour la cohérence.
+
+**Objectif**: Détecter la langue du message
+
+**Input**:
+```json
+{
+  "text": "Can you send an email to John?"
+}
+```
+
+**Output**:
+```json
+{
+  "language": "en",
+  "confidence": 0.98,
+  "alternatives": [
+    {"language": "de", "confidence": 0.01}
+  ]
+}
+```
+
+---
+
+## Architecture d'intégration proposée
+
+```
+Message entrant
+      │
+      ▼
+┌─────────────────────────────────────┐
+│     n8n Webhook: analyze-message    │
+│  (appelle plusieurs sous-workflows) │
+└─────────────────────────────────────┘
+      │
+      ├──► Sentiment Analyzer ──┐
+      ├──► Intent Classifier ───┤
+      ├──► Entity Extractor ────┼──► Résultat agrégé
+      ├──► Priority Scorer ─────┤
+      └──► Language Detector ───┘
+      │
+      ▼
+┌─────────────────────────────────────┐
+│  Réponse JSON enrichie pour MCP    │
+└─────────────────────────────────────┘
+```
+
+**Webhook unifié suggéré**: `POST /webhook/analyze-message`
+
+**Input**:
+```json
+{
+  "text": "Je suis frustré, envoie vite un email à Guy !",
+  "options": {
+    "sentiment": true,
+    "intent": true,
+    "entities": true,
+    "priority": true,
+    "language": true
+  }
+}
+```
+
+**Output**:
+```json
+{
+  "text": "Je suis frustré, envoie vite un email à Guy !",
+  "analysis": {
+    "sentiment": {
+      "sentiment": "negative",
+      "score": -0.6,
+      "emotions": {"frustration": 0.8}
+    },
+    "intent": {
+      "intent": "action_request",
+      "sub_intent": "send_email",
+      "confidence": 0.9
+    },
+    "entities": [
+      {"type": "PERSON", "value": "Guy"}
+    ],
+    "priority": {
+      "priority": "high",
+      "score": 0.75
+    },
+    "language": {
+      "language": "fr",
+      "confidence": 0.99
+    }
+  },
+  "processing_time_ms": 45
+}
+```
+
+---
+
+## Recommandations d'implémentation
+
+### Option A: Services externes (rapide, coûteux)
+
+- Utiliser AWS Comprehend ou Google Cloud NLP
+- Avantage: Déploiement rapide, haute précision
+- Inconvénient: Coût par requête, dépendance externe
+
+### Option B: Modèles Hugging Face (équilibré)
+
+- Déployer des modèles légers sur le serveur n8n
+- Modèles suggérés:
+  - Sentiment: `nlptown/bert-base-multilingual-uncased-sentiment`
+  - Intent: `facebook/bart-large-mnli` (zero-shot)
+  - NER: `Jean-Baptiste/camembert-ner` (français)
+- Avantage: Gratuit, contrôle total
+- Inconvénient: Ressources serveur, maintenance
+
+### Option C: LLM léger dédié (flexible)
+
+- Utiliser un modèle comme Mistral 7B ou Llama 3 8B
+- Prompt structuré pour extraction JSON
+- Avantage: Très flexible, un seul modèle
+- Inconvénient: Plus lent, moins structuré
+
+### Recommandation finale
+
+**Option B** avec fallback vers **Option A** pour les cas critiques.
+
+---
+
+## Priorisation
+
+| Outil | Priorité | Impact | Effort estimé |
+|-------|----------|--------|---------------|
+| Intent Classifier | HAUTE | Permet de router correctement | Moyen |
+| Sentiment Analyzer | HAUTE | Améliore l'UX | Faible |
+| Entity Extractor | MOYENNE | Existe déjà partiellement | Faible |
+| Priority Scorer | BASSE | Nice-to-have | Faible |
+| Language Detector | BASSE | Existe déjà | Très faible |
+
+---
+
+## Questions pour l'équipe n8n
+
+1. Avez-vous déjà des workflows d'analyse NLP existants ?
+2. Quel provider cloud est préféré (AWS/GCP/Azure) ?
+3. Y a-t-il des contraintes de latence (<100ms) ?
+4. Le déploiement de modèles Hugging Face est-il envisageable ?
+5. Faut-il supporter d'autres langues que FR/EN ?
+
+---
+
+## Ressources
+
+- [AWS Comprehend](https://aws.amazon.com/comprehend/)
+- [Google Cloud Natural Language](https://cloud.google.com/natural-language)
+- [Hugging Face Models](https://huggingface.co/models)
+- [spaCy](https://spacy.io/)
+- [Rasa NLU](https://rasa.com/docs/rasa/nlu-training-data/)

--- a/scripts/n8n/import_missing.sh
+++ b/scripts/n8n/import_missing.sh
@@ -109,14 +109,16 @@ for WORKFLOW_FILE in "${MISSING[@]}"; do
 
     echo "📦 Import: $WORKFLOW_NAME"
 
-    # Créer fichier temporaire avec les propriétés non-portables supprimées
-    # Selon docs/n8n/WORKFLOW_BEST_PRACTICES.md:
-    # "Propriétés à Éviter à l'Import: active, versionId, meta, tags, id"
+    # Générer un UUID pour versionId
+    VERSION_ID=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen 2>/dev/null || python3 -c "import uuid; print(uuid.uuid4())")
+
+    # Créer fichier temporaire avec les propriétés adaptées pour l'import
+    # Note: active et versionId sont NOT NULL dans la DB
     TMP_FILE=$(mktemp /tmp/workflow_XXXXXX.json)
-    jq '
+    jq --arg vid "$VERSION_ID" '
       del(.id) |
-      del(.active) |
-      del(.versionId) |
+      .active = false |
+      .versionId = $vid |
       del(.createdAt) |
       del(.updatedAt) |
       del(.meta) |

--- a/scripts/n8n/import_single.sh
+++ b/scripts/n8n/import_single.sh
@@ -23,9 +23,7 @@ echo "📦 Import du workflow: $WORKFLOW_NAME"
 echo "📄 Fichier: $WORKFLOW_FILE"
 echo ""
 
-# Créer fichier temporaire avec les propriétés non-portables supprimées
-# Selon docs/n8n/WORKFLOW_BEST_PRACTICES.md:
-# "Propriétés à Éviter à l'Import: active, versionId, meta, tags, id"
+# Créer fichier temporaire avec les propriétés minimales pour l'API
 TMP_FILE=$(mktemp /tmp/workflow_XXXXXX.json)
 jq '
   del(.id) |
@@ -34,18 +32,41 @@ jq '
   del(.createdAt) |
   del(.updatedAt) |
   del(.meta) |
-  del(.tags)
+  del(.tags) |
+  del(.triggerCount) |
+  del(.staticData)
 ' "$WORKFLOW_FILE" > "$TMP_FILE"
 
-# Import via n8n CLI
-if n8n import:workflow --input="$TMP_FILE"; then
+# Import via API Python (gère correctement le versionId)
+echo "📤 Import via API..."
+if python3 scripts/n8n/n8n_api.py import "$TMP_FILE"; then
     echo ""
     echo "✅ Workflow importé avec succès: $WORKFLOW_NAME"
+    rm -f "$TMP_FILE"
 else
     echo ""
-    echo "❌ Échec de l'import"
-    rm -f "$TMP_FILE"
-    exit 1
-fi
+    echo "⚠️  API failed, trying CLI fallback..."
 
-rm -f "$TMP_FILE"
+    # Fallback: CLI avec UUID généré
+    VERSION_ID=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || uuidgen)
+    jq --arg vid "$VERSION_ID" '
+      del(.id) |
+      .active = false |
+      .versionId = $vid |
+      del(.createdAt) |
+      del(.updatedAt) |
+      del(.meta) |
+      del(.tags)
+    ' "$WORKFLOW_FILE" > "$TMP_FILE"
+
+    if n8n import:workflow --input="$TMP_FILE"; then
+        echo ""
+        echo "✅ Workflow importé via CLI: $WORKFLOW_NAME"
+    else
+        echo ""
+        echo "❌ Échec de l'import"
+        rm -f "$TMP_FILE"
+        exit 1
+    fi
+    rm -f "$TMP_FILE"
+fi

--- a/workflows/mcp-tools/analyze_message_tool.json
+++ b/workflows/mcp-tools/analyze_message_tool.json
@@ -84,17 +84,17 @@
       "name": "Google Sentiment",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [940, 140],
+      "position": [940, 100],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
         "method": "POST",
-        "url": "=https://language.googleapis.com/v1/documents:analyzeEntities?key={{ $('Prepare Data').first().json.googleApiKey }}",
+        "url": "=https://language.googleapis.com/v1/documents:analyzeEntities?key={{ $json.googleApiKey }}",
         "authentication": "none",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"document\": {\n    \"type\": \"PLAIN_TEXT\",\n    \"content\": \"{{ $('Prepare Data').first().json.text }}\"\n  },\n  \"encodingType\": \"UTF8\"\n}",
+        "jsonBody": "={\n  \"document\": {\n    \"type\": \"PLAIN_TEXT\",\n    \"content\": \"{{ $json.text }}\"\n  },\n  \"encodingType\": \"UTF8\"\n}",
         "options": {
           "timeout": 10000
         }
@@ -116,7 +116,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $('Prepare Data').first().json.openaiApiKey }}"
+              "value": "=Bearer {{ $json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -126,7 +126,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un analyseur de messages. Analyse le message utilisateur et retourne un JSON avec:\\n\\n1. intent: {\\n   \\\"intent\\\": \\\"action_request\\\" | \\\"question\\\" | \\\"feedback\\\" | \\\"complaint\\\" | \\\"clarification\\\" | \\\"greeting\\\" | \\\"cancel\\\",\\n   \\\"sub_intent\\\": string ou null,\\n   \\\"confidence\\\": 0.0-1.0,\\n   \\\"requires_confirmation\\\": boolean\\n}\\n\\n2. priority: {\\n   \\\"priority\\\": \\\"critical\\\" | \\\"high\\\" | \\\"medium\\\" | \\\"low\\\",\\n   \\\"score\\\": 0.0-1.0,\\n   \\\"indicators\\\": [mots-clés détectés]\\n}\\n\\n3. language: {\\n   \\\"language\\\": code ISO 2 lettres,\\n   \\\"confidence\\\": 0.0-1.0\\n}\\n\\nRetourne UNIQUEMENT le JSON, pas d'explication.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $('Prepare Data').first().json.text }}\"\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 500\n}",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un analyseur de messages. Analyse le message utilisateur et retourne un JSON avec:\\n\\n1. intents: tableau d'intentions détectées (peut contenir plusieurs si le message demande plusieurs actions)\\n   [{\\n     \\\"type\\\": \\\"action_request\\\" | \\\"question\\\" | \\\"feedback\\\" | \\\"complaint\\\" | \\\"clarification\\\" | \\\"greeting\\\" | \\\"cancel\\\",\\n     \\\"action\\\": string décrivant l'action spécifique (ex: \\\"send_email\\\", \\\"schedule_meeting\\\", \\\"book_restaurant\\\"),\\n     \\\"target\\\": string ou null (cible de l'action: personne, lieu, objet),\\n     \\\"confidence\\\": 0.0-1.0\\n   }]\\n\\n2. priority: {\\n   \\\"level\\\": \\\"critical\\\" | \\\"high\\\" | \\\"medium\\\" | \\\"low\\\",\\n   \\\"score\\\": 0.0-1.0,\\n   \\\"indicators\\\": [mots-clés d'urgence détectés],\\n   \\\"requires_confirmation\\\": boolean (true si action sensible/irréversible)\\n}\\n\\n3. language: {\\n   \\\"code\\\": code ISO 2 lettres,\\n   \\\"confidence\\\": 0.0-1.0\\n}\\n\\nRetourne UNIQUEMENT le JSON, pas d'explication.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $json.text }}\"\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 800\n}",
         "options": {
           "timeout": 15000
         }
@@ -135,18 +135,59 @@
       "name": "OpenAI Intent+Priority",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [940, 460],
+      "position": [940, 500],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// Merge results from parallel calls\nconst prepareData = $('Prepare Data').first().json;\nconst text = prepareData.text;\nconst options = prepareData.options;\nconst startTime = prepareData.startTime;\n\n// Get Google Sentiment result\nlet sentimentResult = null;\ntry {\n  const googleSentiment = $('Google Sentiment').first().json;\n  if (googleSentiment && googleSentiment.documentSentiment) {\n    const ds = googleSentiment.documentSentiment;\n    sentimentResult = {\n      sentiment: ds.score > 0.2 ? 'positive' : ds.score < -0.2 ? 'negative' : 'neutral',\n      score: ds.score,\n      magnitude: ds.magnitude,\n      confidence: Math.min(1, Math.abs(ds.score) + ds.magnitude / 2)\n    };\n  } else if (googleSentiment && googleSentiment.error) {\n    sentimentResult = { error: googleSentiment.error.message || 'Google API error', fallback: true };\n  }\n} catch (e) {\n  sentimentResult = { error: 'Google Sentiment failed: ' + e.message, fallback: true };\n}\n\n// Get Google Entities result\nlet entitiesResult = [];\ntry {\n  const googleEntities = $('Google Entities').first().json;\n  if (googleEntities && googleEntities.entities) {\n    entitiesResult = googleEntities.entities.map(e => ({\n      type: e.type,\n      value: e.name,\n      salience: e.salience,\n      metadata: e.metadata || {}\n    }));\n  } else if (googleEntities && googleEntities.error) {\n    entitiesResult = [{ error: googleEntities.error.message || 'Google API error' }];\n  }\n} catch (e) {\n  entitiesResult = [{ error: 'Google Entities failed: ' + e.message }];\n}\n\n// Get OpenAI result\nlet intentResult = null;\nlet priorityResult = null;\nlet languageResult = null;\n\ntry {\n  const openaiResponse = $('OpenAI Intent+Priority').first().json;\n  if (openaiResponse && openaiResponse.choices && openaiResponse.choices[0]) {\n    const content = openaiResponse.choices[0].message.content;\n    const parsed = JSON.parse(content);\n    \n    intentResult = parsed.intent || null;\n    priorityResult = parsed.priority || null;\n    languageResult = parsed.language || null;\n  } else if (openaiResponse && openaiResponse.error) {\n    intentResult = { error: openaiResponse.error.message || 'OpenAI API error' };\n  }\n} catch (e) {\n  // Fallback values\n  intentResult = { intent: 'unknown', confidence: 0, error: 'OpenAI parsing failed: ' + e.message };\n  priorityResult = { priority: 'medium', score: 0.5 };\n  languageResult = { language: 'unknown', confidence: 0 };\n}\n\n// Build final response\nconst response = {\n  success: true,\n  text: text,\n  analysis: {}\n};\n\nif (options.sentiment !== false) {\n  response.analysis.sentiment = sentimentResult;\n}\n\nif (options.intent !== false) {\n  response.analysis.intent = intentResult;\n}\n\nif (options.entities !== false) {\n  response.analysis.entities = entitiesResult;\n}\n\nif (options.priority !== false) {\n  response.analysis.priority = priorityResult;\n}\n\nif (options.language !== false) {\n  response.analysis.language = languageResult;\n}\n\nresponse.meta = {\n  providers: {\n    sentiment: 'google-cloud-nlp',\n    entities: 'google-cloud-nlp',\n    intent: 'openai-gpt4o-mini',\n    priority: 'openai-gpt4o-mini',\n    language: 'openai-gpt4o-mini'\n  },\n  processing_time_ms: Date.now() - startTime\n};\n\nreturn { json: response };"
+        "jsCode": "// Tag sentiment result\nconst result = $input.first().json;\nreturn {\n  json: {\n    source: 'sentiment',\n    data: result\n  }\n};"
+      },
+      "id": "tag-sentiment",
+      "name": "Tag Sentiment",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Tag entities result\nconst result = $input.first().json;\nreturn {\n  json: {\n    source: 'entities',\n    data: result\n  }\n};"
+      },
+      "id": "tag-entities",
+      "name": "Tag Entities",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Tag OpenAI result\nconst result = $input.first().json;\nreturn {\n  json: {\n    source: 'openai',\n    data: result\n  }\n};"
+      },
+      "id": "tag-openai",
+      "name": "Tag OpenAI",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 500]
+    },
+    {
+      "parameters": {
+        "mode": "append",
+        "numberInputs": 3
+      },
+      "id": "merge-all",
+      "name": "Merge All",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1380, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Merge all tagged results\nconst items = $input.all();\nconst prepareData = $('Prepare Data').first().json;\nconst text = prepareData.text;\nconst options = prepareData.options;\nconst startTime = prepareData.startTime;\n\n// Find results by source tag\nlet sentimentData = null;\nlet entitiesData = null;\nlet openaiData = null;\n\nfor (const item of items) {\n  const source = item.json.source;\n  const data = item.json.data;\n  \n  if (source === 'sentiment') {\n    sentimentData = data;\n  } else if (source === 'entities') {\n    entitiesData = data;\n  } else if (source === 'openai') {\n    openaiData = data;\n  }\n}\n\n// Process sentiment\nlet sentimentResult = null;\ntry {\n  if (sentimentData && sentimentData.documentSentiment) {\n    const ds = sentimentData.documentSentiment;\n    sentimentResult = {\n      label: ds.score > 0.2 ? 'positive' : ds.score < -0.2 ? 'negative' : 'neutral',\n      score: ds.score,\n      magnitude: ds.magnitude,\n      confidence: Math.min(1, Math.abs(ds.score) + ds.magnitude / 2)\n    };\n  } else if (sentimentData && sentimentData.error) {\n    sentimentResult = { error: sentimentData.error.message || 'Google API error', fallback: true };\n  } else {\n    sentimentResult = { error: 'No sentiment data', fallback: true };\n  }\n} catch (e) {\n  sentimentResult = { error: 'Sentiment processing failed: ' + e.message, fallback: true };\n}\n\n// Process entities\nlet entitiesResult = [];\ntry {\n  if (entitiesData && entitiesData.entities) {\n    entitiesResult = entitiesData.entities.map(e => ({\n      type: e.type,\n      value: e.name,\n      salience: e.salience,\n      metadata: e.metadata || {}\n    }));\n  } else if (entitiesData && entitiesData.error) {\n    entitiesResult = [{ error: entitiesData.error.message || 'Google API error' }];\n  }\n} catch (e) {\n  entitiesResult = [{ error: 'Entities processing failed: ' + e.message }];\n}\n\n// Process OpenAI (new multi-intent structure)\nlet intentsResult = [];\nlet priorityResult = null;\nlet languageResult = null;\n\ntry {\n  if (openaiData && openaiData.choices && openaiData.choices[0]) {\n    const content = openaiData.choices[0].message.content;\n    const parsed = JSON.parse(content);\n    \n    // Handle intents array\n    intentsResult = parsed.intents || [];\n    \n    // Handle priority with new structure\n    if (parsed.priority) {\n      priorityResult = {\n        level: parsed.priority.level || parsed.priority.priority || 'medium',\n        score: parsed.priority.score || 0.5,\n        indicators: parsed.priority.indicators || [],\n        requires_confirmation: parsed.priority.requires_confirmation || false\n      };\n    }\n    \n    // Handle language with new structure\n    if (parsed.language) {\n      languageResult = {\n        code: parsed.language.code || parsed.language.language || 'unknown',\n        confidence: parsed.language.confidence || 0\n      };\n    }\n  } else if (openaiData && openaiData.error) {\n    intentsResult = [{ error: openaiData.error.message || 'OpenAI API error' }];\n  } else {\n    intentsResult = [{ error: 'No OpenAI data' }];\n  }\n} catch (e) {\n  intentsResult = [{ type: 'unknown', action: 'unknown', confidence: 0, error: 'OpenAI parsing failed: ' + e.message }];\n  priorityResult = { level: 'medium', score: 0.5, indicators: [], requires_confirmation: false };\n  languageResult = { code: 'unknown', confidence: 0 };\n}\n\n// Build final response\nconst response = {\n  success: true,\n  text: text,\n  analysis: {}\n};\n\nif (options.sentiment !== false) {\n  response.analysis.sentiment = sentimentResult;\n}\n\nif (options.intent !== false) {\n  response.analysis.intents = intentsResult;\n}\n\nif (options.entities !== false) {\n  response.analysis.entities = entitiesResult;\n}\n\nif (options.priority !== false) {\n  response.analysis.priority = priorityResult;\n}\n\nif (options.language !== false) {\n  response.analysis.language = languageResult;\n}\n\nresponse.meta = {\n  providers: {\n    sentiment: 'google-cloud-nlp',\n    entities: 'google-cloud-nlp',\n    intents: 'openai-gpt4o-mini',\n    priority: 'openai-gpt4o-mini',\n    language: 'openai-gpt4o-mini'\n  },\n  processing_time_ms: Date.now() - startTime\n};\n\nreturn { json: response };"
       },
       "id": "merge-results",
       "name": "Merge Results",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1200, 300]
+      "position": [1600, 300]
     },
     {
       "parameters": {
@@ -168,7 +209,7 @@
       "name": "Respond Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1420, 300]
+      "position": [1820, 300]
     }
   ],
   "connections": {
@@ -226,7 +267,7 @@
       "main": [
         [
           {
-            "node": "Merge Results",
+            "node": "Tag Sentiment",
             "type": "main",
             "index": 0
           }
@@ -237,7 +278,7 @@
       "main": [
         [
           {
-            "node": "Merge Results",
+            "node": "Tag Entities",
             "type": "main",
             "index": 0
           }
@@ -248,7 +289,62 @@
       "main": [
         [
           {
+            "node": "Tag OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Tag Sentiment": {
+      "main": [
+        [
+          {
+            "node": "Merge All",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Tag Entities": {
+      "main": [
+        [
+          {
+            "node": "Merge All",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Tag OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Merge All",
+            "type": "main",
+            "index": 2
+          }
+        ]
+      ]
+    },
+    "Merge All": {
+      "main": [
+        [
+          {
             "node": "Merge Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Results": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
             "type": "main",
             "index": 0
           }

--- a/workflows/mcp-tools/code_generator_tool.json
+++ b/workflows/mcp-tools/code_generator_tool.json
@@ -69,39 +69,37 @@
     {
       "id": "openai-code",
       "name": "OpenAI Generate Code",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         700,
         200
       ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "={{ $json.body.model || 'gpt-4o' }}",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "={{ 'You are an expert software developer. Generate clean, well-documented, production-ready code.' + ($json.body.language ? ' Use ' + $json.body.language + ' programming language.' : '') + ($json.body.framework ? ' Use ' + $json.body.framework + ' framework.' : '') + ' Include comments explaining key parts of the code. Follow best practices and design patterns.' }}",
-              "role": "system"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
             },
             {
-              "content": "={{ $json.body.prompt + ($json.body.context ? '\\n\\nContext:\\n' + $json.body.context : '') }}",
-              "role": "user"
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"{{ $json.body.model || 'gpt-4o' }}\",\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are an expert software developer. Generate clean, well-documented, production-ready code.{{ $json.body.language ? ' Use ' + $json.body.language + ' programming language.' : '' }}{{ $json.body.framework ? ' Use ' + $json.body.framework + ' framework.' : '' }} Include comments explaining key parts of the code. Follow best practices and design patterns.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $json.body.prompt }}{{ $json.body.context ? '\\n\\nContext:\\n' + $json.body.context : '' }}\"\n    }\n  ],\n  \"temperature\": {{ $json.body.temperature || 0.2 }},\n  \"max_tokens\": {{ $json.body.max_tokens || 4096 }}\n}",
         "options": {
-          "temperature": "={{ $json.body.temperature || 0.2 }}",
-          "maxTokens": "={{ $json.body.max_tokens || 4096 }}"
+          "timeout": 60000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
@@ -114,7 +112,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"code\": $json.message.content, \"language\": $('Webhook').first().json.body.language || 'auto-detected', \"framework\": $('Webhook').first().json.body.framework || null }, \"meta\": { \"provider\": \"openai\", \"model\": $json.model || $('Webhook').first().json.body.model || 'gpt-4o', \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0, \"total_tokens\": $json.usage?.total_tokens || 0 } } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"code\": $json.choices?.[0]?.message?.content || '', \"language\": $('Webhook').first().json.body.language || 'auto-detected', \"framework\": $('Webhook').first().json.body.framework || null }, \"meta\": { \"provider\": \"openai\", \"model\": $json.model || $('Webhook').first().json.body.model || 'gpt-4o', \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0, \"total_tokens\": $json.usage?.total_tokens || 0 } } } }}"
       }
     },
     {
@@ -144,8 +142,8 @@
       "parameters": {
         "color": 6,
         "width": 550,
-        "height": 240,
-        "content": "## MCP - Code Generator\n\n**Endpoint:** POST /webhook/code-generator\n\n**Parameters:**\n- `prompt` (required): Code generation request\n- `language` (optional): Programming language (python, javascript, etc.)\n- `framework` (optional): Framework to use (react, fastapi, etc.)\n- `context` (optional): Additional context or existing code\n- `model` (optional): gpt-4o, gpt-4o-mini (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.2 for deterministic code)\n- `max_tokens` (optional): Max tokens (default: 4096)\n\n**Returns:** Generated code with metadata"
+        "height": 280,
+        "content": "## MCP - Code Generator\n\n**Endpoint:** POST /webhook/code-generator\n\n**Parameters:**\n- `prompt` (required): Code generation request\n- `openai_api_key` (required): OpenAI API key\n- `language` (optional): Programming language (python, javascript, etc.)\n- `framework` (optional): Framework to use (react, fastapi, etc.)\n- `context` (optional): Additional context or existing code\n- `model` (optional): gpt-4o, gpt-4o-mini (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.2 for deterministic code)\n- `max_tokens` (optional): Max tokens (default: 4096)\n\n**Returns:** Generated code with metadata"
       }
     }
   ],

--- a/workflows/mcp-tools/entity_extractor_tool.json
+++ b/workflows/mcp-tools/entity_extractor_tool.json
@@ -69,35 +69,37 @@
     {
       "id": "openai-extract",
       "name": "OpenAI Extract Entities",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         700,
         200
       ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "gpt-4o-mini",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "={{ \"You are an expert entity extractor. Extract all named entities from the following text and return them in JSON format.\\n\\nCategories to extract:\\n- PERSON: Names of people\\n- ORGANIZATION: Companies, institutions, agencies\\n- LOCATION: Cities, countries, addresses, places\\n- DATE: Dates and time expressions\\n- MONEY: Monetary values\\n- PRODUCT: Products, services\\n- EVENT: Events, conferences\\n- OTHER: Other relevant entities\\n\\nEntity types requested: \" + ($json.body.entity_types ? $json.body.entity_types.join(\", \") : \"all\") + \"\\n\\nText to analyze:\\n\" + $json.body.text + \"\\n\\nReturn ONLY a valid JSON object with this structure:\\n{\\n  \\\"entities\\\": [\\n    {\\\"text\\\": \\\"entity text\\\", \\\"type\\\": \\\"CATEGORY\\\", \\\"confidence\\\": 0.95}\\n  ],\\n  \\\"summary\\\": {\\n    \\\"total_count\\\": number,\\n    \\\"by_type\\\": {\\\"PERSON\\\": count, ...}\\n  }\\n}\" }}",
-              "role": "user"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"You are an expert entity extractor. Extract all named entities from the following text and return them in JSON format.\\n\\nCategories to extract:\\n- PERSON: Names of people\\n- ORGANIZATION: Companies, institutions, agencies\\n- LOCATION: Cities, countries, addresses, places\\n- DATE: Dates and time expressions\\n- MONEY: Monetary values\\n- PRODUCT: Products, services\\n- EVENT: Events, conferences\\n- OTHER: Other relevant entities\\n\\nEntity types requested: {{ $json.body.entity_types ? $json.body.entity_types.join(', ') : 'all' }}\\n\\nText to analyze:\\n{{ $json.body.text }}\\n\\nReturn ONLY a valid JSON object with this structure:\\n{\\n  \\\"entities\\\": [\\n    {\\\"text\\\": \\\"entity text\\\", \\\"type\\\": \\\"CATEGORY\\\", \\\"confidence\\\": 0.95}\\n  ],\\n  \\\"summary\\\": {\\n    \\\"total_count\\\": number,\\n    \\\"by_type\\\": {\\\"PERSON\\\": count, ...}\\n  }\\n}\"\n    }\n  ],\n  \"temperature\": 0.1\n}",
         "options": {
-          "temperature": 0.1,
-          "response_format": "json_object"
+          "timeout": 30000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "parse-response",
@@ -110,7 +112,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ (() => { try { const content = $json.message.content; const parsed = JSON.parse(content); return { entities: parsed.entities || [], summary: parsed.summary || { total_count: 0, by_type: {} } }; } catch(e) { return { entities: [], summary: { total_count: 0, by_type: {} }, parse_error: e.message }; } })() }}"
+        "jsonOutput": "={{ (() => { try { const content = $json.choices?.[0]?.message?.content || '{}'; const parsed = JSON.parse(content); return { entities: parsed.entities || [], summary: parsed.summary || { total_count: 0, by_type: {} } }; } catch(e) { return { entities: [], summary: { total_count: 0, by_type: {} }, parse_error: e.message }; } })() }}"
       }
     },
     {
@@ -154,8 +156,8 @@
       "parameters": {
         "color": 6,
         "width": 500,
-        "height": 180,
-        "content": "## MCP - Entity Extractor\n\n**Endpoint:** POST /webhook/entity-extractor\n\n**Parameters:**\n- `text` (required): Text to extract entities from\n- `entity_types` (optional): Array of types to extract [\"PERSON\", \"ORGANIZATION\", \"LOCATION\", ...]\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of entities with type and confidence"
+        "height": 200,
+        "content": "## MCP - Entity Extractor\n\n**Endpoint:** POST /webhook/entity-extractor\n\n**Parameters:**\n- `text` (required): Text to extract entities from\n- `openai_api_key` (required): OpenAI API key\n- `entity_types` (optional): Array of types to extract [\"PERSON\", \"ORGANIZATION\", \"LOCATION\", ...]\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of entities with type and confidence"
       }
     }
   ],

--- a/workflows/mcp-tools/get_image_ocr_tool.json
+++ b/workflows/mcp-tools/get_image_ocr_tool.json
@@ -80,27 +80,28 @@
       "parameters": {
         "method": "POST",
         "url": "https://api.mistral.ai/v1/chat/completions",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "mistralCloudApi",
+        "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
             {
-              "name": "content-type",
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.mistral_api_key }}"
+            },
+            {
+              "name": "Content-Type",
               "value": "application/json"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"pixtral-12b-2409\", \"messages\": [{ \"role\": \"user\", \"content\": [{ \"type\": \"text\", \"text\": $json.body.prompt || \"Extract all text from this image. Return the text exactly as it appears, preserving formatting where possible. If there are multiple columns or sections, process them in reading order.\" }, { \"type\": \"image_url\", \"image_url\": { \"url\": $json.body.image_url || ('data:image/' + ($binary.data?.mimeType?.split('/')[1] || 'png') + ';base64,' + $binary.data?.data) } }] }], \"max_tokens\": $json.body.max_tokens || 4096 } }}"
-      },
-      "credentials": {
-        "mistralCloudApi": {
-          "id": "mistral-credentials",
-          "name": "Mistral account"
+        "jsonBody": "={{ { \"model\": \"pixtral-12b-2409\", \"messages\": [{ \"role\": \"user\", \"content\": [{ \"type\": \"text\", \"text\": $json.body.prompt || \"Extract all text from this image. Return the text exactly as it appears, preserving formatting where possible. If there are multiple columns or sections, process them in reading order.\" }, { \"type\": \"image_url\", \"image_url\": { \"url\": $json.body.image_url || ('data:image/' + ($binary.data?.mimeType?.split('/')[1] || 'png') + ';base64,' + $binary.data?.data) } }] }], \"max_tokens\": $json.body.max_tokens || 4096 } }}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
@@ -113,7 +114,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.choices[0]?.message?.content || '', \"model\": 'pixtral-12b-2409', \"source\": $('Webhook').first().json.body.image_url ? 'url' : 'binary' }, \"meta\": { \"provider\": \"mistral\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0 } } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.choices?.[0]?.message?.content || '', \"model\": 'pixtral-12b-2409', \"source\": $('Webhook').first().json.body.image_url ? 'url' : 'binary' }, \"meta\": { \"provider\": \"mistral\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0 } } } }}"
       }
     },
     {
@@ -143,8 +144,8 @@
       "parameters": {
         "color": 6,
         "width": 550,
-        "height": 220,
-        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**Parameters:**\n- `image_url` (string): URL of image to process\n- OR upload binary image file\n- `prompt` (optional): Custom extraction instructions\n- `max_tokens` (optional): Max output tokens (default: 4096)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Extracted text from image\n\n**Note:** Uses Mistral Pixtral vision model for OCR"
+        "height": 240,
+        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**Parameters:**\n- `mistral_api_key` (required): Mistral API key\n- `image_url` (string): URL of image to process\n- OR upload binary image file\n- `prompt` (optional): Custom extraction instructions\n- `max_tokens` (optional): Max output tokens (default: 4096)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Extracted text from image\n\n**Note:** Uses Mistral Pixtral vision model for OCR"
       }
     }
   ],

--- a/workflows/mcp-tools/google_searcher_tool.json
+++ b/workflows/mcp-tools/google_searcher_tool.json
@@ -78,11 +78,14 @@
       "parameters": {
         "method": "GET",
         "url": "https://serpapi.com/search",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "serpApi",
+        "authentication": "none",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
+            {
+              "name": "api_key",
+              "value": "={{ $json.body.serpapi_api_key }}"
+            },
             {
               "name": "engine",
               "value": "google"
@@ -105,14 +108,11 @@
             }
           ]
         },
-        "options": {}
-      },
-      "credentials": {
-        "serpApi": {
-          "id": "serpapi-credentials",
-          "name": "SerpAPI"
+        "options": {
+          "timeout": 30000
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
@@ -155,8 +155,8 @@
       "parameters": {
         "color": 6,
         "width": 550,
-        "height": 220,
-        "content": "## MCP - Google Searcher\n\n**Endpoint:** POST /webhook/google-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `num_results` (optional): Number of results 1-100 (default: 10)\n- `language` (optional): Language code, e.g., 'en', 'fr' (default: en)\n- `country` (optional): Country code, e.g., 'us', 'fr' (default: us)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Organic results, knowledge graph, answer box, related searches\n\n**Note:** Requires SerpAPI credentials"
+        "height": 240,
+        "content": "## MCP - Google Searcher\n\n**Endpoint:** POST /webhook/google-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `serpapi_api_key` (required): SerpAPI API key\n- `num_results` (optional): Number of results 1-100 (default: 10)\n- `language` (optional): Language code, e.g., 'en', 'fr' (default: en)\n- `country` (optional): Country code, e.g., 'us', 'fr' (default: us)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Organic results, knowledge graph, answer box, related searches"
       }
     }
   ],

--- a/workflows/mcp-tools/llm_summarizer_tool.json
+++ b/workflows/mcp-tools/llm_summarizer_tool.json
@@ -132,39 +132,37 @@
     {
       "id": "openai-summarize",
       "name": "OpenAI Summarize",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         940,
         100
       ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "gpt-4o-mini",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "You are a professional summarizer. Create clear, concise summaries that capture the main points and key information.",
-              "role": "system"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
             },
             {
-              "content": "={{ 'Summarize the following text' + ($json.body.format ? ' in ' + $json.body.format + ' format' : '') + ':\\n\\n' + $json.body.text }}",
-              "role": "user"
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a professional summarizer. Create clear, concise summaries that capture the main points and key information.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Summarize the following text{{ $json.body.format ? ' in ' + $json.body.format + ' format' : '' }}:\\n\\n{{ $json.body.text }}\"\n    }\n  ],\n  \"temperature\": 0.3,\n  \"max_tokens\": {{ $json.body.max_tokens || 1024 }}\n}",
         "options": {
-          "temperature": 0.3,
-          "maxTokens": "={{ $json.body.max_tokens || 1024 }}"
+          "timeout": 60000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "mistral-summarize",
@@ -178,18 +176,28 @@
       "parameters": {
         "method": "POST",
         "url": "https://api.mistral.ai/v1/chat/completions",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "mistralCloudApi",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.mistral_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"mistral-small-latest\", \"messages\": [{ \"role\": \"system\", \"content\": \"You are a professional summarizer. Create clear, concise summaries.\" }, { \"role\": \"user\", \"content\": \"Summarize the following text\" + ($json.body.format ? \" in \" + $json.body.format + \" format\" : \"\") + \":\\n\\n\" + $json.body.text }], \"max_tokens\": $json.body.max_tokens || 1024, \"temperature\": 0.3 } }}"
-      },
-      "credentials": {
-        "mistralCloudApi": {
-          "id": "mistral-credentials",
-          "name": "Mistral account"
+        "jsonBody": "={\n  \"model\": \"mistral-small-latest\",\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a professional summarizer. Create clear, concise summaries.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Summarize the following text{{ $json.body.format ? ' in ' + $json.body.format + ' format' : '' }}:\\n\\n{{ $json.body.text }}\"\n    }\n  ],\n  \"max_tokens\": {{ $json.body.max_tokens || 1024 }},\n  \"temperature\": 0.3\n}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
       "id": "anthropic-summarize",
@@ -203,27 +211,32 @@
       "parameters": {
         "method": "POST",
         "url": "https://api.anthropic.com/v1/messages",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "anthropicApi",
+        "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
             {
+              "name": "x-api-key",
+              "value": "={{ $json.body.anthropic_api_key }}"
+            },
+            {
               "name": "anthropic-version",
               "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"claude-3-5-sonnet-20241022\", \"max_tokens\": $json.body.max_tokens || 1024, \"messages\": [{ \"role\": \"user\", \"content\": \"Summarize the following text\" + ($json.body.format ? \" in \" + $json.body.format + \" format\" : \"\") + \":\\n\\n\" + $json.body.text }] } }}"
-      },
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-credentials",
-          "name": "Anthropic account"
+        "jsonBody": "={\n  \"model\": \"claude-3-5-sonnet-20241022\",\n  \"max_tokens\": {{ $json.body.max_tokens || 1024 }},\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Summarize the following text{{ $json.body.format ? ' in ' + $json.body.format + ' format' : '' }}:\\n\\n{{ $json.body.text }}\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-openai",
@@ -236,7 +249,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.message.content, \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": $json.message.content.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.choices?.[0]?.message?.content || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.choices?.[0]?.message?.content || '').length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
       }
     },
     {
@@ -250,7 +263,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.choices[0]?.message?.content || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.choices[0]?.message?.content || '').length }, \"meta\": { \"provider\": \"mistral\", \"model\": \"mistral-small-latest\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.choices?.[0]?.message?.content || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.choices?.[0]?.message?.content || '').length }, \"meta\": { \"provider\": \"mistral\", \"model\": \"mistral-small-latest\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
       }
     },
     {
@@ -264,7 +277,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.content[0]?.text || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.content[0]?.text || '').length }, \"meta\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.content?.[0]?.text || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.content?.[0]?.text || '').length }, \"meta\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
       }
     },
     {
@@ -293,9 +306,9 @@
       ],
       "parameters": {
         "color": 6,
-        "width": 550,
-        "height": 220,
-        "content": "## MCP - LLM Summarizer\n\n**Endpoint:** POST /webhook/llm-summarizer\n\n**Parameters:**\n- `text` (required): Text to summarize\n- `provider` (optional): anthropic (default), openai, mistral\n- `format` (optional): bullet-points, paragraph, executive-summary\n- `max_tokens` (optional): Max output tokens (default: 1024)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Summary with length stats and provider info"
+        "width": 600,
+        "height": 260,
+        "content": "## MCP - LLM Summarizer\n\n**Endpoint:** POST /webhook/llm-summarizer\n\n**Parameters:**\n- `text` (required): Text to summarize\n- `provider` (optional): anthropic (default), openai, mistral\n- API key based on provider:\n  - `anthropic_api_key` for anthropic (default)\n  - `openai_api_key` for openai\n  - `mistral_api_key` for mistral\n- `format` (optional): bullet-points, paragraph, executive-summary\n- `max_tokens` (optional): Max output tokens (default: 1024)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Summary with length stats and provider info"
       }
     }
   ],

--- a/workflows/mcp-tools/speaker_identifier_tool.json
+++ b/workflows/mcp-tools/speaker_identifier_tool.json
@@ -101,7 +101,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// For base64 input, we need to upload to a temporary storage\n// In production, this would upload to S3/MinIO and return a URL\n// For now, we'll use AssemblyAI's upload endpoint\n\nconst base64Data = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\n\n// Remove data URL prefix if present\nconst cleanBase64 = base64Data.replace(/^data:audio\\/[a-z]+;base64,/, '');\n\nreturn {\n  json: {\n    audioBase64: cleanBase64,\n    options: options,\n    needsUpload: true\n  }\n};"
+        "jsCode": "// For base64 input, we need to upload to a temporary storage\nconst base64Data = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\nconst apiKey = $input.first().json.body.assemblyai_api_key;\n\n// Remove data URL prefix if present\nconst cleanBase64 = base64Data.replace(/^data:audio\\/[a-z]+;base64,/, '');\n\nreturn {\n  json: {\n    audioBase64: cleanBase64,\n    options: options,\n    needsUpload: true,\n    assemblyai_api_key: apiKey\n  }\n};"
       },
       "id": "prepare-base64",
       "name": "Prepare Base64",
@@ -116,17 +116,25 @@
       "parameters": {
         "method": "POST",
         "url": "https://api.assemblyai.com/v2/upload",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.assemblyai_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/octet-stream"
+            }
+          ]
+        },
         "sendBody": true,
         "contentType": "raw",
         "body": "={{ Buffer.from($json.audioBase64, 'base64') }}",
         "options": {
-          "response": {
-            "response": {
-              "fullResponse": false
-            }
-          }
+          "timeout": 120000
         }
       },
       "id": "upload-to-assemblyai",
@@ -137,16 +145,11 @@
         1120,
         200
       ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "assemblyai-auth",
-          "name": "AssemblyAI API Key"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// Prepare URL audio input\nconst audioUrl = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\n\nreturn {\n  json: {\n    audioUrl: audioUrl,\n    options: options,\n    needsUpload: false\n  }\n};"
+        "jsCode": "// Prepare URL audio input\nconst audioUrl = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\nconst apiKey = $input.first().json.body.assemblyai_api_key;\n\nreturn {\n  json: {\n    audioUrl: audioUrl,\n    options: options,\n    needsUpload: false,\n    assemblyai_api_key: apiKey\n  }\n};"
       },
       "id": "prepare-url",
       "name": "Prepare URL",
@@ -159,7 +162,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Merge uploaded URL with options\nconst uploadResponse = $input.first().json;\nconst previousData = $('Prepare Base64').first().json;\n\nreturn {\n  json: {\n    audioUrl: uploadResponse.upload_url,\n    options: previousData.options\n  }\n};"
+        "jsCode": "// Merge uploaded URL with options\nconst uploadResponse = $input.first().json;\nconst previousData = $('Prepare Base64').first().json;\n\nreturn {\n  json: {\n    audioUrl: uploadResponse.upload_url,\n    options: previousData.options,\n    assemblyai_api_key: previousData.assemblyai_api_key\n  }\n};"
       },
       "id": "merge-upload-result",
       "name": "Merge Upload Result",
@@ -172,7 +175,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Prepare AssemblyAI transcription request\nconst input = $input.first().json;\nconst options = input.options || {};\n\nconst requestBody = {\n  audio_url: input.audioUrl,\n  speaker_labels: true\n};\n\n// Add optional parameters\nif (options.speakers_expected) {\n  requestBody.speakers_expected = options.speakers_expected;\n}\n\nif (options.language && options.language !== 'auto') {\n  requestBody.language_code = options.language;\n}\n\nif (options.language === 'auto') {\n  requestBody.language_detection = true;\n}\n\nreturn {\n  json: {\n    requestBody: requestBody,\n    options: options\n  }\n};"
+        "jsCode": "// Prepare AssemblyAI transcription request\nconst input = $input.first().json;\nconst options = input.options || {};\n\nconst requestBody = {\n  audio_url: input.audioUrl,\n  speaker_labels: true\n};\n\n// Add optional parameters\nif (options.speakers_expected) {\n  requestBody.speakers_expected = options.speakers_expected;\n}\n\nif (options.language && options.language !== 'auto') {\n  requestBody.language_code = options.language;\n}\n\nif (options.language === 'auto') {\n  requestBody.language_detection = true;\n}\n\nreturn {\n  json: {\n    requestBody: requestBody,\n    options: options,\n    assemblyai_api_key: input.assemblyai_api_key\n  }\n};"
       },
       "id": "prepare-transcription-request",
       "name": "Prepare Transcription Request",
@@ -187,12 +190,26 @@
       "parameters": {
         "method": "POST",
         "url": "https://api.assemblyai.com/v2/transcript",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.assemblyai_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify($json.requestBody) }}",
-        "options": {}
+        "options": {
+          "timeout": 30000
+        }
       },
       "id": "start-transcription",
       "name": "Start Transcription",
@@ -202,16 +219,11 @@
         1780,
         300
       ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "assemblyai-auth",
-          "name": "AssemblyAI API Key"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// Store transcript ID and options for polling\nconst response = $input.first().json;\nconst previousData = $('Prepare Transcription Request').first().json;\n\nreturn {\n  json: {\n    transcriptId: response.id,\n    status: response.status,\n    options: previousData.options,\n    pollCount: 0,\n    startTime: Date.now()\n  }\n};"
+        "jsCode": "// Store transcript ID and options for polling\nconst response = $input.first().json;\nconst previousData = $('Prepare Transcription Request').first().json;\n\nreturn {\n  json: {\n    transcriptId: response.id,\n    status: response.status,\n    options: previousData.options,\n    pollCount: 0,\n    startTime: Date.now(),\n    assemblyai_api_key: previousData.assemblyai_api_key\n  }\n};"
       },
       "id": "store-transcript-id",
       "name": "Store Transcript ID",
@@ -226,9 +238,19 @@
       "parameters": {
         "method": "GET",
         "url": "=https://api.assemblyai.com/v2/transcript/{{ $json.transcriptId }}",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
-        "options": {}
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.assemblyai_api_key }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
       },
       "id": "poll-status",
       "name": "Poll Status",
@@ -238,12 +260,7 @@
         2220,
         300
       ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "assemblyai-auth",
-          "name": "AssemblyAI API Key"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
@@ -328,7 +345,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Increment poll count and prepare for next poll\nconst response = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\n\nconst pollCount = storedData.pollCount + 1;\nconst elapsedMs = Date.now() - storedData.startTime;\n\n// Timeout after 30 minutes\nif (elapsedMs > 30 * 60 * 1000) {\n  throw new Error('Transcription timeout after 30 minutes');\n}\n\nreturn {\n  json: {\n    transcriptId: storedData.transcriptId,\n    status: response.status,\n    options: storedData.options,\n    pollCount: pollCount,\n    startTime: storedData.startTime\n  }\n};"
+        "jsCode": "// Increment poll count and prepare for next poll\nconst response = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\n\nconst pollCount = storedData.pollCount + 1;\nconst elapsedMs = Date.now() - storedData.startTime;\n\n// Timeout after 30 minutes\nif (elapsedMs > 30 * 60 * 1000) {\n  throw new Error('Transcription timeout after 30 minutes');\n}\n\nreturn {\n  json: {\n    transcriptId: storedData.transcriptId,\n    status: response.status,\n    options: storedData.options,\n    pollCount: pollCount,\n    startTime: storedData.startTime,\n    assemblyai_api_key: storedData.assemblyai_api_key\n  }\n};"
       },
       "id": "prepare-next-poll",
       "name": "Prepare Next Poll",
@@ -390,6 +407,22 @@
         2880,
         200
       ]
+    },
+    {
+      "id": "sticky-note-doc",
+      "name": "API Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        240,
+        80
+      ],
+      "parameters": {
+        "color": 4,
+        "width": 550,
+        "height": 220,
+        "content": "## MCP - Speaker Identifier\n\n**Endpoint:** POST /webhook/speaker-identifier\n\n**Parameters:**\n- `data` (required): Audio URL or base64 encoded audio\n- `assemblyai_api_key` (required): AssemblyAI API key\n- `source` (optional): 'url' or 'base64' (default: url)\n- `options.speakers_expected` (optional): Number of expected speakers\n- `options.language` (optional): Language code or 'auto'\n- `options.include_transcription` (optional): Include full transcript (default: true)\n\n**Returns:** Speaker statistics, utterances with timestamps"
+      }
     }
   ],
   "connections": {
@@ -600,9 +633,5 @@
   },
   "settings": {
     "executionOrder": "v1"
-  },
-  "staticData": null,
-  "tags": [],
-  "triggerCount": 0,
-  "updatedAt": "2025-12-17T00:00:00.000Z"
+  }
 }

--- a/workflows/mcp-tools/summarizer_tool.json
+++ b/workflows/mcp-tools/summarizer_tool.json
@@ -67,40 +67,17 @@
       }
     },
     {
-      "id": "anthropic-summarize",
-      "name": "Anthropic Summarize",
-      "type": "@n8n/n8n-nodes-langchain.lmChatAnthropic",
-      "typeVersion": 1.2,
-      "position": [
-        700,
-        200
-      ],
-      "parameters": {
-        "model": "claude-3-5-sonnet-20241022",
-        "options": {
-          "maxTokensToSample": 4096,
-          "temperature": 0.3
-        }
-      },
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-credentials",
-          "name": "Anthropic account"
-        }
-      }
-    },
-    {
       "id": "prepare-prompt",
       "name": "Prepare Prompt",
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
         700,
-        100
+        200
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"prompt\": (\"Summarize the following text\" + ($json.body.style ? \" in a \" + $json.body.style + \" style\" : \"\") + ($json.body.max_length ? \" in approximately \" + $json.body.max_length + \" words\" : \"\") + ($json.body.language ? \" in \" + $json.body.language : \"\") + \":\\n\\n\" + $json.body.text + \"\\n\\nProvide a clear, concise summary that captures the main points.\"), \"original_length\": $json.body.text.length } }}"
+        "jsonOutput": "={{ { \"prompt\": (\"Summarize the following text\" + ($json.body.style ? \" in a \" + $json.body.style + \" style\" : \"\") + ($json.body.max_length ? \" in approximately \" + $json.body.max_length + \" words\" : \"\") + ($json.body.language ? \" in \" + $json.body.language : \"\") + \":\\n\\n\" + $json.body.text + \"\\n\\nProvide a clear, concise summary that captures the main points.\"), \"original_length\": $json.body.text.length, \"anthropic_api_key\": $json.body.anthropic_api_key, \"max_tokens\": $json.body.max_tokens || 1024 } }}"
       }
     },
     {
@@ -115,31 +92,32 @@
       "parameters": {
         "method": "POST",
         "url": "https://api.anthropic.com/v1/messages",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "anthropicApi",
+        "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropic_api_key }}"
+            },
             {
               "name": "anthropic-version",
               "value": "2023-06-01"
             },
             {
-              "name": "content-type",
+              "name": "Content-Type",
               "value": "application/json"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"claude-3-5-sonnet-20241022\", \"max_tokens\": $json.body.max_tokens || 1024, \"messages\": [ { \"role\": \"user\", \"content\": $('Prepare Prompt').first().json.prompt } ] } }}"
-      },
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-credentials",
-          "name": "Anthropic account"
+        "jsonBody": "={\n  \"model\": \"claude-3-5-sonnet-20241022\",\n  \"max_tokens\": {{ $json.max_tokens }},\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $json.prompt }}\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
@@ -152,7 +130,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.content[0].text, \"original_length\": $('Prepare Prompt').first().json.original_length, \"summary_length\": $json.content[0].text.length, \"compression_ratio\": Math.round(($('Prepare Prompt').first().json.original_length / $json.content[0].text.length) * 100) / 100 }, \"meta\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"input_tokens\": $json.usage.input_tokens, \"output_tokens\": $json.usage.output_tokens } } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.content?.[0]?.text || '', \"original_length\": $('Prepare Prompt').first().json.original_length, \"summary_length\": ($json.content?.[0]?.text || '').length, \"compression_ratio\": Math.round(($('Prepare Prompt').first().json.original_length / ($json.content?.[0]?.text || ' ').length) * 100) / 100 }, \"meta\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"input_tokens\": $json.usage?.input_tokens || 0, \"output_tokens\": $json.usage?.output_tokens || 0 } } } }}"
       }
     },
     {
@@ -182,8 +160,8 @@
       "parameters": {
         "color": 6,
         "width": 550,
-        "height": 200,
-        "content": "## MCP - Summarizer\n\n**Endpoint:** POST /webhook/summarizer\n\n**Parameters:**\n- `text` (required): Text to summarize\n- `style` (optional): Summary style (brief, detailed, bullet-points)\n- `max_length` (optional): Target word count\n- `language` (optional): Output language\n- `execution_mode` (optional): online | offline\n\n**Returns:** Summary with compression ratio and token usage"
+        "height": 220,
+        "content": "## MCP - Summarizer\n\n**Endpoint:** POST /webhook/summarizer\n\n**Parameters:**\n- `text` (required): Text to summarize\n- `anthropic_api_key` (required): Anthropic API key\n- `style` (optional): Summary style (brief, detailed, bullet-points)\n- `max_length` (optional): Target word count\n- `language` (optional): Output language\n- `execution_mode` (optional): online | offline\n\n**Returns:** Summary with compression ratio and token usage"
       }
     }
   ],

--- a/workflows/mcp-tools/text_classifier_tool.json
+++ b/workflows/mcp-tools/text_classifier_tool.json
@@ -118,76 +118,72 @@
     {
       "id": "single-label-classify",
       "name": "Single Label Classification",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         940,
         300
       ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "gpt-4o-mini",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "You are a precise text classifier. Classify the given text into exactly ONE of the provided categories. Return a JSON object with 'category' (the chosen category) and 'confidence' (a number between 0 and 1). Only respond with valid JSON, no explanation.",
-              "role": "system"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
             },
             {
-              "content": "={{ 'Classify the following text into one of these categories: ' + $json.body.categories.join(', ') + '\\n\\nText to classify:\\n' + $json.body.text }}",
-              "role": "user"
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a precise text classifier. Classify the given text into exactly ONE of the provided categories. Return a JSON object with 'category' (the chosen category) and 'confidence' (a number between 0 and 1). Only respond with valid JSON, no explanation.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Classify the following text into one of these categories: {{ $json.body.categories.join(', ') }}\\n\\nText to classify:\\n{{ $json.body.text }}\"\n    }\n  ],\n  \"temperature\": 0.1\n}",
         "options": {
-          "temperature": 0.1,
-          "responseFormat": "json_object"
+          "timeout": 30000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "multi-label-classify",
       "name": "Multi Label Classification",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         940,
         100
       ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "gpt-4o-mini",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "You are a precise text classifier. Classify the given text into ALL applicable categories from the provided list. Return a JSON object with 'categories' (array of objects, each with 'category' and 'confidence' between 0 and 1). Only include categories with confidence > 0.3. Only respond with valid JSON, no explanation.",
-              "role": "system"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
             },
             {
-              "content": "={{ 'Classify the following text into applicable categories from this list: ' + $json.body.categories.join(', ') + '\\n\\nText to classify:\\n' + $json.body.text }}",
-              "role": "user"
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a precise text classifier. Classify the given text into ALL applicable categories from the provided list. Return a JSON object with 'categories' (array of objects, each with 'category' and 'confidence' between 0 and 1). Only include categories with confidence > 0.3. Only respond with valid JSON, no explanation.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Classify the following text into applicable categories from this list: {{ $json.body.categories.join(', ') }}\\n\\nText to classify:\\n{{ $json.body.text }}\"\n    }\n  ],\n  \"temperature\": 0.1\n}",
         "options": {
-          "temperature": 0.1,
-          "responseFormat": "json_object"
+          "timeout": 30000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-single",
@@ -200,7 +196,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ (() => { try { const result = JSON.parse($json.message.content); return { \"success\": true, \"data\": { \"classification\": { \"category\": result.category, \"confidence\": result.confidence }, \"mode\": \"single_label\", \"input_categories\": $('Webhook').first().json.body.categories, \"text_length\": $('Webhook').first().json.body.text.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } }; } catch(e) { return { \"success\": false, \"error\": { \"code\": 500, \"message\": \"Failed to parse classification result\", \"status\": \"PARSE_ERROR\" } }; } })() }}"
+        "jsonOutput": "={{ (() => { try { const content = $json.choices?.[0]?.message?.content || '{}'; const result = JSON.parse(content); return { \"success\": true, \"data\": { \"classification\": { \"category\": result.category, \"confidence\": result.confidence }, \"mode\": \"single_label\", \"input_categories\": $('Webhook').first().json.body.categories, \"text_length\": $('Webhook').first().json.body.text.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } }; } catch(e) { return { \"success\": false, \"error\": { \"code\": 500, \"message\": \"Failed to parse classification result: \" + e.message, \"status\": \"PARSE_ERROR\" } }; } })() }}"
       }
     },
     {
@@ -214,7 +210,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ (() => { try { const result = JSON.parse($json.message.content); return { \"success\": true, \"data\": { \"classifications\": result.categories || [], \"mode\": \"multi_label\", \"input_categories\": $('Webhook').first().json.body.categories, \"text_length\": $('Webhook').first().json.body.text.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } }; } catch(e) { return { \"success\": false, \"error\": { \"code\": 500, \"message\": \"Failed to parse classification result\", \"status\": \"PARSE_ERROR\" } }; } })() }}"
+        "jsonOutput": "={{ (() => { try { const content = $json.choices?.[0]?.message?.content || '{}'; const result = JSON.parse(content); return { \"success\": true, \"data\": { \"classifications\": result.categories || [], \"mode\": \"multi_label\", \"input_categories\": $('Webhook').first().json.body.categories, \"text_length\": $('Webhook').first().json.body.text.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } }; } catch(e) { return { \"success\": false, \"error\": { \"code\": 500, \"message\": \"Failed to parse classification result: \" + e.message, \"status\": \"PARSE_ERROR\" } }; } })() }}"
       }
     },
     {
@@ -244,8 +240,8 @@
       "parameters": {
         "color": 4,
         "width": 550,
-        "height": 220,
-        "content": "## MCP - Text Classifier\n\n**Endpoint:** POST /webhook/text-classifier\n\n**Parameters:**\n- `text` (required): Text to classify\n- `categories` (required): Array of category labels\n- `multi_label` (optional): true for multi-label classification (default: false)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Classification result with category/confidence scores"
+        "height": 240,
+        "content": "## MCP - Text Classifier\n\n**Endpoint:** POST /webhook/text-classifier\n\n**Parameters:**\n- `text` (required): Text to classify\n- `categories` (required): Array of category labels\n- `openai_api_key` (required): OpenAI API key\n- `multi_label` (optional): true for multi-label classification (default: false)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Classification result with category/confidence scores"
       }
     }
   ],

--- a/workflows/mcp-tools/text_generator_tool.json
+++ b/workflows/mcp-tools/text_generator_tool.json
@@ -69,39 +69,37 @@
     {
       "id": "openai-generate",
       "name": "OpenAI Generate Text",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         700,
         200
       ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "={{ $json.body.model || 'gpt-4o' }}",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "={{ $json.body.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.' }}",
-              "role": "system"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
             },
             {
-              "content": "={{ $json.body.prompt }}",
-              "role": "user"
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"{{ $json.body.model || 'gpt-4o' }}\",\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{ $json.body.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.' }}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $json.body.prompt }}\"\n    }\n  ],\n  \"temperature\": {{ $json.body.temperature || 0.7 }},\n  \"max_tokens\": {{ $json.body.max_tokens || 2048 }}\n}",
         "options": {
-          "temperature": "={{ $json.body.temperature || 0.7 }}",
-          "maxTokens": "={{ $json.body.max_tokens || 2048 }}"
+          "timeout": 60000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
@@ -114,7 +112,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.message.content, \"model\": $json.model || $('Webhook').first().json.body.model || 'gpt-4o', \"finish_reason\": $json.finish_reason || 'stop' }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0, \"total_tokens\": $json.usage?.total_tokens || 0 } } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.choices?.[0]?.message?.content || '', \"model\": $json.model || $('Webhook').first().json.body.model || 'gpt-4o', \"finish_reason\": $json.choices?.[0]?.finish_reason || 'stop' }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0, \"total_tokens\": $json.usage?.total_tokens || 0 } } } }}"
       }
     },
     {
@@ -144,8 +142,8 @@
       "parameters": {
         "color": 6,
         "width": 550,
-        "height": 220,
-        "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Parameters:**\n- `prompt` (required): Text generation prompt\n- `system_prompt` (optional): System instructions\n- `model` (optional): gpt-4o, gpt-4o-mini, gpt-4-turbo (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.7)\n- `max_tokens` (optional): Max output tokens (default: 2048)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Generated text with usage stats"
+        "height": 240,
+        "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Parameters:**\n- `prompt` (required): Text generation prompt\n- `openai_api_key` (required): OpenAI API key\n- `system_prompt` (optional): System instructions\n- `model` (optional): gpt-4o, gpt-4o-mini, gpt-4-turbo (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.7)\n- `max_tokens` (optional): Max output tokens (default: 2048)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Generated text with usage stats"
       }
     }
   ],

--- a/workflows/mcp-tools/text_to_speech_tool.json
+++ b/workflows/mcp-tools/text_to_speech_tool.json
@@ -70,42 +70,54 @@
     {
       "id": "openai-tts",
       "name": "OpenAI TTS",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [
         680,
         300
       ],
       "parameters": {
-        "resource": "audio",
-        "operation": "generate",
-        "input": "={{ $json.body.text }}",
-        "voice": "={{ $json.body.voice || 'alloy' }}",
+        "method": "POST",
+        "url": "https://api.openai.com/v1/audio/speech",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.body.openai_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"{{ $json.body.model || 'tts-1' }}\",\n  \"input\": \"{{ $json.body.text }}\",\n  \"voice\": \"{{ $json.body.voice || 'alloy' }}\",\n  \"response_format\": \"{{ $json.body.format || 'mp3' }}\",\n  \"speed\": {{ $json.body.speed || 1 }}\n}",
         "options": {
-          "model": "={{ $json.body.model || 'tts-1' }}",
-          "responseFormat": "={{ $json.body.format || 'mp3' }}",
-          "speed": "={{ $json.body.speed || 1 }}"
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          },
+          "timeout": 60000
         }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
       "name": "Format Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
         900,
         300
       ],
       "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"audio_base64\": $json.data, \"format\": $('Webhook').first().json.body.format || 'mp3', \"voice\": $('Webhook').first().json.body.voice || 'alloy' }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"model\": $('Webhook').first().json.body.model || 'tts-1' } } }}"
+        "jsCode": "// Get the binary data from TTS response\nconst items = $input.all();\nconst webhookData = $('Webhook').first().json;\n\nconst format = webhookData.body.format || 'mp3';\nconst voice = webhookData.body.voice || 'alloy';\nconst model = webhookData.body.model || 'tts-1';\n\n// Check if we have binary data\nif (items[0].binary && items[0].binary.data) {\n  const binaryData = items[0].binary.data;\n  \n  return {\n    json: {\n      success: true,\n      data: {\n        audio_base64: binaryData.data,\n        format: format,\n        voice: voice,\n        mime_type: binaryData.mimeType || `audio/${format}`\n      },\n      meta: {\n        provider: 'openai',\n        model: model,\n        execution_mode: webhookData.body.execution_mode || 'online'\n      }\n    }\n  };\n} else {\n  // Return error if no binary data\n  return {\n    json: {\n      success: false,\n      error: {\n        code: 500,\n        message: 'Failed to generate audio',\n        status: 'TTS_ERROR'\n      },\n      meta: {\n        provider: 'openai',\n        execution_mode: webhookData.body.execution_mode || 'online'\n      }\n    }\n  };\n}"
       }
     },
     {
@@ -134,9 +146,9 @@
       ],
       "parameters": {
         "color": 6,
-        "width": 400,
-        "height": 180,
-        "content": "## MCP - Text to Speech\n\n**Endpoint:** POST /webhook/text-to-speech\n\n**Parameters:**\n- `text` (required): Text to convert\n- `voice`: alloy, echo, fable, onyx, nova, shimmer\n- `model`: tts-1 or tts-1-hd\n- `format`: mp3, opus, aac, flac\n- `speed`: 0.25 to 4.0"
+        "width": 450,
+        "height": 220,
+        "content": "## MCP - Text to Speech\n\n**Endpoint:** POST /webhook/text-to-speech\n\n**Parameters:**\n- `text` (required): Text to convert\n- `openai_api_key` (required): OpenAI API key\n- `voice`: alloy, echo, fable, onyx, nova, shimmer\n- `model`: tts-1 or tts-1-hd\n- `format`: mp3, opus, aac, flac\n- `speed`: 0.25 to 4.0\n\n**Returns:** Audio as base64"
       }
     }
   ],

--- a/workflows/mcp-tools/youtube_searcher_tool.json
+++ b/workflows/mcp-tools/youtube_searcher_tool.json
@@ -78,11 +78,14 @@
       "parameters": {
         "method": "GET",
         "url": "https://www.googleapis.com/youtube/v3/search",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "googleApi",
+        "authentication": "none",
         "sendQuery": true,
         "queryParameters": {
           "parameters": [
+            {
+              "name": "key",
+              "value": "={{ $json.body.google_api_key }}"
+            },
             {
               "name": "part",
               "value": "snippet"
@@ -105,14 +108,11 @@
             }
           ]
         },
-        "options": {}
-      },
-      "credentials": {
-        "googleApi": {
-          "id": "google-api-credentials",
-          "name": "Google API"
+        "options": {
+          "timeout": 30000
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
       "id": "format-output",
@@ -155,8 +155,8 @@
       "parameters": {
         "color": 6,
         "width": 550,
-        "height": 220,
-        "content": "## MCP - YouTube Searcher\n\n**Endpoint:** POST /webhook/youtube-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `type` (optional): video, channel, playlist (default: video)\n- `max_results` (optional): 1-50 (default: 10)\n- `order` (optional): relevance, date, rating, viewCount, title\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of videos/channels with metadata\n\n**Note:** Requires Google API credentials with YouTube Data API v3 enabled"
+        "height": 260,
+        "content": "## MCP - YouTube Searcher\n\n**Endpoint:** POST /webhook/youtube-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `google_api_key` (required): Google API key with YouTube Data API v3 enabled\n- `type` (optional): video, channel, playlist (default: video)\n- `max_results` (optional): 1-50 (default: 10)\n- `order` (optional): relevance, date, rating, viewCount, title\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of videos/channels with metadata"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- **analyze_message_tool**: Fix parallel execution with `numberInputs: 3` on Merge node
- **Multi-intent detection**: `intents[]` array replaces single `intent` object
- **All MCP tools**: Now accept API keys as request parameters (no n8n credentials needed)

## Changes

### analyze_message_tool.json
- Fixed Merge node not waiting for all 3 parallel branches
- New prompt with multi-intent support:
  ```json
  "intents": [
    { "type": "action_request", "action": "send_email", "target": "Guy", "confidence": 0.9 },
    { "type": "action_request", "action": "schedule_meeting", "target": "café", "confidence": 0.85 }
  ]
  ```
- Restructured output fields: `sentiment.label`, `priority.level`, `language.code`

### API Key Parameters (all tools)
| Tool | API Key Parameter |
|------|-------------------|
| code_generator_tool | `openai_api_key` |
| entity_extractor_tool | `openai_api_key` |
| text_generator_tool | `openai_api_key` |
| text_classifier_tool | `openai_api_key` |
| text_to_speech_tool | `openai_api_key` |
| llm_summarizer_tool | `anthropic/openai/mistral_api_key` |
| summarizer_tool | `anthropic_api_key` |
| get_image_ocr_tool | `mistral_api_key` |
| youtube_searcher_tool | `google_api_key` |
| google_searcher_tool | `serpapi_api_key` |
| speaker_identifier_tool | `assemblyai_api_key` |

## Test plan
- [x] Test analyze_message_tool with simple message
- [x] Test analyze_message_tool with multi-action message
- [x] Verify all 3 parallel branches merge correctly
- [ ] Import and activate all modified workflows
- [ ] Test other MCP tools with API key parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)