### PR TITLE
fix(docs): pdf_layout_translator uses Mistral OCR, not Mathpix

### DIFF
--- a/docs/issues/DOC-11-get-pdf-layout-translator.md
+++ b/docs/issues/DOC-11-get-pdf-layout-translator.md
@@ -12,17 +12,18 @@
 
 ## Description
 
-Workflow n8n pour la traduction de PDF en préservant la mise en page originale (layout). Utilise **Mistral OCR** pour l'extraction structurée, puis un LLM pour la traduction, et génère un nouveau PDF avec la même mise en page. Pour les documents avec formules mathématiques, **Mathpix** est combiné pour l'extraction LaTeX.
+Workflow n8n pour la traduction de PDF en préservant la mise en page originale (layout). Utilise **Mistral OCR** pour l'extraction structurée (y compris les formules mathématiques), puis un LLM pour la traduction, et génère un nouveau PDF avec la même mise en page.
+
+> **Note**: Mistral OCR gère nativement l'extraction des formules mathématiques en LaTeX. Pour un outil dédié à l'extraction math/LaTeX, voir `mathpix_tool`.
 
 ## Stack technique
 
 | Composant | Outil | Justification |
 |-----------|-------|---------------|
-| Extraction PDF | **Mistral OCR** | Souverain 🇫🇷, extraction structurée |
-| Formules maths (optionnel) | **Mathpix** | Spécialisé LaTeX, si formules détectées |
+| Extraction PDF + OCR | **Mistral OCR** | Souverain 🇫🇷, extraction structurée, formules LaTeX natives |
 | Traduction | **DeepL** / OpenAI | Qualité traduction |
 | Génération PDF | **Puppeteer** / WeasyPrint | HTML → PDF |
-| Rendu formules | **KaTeX** / MathJax | Rendu LaTeX (si Mathpix utilisé) |
+| Rendu formules | **KaTeX** / MathJax | Rendu LaTeX dans le PDF généré |
 
 ## Endpoint
 
@@ -36,9 +37,9 @@ Content-Type: application/json
   "options": {
     "source_language": "en" | "auto",
     "target_language": "fr",
-    "has_math_formulas": false,
     "preserve_tables": true,
     "preserve_images": true,
+    "preserve_math": true,
     "output_format": "pdf" | "docx" | "html",
     "translation_provider": "deepl" | "openai" | "google"
   },
@@ -60,17 +61,15 @@ Content-Type: application/json
       "words_translated": 5420,
       "formulas_preserved": 45,
       "tables_preserved": 8,
-      "images_preserved": 12,
-      "mathpix_used": false
+      "images_preserved": 12
     },
     "source_language_detected": "en",
     "target_language": "fr"
   },
   "meta": {
     "provider": "mistral-ocr+deepl",
-    "mathpix_used": false,
     "execution_mode": "online",
-    "cost_estimate_usd": 0.50,
+    "cost_estimate_usd": 0.15,
     "processing_time_ms": 25000
   }
 }
@@ -78,52 +77,16 @@ Content-Type: application/json
 
 ## Workflow Architecture
 
-### Cas standard (sans formules mathématiques)
-
 ```
 [Input PDF]
       │
       ▼
 [Mistral OCR] → Extraction structurée
-      │         (Markdown, positions, tableaux)
+      │         (Markdown, positions, tableaux, formules LaTeX)
       ▼
 [Parse Structure] → Identifier éléments:
       │            - Texte à traduire
-      │            - Tableaux (traduire contenu)
-      │            - Images (conserver)
-      ▼
-[Translation API] → Traduire texte uniquement
-      │            (DeepL / OpenAI)
-      ▼
-[Reconstruct] → Réassembler avec layout
-      │         - Replacer texte traduit
-      │         - Reconstruire tableaux
-      ▼
-[Generate PDF] → Puppeteer/WeasyPrint
-      │         HTML + CSS → PDF
-      ▼
-[Output] → PDF traduit + statistiques
-```
-
-### Cas avec formules mathématiques (has_math_formulas: true)
-
-```
-[Input PDF]
-      │
-      ▼
-[Mistral OCR] → Extraction texte + layout
-      │
-      ▼
-[Mathpix API] → Extraction formules LaTeX uniquement
-      │         ($E=mc^2$, équations, etc.)
-      ▼
-[Merge] → Combiner résultats
-      │   - Texte de Mistral
-      │   - Formules de Mathpix
-      ▼
-[Parse Structure] → Identifier éléments:
-      │            - Texte à traduire
-      │            - Formules (NE PAS traduire)
+      │            - Formules LaTeX (NE PAS traduire)
       │            - Tableaux (traduire contenu)
       │            - Images (conserver)
       ▼
@@ -169,58 +132,20 @@ Body:
 }
 ```
 
-## Mathpix API - Formules uniquement (optionnel)
-
-> **Utilisé seulement si** `has_math_formulas: true`
-
-### Endpoint Mathpix
-
-```
-POST https://api.mathpix.com/v3/pdf
-Headers:
-  app_id: <MATHPIX_APP_ID>
-  app_key: <MATHPIX_APP_KEY>
-
-Body:
-{
-  "url": "https://example.com/document.pdf",
-  "conversion_formats": {
-    "md": true,
-    "tex.zip": true
-  },
-  "math_inline_delimiters": ["$", "$"],
-  "math_display_delimiters": ["$$", "$$"]
-}
-```
-
-### Response Mathpix (formules extraites)
-
-```json
-{
-  "pdf_id": "abc123",
-  "status": "completed",
-  "md": "# Title\n\nThis is a paragraph with $E=mc^2$ inline math.\n\n$$\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}$$",
-  "formulas": [
-    {"latex": "E=mc^2", "type": "inline", "page": 1},
-    {"latex": "\\int_0^\\infty e^{-x^2} dx = \\frac{\\sqrt{\\pi}}{2}", "type": "display", "page": 1}
-  ]
-}
-```
-
 ## Stratégie de traduction
 
 ```javascript
-function translateWithLayout(mathpixOutput, targetLang) {
+function translateWithLayout(mistralOutput, targetLang) {
   const segments = [];
 
-  for (const element of mathpixOutput.elements) {
+  for (const element of mistralOutput.elements) {
     if (element.type === 'math') {
-      // Conserver les formules telles quelles
+      // Conserver les formules LaTeX telles quelles
       segments.push({ type: 'math', content: element.latex, translate: false });
     } else if (element.type === 'table') {
       // Traduire le contenu des cellules
       const translatedCells = element.cells.map(cell =>
-        cell.is_header ? translate(cell.text, targetLang) : translate(cell.text, targetLang)
+        translate(cell.text, targetLang)
       );
       segments.push({ type: 'table', cells: translatedCells, translate: false });
     } else if (element.type === 'text') {
@@ -239,9 +164,8 @@ function translateWithLayout(mathpixOutput, targetLang) {
 ## Definition of Done
 
 - [ ] Endpoint `POST /webhook/pdf-layout-translator`
-- [ ] Extraction via Mistral OCR (Markdown structuré)
-- [ ] Option Mathpix si formules mathématiques (`has_math_formulas: true`)
-- [ ] Préservation formules mathématiques (si présentes)
+- [ ] Extraction via Mistral OCR (Markdown structuré + formules LaTeX)
+- [ ] Préservation formules mathématiques LaTeX (via Mistral OCR)
 - [ ] Préservation tableaux (traduction contenu)
 - [ ] Préservation images
 - [ ] Traduction via DeepL ou OpenAI
@@ -254,19 +178,18 @@ function translateWithLayout(mathpixOutput, targetLang) {
 | Test | Description | Attendu |
 |------|-------------|---------|
 | Document standard | PDF texte simple | Mistral OCR utilisé |
-| Article scientifique | PDF avec formules (`has_math_formulas: true`) | Mathpix combiné, formules préservées |
+| Article scientifique | PDF avec formules | Formules LaTeX préservées |
 | Tableau complexe | PDF avec tableaux | Tableaux traduits |
 | Document technique | Manuel avec images | Images conservées |
 | Multi-colonnes | PDF 2 colonnes | Layout préservé |
 | Citations | Références biblio | Non traduit |
 | EN→FR | Document anglais | Traduction FR |
 | FR→EN | Document français | Traduction EN |
-| Sans formules | PDF scientifique sans maths | Mistral seul, pas de Mathpix |
 
 ## Dépendances
 
 ### Requis
-- **Mistral API** - Extraction OCR principale
+- **Mistral API** - Extraction OCR + formules LaTeX
   - `MISTRAL_API_KEY`
 - **DeepL API** - Traduction
   - `DEEPL_API_KEY`
@@ -274,38 +197,21 @@ function translateWithLayout(mathpixOutput, targetLang) {
   - `OPENAI_API_KEY`
 - **Puppeteer** (npm) - Génération PDF
 
-### Optionnel (si formules mathématiques)
-- **Mathpix API** - Extraction LaTeX uniquement
-  - `MATHPIX_APP_ID`
-  - `MATHPIX_APP_KEY`
-
 ## Tarification
 
-### Mistral OCR (principal)
+### Mistral OCR
 - Tarification selon tokens traités
-- **Coût estimé**: ~$0.01-0.05 par page
-
-### Mathpix (optionnel - formules maths)
-
-| Plan | Prix | Limites |
-|------|------|---------|
-| Free | $0 | 100 pages/mois |
-| Education | $10/mois | 5000 pages/mois |
-| Pro | $99/mois | 50000 pages/mois |
-| Enterprise | Custom | Illimité |
-
-**Coût estimé par page**: ~$0.10 (uniquement si `has_math_formulas: true`)
+- **Coût estimé**: ~$0.01-0.05 par page (incluant extraction des formules LaTeX)
 
 ## Notes d'implémentation
 
-1. **Mistral OCR par défaut** pour tous les PDF
-2. **Mathpix uniquement si** `has_math_formulas: true` (détection manuelle ou auto)
-3. Traitement asynchrone pour gros PDF (> 20 pages)
-4. Callback webhook pour notification fin de traitement
-5. Stockage temporaire des PDF générés (TTL 24h)
-6. Cache Mistral et Mathpix séparément (extraction coûteuse)
-7. Fallback OpenAI si DeepL indisponible
-8. Métriques: pages/jour, coût/document, mathpix_used
+1. **Mistral OCR** pour tous les PDF (extraction structurée + formules LaTeX)
+2. Traitement asynchrone pour gros PDF (> 20 pages)
+3. Callback webhook pour notification fin de traitement
+4. Stockage temporaire des PDF générés (TTL 24h)
+5. Cache Mistral (extraction coûteuse)
+6. Fallback OpenAI si DeepL indisponible
+7. Métriques: pages/jour, coût/document
 
 ## Cas particuliers
 
@@ -320,5 +226,7 @@ function translateWithLayout(mathpixOutput, targetLang) {
 ## Références
 
 - [TOOLS_MIGRATION_LIST.md](../mcp-server/TOOLS_MIGRATION_LIST.md)
-- [Mathpix API Documentation](https://docs.mathpix.com/)
+- [Mistral OCR API](https://docs.mistral.ai/)
 - [DeepL API](https://www.deepl.com/docs-api)
+
+> **Note**: Pour l'extraction spécialisée math/LaTeX (équations complexes, documents scientifiques), voir `mathpix_tool` qui utilise l'API Mathpix dédiée.


### PR DESCRIPTION
## Summary
- pdf_layout_translator now uses **Mistral OCR** exclusively for PDF extraction (including math formulas)
- Removed Mathpix as optional component - Mistral OCR handles LaTeX natively
- `mathpix_tool` remains as a separate standalone tool for dedicated math/LaTeX extraction use cases

## Changes
- Removed `has_math_formulas` option (no longer needed)
- Simplified workflow architecture to single Mistral OCR flow
- Updated dependencies (removed Mathpix API keys from requirements)
- Updated pricing section (Mathpix costs removed)

## Test plan
- [ ] Verify documentation is accurate for pdf_layout_translator
- [ ] Confirm mathpix_tool documentation is separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)