### PR TITLE
feat(phase-4b): GCS upload support for Gemini Image

### DIFF
--- a/custom-nodes/n8n-nodes-gemini-image/nodes/GeminiImage/GeminiImage.node.ts
+++ b/custom-nodes/n8n-nodes-gemini-image/nodes/GeminiImage/GeminiImage.node.ts
@@ -3,6 +3,7 @@ import {
   INodeExecutionData,
   INodeType,
   INodeTypeDescription,
+  IDataObject,
   NodeOperationError,
 } from 'n8n-workflow';
 
@@ -11,6 +12,7 @@ import {
   GeminiImageOptions,
   ReferenceImage,
 } from '../../shared/GeminiImageClient';
+import { GcsUploader } from '../../shared/GcsUploader';
 
 export class GeminiImage implements INodeType {
   description: INodeTypeDescription = {
@@ -303,6 +305,63 @@ export class GeminiImage implements INodeType {
             default: false,
             description: 'Include textual feedback from the model',
           },
+          {
+            displayName: 'Upload to GCS',
+            name: 'uploadToGcs',
+            type: 'boolean',
+            default: false,
+            description: 'Upload generated image to Google Cloud Storage and return signed URL',
+          },
+          {
+            displayName: 'GCS Bucket',
+            name: 'gcsBucket',
+            type: 'string',
+            default: '',
+            placeholder: 'my-bucket-name',
+            description: 'Google Cloud Storage bucket name (required if uploadToGcs is true)',
+            displayOptions: {
+              show: {
+                uploadToGcs: [true],
+              },
+            },
+          },
+          {
+            displayName: 'GCS Path Prefix',
+            name: 'gcsPathPrefix',
+            type: 'string',
+            default: 'gemini-images',
+            description: 'Path prefix for uploaded images in the bucket',
+            displayOptions: {
+              show: {
+                uploadToGcs: [true],
+              },
+            },
+          },
+          {
+            displayName: 'Signed URL Expiration (Hours)',
+            name: 'signedUrlExpirationHours',
+            type: 'number',
+            default: 24,
+            description: 'How many hours the signed URL should be valid',
+            displayOptions: {
+              show: {
+                uploadToGcs: [true],
+              },
+            },
+          },
+          {
+            displayName: 'User ID',
+            name: 'userId',
+            type: 'string',
+            default: '',
+            placeholder: 'user-123',
+            description: 'Optional user ID to organize files in GCS',
+            displayOptions: {
+              show: {
+                uploadToGcs: [true],
+              },
+            },
+          },
         ],
       },
     ],
@@ -320,6 +379,11 @@ export class GeminiImage implements INodeType {
         const advancedOptions = this.getNodeParameter('options', i, {}) as {
           model?: string;
           includeTextFeedback?: boolean;
+          uploadToGcs?: boolean;
+          gcsBucket?: string;
+          gcsPathPrefix?: string;
+          signedUrlExpirationHours?: number;
+          userId?: string;
         };
 
         // Get credentials
@@ -423,16 +487,18 @@ export class GeminiImage implements INodeType {
         }
 
         // Prepare output
-        const outputData: INodeExecutionData = {
-          json: {
-            operation,
-            mimeType: result.mimeType,
-            model: result.model,
-            textFeedback: result.textFeedback,
-            metadata: {
-              processedAt: new Date().toISOString(),
-            },
+        const jsonOutput: IDataObject = {
+          operation,
+          mimeType: result.mimeType,
+          model: result.model,
+          textFeedback: result.textFeedback,
+          metadata: {
+            processedAt: new Date().toISOString(),
           },
+        };
+
+        const outputData: INodeExecutionData = {
+          json: jsonOutput,
           binary: {
             data: await this.helpers.prepareBinaryData(
               result.imageData,
@@ -443,7 +509,38 @@ export class GeminiImage implements INodeType {
         };
 
         // Also include base64 in JSON for easy use
-        outputData.json.imageBase64 = result.imageData.toString('base64');
+        jsonOutput.imageBase64 = result.imageData.toString('base64');
+
+        // Upload to GCS if requested
+        if (advancedOptions.uploadToGcs) {
+          if (!advancedOptions.gcsBucket) {
+            throw new NodeOperationError(this.getNode(), 'GCS Bucket is required when uploadToGcs is enabled', { itemIndex: i });
+          }
+
+          const gcsUploader = new GcsUploader(
+            {
+              bucketName: advancedOptions.gcsBucket,
+              pathPrefix: advancedOptions.gcsPathPrefix || 'gemini-images',
+              signedUrlExpirationHours: advancedOptions.signedUrlExpirationHours || 24,
+            },
+            credentialType === 'vertexai' ? credentials.serviceAccountKey as string | undefined : undefined
+          );
+
+          const gcsResult = await gcsUploader.upload(
+            result.imageData,
+            `${operation}-${outputFormat}.${outputFormat}`,
+            result.mimeType,
+            advancedOptions.userId
+          );
+
+          jsonOutput.gcs = {
+            bucket: gcsResult.bucket,
+            path: gcsResult.path,
+            gcsUrl: gcsResult.gcsUrl,
+            signedUrl: gcsResult.signedUrl,
+            expiresAt: gcsResult.expiresAt.toISOString(),
+          };
+        }
 
         returnData.push(outputData);
       } catch (error) {

--- a/custom-nodes/n8n-nodes-gemini-image/package.json
+++ b/custom-nodes/n8n-nodes-gemini-image/package.json
@@ -48,6 +48,7 @@
     "n8n-workflow": "*"
   },
   "dependencies": {
-    "google-auth-library": "^9.0.0"
+    "google-auth-library": "^9.0.0",
+    "@google-cloud/storage": "^7.0.0"
   }
 }

--- a/custom-nodes/n8n-nodes-gemini-image/shared/GcsUploader.ts
+++ b/custom-nodes/n8n-nodes-gemini-image/shared/GcsUploader.ts
@@ -1,0 +1,141 @@
+/**
+ * Helper pour l'upload d'images vers Google Cloud Storage
+ * et la génération d'URLs signées
+ */
+
+import { Storage, Bucket, File } from '@google-cloud/storage';
+
+export interface GcsConfig {
+  bucketName: string;
+  pathPrefix?: string;
+  signedUrlExpirationHours?: number;
+}
+
+export interface GcsUploadResult {
+  bucket: string;
+  path: string;
+  gcsUrl: string;
+  signedUrl: string;
+  expiresAt: Date;
+  sizeBytes: number;
+  mimeType: string;
+}
+
+const DEFAULT_CONFIG = {
+  pathPrefix: 'gemini-images',
+  signedUrlExpirationHours: 24,
+};
+
+export class GcsUploader {
+  private storage: Storage;
+  private bucket: Bucket;
+  private config: Required<GcsConfig>;
+
+  constructor(
+    config: GcsConfig,
+    serviceAccountKey?: string
+  ) {
+    this.config = {
+      ...DEFAULT_CONFIG,
+      ...config,
+    } as Required<GcsConfig>;
+
+    // Initialiser le client Storage
+    if (serviceAccountKey) {
+      const credentials = typeof serviceAccountKey === 'string'
+        ? JSON.parse(serviceAccountKey)
+        : serviceAccountKey;
+
+      this.storage = new Storage({
+        projectId: credentials.project_id,
+        credentials,
+      });
+    } else {
+      // Utiliser les credentials par défaut (ADC)
+      this.storage = new Storage();
+    }
+
+    this.bucket = this.storage.bucket(this.config.bucketName);
+  }
+
+  /**
+   * Upload une image vers GCS
+   */
+  async upload(
+    imageData: Buffer,
+    filename: string,
+    mimeType: string,
+    userId?: string
+  ): Promise<GcsUploadResult> {
+    // Construire le chemin complet
+    const timestamp = Date.now();
+    const parts = [
+      this.config.pathPrefix,
+      userId,
+      `${timestamp}-${filename}`,
+    ].filter(Boolean);
+    const path = parts.join('/');
+
+    // Référence au fichier
+    const file = this.bucket.file(path);
+
+    // Upload
+    await file.save(imageData, {
+      contentType: mimeType,
+      metadata: {
+        cacheControl: 'public, max-age=3600',
+      },
+    });
+
+    // Générer l'URL signée
+    const signedUrl = await this.generateSignedUrl(file);
+
+    // Calculer la date d'expiration
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + this.config.signedUrlExpirationHours);
+
+    return {
+      bucket: this.config.bucketName,
+      path,
+      gcsUrl: `gs://${this.config.bucketName}/${path}`,
+      signedUrl,
+      expiresAt,
+      sizeBytes: imageData.length,
+      mimeType,
+    };
+  }
+
+  /**
+   * Génère une URL signée pour un fichier
+   */
+  private async generateSignedUrl(file: File): Promise<string> {
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + this.config.signedUrlExpirationHours);
+
+    const [signedUrl] = await file.getSignedUrl({
+      action: 'read',
+      expires: expiresAt,
+    });
+
+    return signedUrl;
+  }
+}
+
+/**
+ * Factory pour créer un GcsUploader
+ */
+export function createGcsUploader(
+  bucketName: string,
+  serviceAccountKey?: string,
+  pathPrefix: string = 'gemini-images',
+  signedUrlExpirationHours: number = 24
+): GcsUploader {
+  return new GcsUploader(
+    {
+      bucketName,
+      pathPrefix,
+      signedUrlExpirationHours,
+    },
+    serviceAccountKey
+  );
+}

--- a/docs/n8n/gemini-image-mcp-server.md
+++ b/docs/n8n/gemini-image-mcp-server.md
@@ -38,6 +38,16 @@ Compose une scène en utilisant des images de référence.
 | `model` | string | `"gemini-2.5-flash-preview-native-audio-dialog"` | Modèle Gemini |
 | `includeTextFeedback` | boolean | `false` | Inclure le feedback textuel du modèle |
 
+### Paramètres GCS (optionnels)
+
+| Paramètre | Type | Défaut | Description |
+|-----------|------|--------|-------------|
+| `uploadToGcs` | boolean | `false` | Uploader l'image générée vers Google Cloud Storage |
+| `gcsBucket` | string | - | **Requis si uploadToGcs=true.** Nom du bucket GCS |
+| `gcsPathPrefix` | string | `"gemini-images"` | Préfixe du chemin dans le bucket |
+| `signedUrlExpirationHours` | number | `24` | Durée de validité de l'URL signée (en heures) |
+| `userId` | string | - | ID utilisateur pour organiser les fichiers |
+
 ### Paramètres pour `generate`
 
 | Paramètre | Type | Description |
@@ -92,6 +102,8 @@ Compose une scène en utilisant des images de référence.
 
 ## Format de sortie
 
+### Sans GCS (base64 uniquement)
+
 ```json
 {
   "success": true,
@@ -100,6 +112,32 @@ Compose une scène en utilisant des images de référence.
     "base64": "<base64_encoded_image>",
     "mimeType": "image/png",
     "format": "png"
+  },
+  "model": "gemini-2.5-flash-preview-native-audio-dialog",
+  "textFeedback": null,
+  "metadata": {
+    "processedAt": "2024-12-19T10:30:00Z"
+  }
+}
+```
+
+### Avec GCS (base64 + URL signée)
+
+```json
+{
+  "success": true,
+  "operation": "generate",
+  "image": {
+    "base64": "<base64_encoded_image>",
+    "mimeType": "image/png",
+    "format": "png"
+  },
+  "gcs": {
+    "bucket": "my-bucket",
+    "path": "gemini-images/user-123/1703001234567-generate-png.png",
+    "gcsUrl": "gs://my-bucket/gemini-images/user-123/1703001234567-generate-png.png",
+    "signedUrl": "https://storage.googleapis.com/my-bucket/gemini-images/...",
+    "expiresAt": "2024-12-20T10:30:00Z"
   },
   "model": "gemini-2.5-flash-preview-native-audio-dialog",
   "textFeedback": null,
@@ -120,6 +158,23 @@ curl -X POST http://localhost:5678/webhook/gemini-image \
     "operation": "generate",
     "prompt": "A cute robot made of felt, standing on a mountain, studio lighting, soft textures",
     "aspectRatio": "16:9"
+  }'
+```
+
+### Générer et uploader vers GCS
+
+```bash
+curl -X POST http://localhost:5678/webhook/gemini-image \
+  -H "Content-Type: application/json" \
+  -d '{
+    "operation": "generate",
+    "prompt": "A cute robot made of felt, standing on a mountain",
+    "aspectRatio": "16:9",
+    "uploadToGcs": true,
+    "gcsBucket": "my-images-bucket",
+    "gcsPathPrefix": "generated",
+    "userId": "user-123",
+    "signedUrlExpirationHours": 48
   }'
 ```
 
@@ -217,9 +272,10 @@ Remove the ice axes. Move the mountain to the left. Add a bridge...
 
 ## APIs Google requises
 
-| API | Console URL |
-|-----|-------------|
-| **Vertex AI API** | [Activer](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com) |
+| API | Console URL | Requis pour |
+|-----|-------------|-------------|
+| **Vertex AI API** | [Activer](https://console.cloud.google.com/flows/enableapi?apiid=aiplatform.googleapis.com) | Génération d'images |
+| **Cloud Storage API** | [Activer](https://console.cloud.google.com/flows/enableapi?apiid=storage.googleapis.com) | Upload GCS (si `uploadToGcs=true`) |
 
 ## Notes d'implémentation
 
@@ -227,6 +283,8 @@ Remove the ice axes. Move the mountain to the left. Add a bridge...
 - Location: `global` pour les modèles preview
 - Les credentials Vertex AI sont gérés par n8n (pas de clé en dur)
 - Les images sont retournées en base64 dans la réponse JSON
+- **GCS Upload**: Optionnel, permet de stocker l'image dans Cloud Storage et retourne une URL signée
+- Les URLs signées expirent après la durée configurée (défaut: 24h)
 
 ## Intégration avec MCP Server
 

--- a/workflows/gemini-image-workflow.json
+++ b/workflows/gemini-image-workflow.json
@@ -56,7 +56,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Prepare data for Gemini Image node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: generate)\nconst operation = body.operation || 'generate';\n\n// Common parameters\nconst aspectRatio = body.aspectRatio || '16:9';\nconst outputFormat = body.outputFormat || 'png';\nconst model = body.model || 'gemini-2.5-flash-preview-native-audio-dialog';\nconst includeTextFeedback = body.includeTextFeedback === true || body.includeTextFeedback === 'true';\n\n// Operation-specific parameters\nconst result = {\n  operation,\n  aspectRatio,\n  outputFormat,\n  model,\n  includeTextFeedback,\n  originalRequest: { ...body }\n};\n\nswitch (operation) {\n  case 'generate':\n    result.prompt = body.prompt || '';\n    break;\n    \n  case 'extractCharacter':\n    result.sourceImage = body.sourceImage || '';\n    result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n    result.characterDescription = body.characterDescription || 'the main character';\n    break;\n    \n  case 'createCharacterSheet':\n    result.sourceImage = body.sourceImage || '';\n    result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n    result.views = body.views || ['front', 'back'];\n    break;\n    \n  case 'composeScene':\n    result.referenceImages = body.referenceImages || [];\n    result.scenePrompt = body.scenePrompt || '';\n    break;\n}\n\nreturn [{ json: result }];"
+        "jsCode": "// Prepare data for Gemini Image node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: generate)\nconst operation = body.operation || 'generate';\n\n// Common parameters\nconst aspectRatio = body.aspectRatio || '16:9';\nconst outputFormat = body.outputFormat || 'png';\nconst model = body.model || 'gemini-2.5-flash-preview-native-audio-dialog';\nconst includeTextFeedback = body.includeTextFeedback === true || body.includeTextFeedback === 'true';\n\n// GCS upload parameters\nconst uploadToGcs = body.uploadToGcs === true || body.uploadToGcs === 'true';\nconst gcsBucket = body.gcsBucket || '';\nconst gcsPathPrefix = body.gcsPathPrefix || 'gemini-images';\nconst signedUrlExpirationHours = body.signedUrlExpirationHours || 24;\nconst userId = body.userId || '';\n\n// Operation-specific parameters\nconst result = {\n  operation,\n  aspectRatio,\n  outputFormat,\n  model,\n  includeTextFeedback,\n  uploadToGcs,\n  gcsBucket,\n  gcsPathPrefix,\n  signedUrlExpirationHours,\n  userId,\n  originalRequest: { ...body }\n};\n\nswitch (operation) {\n  case 'generate':\n    result.prompt = body.prompt || '';\n    break;\n    \n  case 'extractCharacter':\n    result.sourceImage = body.sourceImage || '';\n    result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n    result.characterDescription = body.characterDescription || 'the main character';\n    break;\n    \n  case 'createCharacterSheet':\n    result.sourceImage = body.sourceImage || '';\n    result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n    result.views = body.views || ['front', 'back'];\n    break;\n    \n  case 'composeScene':\n    result.referenceImages = body.referenceImages || [];\n    result.scenePrompt = body.scenePrompt || '';\n    break;\n}\n\nreturn [{ json: result }];"
       },
       "id": "prepare-config",
       "name": "Prepare Config",
@@ -81,7 +81,12 @@
         "outputFormat": "={{ $json.outputFormat }}",
         "options": {
           "model": "={{ $json.model }}",
-          "includeTextFeedback": "={{ $json.includeTextFeedback }}"
+          "includeTextFeedback": "={{ $json.includeTextFeedback }}",
+          "uploadToGcs": "={{ $json.uploadToGcs }}",
+          "gcsBucket": "={{ $json.gcsBucket }}",
+          "gcsPathPrefix": "={{ $json.gcsPathPrefix }}",
+          "signedUrlExpirationHours": "={{ $json.signedUrlExpirationHours }}",
+          "userId": "={{ $json.userId }}"
         }
       },
       "id": "gemini-image",
@@ -98,7 +103,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Format response\nconst input = $input.first().json;\nconst binary = $input.first().binary;\n\nconst response = {\n  success: true,\n  operation: input.operation,\n  image: {\n    base64: input.imageBase64,\n    mimeType: input.mimeType,\n    format: input.mimeType.split('/')[1]\n  },\n  model: input.model,\n  textFeedback: input.textFeedback || null,\n  metadata: input.metadata\n};\n\nreturn [{ json: response }];"
+        "jsCode": "// Format response\nconst input = $input.first().json;\nconst binary = $input.first().binary;\n\nconst response = {\n  success: true,\n  operation: input.operation,\n  image: {\n    base64: input.imageBase64,\n    mimeType: input.mimeType,\n    format: input.mimeType.split('/')[1]\n  },\n  model: input.model,\n  textFeedback: input.textFeedback || null,\n  metadata: input.metadata\n};\n\n// Add GCS info if present\nif (input.gcs) {\n  response.gcs = input.gcs;\n}\n\nreturn [{ json: response }];"
       },
       "id": "format-response",
       "name": "Format Response",


### PR DESCRIPTION
## Summary

Adds optional Google Cloud Storage upload capability for Gemini Image workflow.

- New `GcsUploader` class for image upload and signed URL generation
- Node options: `uploadToGcs`, `gcsBucket`, `gcsPathPrefix`, `signedUrlExpirationHours`, `userId`
- Workflow updated to pass GCS parameters from webhook body
- Documentation updated with GCS examples and API reference

## New Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `uploadToGcs` | boolean | `false` | Enable GCS upload |
| `gcsBucket` | string | - | **Required** if uploadToGcs=true |
| `gcsPathPrefix` | string | `"gemini-images"` | Path prefix in bucket |
| `signedUrlExpirationHours` | number | `24` | Signed URL validity |
| `userId` | string | - | Optional user ID for file organization |

## Response with GCS

```json
{
  "success": true,
  "image": { "base64": "...", "mimeType": "image/png" },
  "gcs": {
    "bucket": "my-bucket",
    "path": "gemini-images/user-123/...",
    "gcsUrl": "gs://my-bucket/...",
    "signedUrl": "https://storage.googleapis.com/...",
    "expiresAt": "2024-12-20T10:30:00Z"
  }
}
```

## Test Plan

- [ ] Build custom node: `npm run build`
- [ ] Copy to ~/.n8n/nodes/ and npm install
- [ ] Restart n8n
- [ ] Test generate without GCS (should work as before)
- [ ] Test generate with GCS upload (requires GCS bucket)

## APIs Required

- **Cloud Storage API** must be enabled if using `uploadToGcs=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)