### PR TITLE
feat(phase-5a): Veo Video custom node with basic operations

### DIFF
--- a/custom-nodes/n8n-nodes-veo-video/gulpfile.js
+++ b/custom-nodes/n8n-nodes-veo-video/gulpfile.js
@@ -1,0 +1,7 @@
+const { src, dest } = require('gulp');
+
+function buildIcons() {
+  return src('nodes/**/*.svg').pipe(dest('dist/nodes'));
+}
+
+exports['build:icons'] = buildIcons;

--- a/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/VeoVideo.node.ts
+++ b/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/VeoVideo.node.ts
@@ -1,0 +1,307 @@
+import {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeType,
+  INodeTypeDescription,
+  IDataObject,
+  NodeOperationError,
+} from 'n8n-workflow';
+
+import { VeoVideoClient, VeoVideoOptions } from '../../shared/VeoVideoClient';
+
+export class VeoVideo implements INodeType {
+  description: INodeTypeDescription = {
+    displayName: 'Veo Video',
+    name: 'veoVideo',
+    icon: 'file:veo-video.svg',
+    group: ['transform'],
+    version: 1,
+    subtitle: '={{$parameter["operation"]}}',
+    description: 'Generate videos using Veo 3',
+    defaults: {
+      name: 'Veo Video',
+    },
+    inputs: ['main'],
+    outputs: ['main'],
+    credentials: [
+      {
+        name: 'googleVertexAiApi',
+        required: true,
+      },
+    ],
+    properties: [
+      // Operation
+      {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: true,
+        options: [
+          {
+            name: 'Generate from Text',
+            value: 'generateFromText',
+            description: 'Generate a video from a text prompt',
+            action: 'Generate video from text prompt',
+          },
+          {
+            name: 'Generate from Image',
+            value: 'generateFromImage',
+            description: 'Animate an image into a video',
+            action: 'Generate video from image',
+          },
+        ],
+        default: 'generateFromText',
+      },
+      // Prompt
+      {
+        displayName: 'Prompt',
+        name: 'prompt',
+        type: 'string',
+        typeOptions: {
+          rows: 4,
+        },
+        required: true,
+        default: '',
+        placeholder: 'A robot walking through a futuristic city...',
+        description: 'Description of the video to generate',
+      },
+      // Source Image (for generateFromImage)
+      {
+        displayName: 'Source Image',
+        name: 'sourceImage',
+        type: 'string',
+        required: true,
+        default: '',
+        placeholder: 'Base64 encoded image data',
+        description: 'Image to animate (base64 encoded)',
+        displayOptions: {
+          show: {
+            operation: ['generateFromImage'],
+          },
+        },
+      },
+      // Source Image MIME Type
+      {
+        displayName: 'Source Image MIME Type',
+        name: 'sourceImageMimeType',
+        type: 'options',
+        options: [
+          { name: 'PNG', value: 'image/png' },
+          { name: 'JPEG', value: 'image/jpeg' },
+          { name: 'WebP', value: 'image/webp' },
+        ],
+        default: 'image/png',
+        displayOptions: {
+          show: {
+            operation: ['generateFromImage'],
+          },
+        },
+      },
+      // Model
+      {
+        displayName: 'Model',
+        name: 'model',
+        type: 'options',
+        options: [
+          {
+            name: 'Veo 3.1 (Quality)',
+            value: 'veo-3.1-generate-001',
+            description: 'Higher quality, slower generation',
+          },
+          {
+            name: 'Veo 3.1 Fast',
+            value: 'veo-3.1-fast-generate-001',
+            description: 'Faster generation, slightly lower quality',
+          },
+        ],
+        default: 'veo-3.1-generate-001',
+      },
+      // Duration
+      {
+        displayName: 'Duration (Seconds)',
+        name: 'durationSeconds',
+        type: 'options',
+        options: [
+          { name: '4 seconds', value: 4 },
+          { name: '6 seconds', value: 6 },
+          { name: '8 seconds', value: 8 },
+        ],
+        default: 6,
+      },
+      // Aspect Ratio
+      {
+        displayName: 'Aspect Ratio',
+        name: 'aspectRatio',
+        type: 'options',
+        options: [
+          { name: '16:9 (Landscape)', value: '16:9' },
+          { name: '9:16 (Portrait/Mobile)', value: '9:16' },
+        ],
+        default: '16:9',
+      },
+      // Resolution
+      {
+        displayName: 'Resolution',
+        name: 'resolution',
+        type: 'options',
+        options: [
+          { name: '1080p (Full HD)', value: '1080p' },
+          { name: '720p (HD)', value: '720p' },
+        ],
+        default: '1080p',
+      },
+      // Generate Audio
+      {
+        displayName: 'Generate Audio',
+        name: 'generateAudio',
+        type: 'boolean',
+        default: true,
+        description: 'Whether to generate dialogue and sound effects',
+      },
+      // Enhance Prompt
+      {
+        displayName: 'Enhance Prompt',
+        name: 'enhancePrompt',
+        type: 'boolean',
+        default: true,
+        description: 'Whether to use AI to enhance the prompt before generation',
+      },
+      // Advanced Options
+      {
+        displayName: 'Options',
+        name: 'options',
+        type: 'collection',
+        placeholder: 'Add Option',
+        default: {},
+        options: [
+          {
+            displayName: 'Person Generation',
+            name: 'personGeneration',
+            type: 'options',
+            options: [
+              { name: 'Allow Adults', value: 'allow_adult' },
+              { name: "Don't Allow", value: 'dont_allow' },
+            ],
+            default: 'allow_adult',
+            description: 'Whether to allow generation of people in videos',
+          },
+        ],
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const returnData: INodeExecutionData[] = [];
+
+    for (let i = 0; i < items.length; i++) {
+      try {
+        const operation = this.getNodeParameter('operation', i) as string;
+        const prompt = this.getNodeParameter('prompt', i) as string;
+        const model = this.getNodeParameter('model', i) as string;
+        const durationSeconds = this.getNodeParameter('durationSeconds', i) as number;
+        const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
+        const resolution = this.getNodeParameter('resolution', i) as string;
+        const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
+        const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+        const advancedOptions = this.getNodeParameter('options', i, {}) as {
+          personGeneration?: string;
+        };
+
+        if (!prompt) {
+          throw new NodeOperationError(this.getNode(), 'Prompt is required', { itemIndex: i });
+        }
+
+        // Get credentials
+        const credentials = await this.getCredentials('googleVertexAiApi');
+
+        // Create client
+        const client = new VeoVideoClient({
+          projectId: credentials.projectId as string,
+          location: (credentials.location as string) || 'us-central1',
+          serviceAccountKey: credentials.serviceAccountKey as string | undefined,
+        });
+
+        const videoOptions: VeoVideoOptions = {
+          model: model as VeoVideoOptions['model'],
+          aspectRatio: aspectRatio as VeoVideoOptions['aspectRatio'],
+          durationSeconds: durationSeconds as VeoVideoOptions['durationSeconds'],
+          resolution: resolution as VeoVideoOptions['resolution'],
+          generateAudio,
+          enhancePrompt,
+          personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+        };
+
+        let result;
+
+        switch (operation) {
+          case 'generateFromText': {
+            result = await client.generateFromText(prompt, videoOptions);
+            break;
+          }
+
+          case 'generateFromImage': {
+            const sourceImage = this.getNodeParameter('sourceImage', i) as string;
+            const sourceImageMimeType = this.getNodeParameter('sourceImageMimeType', i) as string;
+
+            if (!sourceImage) {
+              throw new NodeOperationError(this.getNode(), 'Source image is required', { itemIndex: i });
+            }
+
+            const imageBuffer = Buffer.from(sourceImage, 'base64');
+            result = await client.generateFromImage(imageBuffer, sourceImageMimeType, prompt, videoOptions);
+            break;
+          }
+
+          default:
+            throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, { itemIndex: i });
+        }
+
+        // Prepare output
+        const jsonOutput: IDataObject = {
+          operation,
+          video: {
+            format: 'mp4',
+            durationSeconds: result.durationSeconds,
+            resolution: result.resolution,
+            aspectRatio: result.aspectRatio,
+            hasAudio: result.hasAudio,
+          },
+          model: result.model,
+          generationTimeSeconds: result.generationTimeSeconds,
+          metadata: {
+            processedAt: new Date().toISOString(),
+          },
+        };
+
+        // Include base64 in JSON
+        jsonOutput.videoBase64 = result.videoData.toString('base64');
+
+        const outputData: INodeExecutionData = {
+          json: jsonOutput,
+          binary: {
+            data: await this.helpers.prepareBinaryData(
+              result.videoData,
+              'generated-video.mp4',
+              result.mimeType
+            ),
+          },
+        };
+
+        returnData.push(outputData);
+      } catch (error) {
+        if (this.continueOnFail()) {
+          returnData.push({
+            json: {
+              error: error instanceof Error ? error.message : 'Unknown error',
+            },
+          });
+          continue;
+        }
+        throw error;
+      }
+    }
+
+    return [returnData];
+  }
+}

--- a/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/veo-video.svg
+++ b/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/veo-video.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <defs>
+    <linearGradient id="veo-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#4285F4"/>
+      <stop offset="50%" style="stop-color:#9B72CB"/>
+      <stop offset="100%" style="stop-color:#EA4335"/>
+    </linearGradient>
+  </defs>
+  <rect width="48" height="48" rx="8" fill="url(#veo-gradient)"/>
+  <g fill="white">
+    <!-- Video/Film icon -->
+    <rect x="10" y="12" width="28" height="18" rx="2" fill="none" stroke="white" stroke-width="2"/>
+    <!-- Film holes -->
+    <circle cx="14" cy="16" r="1.5"/>
+    <circle cx="14" cy="26" r="1.5"/>
+    <circle cx="34" cy="16" r="1.5"/>
+    <circle cx="34" cy="26" r="1.5"/>
+    <!-- Play button -->
+    <path d="M21 17 L21 25 L28 21 Z" fill="white"/>
+    <!-- AI sparkle -->
+    <path d="M36 8 L37.5 12 L36 16 L34.5 12 Z" fill="white"/>
+    <path d="M32 12 L36 13.5 L40 12 L36 10.5 Z" fill="white"/>
+    <!-- Progress bar -->
+    <rect x="12" y="34" width="24" height="3" rx="1.5" fill="none" stroke="white" stroke-width="1.5"/>
+    <rect x="12" y="34" width="14" height="3" rx="1.5" fill="white"/>
+  </g>
+</svg>

--- a/custom-nodes/n8n-nodes-veo-video/package.json
+++ b/custom-nodes/n8n-nodes-veo-video/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "n8n-nodes-veo-video",
+  "version": "0.1.0",
+  "description": "n8n nodes for Veo 3 video generation",
+  "keywords": [
+    "n8n-community-node-package",
+    "n8n",
+    "veo",
+    "video",
+    "generation",
+    "vertex-ai"
+  ],
+  "license": "MIT",
+  "homepage": "",
+  "author": {
+    "name": "n8n-workflows"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fsebb/n8n-workflows.git"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc && gulp build:icons",
+    "dev": "tsc --watch",
+    "format": "prettier nodes --write",
+    "lint": "eslint nodes --ext .ts --fix",
+    "prepublishOnly": "npm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "nodes": [
+      "dist/nodes/VeoVideo/VeoVideo.node.js"
+    ],
+    "credentials": []
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "gulp": "^4.0.2",
+    "n8n-workflow": "^1.0.0",
+    "typescript": "^5.3.2"
+  },
+  "peerDependencies": {
+    "n8n-workflow": "*"
+  },
+  "dependencies": {
+    "google-auth-library": "^9.0.0",
+    "@google-cloud/storage": "^7.0.0"
+  }
+}

--- a/custom-nodes/n8n-nodes-veo-video/shared/VeoVideoClient.ts
+++ b/custom-nodes/n8n-nodes-veo-video/shared/VeoVideoClient.ts
@@ -1,0 +1,320 @@
+/**
+ * Client pour l'API Veo 3 Video Generation
+ * Gère les appels API et le polling des opérations longues
+ */
+
+import { GoogleAuth } from 'google-auth-library';
+
+// Types
+export interface VeoVideoConfig {
+  projectId: string;
+  location?: string;
+  serviceAccountKey?: string;
+}
+
+export interface VeoVideoOptions {
+  model?: 'veo-3.1-generate-001' | 'veo-3.1-fast-generate-001';
+  aspectRatio?: '16:9' | '9:16';
+  durationSeconds?: 4 | 6 | 8;
+  resolution?: '1080p' | '720p';
+  numberOfVideos?: 1 | 2;
+  personGeneration?: 'allow_adult' | 'dont_allow';
+  enhancePrompt?: boolean;
+  generateAudio?: boolean;
+}
+
+export interface VeoVideoResult {
+  videoData: Buffer;
+  mimeType: string;
+  model: string;
+  durationSeconds: number;
+  resolution: string;
+  aspectRatio: string;
+  hasAudio: boolean;
+  generationTimeSeconds: number;
+  enhancedPrompt?: string;
+}
+
+export interface VeoOperationStatus {
+  name: string;
+  done: boolean;
+  error?: {
+    code: number;
+    message: string;
+  };
+  response?: {
+    generatedVideos: Array<{
+      video: {
+        videoBytes?: string;
+        uri?: string;
+      };
+    }>;
+  };
+}
+
+const DEFAULT_OPTIONS: VeoVideoOptions = {
+  model: 'veo-3.1-generate-001',
+  aspectRatio: '16:9',
+  durationSeconds: 6,
+  resolution: '1080p',
+  numberOfVideos: 1,
+  personGeneration: 'allow_adult',
+  enhancePrompt: true,
+  generateAudio: true,
+};
+
+const POLLING_INTERVAL_MS = 15000; // 15 seconds
+const MAX_POLLING_TIME_MS = 300000; // 5 minutes
+
+export class VeoVideoClient {
+  private auth: GoogleAuth;
+  private projectId: string;
+  private location: string;
+
+  constructor(config: VeoVideoConfig) {
+    this.projectId = config.projectId;
+    this.location = config.location || 'us-central1';
+
+    // Initialize auth
+    if (config.serviceAccountKey) {
+      const credentials = typeof config.serviceAccountKey === 'string'
+        ? JSON.parse(config.serviceAccountKey)
+        : config.serviceAccountKey;
+
+      this.auth = new GoogleAuth({
+        credentials,
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+    } else {
+      this.auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+      });
+    }
+  }
+
+  /**
+   * Génère une vidéo à partir d'un prompt texte
+   */
+  async generateFromText(
+    prompt: string,
+    options?: VeoVideoOptions
+  ): Promise<VeoVideoResult> {
+    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const startTime = Date.now();
+
+    // Build request body
+    const requestBody = {
+      instances: [{ prompt }],
+      parameters: {
+        aspectRatio: opts.aspectRatio,
+        sampleCount: opts.numberOfVideos,
+        durationSeconds: opts.durationSeconds,
+        resolution: opts.resolution,
+        personGeneration: opts.personGeneration,
+        enhancePrompt: opts.enhancePrompt,
+        generateAudio: opts.generateAudio,
+      },
+    };
+
+    // Start the generation operation
+    const operation = await this.startOperation(opts.model!, requestBody);
+
+    // Poll until completion
+    const result = await this.pollOperation(operation.name);
+
+    // Extract video data
+    const videoData = await this.extractVideoData(result);
+    const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
+
+    return {
+      videoData,
+      mimeType: 'video/mp4',
+      model: opts.model!,
+      durationSeconds: opts.durationSeconds!,
+      resolution: opts.resolution!,
+      aspectRatio: opts.aspectRatio!,
+      hasAudio: opts.generateAudio!,
+      generationTimeSeconds,
+    };
+  }
+
+  /**
+   * Génère une vidéo à partir d'une image (animation)
+   */
+  async generateFromImage(
+    imageData: Buffer,
+    imageMimeType: string,
+    prompt: string,
+    options?: VeoVideoOptions
+  ): Promise<VeoVideoResult> {
+    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const startTime = Date.now();
+
+    // Build request body with image
+    const imageBase64 = imageData.toString('base64');
+    const requestBody = {
+      instances: [
+        {
+          prompt,
+          image: {
+            bytesBase64Encoded: imageBase64,
+            mimeType: imageMimeType,
+          },
+        },
+      ],
+      parameters: {
+        aspectRatio: opts.aspectRatio,
+        sampleCount: opts.numberOfVideos,
+        durationSeconds: opts.durationSeconds,
+        resolution: opts.resolution,
+        personGeneration: opts.personGeneration,
+        enhancePrompt: opts.enhancePrompt,
+        generateAudio: opts.generateAudio,
+      },
+    };
+
+    // Start the generation operation
+    const operation = await this.startOperation(opts.model!, requestBody);
+
+    // Poll until completion
+    const result = await this.pollOperation(operation.name);
+
+    // Extract video data
+    const videoData = await this.extractVideoData(result);
+    const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
+
+    return {
+      videoData,
+      mimeType: 'video/mp4',
+      model: opts.model!,
+      durationSeconds: opts.durationSeconds!,
+      resolution: opts.resolution!,
+      aspectRatio: opts.aspectRatio!,
+      hasAudio: opts.generateAudio!,
+      generationTimeSeconds,
+    };
+  }
+
+  /**
+   * Démarre une opération de génération vidéo
+   */
+  private async startOperation(
+    model: string,
+    requestBody: Record<string, unknown>
+  ): Promise<{ name: string }> {
+    const client = await this.auth.getClient();
+    const accessToken = await client.getAccessToken();
+
+    const endpoint = `https://${this.location}-aiplatform.googleapis.com/v1/projects/${this.projectId}/locations/${this.location}/publishers/google/models/${model}:predictLongRunning`;
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Veo API error: ${response.status} - ${errorText}`);
+    }
+
+    const data = await response.json() as { name: string };
+    return data;
+  }
+
+  /**
+   * Poll l'opération jusqu'à completion
+   */
+  private async pollOperation(operationName: string): Promise<VeoOperationStatus> {
+    const client = await this.auth.getClient();
+    const startTime = Date.now();
+
+    while (true) {
+      // Check timeout
+      if (Date.now() - startTime > MAX_POLLING_TIME_MS) {
+        throw new Error(`Video generation timed out after ${MAX_POLLING_TIME_MS / 1000} seconds`);
+      }
+
+      const accessToken = await client.getAccessToken();
+      const endpoint = `https://${this.location}-aiplatform.googleapis.com/v1/${operationName}`;
+
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        headers: {
+          'Authorization': `Bearer ${accessToken.token}`,
+        },
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Veo polling error: ${response.status} - ${errorText}`);
+      }
+
+      const status = await response.json() as VeoOperationStatus;
+
+      if (status.done) {
+        if (status.error) {
+          throw new Error(`Veo generation failed: ${status.error.message}`);
+        }
+        return status;
+      }
+
+      // Wait before next poll
+      await this.sleep(POLLING_INTERVAL_MS);
+    }
+  }
+
+  /**
+   * Extrait les données vidéo du résultat
+   */
+  private async extractVideoData(result: VeoOperationStatus): Promise<Buffer> {
+    if (!result.response?.generatedVideos?.length) {
+      throw new Error('No video generated in response');
+    }
+
+    const video = result.response.generatedVideos[0].video;
+
+    if (video.videoBytes) {
+      return Buffer.from(video.videoBytes, 'base64');
+    }
+
+    if (video.uri) {
+      // Fetch from GCS URI
+      return await this.fetchFromGcs(video.uri);
+    }
+
+    throw new Error('No video data or URI in response');
+  }
+
+  /**
+   * Récupère une vidéo depuis GCS
+   */
+  private async fetchFromGcs(gcsUri: string): Promise<Buffer> {
+    // gs://bucket/path -> https://storage.googleapis.com/bucket/path
+    const httpUrl = gcsUri
+      .replace('gs://', 'https://storage.googleapis.com/');
+
+    const client = await this.auth.getClient();
+    const accessToken = await client.getAccessToken();
+
+    const response = await fetch(httpUrl, {
+      headers: {
+        'Authorization': `Bearer ${accessToken.token}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch video from GCS: ${response.status}`);
+    }
+
+    const arrayBuffer = await response.arrayBuffer();
+    return Buffer.from(arrayBuffer);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+}

--- a/custom-nodes/n8n-nodes-veo-video/tsconfig.json
+++ b/custom-nodes/n8n-nodes-veo-video/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "commonjs",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "declaration": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noImplicitAny": true,
+    "outDir": "./dist",
+    "rootDir": "."
+  },
+  "include": [
+    "nodes/**/*.ts",
+    "shared/**/*.ts",
+    "presets/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/workflows/veo-video-workflow.json
+++ b/workflows/veo-video-workflow.json
@@ -1,0 +1,185 @@
+{
+  "name": "Veo Video",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "veo-video",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "veo-video-webhook"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-input",
+              "leftValue": "={{ $json.body.prompt }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-input",
+      "name": "Has prompt?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "errorMessage": "={{ \"No prompt provided. Please send a prompt in the request body\" }}"
+      },
+      "id": "error-no-input",
+      "name": "Error: No Prompt",
+      "type": "n8n-nodes-base.stopAndError",
+      "typeVersion": 1,
+      "position": [680, 420]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare data for Veo Video node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: generateFromText)\nconst operation = body.operation || 'generateFromText';\n\n// Video parameters\nconst model = body.model || 'veo-3.1-generate-001';\nconst durationSeconds = body.durationSeconds || 6;\nconst aspectRatio = body.aspectRatio || '16:9';\nconst resolution = body.resolution || '1080p';\nconst generateAudio = body.generateAudio !== false;\nconst enhancePrompt = body.enhancePrompt !== false;\nconst personGeneration = body.personGeneration || 'allow_adult';\n\n// Build result\nconst result = {\n  operation,\n  prompt: body.prompt || '',\n  model,\n  durationSeconds,\n  aspectRatio,\n  resolution,\n  generateAudio,\n  enhancePrompt,\n  personGeneration,\n  originalRequest: { ...body }\n};\n\n// For generateFromImage\nif (operation === 'generateFromImage') {\n  result.sourceImage = body.sourceImage || '';\n  result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n}\n\nreturn [{ json: result }];"
+      },
+      "id": "prepare-config",
+      "name": "Prepare Config",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [680, 180]
+    },
+    {
+      "parameters": {
+        "operation": "={{ $json.operation }}",
+        "prompt": "={{ $json.prompt }}",
+        "sourceImage": "={{ $json.sourceImage }}",
+        "sourceImageMimeType": "={{ $json.sourceImageMimeType }}",
+        "model": "={{ $json.model }}",
+        "durationSeconds": "={{ $json.durationSeconds }}",
+        "aspectRatio": "={{ $json.aspectRatio }}",
+        "resolution": "={{ $json.resolution }}",
+        "generateAudio": "={{ $json.generateAudio }}",
+        "enhancePrompt": "={{ $json.enhancePrompt }}",
+        "options": {
+          "personGeneration": "={{ $json.personGeneration }}"
+        }
+      },
+      "id": "veo-video",
+      "name": "Veo Video",
+      "type": "n8n-nodes-veo-video.veoVideo",
+      "typeVersion": 1,
+      "position": [900, 180],
+      "credentials": {
+        "googleVertexAiApi": {
+          "id": "google-vertex-ai",
+          "name": "Google Vertex AI account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response\nconst input = $input.first().json;\n\nconst response = {\n  success: true,\n  operation: input.operation,\n  video: input.video,\n  videoBase64: input.videoBase64,\n  model: input.model,\n  generationTimeSeconds: input.generationTimeSeconds,\n  metadata: input.metadata\n};\n\nreturn [{ json: response }];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 180]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 180]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Has prompt?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has prompt?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Config",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: No Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Config": {
+      "main": [
+        [
+          {
+            "node": "Veo Video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Veo Video": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

Implements Phase A of Issue #48 - Veo Video Generation.

## Custom Node: n8n-nodes-veo-video

### Operations
| Operation | Description |
|-----------|-------------|
| `generateFromText` | Generate video from text prompt |
| `generateFromImage` | Animate a static image into video |

### Parameters
| Parameter | Options | Default |
|-----------|---------|---------|
| Model | Veo 3.1 (Quality), Veo 3.1 Fast | Veo 3.1 |
| Duration | 4s, 6s, 8s | 6s |
| Aspect Ratio | 16:9, 9:16 | 16:9 |
| Resolution | 1080p, 720p | 1080p |
| Generate Audio | true/false | true |
| Enhance Prompt | true/false | true |

### Polling
- Interval: 15 seconds
- Timeout: 5 minutes (300s)
- Handles long-running Veo operations automatically

## Workflow
- **Endpoint:** `POST /webhook/veo-video`
- Validates input prompt
- Returns video as base64 in JSON response

## Files Added
- `custom-nodes/n8n-nodes-veo-video/` - Complete node package
- `workflows/veo-video-workflow.json` - Webhook workflow

## Test Plan
- [ ] Build: `npm run build`
- [ ] Install in n8n: copy to `~/.n8n/nodes/`
- [ ] Import and activate workflow
- [ ] Test generateFromText with simple prompt
- [ ] Test generateFromImage with static image

## Next Phases
- **Phase B:** Presets + optimizePrompt operation
- **Phase C:** GCS Upload + signed URLs
- **Phase D:** Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)