### PR TITLE
feat(phase-5b): Video extension, long video, presets and prompt optimization

### DIFF
--- a/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/VeoVideo.node.ts
+++ b/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/VeoVideo.node.ts
@@ -7,7 +7,26 @@ import {
   NodeOperationError,
 } from 'n8n-workflow';
 
-import { VeoVideoClient, VeoVideoOptions } from '../../shared/VeoVideoClient';
+import { VeoVideoClient, VeoVideoOptions, VeoExtendOptions, VeoLongVideoOptions } from '../../shared/VeoVideoClient';
+import * as presets from '../../shared/presets/veo-presets.json';
+
+// Type for preset config
+interface PresetConfig {
+  name: string;
+  description: string;
+  style: string;
+  camera_movement: string;
+  lighting: string;
+  prompt_prefix: string;
+  prompt_suffix: string;
+  defaults: {
+    aspectRatio?: string;
+    resolution?: string;
+    durationSeconds?: number;
+    generateAudio?: boolean;
+    enhancePrompt?: boolean;
+  };
+}
 
 export class VeoVideo implements INodeType {
   description: INodeTypeDescription = {
@@ -17,7 +36,7 @@ export class VeoVideo implements INodeType {
     group: ['transform'],
     version: 1,
     subtitle: '={{$parameter["operation"]}}',
-    description: 'Generate videos using Veo 3',
+    description: 'Generate videos using Veo 3 with presets and long video support',
     defaults: {
       name: 'Veo Video',
     },
@@ -49,6 +68,24 @@ export class VeoVideo implements INodeType {
             description: 'Animate an image into a video',
             action: 'Generate video from image',
           },
+          {
+            name: 'Generate Long Video',
+            value: 'generateLongVideo',
+            description: 'Generate a video longer than 8 seconds by chaining clips',
+            action: 'Generate long video by chaining clips',
+          },
+          {
+            name: 'Extend Video',
+            value: 'extendVideo',
+            description: 'Extend an existing video with additional footage',
+            action: 'Extend existing video',
+          },
+          {
+            name: 'Optimize Prompt',
+            value: 'optimizePrompt',
+            description: 'Enhance a prompt using AI for better video generation',
+            action: 'Optimize prompt with AI',
+          },
         ],
         default: 'generateFromText',
       },
@@ -64,6 +101,43 @@ export class VeoVideo implements INodeType {
         default: '',
         placeholder: 'A robot walking through a futuristic city...',
         description: 'Description of the video to generate',
+        displayOptions: {
+          hide: {
+            operation: ['extendVideo'],
+          },
+        },
+      },
+      // Extension Prompt (for extendVideo)
+      {
+        displayName: 'Extension Prompt',
+        name: 'extensionPrompt',
+        type: 'string',
+        typeOptions: {
+          rows: 2,
+        },
+        default: '',
+        placeholder: 'Continue the scene with...',
+        description: 'Optional prompt to guide how the video should be extended',
+        displayOptions: {
+          show: {
+            operation: ['extendVideo'],
+          },
+        },
+      },
+      // Source Video (for extendVideo)
+      {
+        displayName: 'Source Video',
+        name: 'sourceVideo',
+        type: 'string',
+        required: true,
+        default: '',
+        placeholder: 'Base64 encoded video data',
+        description: 'Video to extend (base64 encoded)',
+        displayOptions: {
+          show: {
+            operation: ['extendVideo'],
+          },
+        },
       },
       // Source Image (for generateFromImage)
       {
@@ -97,6 +171,28 @@ export class VeoVideo implements INodeType {
           },
         },
       },
+      // Preset Selection
+      {
+        displayName: 'Preset',
+        name: 'preset',
+        type: 'options',
+        options: [
+          { name: 'None (Custom)', value: 'none' },
+          { name: 'Corporate / Professional', value: 'corporate' },
+          { name: 'Social Media Short', value: 'social_short' },
+          { name: 'Product Demo', value: 'product_demo' },
+          { name: 'Cinematic', value: 'cinematic' },
+          { name: 'Explainer / Tutorial', value: 'explainer' },
+          { name: 'Artistic / Creative', value: 'artistic' },
+        ],
+        default: 'none',
+        description: 'Apply a preset style to the video generation',
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'generateLongVideo', 'optimizePrompt'],
+          },
+        },
+      },
       // Model
       {
         displayName: 'Model',
@@ -115,8 +211,30 @@ export class VeoVideo implements INodeType {
           },
         ],
         default: 'veo-3.1-generate-001',
+        displayOptions: {
+          hide: {
+            operation: ['optimizePrompt'],
+          },
+        },
       },
-      // Duration
+      // Target Duration (for generateLongVideo)
+      {
+        displayName: 'Target Duration (Seconds)',
+        name: 'targetDuration',
+        type: 'number',
+        typeOptions: {
+          minValue: 4,
+          maxValue: 120,
+        },
+        default: 30,
+        description: 'Total desired video duration. Videos longer than 8s are created by chaining multiple clips.',
+        displayOptions: {
+          show: {
+            operation: ['generateLongVideo'],
+          },
+        },
+      },
+      // Duration (for single clips)
       {
         displayName: 'Duration (Seconds)',
         name: 'durationSeconds',
@@ -127,6 +245,11 @@ export class VeoVideo implements INodeType {
           { name: '8 seconds', value: 8 },
         ],
         default: 6,
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'extendVideo'],
+          },
+        },
       },
       // Aspect Ratio
       {
@@ -138,6 +261,11 @@ export class VeoVideo implements INodeType {
           { name: '9:16 (Portrait/Mobile)', value: '9:16' },
         ],
         default: '16:9',
+        displayOptions: {
+          hide: {
+            operation: ['optimizePrompt'],
+          },
+        },
       },
       // Resolution
       {
@@ -149,6 +277,11 @@ export class VeoVideo implements INodeType {
           { name: '720p (HD)', value: '720p' },
         ],
         default: '1080p',
+        displayOptions: {
+          hide: {
+            operation: ['optimizePrompt'],
+          },
+        },
       },
       // Generate Audio
       {
@@ -157,6 +290,11 @@ export class VeoVideo implements INodeType {
         type: 'boolean',
         default: true,
         description: 'Whether to generate dialogue and sound effects',
+        displayOptions: {
+          hide: {
+            operation: ['optimizePrompt'],
+          },
+        },
       },
       // Enhance Prompt
       {
@@ -165,6 +303,11 @@ export class VeoVideo implements INodeType {
         type: 'boolean',
         default: true,
         description: 'Whether to use AI to enhance the prompt before generation',
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'generateLongVideo'],
+          },
+        },
       },
       // Advanced Options
       {
@@ -173,6 +316,11 @@ export class VeoVideo implements INodeType {
         type: 'collection',
         placeholder: 'Add Option',
         default: {},
+        displayOptions: {
+          hide: {
+            operation: ['optimizePrompt'],
+          },
+        },
         options: [
           {
             displayName: 'Person Generation',
@@ -197,20 +345,6 @@ export class VeoVideo implements INodeType {
     for (let i = 0; i < items.length; i++) {
       try {
         const operation = this.getNodeParameter('operation', i) as string;
-        const prompt = this.getNodeParameter('prompt', i) as string;
-        const model = this.getNodeParameter('model', i) as string;
-        const durationSeconds = this.getNodeParameter('durationSeconds', i) as number;
-        const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
-        const resolution = this.getNodeParameter('resolution', i) as string;
-        const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
-        const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
-        const advancedOptions = this.getNodeParameter('options', i, {}) as {
-          personGeneration?: string;
-        };
-
-        if (!prompt) {
-          throw new NodeOperationError(this.getNode(), 'Prompt is required', { itemIndex: i });
-        }
 
         // Get credentials
         const credentials = await this.getCredentials('googleVertexAiApi');
@@ -222,68 +356,276 @@ export class VeoVideo implements INodeType {
           serviceAccountKey: credentials.serviceAccountKey as string | undefined,
         });
 
-        const videoOptions: VeoVideoOptions = {
-          model: model as VeoVideoOptions['model'],
-          aspectRatio: aspectRatio as VeoVideoOptions['aspectRatio'],
-          durationSeconds: durationSeconds as VeoVideoOptions['durationSeconds'],
-          resolution: resolution as VeoVideoOptions['resolution'],
-          generateAudio,
-          enhancePrompt,
-          personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
-        };
-
         let result;
+        let jsonOutput: IDataObject;
+
+        // Get preset if selected
+        const presetName = operation !== 'extendVideo'
+          ? this.getNodeParameter('preset', i, 'none') as string
+          : 'none';
+        const presetConfig = presetName !== 'none'
+          ? (presets.presets as Record<string, PresetConfig>)[presetName]
+          : null;
 
         switch (operation) {
           case 'generateFromText': {
-            result = await client.generateFromText(prompt, videoOptions);
+            const prompt = this.getNodeParameter('prompt', i) as string;
+            const model = this.getNodeParameter('model', i) as string;
+            const durationSeconds = this.getNodeParameter('durationSeconds', i) as number;
+            const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
+            const resolution = this.getNodeParameter('resolution', i) as string;
+            const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
+            const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+            const advancedOptions = this.getNodeParameter('options', i, {}) as {
+              personGeneration?: string;
+            };
+
+            if (!prompt) {
+              throw new NodeOperationError(this.getNode(), 'Prompt is required', { itemIndex: i });
+            }
+
+            // Apply preset to prompt if selected
+            let finalPrompt = prompt;
+            if (presetConfig) {
+              finalPrompt = `${presetConfig.prompt_prefix}${prompt}${presetConfig.prompt_suffix}`;
+            }
+
+            const videoOptions: VeoVideoOptions = {
+              model: model as VeoVideoOptions['model'],
+              aspectRatio: (presetConfig?.defaults.aspectRatio || aspectRatio) as VeoVideoOptions['aspectRatio'],
+              durationSeconds: durationSeconds as VeoVideoOptions['durationSeconds'],
+              resolution: (presetConfig?.defaults.resolution || resolution) as VeoVideoOptions['resolution'],
+              generateAudio: presetConfig?.defaults.generateAudio ?? generateAudio,
+              enhancePrompt: presetConfig?.defaults.enhancePrompt ?? enhancePrompt,
+              personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+            };
+
+            result = await client.generateFromText(finalPrompt, videoOptions);
+
+            jsonOutput = {
+              operation,
+              video: {
+                format: 'mp4',
+                durationSeconds: result.durationSeconds,
+                resolution: result.resolution,
+                aspectRatio: result.aspectRatio,
+                hasAudio: result.hasAudio,
+              },
+              model: result.model,
+              generationTimeSeconds: result.generationTimeSeconds,
+              preset: presetName !== 'none' ? presetName : undefined,
+              metadata: {
+                processedAt: new Date().toISOString(),
+              },
+              videoBase64: result.videoData.toString('base64'),
+            };
             break;
           }
 
           case 'generateFromImage': {
+            const prompt = this.getNodeParameter('prompt', i) as string;
             const sourceImage = this.getNodeParameter('sourceImage', i) as string;
             const sourceImageMimeType = this.getNodeParameter('sourceImageMimeType', i) as string;
+            const model = this.getNodeParameter('model', i) as string;
+            const durationSeconds = this.getNodeParameter('durationSeconds', i) as number;
+            const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
+            const resolution = this.getNodeParameter('resolution', i) as string;
+            const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
+            const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+            const advancedOptions = this.getNodeParameter('options', i, {}) as {
+              personGeneration?: string;
+            };
 
+            if (!prompt) {
+              throw new NodeOperationError(this.getNode(), 'Prompt is required', { itemIndex: i });
+            }
             if (!sourceImage) {
               throw new NodeOperationError(this.getNode(), 'Source image is required', { itemIndex: i });
             }
 
+            let finalPrompt = prompt;
+            if (presetConfig) {
+              finalPrompt = `${presetConfig.prompt_prefix}${prompt}${presetConfig.prompt_suffix}`;
+            }
+
+            const videoOptions: VeoVideoOptions = {
+              model: model as VeoVideoOptions['model'],
+              aspectRatio: (presetConfig?.defaults.aspectRatio || aspectRatio) as VeoVideoOptions['aspectRatio'],
+              durationSeconds: durationSeconds as VeoVideoOptions['durationSeconds'],
+              resolution: (presetConfig?.defaults.resolution || resolution) as VeoVideoOptions['resolution'],
+              generateAudio: presetConfig?.defaults.generateAudio ?? generateAudio,
+              enhancePrompt: presetConfig?.defaults.enhancePrompt ?? enhancePrompt,
+              personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+            };
+
             const imageBuffer = Buffer.from(sourceImage, 'base64');
-            result = await client.generateFromImage(imageBuffer, sourceImageMimeType, prompt, videoOptions);
+            result = await client.generateFromImage(imageBuffer, sourceImageMimeType, finalPrompt, videoOptions);
+
+            jsonOutput = {
+              operation,
+              video: {
+                format: 'mp4',
+                durationSeconds: result.durationSeconds,
+                resolution: result.resolution,
+                aspectRatio: result.aspectRatio,
+                hasAudio: result.hasAudio,
+              },
+              model: result.model,
+              generationTimeSeconds: result.generationTimeSeconds,
+              preset: presetName !== 'none' ? presetName : undefined,
+              metadata: {
+                processedAt: new Date().toISOString(),
+              },
+              videoBase64: result.videoData.toString('base64'),
+            };
             break;
+          }
+
+          case 'generateLongVideo': {
+            const prompt = this.getNodeParameter('prompt', i) as string;
+            const targetDuration = this.getNodeParameter('targetDuration', i) as number;
+            const model = this.getNodeParameter('model', i) as string;
+            const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
+            const resolution = this.getNodeParameter('resolution', i) as string;
+            const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
+            const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+            const advancedOptions = this.getNodeParameter('options', i, {}) as {
+              personGeneration?: string;
+            };
+
+            if (!prompt) {
+              throw new NodeOperationError(this.getNode(), 'Prompt is required', { itemIndex: i });
+            }
+
+            let finalPrompt = prompt;
+            if (presetConfig) {
+              finalPrompt = `${presetConfig.prompt_prefix}${prompt}${presetConfig.prompt_suffix}`;
+            }
+
+            const longVideoOptions: VeoLongVideoOptions = {
+              targetDuration,
+              model: model as VeoVideoOptions['model'],
+              aspectRatio: (presetConfig?.defaults.aspectRatio || aspectRatio) as VeoVideoOptions['aspectRatio'],
+              resolution: (presetConfig?.defaults.resolution || resolution) as VeoVideoOptions['resolution'],
+              generateAudio: presetConfig?.defaults.generateAudio ?? generateAudio,
+              enhancePrompt: presetConfig?.defaults.enhancePrompt ?? enhancePrompt,
+              personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+            };
+
+            result = await client.generateLongVideo(finalPrompt, longVideoOptions);
+
+            jsonOutput = {
+              operation,
+              video: {
+                format: 'mp4',
+                durationSeconds: result.durationSeconds,
+                resolution: result.resolution,
+                aspectRatio: result.aspectRatio,
+                hasAudio: result.hasAudio,
+                clipCount: result.clipCount,
+                clipDurations: result.clipDurations,
+              },
+              model: result.model,
+              generationTimeSeconds: result.generationTimeSeconds,
+              preset: presetName !== 'none' ? presetName : undefined,
+              metadata: {
+                processedAt: new Date().toISOString(),
+                targetDuration,
+                actualDuration: result.durationSeconds,
+              },
+              videoBase64: result.videoData.toString('base64'),
+            };
+            break;
+          }
+
+          case 'extendVideo': {
+            const sourceVideo = this.getNodeParameter('sourceVideo', i) as string;
+            const extensionPrompt = this.getNodeParameter('extensionPrompt', i, '') as string;
+            const model = this.getNodeParameter('model', i) as string;
+            const durationSeconds = this.getNodeParameter('durationSeconds', i) as number;
+            const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
+            const resolution = this.getNodeParameter('resolution', i) as string;
+            const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
+            const advancedOptions = this.getNodeParameter('options', i, {}) as {
+              personGeneration?: string;
+            };
+
+            if (!sourceVideo) {
+              throw new NodeOperationError(this.getNode(), 'Source video is required', { itemIndex: i });
+            }
+
+            const extendOptions: VeoExtendOptions = {
+              model: model as VeoVideoOptions['model'],
+              aspectRatio: aspectRatio as VeoVideoOptions['aspectRatio'],
+              resolution: resolution as VeoVideoOptions['resolution'],
+              generateAudio,
+              extensionPrompt: extensionPrompt || undefined,
+              personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+            };
+
+            const videoBuffer = Buffer.from(sourceVideo, 'base64');
+            result = await client.extendVideo(videoBuffer, durationSeconds as 4 | 6 | 8, extendOptions);
+
+            jsonOutput = {
+              operation,
+              video: {
+                format: 'mp4',
+                durationSeconds: result.durationSeconds,
+                resolution: result.resolution,
+                aspectRatio: result.aspectRatio,
+                hasAudio: result.hasAudio,
+              },
+              model: result.model,
+              generationTimeSeconds: result.generationTimeSeconds,
+              metadata: {
+                processedAt: new Date().toISOString(),
+                extensionDuration: durationSeconds,
+              },
+              videoBase64: result.videoData.toString('base64'),
+            };
+            break;
+          }
+
+          case 'optimizePrompt': {
+            const prompt = this.getNodeParameter('prompt', i) as string;
+
+            if (!prompt) {
+              throw new NodeOperationError(this.getNode(), 'Prompt is required', { itemIndex: i });
+            }
+
+            const optimizationResult = await client.optimizePrompt(
+              prompt,
+              presetName !== 'none' ? presetName : undefined,
+              presetConfig ? presetConfig as unknown as Record<string, unknown> : undefined
+            );
+
+            jsonOutput = {
+              operation,
+              originalPrompt: optimizationResult.originalPrompt,
+              optimizedPrompt: optimizationResult.optimizedPrompt,
+              keywordsAdded: optimizationResult.keywordsAdded,
+              preset: optimizationResult.preset,
+              metadata: {
+                processedAt: new Date().toISOString(),
+              },
+            };
+
+            returnData.push({ json: jsonOutput });
+            continue; // Skip binary data for this operation
           }
 
           default:
             throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`, { itemIndex: i });
         }
 
-        // Prepare output
-        const jsonOutput: IDataObject = {
-          operation,
-          video: {
-            format: 'mp4',
-            durationSeconds: result.durationSeconds,
-            resolution: result.resolution,
-            aspectRatio: result.aspectRatio,
-            hasAudio: result.hasAudio,
-          },
-          model: result.model,
-          generationTimeSeconds: result.generationTimeSeconds,
-          metadata: {
-            processedAt: new Date().toISOString(),
-          },
-        };
-
-        // Include base64 in JSON
-        jsonOutput.videoBase64 = result.videoData.toString('base64');
-
+        // Prepare output with binary data for video operations
         const outputData: INodeExecutionData = {
-          json: jsonOutput,
+          json: jsonOutput!,
           binary: {
             data: await this.helpers.prepareBinaryData(
-              result.videoData,
+              result!.videoData,
               'generated-video.mp4',
-              result.mimeType
+              result!.mimeType
             ),
           },
         };

--- a/custom-nodes/n8n-nodes-veo-video/shared/VeoVideoClient.ts
+++ b/custom-nodes/n8n-nodes-veo-video/shared/VeoVideoClient.ts
@@ -33,6 +33,24 @@ export interface VeoVideoResult {
   hasAudio: boolean;
   generationTimeSeconds: number;
   enhancedPrompt?: string;
+  clipCount?: number;  // For long videos: number of clips generated
+  clipDurations?: number[];  // Duration of each clip
+}
+
+export interface VeoExtendOptions extends VeoVideoOptions {
+  extensionPrompt?: string;  // Optional prompt for the extension
+}
+
+export interface VeoLongVideoOptions extends VeoVideoOptions {
+  targetDuration: number;  // Total desired duration in seconds
+  onClipComplete?: (clipNumber: number, totalClips: number, currentDuration: number) => void;
+}
+
+export interface PromptOptimizationResult {
+  originalPrompt: string;
+  optimizedPrompt: string;
+  keywordsAdded: string[];
+  preset?: string;
 }
 
 export interface VeoOperationStatus {
@@ -192,6 +210,252 @@ export class VeoVideoClient {
       aspectRatio: opts.aspectRatio!,
       hasAudio: opts.generateAudio!,
       generationTimeSeconds,
+    };
+  }
+
+  /**
+   * Étend une vidéo existante
+   * Permet de créer des vidéos plus longues en chaînant les clips
+   */
+  async extendVideo(
+    videoData: Buffer,
+    extensionDuration: 4 | 6 | 8,
+    options?: VeoExtendOptions
+  ): Promise<VeoVideoResult> {
+    const opts = { ...DEFAULT_OPTIONS, ...options };
+    const startTime = Date.now();
+
+    const videoBase64 = videoData.toString('base64');
+    const requestBody = {
+      instances: [
+        {
+          prompt: options?.extensionPrompt || 'Continue the video seamlessly',
+          video: {
+            bytesBase64Encoded: videoBase64,
+            mimeType: 'video/mp4',
+          },
+        },
+      ],
+      parameters: {
+        aspectRatio: opts.aspectRatio,
+        sampleCount: 1,
+        durationSeconds: extensionDuration,
+        resolution: opts.resolution,
+        personGeneration: opts.personGeneration,
+        enhancePrompt: false,  // Don't enhance for extensions
+        generateAudio: opts.generateAudio,
+      },
+    };
+
+    const operation = await this.startOperation(opts.model!, requestBody);
+    const result = await this.pollOperation(operation.name);
+    const extendedVideoData = await this.extractVideoData(result);
+    const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
+
+    return {
+      videoData: extendedVideoData,
+      mimeType: 'video/mp4',
+      model: opts.model!,
+      durationSeconds: extensionDuration,
+      resolution: opts.resolution!,
+      aspectRatio: opts.aspectRatio!,
+      hasAudio: opts.generateAudio!,
+      generationTimeSeconds,
+    };
+  }
+
+  /**
+   * Génère une vidéo longue en chaînant plusieurs clips
+   * Ex: targetDuration=30 -> génère 8s + 8s + 8s + 6s = 30s
+   */
+  async generateLongVideo(
+    prompt: string,
+    options: VeoLongVideoOptions
+  ): Promise<VeoVideoResult> {
+    const { targetDuration, onClipComplete, ...baseOptions } = options;
+    const startTime = Date.now();
+
+    // Calculer les durées des clips nécessaires
+    const clipDurations = this.calculateClipDurations(targetDuration);
+    const totalClips = clipDurations.length;
+
+    // Générer le premier clip
+    const firstClipDuration = clipDurations[0] as 4 | 6 | 8;
+    let currentVideo = await this.generateFromText(prompt, {
+      ...baseOptions,
+      durationSeconds: firstClipDuration,
+    });
+
+    let totalDuration = firstClipDuration;
+    const allClipDurations: number[] = [firstClipDuration];
+
+    if (onClipComplete) {
+      onClipComplete(1, totalClips, totalDuration);
+    }
+
+    // Étendre avec les clips suivants
+    for (let i = 1; i < clipDurations.length; i++) {
+      const extensionDuration = clipDurations[i] as 4 | 6 | 8;
+
+      const extendedResult = await this.extendVideo(
+        currentVideo.videoData,
+        extensionDuration,
+        {
+          ...baseOptions,
+          extensionPrompt: `Continue the scene: ${prompt}`,
+        }
+      );
+
+      currentVideo = extendedResult;
+      totalDuration += extensionDuration;
+      allClipDurations.push(extensionDuration);
+
+      if (onClipComplete) {
+        onClipComplete(i + 1, totalClips, totalDuration);
+      }
+    }
+
+    const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
+
+    return {
+      videoData: currentVideo.videoData,
+      mimeType: 'video/mp4',
+      model: baseOptions.model || DEFAULT_OPTIONS.model!,
+      durationSeconds: totalDuration,
+      resolution: baseOptions.resolution || DEFAULT_OPTIONS.resolution!,
+      aspectRatio: baseOptions.aspectRatio || DEFAULT_OPTIONS.aspectRatio!,
+      hasAudio: baseOptions.generateAudio ?? DEFAULT_OPTIONS.generateAudio!,
+      generationTimeSeconds,
+      clipCount: totalClips,
+      clipDurations: allClipDurations,
+    };
+  }
+
+  /**
+   * Calcule les durées optimales des clips pour atteindre la durée cible
+   * Privilégie les clips de 8s pour minimiser le nombre d'appels API
+   */
+  private calculateClipDurations(targetDuration: number): number[] {
+    if (targetDuration <= 8) {
+      // Durée simple
+      if (targetDuration <= 4) return [4];
+      if (targetDuration <= 6) return [6];
+      return [8];
+    }
+
+    const durations: number[] = [];
+    let remaining = targetDuration;
+
+    // Utiliser des clips de 8s autant que possible
+    while (remaining > 0) {
+      if (remaining >= 8) {
+        durations.push(8);
+        remaining -= 8;
+      } else if (remaining >= 6) {
+        durations.push(6);
+        remaining -= 6;
+      } else if (remaining >= 4) {
+        durations.push(4);
+        remaining -= 4;
+      } else {
+        // Ajuster le dernier clip pour atteindre exactement la durée
+        // Si on a un reste < 4, on ajoute au dernier clip ou on ajuste
+        if (durations.length > 0) {
+          // On ne peut pas faire moins de 4s, donc on arrondit
+          break;
+        } else {
+          durations.push(4);
+          break;
+        }
+      }
+    }
+
+    return durations;
+  }
+
+  /**
+   * Optimise un prompt pour la génération vidéo avec Gemini
+   */
+  async optimizePrompt(
+    prompt: string,
+    preset?: string,
+    presetConfig?: Record<string, unknown>
+  ): Promise<PromptOptimizationResult> {
+    const client = await this.auth.getClient();
+    const accessToken = await client.getAccessToken();
+
+    // Construire le prompt système pour Gemini
+    const systemPrompt = `You are an expert video prompt engineer for Google's Veo 3 model.
+Your task is to enhance the given prompt to create a more detailed, cinematic video description.
+Include specific details about:
+- Camera angles and movements (dolly, pan, tilt, crane)
+- Lighting conditions
+- Visual style and atmosphere
+- Temporal elements and pacing
+- Audio cues if applicable
+
+Keep the output concise (2-3 sentences max).
+Output ONLY the enhanced prompt, no explanations.`;
+
+    let userPrompt = `Enhance this video prompt: "${prompt}"`;
+
+    if (preset && presetConfig) {
+      userPrompt += `\n\nApply this style: ${preset}`;
+      if (presetConfig.style) userPrompt += `\nStyle: ${presetConfig.style}`;
+      if (presetConfig.camera_movement) userPrompt += `\nCamera: ${presetConfig.camera_movement}`;
+      if (presetConfig.prompt_prefix) userPrompt += `\nPrefix: ${presetConfig.prompt_prefix}`;
+      if (presetConfig.prompt_suffix) userPrompt += `\nSuffix: ${presetConfig.prompt_suffix}`;
+    }
+
+    const endpoint = `https://${this.location}-aiplatform.googleapis.com/v1/projects/${this.projectId}/locations/${this.location}/publishers/google/models/gemini-2.0-flash:generateContent`;
+
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: `${systemPrompt}\n\n${userPrompt}` }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.7,
+          maxOutputTokens: 500,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Gemini API error: ${response.status} - ${errorText}`);
+    }
+
+    const data = await response.json() as {
+      candidates: Array<{
+        content: {
+          parts: Array<{ text: string }>;
+        };
+      }>;
+    };
+
+    const optimizedPrompt = data.candidates?.[0]?.content?.parts?.[0]?.text || prompt;
+
+    // Extraire les mots-clés ajoutés (simplification)
+    const originalWords = new Set(prompt.toLowerCase().split(/\s+/));
+    const newWords = optimizedPrompt.toLowerCase().split(/\s+/);
+    const keywordsAdded = newWords
+      .filter(word => !originalWords.has(word) && word.length > 4)
+      .slice(0, 10);
+
+    return {
+      originalPrompt: prompt,
+      optimizedPrompt,
+      keywordsAdded,
+      preset,
     };
   }
 

--- a/custom-nodes/n8n-nodes-veo-video/shared/presets/veo-presets.json
+++ b/custom-nodes/n8n-nodes-veo-video/shared/presets/veo-presets.json
@@ -1,0 +1,97 @@
+{
+  "presets": {
+    "corporate": {
+      "name": "Corporate / Professional",
+      "description": "Clean, professional videos for business communication",
+      "style": "Professional, clean, modern corporate aesthetic",
+      "camera_movement": "Smooth dolly or static shots",
+      "lighting": "Even, professional lighting",
+      "prompt_prefix": "Professional corporate video: ",
+      "prompt_suffix": ", clean modern aesthetic, professional lighting, 4K quality",
+      "defaults": {
+        "aspectRatio": "16:9",
+        "resolution": "1080p",
+        "generateAudio": false,
+        "enhancePrompt": true
+      }
+    },
+    "social_short": {
+      "name": "Social Media Short",
+      "description": "Engaging vertical videos for TikTok, Instagram Reels, YouTube Shorts",
+      "style": "Dynamic, eye-catching, trendy",
+      "camera_movement": "Dynamic movements, quick cuts feel",
+      "lighting": "Vibrant, high contrast",
+      "prompt_prefix": "Viral social media video: ",
+      "prompt_suffix": ", dynamic and engaging, vibrant colors, eye-catching movement",
+      "defaults": {
+        "aspectRatio": "9:16",
+        "resolution": "1080p",
+        "durationSeconds": 6,
+        "generateAudio": true,
+        "enhancePrompt": true
+      }
+    },
+    "product_demo": {
+      "name": "Product Demo",
+      "description": "Product showcase videos with focus on details",
+      "style": "Clean product photography style, focus on details",
+      "camera_movement": "Slow orbit, smooth reveal shots",
+      "lighting": "Studio lighting, soft shadows",
+      "prompt_prefix": "Product showcase video: ",
+      "prompt_suffix": ", studio lighting, clean background, detailed product focus, commercial quality",
+      "defaults": {
+        "aspectRatio": "16:9",
+        "resolution": "1080p",
+        "generateAudio": false,
+        "enhancePrompt": true
+      }
+    },
+    "cinematic": {
+      "name": "Cinematic",
+      "description": "Film-quality videos with dramatic cinematography",
+      "style": "Cinematic, film-like quality, dramatic",
+      "camera_movement": "Crane shots, dramatic dolly moves, cinematic framing",
+      "lighting": "Dramatic lighting, film-like color grading",
+      "prompt_prefix": "Cinematic film scene: ",
+      "prompt_suffix": ", dramatic lighting, film-like color grading, 24fps cinematic look, anamorphic lens feel",
+      "defaults": {
+        "aspectRatio": "16:9",
+        "resolution": "1080p",
+        "generateAudio": true,
+        "enhancePrompt": true
+      }
+    },
+    "explainer": {
+      "name": "Explainer / Tutorial",
+      "description": "Educational content with clear visuals",
+      "style": "Clear, educational, informative",
+      "camera_movement": "Steady shots, smooth transitions",
+      "lighting": "Bright, clear visibility",
+      "prompt_prefix": "Educational explainer video: ",
+      "prompt_suffix": ", clear visuals, easy to follow, informative style",
+      "defaults": {
+        "aspectRatio": "16:9",
+        "resolution": "1080p",
+        "generateAudio": true,
+        "enhancePrompt": true
+      }
+    },
+    "artistic": {
+      "name": "Artistic / Creative",
+      "description": "Abstract and creative artistic videos",
+      "style": "Artistic, abstract, creative expression",
+      "camera_movement": "Experimental, creative angles",
+      "lighting": "Artistic lighting, experimental",
+      "prompt_prefix": "Artistic creative video: ",
+      "prompt_suffix": ", artistic expression, creative visuals, unique aesthetic",
+      "defaults": {
+        "aspectRatio": "16:9",
+        "resolution": "1080p",
+        "generateAudio": true,
+        "enhancePrompt": true
+      }
+    }
+  },
+  "version": "1.0.0",
+  "description": "Veo Video generation presets for different use cases"
+}

--- a/custom-nodes/n8n-nodes-veo-video/tsconfig.json
+++ b/custom-nodes/n8n-nodes-veo-video/tsconfig.json
@@ -18,7 +18,7 @@
   "include": [
     "nodes/**/*.ts",
     "shared/**/*.ts",
-    "presets/**/*.ts"
+    "shared/**/*.json"
   ],
   "exclude": [
     "node_modules",

--- a/docs/n8n/veo-video-mcp-server.md
+++ b/docs/n8n/veo-video-mcp-server.md
@@ -1,0 +1,266 @@
+# Veo Video - MCP Server Documentation
+
+Documentation for the MCP Server team to integrate with the Veo Video n8n workflow.
+
+## Overview
+
+The Veo Video workflow provides AI video generation capabilities using Google's Veo 3.1 model via Vertex AI. It supports:
+
+- **Text-to-Video**: Generate videos from text prompts
+- **Image-to-Video**: Animate images into videos
+- **Long Video Generation**: Create videos longer than 8 seconds by automatically chaining clips
+- **Video Extension**: Extend existing videos with additional footage
+- **Prompt Optimization**: Enhance prompts using Gemini for better video results
+- **Presets**: Pre-configured styles for different use cases
+
+## Endpoint
+
+```
+POST /webhook/veo-video
+Content-Type: application/json
+```
+
+## Operations
+
+### 1. Generate from Text (default)
+
+Generate a video from a text prompt.
+
+```json
+{
+  "operation": "generateFromText",
+  "prompt": "A robot walking through a futuristic city at sunset",
+  "model": "veo-3.1-generate-001",
+  "durationSeconds": 6,
+  "aspectRatio": "16:9",
+  "resolution": "1080p",
+  "generateAudio": true,
+  "enhancePrompt": true,
+  "preset": "cinematic"
+}
+```
+
+### 2. Generate from Image
+
+Animate an image into a video.
+
+```json
+{
+  "operation": "generateFromImage",
+  "prompt": "The character slowly turns their head and smiles",
+  "sourceImage": "<base64-encoded-image>",
+  "sourceImageMimeType": "image/png",
+  "durationSeconds": 6,
+  "aspectRatio": "16:9"
+}
+```
+
+### 3. Generate Long Video
+
+Generate videos longer than 8 seconds by automatically chaining clips.
+
+```json
+{
+  "operation": "generateLongVideo",
+  "prompt": "A drone flying over a mountain landscape",
+  "targetDuration": 30,
+  "model": "veo-3.1-generate-001",
+  "aspectRatio": "16:9",
+  "resolution": "1080p"
+}
+```
+
+**Note**: The API will automatically calculate the optimal clip sequence. For example:
+- 30 seconds = 8s + 8s + 8s + 6s (4 API calls)
+- 20 seconds = 8s + 8s + 4s (3 API calls)
+
+### 4. Extend Video
+
+Extend an existing video with additional footage.
+
+```json
+{
+  "operation": "extendVideo",
+  "sourceVideo": "<base64-encoded-video>",
+  "extensionPrompt": "The camera continues to pan right",
+  "durationSeconds": 8,
+  "aspectRatio": "16:9"
+}
+```
+
+### 5. Optimize Prompt
+
+Enhance a prompt using Gemini AI for better video generation results.
+
+```json
+{
+  "operation": "optimizePrompt",
+  "prompt": "A cat sitting on a sofa",
+  "preset": "cinematic"
+}
+```
+
+**Response**:
+```json
+{
+  "success": true,
+  "operation": "optimizePrompt",
+  "originalPrompt": "A cat sitting on a sofa",
+  "optimizedPrompt": "Cinematic film scene: A fluffy orange tabby cat lounges gracefully on a vintage velvet sofa, dramatic lighting, film-like color grading, 24fps cinematic look, anamorphic lens feel",
+  "keywordsAdded": ["cinematic", "dramatic", "gracefully", "vintage"],
+  "preset": "cinematic"
+}
+```
+
+## Parameters
+
+### Common Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `operation` | string | `generateFromText` | Operation to perform |
+| `prompt` | string | required | Text description of the video |
+| `model` | string | `veo-3.1-generate-001` | Model to use |
+| `aspectRatio` | string | `16:9` | `16:9` or `9:16` |
+| `resolution` | string | `1080p` | `1080p` or `720p` |
+| `generateAudio` | boolean | `true` | Generate audio/sound effects |
+| `enhancePrompt` | boolean | `true` | AI-enhance the prompt |
+| `preset` | string | `none` | Preset style to apply |
+| `personGeneration` | string | `allow_adult` | `allow_adult` or `dont_allow` |
+
+### Duration Parameters
+
+| Parameter | Operation | Values | Description |
+|-----------|-----------|--------|-------------|
+| `durationSeconds` | generateFromText, generateFromImage, extendVideo | `4`, `6`, `8` | Clip duration in seconds |
+| `targetDuration` | generateLongVideo | `4-120` | Total target duration |
+
+### Models
+
+| Model ID | Description |
+|----------|-------------|
+| `veo-3.1-generate-001` | Higher quality, slower generation |
+| `veo-3.1-fast-generate-001` | Faster generation, slightly lower quality |
+
+## Presets
+
+Available presets that automatically configure prompt styling and defaults:
+
+| Preset | Description | Default Aspect Ratio |
+|--------|-------------|---------------------|
+| `none` | Custom settings, no preset applied | - |
+| `corporate` | Clean, professional videos for business | 16:9 |
+| `social_short` | Dynamic vertical videos for TikTok/Reels | 9:16 |
+| `product_demo` | Product showcase with studio lighting | 16:9 |
+| `cinematic` | Film-quality with dramatic cinematography | 16:9 |
+| `explainer` | Educational content with clear visuals | 16:9 |
+| `artistic` | Abstract and creative artistic videos | 16:9 |
+
+## Response Format
+
+### Video Operations Response
+
+```json
+{
+  "success": true,
+  "operation": "generateFromText",
+  "video": {
+    "format": "mp4",
+    "durationSeconds": 6,
+    "resolution": "1080p",
+    "aspectRatio": "16:9",
+    "hasAudio": true
+  },
+  "videoBase64": "<base64-encoded-video>",
+  "model": "veo-3.1-generate-001",
+  "generationTimeSeconds": 45,
+  "preset": "cinematic",
+  "metadata": {
+    "processedAt": "2024-01-15T10:30:00.000Z"
+  }
+}
+```
+
+### Long Video Response
+
+Additional fields for `generateLongVideo`:
+
+```json
+{
+  "video": {
+    "format": "mp4",
+    "durationSeconds": 30,
+    "clipCount": 4,
+    "clipDurations": [8, 8, 8, 6]
+  },
+  "metadata": {
+    "targetDuration": 30,
+    "actualDuration": 30
+  }
+}
+```
+
+## Error Handling
+
+Errors are returned with a descriptive message:
+
+```json
+{
+  "error": "Missing required input. Provide 'prompt' for most operations or 'sourceVideo' for extendVideo"
+}
+```
+
+## Timing Considerations
+
+- **Single clip (4-8s)**: ~30-90 seconds generation time
+- **Long video (30s)**: ~2-4 minutes (4 clips)
+- **Polling interval**: 15 seconds
+- **Maximum timeout**: 5 minutes per clip
+
+## Best Practices
+
+1. **Use Presets**: Apply presets for consistent styling
+2. **Optimize Prompts First**: Use `optimizePrompt` before `generateFromText` for better results
+3. **Choose Appropriate Duration**: Longer clips use more resources
+4. **Use Fast Model for Drafts**: `veo-3.1-fast-generate-001` for quick iterations
+5. **Portrait for Social**: Use `9:16` aspect ratio for social media content
+
+## Example: Full Workflow
+
+```javascript
+// Step 1: Optimize the prompt
+const optimizeResponse = await fetch('/webhook/veo-video', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    operation: 'optimizePrompt',
+    prompt: 'A startup team celebrating',
+    preset: 'corporate'
+  })
+});
+
+const { optimizedPrompt } = await optimizeResponse.json();
+
+// Step 2: Generate the video with optimized prompt
+const videoResponse = await fetch('/webhook/veo-video', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    operation: 'generateLongVideo',
+    prompt: optimizedPrompt,
+    targetDuration: 15,
+    preset: 'corporate',
+    model: 'veo-3.1-generate-001'
+  })
+});
+
+const { videoBase64, video } = await videoResponse.json();
+console.log(`Generated ${video.durationSeconds}s video with ${video.clipCount} clips`);
+```
+
+## Credentials Required
+
+The workflow requires `googleVertexAiApi` credentials configured in n8n with:
+- `projectId`: GCP Project ID
+- `location`: Region (default: `us-central1`)
+- `serviceAccountKey`: Service account JSON key (optional if using default credentials)

--- a/workflows/veo-video-workflow.json
+++ b/workflows/veo-video-workflow.json
@@ -26,7 +26,7 @@
           "conditions": [
             {
               "id": "condition-input",
-              "leftValue": "={{ $json.body.prompt }}",
+              "leftValue": "={{ $json.body.prompt || $json.body.sourceVideo }}",
               "rightValue": "",
               "operator": {
                 "type": "string",
@@ -39,24 +39,24 @@
         "options": {}
       },
       "id": "check-input",
-      "name": "Has prompt?",
+      "name": "Has required input?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [460, 300]
     },
     {
       "parameters": {
-        "errorMessage": "={{ \"No prompt provided. Please send a prompt in the request body\" }}"
+        "errorMessage": "={{ \"Missing required input. Provide 'prompt' for most operations or 'sourceVideo' for extendVideo\" }}"
       },
       "id": "error-no-input",
-      "name": "Error: No Prompt",
+      "name": "Error: Missing Input",
       "type": "n8n-nodes-base.stopAndError",
       "typeVersion": 1,
       "position": [680, 420]
     },
     {
       "parameters": {
-        "jsCode": "// Prepare data for Veo Video node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: generateFromText)\nconst operation = body.operation || 'generateFromText';\n\n// Video parameters\nconst model = body.model || 'veo-3.1-generate-001';\nconst durationSeconds = body.durationSeconds || 6;\nconst aspectRatio = body.aspectRatio || '16:9';\nconst resolution = body.resolution || '1080p';\nconst generateAudio = body.generateAudio !== false;\nconst enhancePrompt = body.enhancePrompt !== false;\nconst personGeneration = body.personGeneration || 'allow_adult';\n\n// Build result\nconst result = {\n  operation,\n  prompt: body.prompt || '',\n  model,\n  durationSeconds,\n  aspectRatio,\n  resolution,\n  generateAudio,\n  enhancePrompt,\n  personGeneration,\n  originalRequest: { ...body }\n};\n\n// For generateFromImage\nif (operation === 'generateFromImage') {\n  result.sourceImage = body.sourceImage || '';\n  result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n}\n\nreturn [{ json: result }];"
+        "jsCode": "// Prepare data for Veo Video node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: generateFromText)\nconst operation = body.operation || 'generateFromText';\n\n// Video parameters\nconst model = body.model || 'veo-3.1-generate-001';\nconst durationSeconds = body.durationSeconds || 6;\nconst aspectRatio = body.aspectRatio || '16:9';\nconst resolution = body.resolution || '1080p';\nconst generateAudio = body.generateAudio !== false;\nconst enhancePrompt = body.enhancePrompt !== false;\nconst personGeneration = body.personGeneration || 'allow_adult';\nconst preset = body.preset || 'none';\n\n// Build result\nconst result = {\n  operation,\n  prompt: body.prompt || '',\n  model,\n  durationSeconds,\n  aspectRatio,\n  resolution,\n  generateAudio,\n  enhancePrompt,\n  personGeneration,\n  preset,\n  originalRequest: { ...body }\n};\n\n// For generateFromImage\nif (operation === 'generateFromImage') {\n  result.sourceImage = body.sourceImage || '';\n  result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n}\n\n// For generateLongVideo\nif (operation === 'generateLongVideo') {\n  result.targetDuration = body.targetDuration || 30;\n}\n\n// For extendVideo\nif (operation === 'extendVideo') {\n  result.sourceVideo = body.sourceVideo || '';\n  result.extensionPrompt = body.extensionPrompt || '';\n}\n\nreturn [{ json: result }];"
       },
       "id": "prepare-config",
       "name": "Prepare Config",
@@ -66,25 +66,44 @@
     },
     {
       "parameters": {
-        "operation": "={{ $json.operation }}",
-        "prompt": "={{ $json.prompt }}",
-        "sourceImage": "={{ $json.sourceImage }}",
-        "sourceImageMimeType": "={{ $json.sourceImageMimeType }}",
-        "model": "={{ $json.model }}",
-        "durationSeconds": "={{ $json.durationSeconds }}",
-        "aspectRatio": "={{ $json.aspectRatio }}",
-        "resolution": "={{ $json.resolution }}",
-        "generateAudio": "={{ $json.generateAudio }}",
-        "enhancePrompt": "={{ $json.enhancePrompt }}",
-        "options": {
-          "personGeneration": "={{ $json.personGeneration }}"
-        }
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-optimize",
+              "leftValue": "={{ $json.operation }}",
+              "rightValue": "optimizePrompt",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
       },
-      "id": "veo-video",
-      "name": "Veo Video",
+      "id": "route-operation",
+      "name": "Optimize Prompt?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [900, 180]
+    },
+    {
+      "parameters": {
+        "operation": "optimizePrompt",
+        "prompt": "={{ $json.prompt }}",
+        "preset": "={{ $json.preset }}"
+      },
+      "id": "veo-optimize",
+      "name": "Optimize Prompt",
       "type": "n8n-nodes-veo-video.veoVideo",
       "typeVersion": 1,
-      "position": [900, 180],
+      "position": [1120, 60],
       "credentials": {
         "googleVertexAiApi": {
           "id": "google-vertex-ai",
@@ -94,13 +113,55 @@
     },
     {
       "parameters": {
-        "jsCode": "// Format response\nconst input = $input.first().json;\n\nconst response = {\n  success: true,\n  operation: input.operation,\n  video: input.video,\n  videoBase64: input.videoBase64,\n  model: input.model,\n  generationTimeSeconds: input.generationTimeSeconds,\n  metadata: input.metadata\n};\n\nreturn [{ json: response }];"
+        "operation": "={{ $json.operation }}",
+        "prompt": "={{ $json.prompt }}",
+        "sourceImage": "={{ $json.sourceImage }}",
+        "sourceImageMimeType": "={{ $json.sourceImageMimeType }}",
+        "sourceVideo": "={{ $json.sourceVideo }}",
+        "extensionPrompt": "={{ $json.extensionPrompt }}",
+        "targetDuration": "={{ $json.targetDuration }}",
+        "model": "={{ $json.model }}",
+        "durationSeconds": "={{ $json.durationSeconds }}",
+        "aspectRatio": "={{ $json.aspectRatio }}",
+        "resolution": "={{ $json.resolution }}",
+        "generateAudio": "={{ $json.generateAudio }}",
+        "enhancePrompt": "={{ $json.enhancePrompt }}",
+        "preset": "={{ $json.preset }}",
+        "options": {
+          "personGeneration": "={{ $json.personGeneration }}"
+        }
+      },
+      "id": "veo-video",
+      "name": "Veo Video",
+      "type": "n8n-nodes-veo-video.veoVideo",
+      "typeVersion": 1,
+      "position": [1120, 260],
+      "credentials": {
+        "googleVertexAiApi": {
+          "id": "google-vertex-ai",
+          "name": "Google Vertex AI account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response for optimizePrompt\nconst input = $input.first().json;\n\nconst response = {\n  success: true,\n  operation: 'optimizePrompt',\n  originalPrompt: input.originalPrompt,\n  optimizedPrompt: input.optimizedPrompt,\n  keywordsAdded: input.keywordsAdded,\n  preset: input.preset,\n  metadata: input.metadata\n};\n\nreturn [{ json: response }];"
+      },
+      "id": "format-optimize-response",
+      "name": "Format Optimize Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 60]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response for video operations\nconst input = $input.first().json;\n\nconst response = {\n  success: true,\n  operation: input.operation,\n  video: input.video,\n  videoBase64: input.videoBase64,\n  model: input.model,\n  generationTimeSeconds: input.generationTimeSeconds,\n  preset: input.preset,\n  metadata: input.metadata\n};\n\nreturn [{ json: response }];"
       },
       "id": "format-response",
       "name": "Format Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1120, 180]
+      "position": [1340, 260]
     },
     {
       "parameters": {
@@ -112,7 +173,7 @@
       "name": "Respond Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1340, 180]
+      "position": [1560, 180]
     }
   ],
   "connections": {
@@ -120,14 +181,14 @@
       "main": [
         [
           {
-            "node": "Has prompt?",
+            "node": "Has required input?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Has prompt?": {
+    "Has required input?": {
       "main": [
         [
           {
@@ -138,7 +199,7 @@
         ],
         [
           {
-            "node": "Error: No Prompt",
+            "node": "Error: Missing Input",
             "type": "main",
             "index": 0
           }
@@ -149,7 +210,36 @@
       "main": [
         [
           {
+            "node": "Optimize Prompt?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Optimize Prompt?": {
+      "main": [
+        [
+          {
+            "node": "Optimize Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
             "node": "Veo Video",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Optimize Prompt": {
+      "main": [
+        [
+          {
+            "node": "Format Optimize Response",
             "type": "main",
             "index": 0
           }
@@ -161,6 +251,17 @@
         [
           {
             "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Optimize Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- **extendVideo operation**: Extend existing videos with additional footage
- **generateLongVideo operation**: Create videos longer than 8 seconds by automatically chaining clips (e.g., 30s = 8s + 8s + 8s + 6s)
- **optimizePrompt operation**: Enhance prompts using Gemini AI for better video results
- **Presets system**: 6 pre-configured styles (corporate, social_short, product_demo, cinematic, explainer, artistic)
- **MCP Server documentation**: Full API documentation for the integration team

## Test plan
- [ ] Import updated workflow in n8n
- [ ] Test generateFromText with preset
- [ ] Test generateLongVideo with targetDuration=30
- [ ] Test optimizePrompt with different presets
- [ ] Review MCP Server documentation

## Related
- Closes part of #48 (Phase 5 - Veo Video)

🤖 Generated with [Claude Code](https://claude.com/claude-code)