### PR TITLE
feat(veo-video): Phase 5C improvements - advanced control parameters

### DIFF
--- a/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/VeoVideo.node.ts
+++ b/custom-nodes/n8n-nodes-veo-video/nodes/VeoVideo/VeoVideo.node.ts
@@ -309,6 +309,149 @@ export class VeoVideo implements INodeType {
           },
         },
       },
+      // Phase 5C: Negative Prompt
+      {
+        displayName: 'Negative Prompt',
+        name: 'negativePrompt',
+        type: 'string',
+        typeOptions: {
+          rows: 2,
+        },
+        default: '',
+        placeholder: 'blurry, low quality, text, watermark, distorted limbs',
+        description: 'Elements to exclude from the generated video',
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'generateLongVideo', 'extendVideo'],
+          },
+        },
+      },
+      // Phase 5C: Seed
+      {
+        displayName: 'Seed',
+        name: 'seed',
+        type: 'number',
+        default: 0,
+        placeholder: '42',
+        description: 'Seed for reproducibility (0 = random). Same seed = same visual base. Critical for long videos.',
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'generateLongVideo', 'extendVideo'],
+          },
+        },
+      },
+      // Phase 5C: FPS
+      {
+        displayName: 'FPS',
+        name: 'fps',
+        type: 'options',
+        options: [
+          { name: '24 fps (Cinematic)', value: 24 },
+          { name: '30 fps (Standard/TV)', value: 30 },
+        ],
+        default: 24,
+        description: 'Frames per second. 24fps for cinematic, 30fps for corporate/TV',
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'generateLongVideo', 'extendVideo'],
+          },
+        },
+      },
+      // Phase 5C: Safety Setting
+      {
+        displayName: 'Safety Filter',
+        name: 'safetySetting',
+        type: 'options',
+        options: [
+          {
+            name: 'Block Low and Above (Strictest)',
+            value: 'block_low_and_above',
+            description: 'Block most potentially sensitive content',
+          },
+          {
+            name: 'Block Medium and Above (Default)',
+            value: 'block_medium_and_above',
+            description: 'Balanced filtering',
+          },
+          {
+            name: 'Block Only High (Most Permissive)',
+            value: 'block_only_high',
+            description: 'Only block clearly inappropriate content',
+          },
+        ],
+        default: 'block_medium_and_above',
+        description: 'Safety filter level for content generation',
+        displayOptions: {
+          hide: {
+            operation: ['optimizePrompt'],
+          },
+        },
+      },
+      // Phase 5C: Output Mode
+      {
+        displayName: 'Output Mode',
+        name: 'outputMode',
+        type: 'options',
+        options: [
+          {
+            name: 'Base64 (Inline)',
+            value: 'base64',
+            description: 'Return video as base64 in response (good for short clips)',
+          },
+          {
+            name: 'GCS URL (Recommended for Long Videos)',
+            value: 'url',
+            description: 'Upload to Google Cloud Storage and return signed URL',
+          },
+        ],
+        default: 'base64',
+        description: 'How to return the generated video. GCS URL recommended for videos > 10s',
+        displayOptions: {
+          show: {
+            operation: ['generateFromText', 'generateFromImage', 'generateLongVideo', 'extendVideo'],
+          },
+        },
+      },
+      // Phase 5C: GCS Bucket
+      {
+        displayName: 'GCS Bucket',
+        name: 'gcsBucket',
+        type: 'string',
+        default: '',
+        placeholder: 'my-videos-bucket',
+        description: 'Google Cloud Storage bucket for video upload',
+        displayOptions: {
+          show: {
+            outputMode: ['url'],
+          },
+        },
+      },
+      // Phase 5C: GCS Path Prefix
+      {
+        displayName: 'GCS Path Prefix',
+        name: 'gcsPathPrefix',
+        type: 'string',
+        default: 'veo-videos',
+        description: 'Path prefix for uploaded videos in the bucket',
+        displayOptions: {
+          show: {
+            outputMode: ['url'],
+          },
+        },
+      },
+      // Phase 5C: Signed URL Expiration
+      {
+        displayName: 'Signed URL Expiration (Hours)',
+        name: 'signedUrlExpirationHours',
+        type: 'number',
+        default: 24,
+        description: 'How long the signed URL remains valid',
+        displayOptions: {
+          show: {
+            outputMode: ['url'],
+          },
+        },
+      },
       // Advanced Options
       {
         displayName: 'Options',
@@ -376,6 +519,15 @@ export class VeoVideo implements INodeType {
             const resolution = this.getNodeParameter('resolution', i) as string;
             const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
             const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+            // Phase 5C parameters
+            const negativePrompt = this.getNodeParameter('negativePrompt', i, '') as string;
+            const seed = this.getNodeParameter('seed', i, 0) as number;
+            const fps = this.getNodeParameter('fps', i, 24) as number;
+            const safetySetting = this.getNodeParameter('safetySetting', i, 'block_medium_and_above') as string;
+            const outputMode = this.getNodeParameter('outputMode', i, 'base64') as string;
+            const gcsBucket = this.getNodeParameter('gcsBucket', i, '') as string;
+            const gcsPathPrefix = this.getNodeParameter('gcsPathPrefix', i, 'veo-videos') as string;
+            const signedUrlExpirationHours = this.getNodeParameter('signedUrlExpirationHours', i, 24) as number;
             const advancedOptions = this.getNodeParameter('options', i, {}) as {
               personGeneration?: string;
             };
@@ -398,6 +550,15 @@ export class VeoVideo implements INodeType {
               generateAudio: presetConfig?.defaults.generateAudio ?? generateAudio,
               enhancePrompt: presetConfig?.defaults.enhancePrompt ?? enhancePrompt,
               personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+              // Phase 5C
+              negativePrompt: negativePrompt || undefined,
+              seed: seed > 0 ? seed : undefined,
+              fps: fps as VeoVideoOptions['fps'],
+              safetySetting: safetySetting as VeoVideoOptions['safetySetting'],
+              outputMode: outputMode as VeoVideoOptions['outputMode'],
+              gcsBucket: gcsBucket || undefined,
+              gcsPathPrefix,
+              signedUrlExpirationHours,
             };
 
             result = await client.generateFromText(finalPrompt, videoOptions);
@@ -410,10 +571,14 @@ export class VeoVideo implements INodeType {
                 resolution: result.resolution,
                 aspectRatio: result.aspectRatio,
                 hasAudio: result.hasAudio,
+                fps: result.fps,
+                seedUsed: result.seedUsed,
               },
               model: result.model,
               generationTimeSeconds: result.generationTimeSeconds,
               preset: presetName !== 'none' ? presetName : undefined,
+              videoUrl: result.videoUrl,
+              expiresAt: result.expiresAt,
               metadata: {
                 processedAt: new Date().toISOString(),
               },
@@ -432,6 +597,15 @@ export class VeoVideo implements INodeType {
             const resolution = this.getNodeParameter('resolution', i) as string;
             const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
             const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+            // Phase 5C parameters
+            const negativePrompt = this.getNodeParameter('negativePrompt', i, '') as string;
+            const seed = this.getNodeParameter('seed', i, 0) as number;
+            const fps = this.getNodeParameter('fps', i, 24) as number;
+            const safetySetting = this.getNodeParameter('safetySetting', i, 'block_medium_and_above') as string;
+            const outputMode = this.getNodeParameter('outputMode', i, 'base64') as string;
+            const gcsBucket = this.getNodeParameter('gcsBucket', i, '') as string;
+            const gcsPathPrefix = this.getNodeParameter('gcsPathPrefix', i, 'veo-videos') as string;
+            const signedUrlExpirationHours = this.getNodeParameter('signedUrlExpirationHours', i, 24) as number;
             const advancedOptions = this.getNodeParameter('options', i, {}) as {
               personGeneration?: string;
             };
@@ -456,6 +630,15 @@ export class VeoVideo implements INodeType {
               generateAudio: presetConfig?.defaults.generateAudio ?? generateAudio,
               enhancePrompt: presetConfig?.defaults.enhancePrompt ?? enhancePrompt,
               personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+              // Phase 5C
+              negativePrompt: negativePrompt || undefined,
+              seed: seed > 0 ? seed : undefined,
+              fps: fps as VeoVideoOptions['fps'],
+              safetySetting: safetySetting as VeoVideoOptions['safetySetting'],
+              outputMode: outputMode as VeoVideoOptions['outputMode'],
+              gcsBucket: gcsBucket || undefined,
+              gcsPathPrefix,
+              signedUrlExpirationHours,
             };
 
             const imageBuffer = Buffer.from(sourceImage, 'base64');
@@ -469,10 +652,14 @@ export class VeoVideo implements INodeType {
                 resolution: result.resolution,
                 aspectRatio: result.aspectRatio,
                 hasAudio: result.hasAudio,
+                fps: result.fps,
+                seedUsed: result.seedUsed,
               },
               model: result.model,
               generationTimeSeconds: result.generationTimeSeconds,
               preset: presetName !== 'none' ? presetName : undefined,
+              videoUrl: result.videoUrl,
+              expiresAt: result.expiresAt,
               metadata: {
                 processedAt: new Date().toISOString(),
               },
@@ -489,6 +676,15 @@ export class VeoVideo implements INodeType {
             const resolution = this.getNodeParameter('resolution', i) as string;
             const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
             const enhancePrompt = this.getNodeParameter('enhancePrompt', i) as boolean;
+            // Phase 5C parameters
+            const negativePrompt = this.getNodeParameter('negativePrompt', i, '') as string;
+            const seed = this.getNodeParameter('seed', i, 0) as number;
+            const fps = this.getNodeParameter('fps', i, 24) as number;
+            const safetySetting = this.getNodeParameter('safetySetting', i, 'block_medium_and_above') as string;
+            const outputMode = this.getNodeParameter('outputMode', i, 'base64') as string;
+            const gcsBucket = this.getNodeParameter('gcsBucket', i, '') as string;
+            const gcsPathPrefix = this.getNodeParameter('gcsPathPrefix', i, 'veo-videos') as string;
+            const signedUrlExpirationHours = this.getNodeParameter('signedUrlExpirationHours', i, 24) as number;
             const advancedOptions = this.getNodeParameter('options', i, {}) as {
               personGeneration?: string;
             };
@@ -510,6 +706,15 @@ export class VeoVideo implements INodeType {
               generateAudio: presetConfig?.defaults.generateAudio ?? generateAudio,
               enhancePrompt: presetConfig?.defaults.enhancePrompt ?? enhancePrompt,
               personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+              // Phase 5C
+              negativePrompt: negativePrompt || undefined,
+              seed: seed > 0 ? seed : undefined,
+              fps: fps as VeoVideoOptions['fps'],
+              safetySetting: safetySetting as VeoVideoOptions['safetySetting'],
+              outputMode: outputMode as VeoVideoOptions['outputMode'],
+              gcsBucket: gcsBucket || undefined,
+              gcsPathPrefix,
+              signedUrlExpirationHours,
             };
 
             result = await client.generateLongVideo(finalPrompt, longVideoOptions);
@@ -524,10 +729,14 @@ export class VeoVideo implements INodeType {
                 hasAudio: result.hasAudio,
                 clipCount: result.clipCount,
                 clipDurations: result.clipDurations,
+                fps: result.fps,
+                seedUsed: result.seedUsed,
               },
               model: result.model,
               generationTimeSeconds: result.generationTimeSeconds,
               preset: presetName !== 'none' ? presetName : undefined,
+              videoUrl: result.videoUrl,
+              expiresAt: result.expiresAt,
               metadata: {
                 processedAt: new Date().toISOString(),
                 targetDuration,
@@ -546,6 +755,15 @@ export class VeoVideo implements INodeType {
             const aspectRatio = this.getNodeParameter('aspectRatio', i) as string;
             const resolution = this.getNodeParameter('resolution', i) as string;
             const generateAudio = this.getNodeParameter('generateAudio', i) as boolean;
+            // Phase 5C parameters
+            const negativePrompt = this.getNodeParameter('negativePrompt', i, '') as string;
+            const seed = this.getNodeParameter('seed', i, 0) as number;
+            const fps = this.getNodeParameter('fps', i, 24) as number;
+            const safetySetting = this.getNodeParameter('safetySetting', i, 'block_medium_and_above') as string;
+            const outputMode = this.getNodeParameter('outputMode', i, 'base64') as string;
+            const gcsBucket = this.getNodeParameter('gcsBucket', i, '') as string;
+            const gcsPathPrefix = this.getNodeParameter('gcsPathPrefix', i, 'veo-videos') as string;
+            const signedUrlExpirationHours = this.getNodeParameter('signedUrlExpirationHours', i, 24) as number;
             const advancedOptions = this.getNodeParameter('options', i, {}) as {
               personGeneration?: string;
             };
@@ -561,6 +779,15 @@ export class VeoVideo implements INodeType {
               generateAudio,
               extensionPrompt: extensionPrompt || undefined,
               personGeneration: (advancedOptions.personGeneration || 'allow_adult') as VeoVideoOptions['personGeneration'],
+              // Phase 5C
+              negativePrompt: negativePrompt || undefined,
+              seed: seed > 0 ? seed : undefined,
+              fps: fps as VeoVideoOptions['fps'],
+              safetySetting: safetySetting as VeoVideoOptions['safetySetting'],
+              outputMode: outputMode as VeoVideoOptions['outputMode'],
+              gcsBucket: gcsBucket || undefined,
+              gcsPathPrefix,
+              signedUrlExpirationHours,
             };
 
             const videoBuffer = Buffer.from(sourceVideo, 'base64');
@@ -574,9 +801,13 @@ export class VeoVideo implements INodeType {
                 resolution: result.resolution,
                 aspectRatio: result.aspectRatio,
                 hasAudio: result.hasAudio,
+                fps: result.fps,
+                seedUsed: result.seedUsed,
               },
               model: result.model,
               generationTimeSeconds: result.generationTimeSeconds,
+              videoUrl: result.videoUrl,
+              expiresAt: result.expiresAt,
               metadata: {
                 processedAt: new Date().toISOString(),
                 extensionDuration: durationSeconds,

--- a/custom-nodes/n8n-nodes-veo-video/shared/VeoVideoClient.ts
+++ b/custom-nodes/n8n-nodes-veo-video/shared/VeoVideoClient.ts
@@ -21,6 +21,16 @@ export interface VeoVideoOptions {
   personGeneration?: 'allow_adult' | 'dont_allow';
   enhancePrompt?: boolean;
   generateAudio?: boolean;
+  // Phase 5C: New parameters
+  seed?: number;
+  negativePrompt?: string;
+  fps?: 24 | 30;
+  safetySetting?: 'block_low_and_above' | 'block_medium_and_above' | 'block_only_high';
+  // Output options
+  outputMode?: 'base64' | 'url';
+  gcsBucket?: string;
+  gcsPathPrefix?: string;
+  signedUrlExpirationHours?: number;
 }
 
 export interface VeoVideoResult {
@@ -35,6 +45,11 @@ export interface VeoVideoResult {
   enhancedPrompt?: string;
   clipCount?: number;  // For long videos: number of clips generated
   clipDurations?: number[];  // Duration of each clip
+  // Phase 5C: New fields
+  seedUsed?: number;
+  fps?: number;
+  videoUrl?: string;  // GCS signed URL if outputMode='url'
+  expiresAt?: string;  // URL expiration timestamp
 }
 
 export interface VeoExtendOptions extends VeoVideoOptions {
@@ -70,6 +85,13 @@ export interface VeoOperationStatus {
   };
 }
 
+export interface VeoSafetyError {
+  code: 'SAFETY_BLOCKED';
+  reason: string;
+  message: string;
+  suggestion: string;
+}
+
 const DEFAULT_OPTIONS: VeoVideoOptions = {
   model: 'veo-3.1-generate-001',
   aspectRatio: '16:9',
@@ -79,6 +101,12 @@ const DEFAULT_OPTIONS: VeoVideoOptions = {
   personGeneration: 'allow_adult',
   enhancePrompt: true,
   generateAudio: true,
+  // Phase 5C defaults
+  fps: 24,
+  safetySetting: 'block_medium_and_above',
+  outputMode: 'base64',
+  gcsPathPrefix: 'veo-videos',
+  signedUrlExpirationHours: 24,
 };
 
 const POLLING_INTERVAL_MS = 15000; // 15 seconds
@@ -120,18 +148,34 @@ export class VeoVideoClient {
     const opts = { ...DEFAULT_OPTIONS, ...options };
     const startTime = Date.now();
 
-    // Build request body
+    // Build request body with Phase 5C parameters
+    const parameters: Record<string, unknown> = {
+      aspectRatio: opts.aspectRatio,
+      sampleCount: opts.numberOfVideos,
+      durationSeconds: opts.durationSeconds,
+      resolution: opts.resolution,
+      personGeneration: opts.personGeneration,
+      enhancePrompt: opts.enhancePrompt,
+      generateAudio: opts.generateAudio,
+    };
+
+    // Add Phase 5C parameters
+    if (opts.seed !== undefined && opts.seed > 0) {
+      parameters.seed = opts.seed;
+    }
+    if (opts.negativePrompt) {
+      parameters.negativePrompt = opts.negativePrompt;
+    }
+    if (opts.fps) {
+      parameters.fps = opts.fps;
+    }
+    if (opts.safetySetting) {
+      parameters.safetySetting = opts.safetySetting;
+    }
+
     const requestBody = {
       instances: [{ prompt }],
-      parameters: {
-        aspectRatio: opts.aspectRatio,
-        sampleCount: opts.numberOfVideos,
-        durationSeconds: opts.durationSeconds,
-        resolution: opts.resolution,
-        personGeneration: opts.personGeneration,
-        enhancePrompt: opts.enhancePrompt,
-        generateAudio: opts.generateAudio,
-      },
+      parameters,
     };
 
     // Start the generation operation
@@ -144,8 +188,11 @@ export class VeoVideoClient {
     const videoData = await this.extractVideoData(result);
     const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
 
+    // Handle output mode (base64 vs GCS URL)
+    const outputResult = await this.handleOutput(videoData, opts);
+
     return {
-      videoData,
+      videoData: outputResult.videoData,
       mimeType: 'video/mp4',
       model: opts.model!,
       durationSeconds: opts.durationSeconds!,
@@ -153,6 +200,10 @@ export class VeoVideoClient {
       aspectRatio: opts.aspectRatio!,
       hasAudio: opts.generateAudio!,
       generationTimeSeconds,
+      seedUsed: opts.seed,
+      fps: opts.fps,
+      videoUrl: outputResult.videoUrl,
+      expiresAt: outputResult.expiresAt,
     };
   }
 
@@ -168,6 +219,31 @@ export class VeoVideoClient {
     const opts = { ...DEFAULT_OPTIONS, ...options };
     const startTime = Date.now();
 
+    // Build parameters with Phase 5C additions
+    const parameters: Record<string, unknown> = {
+      aspectRatio: opts.aspectRatio,
+      sampleCount: opts.numberOfVideos,
+      durationSeconds: opts.durationSeconds,
+      resolution: opts.resolution,
+      personGeneration: opts.personGeneration,
+      enhancePrompt: opts.enhancePrompt,
+      generateAudio: opts.generateAudio,
+    };
+
+    // Add Phase 5C parameters
+    if (opts.seed !== undefined && opts.seed > 0) {
+      parameters.seed = opts.seed;
+    }
+    if (opts.negativePrompt) {
+      parameters.negativePrompt = opts.negativePrompt;
+    }
+    if (opts.fps) {
+      parameters.fps = opts.fps;
+    }
+    if (opts.safetySetting) {
+      parameters.safetySetting = opts.safetySetting;
+    }
+
     // Build request body with image
     const imageBase64 = imageData.toString('base64');
     const requestBody = {
@@ -180,15 +256,7 @@ export class VeoVideoClient {
           },
         },
       ],
-      parameters: {
-        aspectRatio: opts.aspectRatio,
-        sampleCount: opts.numberOfVideos,
-        durationSeconds: opts.durationSeconds,
-        resolution: opts.resolution,
-        personGeneration: opts.personGeneration,
-        enhancePrompt: opts.enhancePrompt,
-        generateAudio: opts.generateAudio,
-      },
+      parameters,
     };
 
     // Start the generation operation
@@ -201,8 +269,11 @@ export class VeoVideoClient {
     const videoData = await this.extractVideoData(result);
     const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
 
+    // Handle output mode
+    const outputResult = await this.handleOutput(videoData, opts);
+
     return {
-      videoData,
+      videoData: outputResult.videoData,
       mimeType: 'video/mp4',
       model: opts.model!,
       durationSeconds: opts.durationSeconds!,
@@ -210,6 +281,10 @@ export class VeoVideoClient {
       aspectRatio: opts.aspectRatio!,
       hasAudio: opts.generateAudio!,
       generationTimeSeconds,
+      seedUsed: opts.seed,
+      fps: opts.fps,
+      videoUrl: outputResult.videoUrl,
+      expiresAt: outputResult.expiresAt,
     };
   }
 
@@ -225,6 +300,30 @@ export class VeoVideoClient {
     const opts = { ...DEFAULT_OPTIONS, ...options };
     const startTime = Date.now();
 
+    const parameters: Record<string, unknown> = {
+      aspectRatio: opts.aspectRatio,
+      sampleCount: 1,
+      durationSeconds: extensionDuration,
+      resolution: opts.resolution,
+      personGeneration: opts.personGeneration,
+      enhancePrompt: false,  // Don't enhance for extensions
+      generateAudio: opts.generateAudio,
+    };
+
+    // Add Phase 5C parameters (seed is critical for coherence)
+    if (opts.seed !== undefined && opts.seed > 0) {
+      parameters.seed = opts.seed;
+    }
+    if (opts.negativePrompt) {
+      parameters.negativePrompt = opts.negativePrompt;
+    }
+    if (opts.fps) {
+      parameters.fps = opts.fps;
+    }
+    if (opts.safetySetting) {
+      parameters.safetySetting = opts.safetySetting;
+    }
+
     const videoBase64 = videoData.toString('base64');
     const requestBody = {
       instances: [
@@ -236,15 +335,7 @@ export class VeoVideoClient {
           },
         },
       ],
-      parameters: {
-        aspectRatio: opts.aspectRatio,
-        sampleCount: 1,
-        durationSeconds: extensionDuration,
-        resolution: opts.resolution,
-        personGeneration: opts.personGeneration,
-        enhancePrompt: false,  // Don't enhance for extensions
-        generateAudio: opts.generateAudio,
-      },
+      parameters,
     };
 
     const operation = await this.startOperation(opts.model!, requestBody);
@@ -252,8 +343,11 @@ export class VeoVideoClient {
     const extendedVideoData = await this.extractVideoData(result);
     const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
 
+    // Handle output mode
+    const outputResult = await this.handleOutput(extendedVideoData, opts);
+
     return {
-      videoData: extendedVideoData,
+      videoData: outputResult.videoData,
       mimeType: 'video/mp4',
       model: opts.model!,
       durationSeconds: extensionDuration,
@@ -261,12 +355,17 @@ export class VeoVideoClient {
       aspectRatio: opts.aspectRatio!,
       hasAudio: opts.generateAudio!,
       generationTimeSeconds,
+      seedUsed: opts.seed,
+      fps: opts.fps,
+      videoUrl: outputResult.videoUrl,
+      expiresAt: outputResult.expiresAt,
     };
   }
 
   /**
    * Génère une vidéo longue en chaînant plusieurs clips
    * Ex: targetDuration=30 -> génère 8s + 8s + 8s + 6s = 30s
+   * Phase 5C: Uses same seed for all clips to maintain visual coherence
    */
   async generateLongVideo(
     prompt: string,
@@ -275,15 +374,22 @@ export class VeoVideoClient {
     const { targetDuration, onClipComplete, ...baseOptions } = options;
     const startTime = Date.now();
 
+    // Phase 5C: Generate or use provided seed for coherence
+    const coherenceSeed = baseOptions.seed && baseOptions.seed > 0
+      ? baseOptions.seed
+      : Math.floor(Math.random() * 2147483647);
+
     // Calculer les durées des clips nécessaires
     const clipDurations = this.calculateClipDurations(targetDuration);
     const totalClips = clipDurations.length;
 
-    // Générer le premier clip
+    // Générer le premier clip with seed
     const firstClipDuration = clipDurations[0] as 4 | 6 | 8;
     let currentVideo = await this.generateFromText(prompt, {
       ...baseOptions,
       durationSeconds: firstClipDuration,
+      seed: coherenceSeed,
+      outputMode: 'base64', // Keep intermediate clips as base64
     });
 
     let totalDuration = firstClipDuration;
@@ -293,7 +399,7 @@ export class VeoVideoClient {
       onClipComplete(1, totalClips, totalDuration);
     }
 
-    // Étendre avec les clips suivants
+    // Étendre avec les clips suivants using same seed
     for (let i = 1; i < clipDurations.length; i++) {
       const extensionDuration = clipDurations[i] as 4 | 6 | 8;
 
@@ -303,6 +409,8 @@ export class VeoVideoClient {
         {
           ...baseOptions,
           extensionPrompt: `Continue the scene: ${prompt}`,
+          seed: coherenceSeed,  // Same seed for coherence
+          outputMode: 'base64', // Keep intermediate clips as base64
         }
       );
 
@@ -317,8 +425,11 @@ export class VeoVideoClient {
 
     const generationTimeSeconds = Math.round((Date.now() - startTime) / 1000);
 
+    // Handle final output mode (only upload final concatenated video)
+    const outputResult = await this.handleOutput(currentVideo.videoData, baseOptions);
+
     return {
-      videoData: currentVideo.videoData,
+      videoData: outputResult.videoData,
       mimeType: 'video/mp4',
       model: baseOptions.model || DEFAULT_OPTIONS.model!,
       durationSeconds: totalDuration,
@@ -328,6 +439,10 @@ export class VeoVideoClient {
       generationTimeSeconds,
       clipCount: totalClips,
       clipDurations: allClipDurations,
+      seedUsed: coherenceSeed,
+      fps: baseOptions.fps,
+      videoUrl: outputResult.videoUrl,
+      expiresAt: outputResult.expiresAt,
     };
   }
 
@@ -461,6 +576,7 @@ Output ONLY the enhanced prompt, no explanations.`;
 
   /**
    * Démarre une opération de génération vidéo
+   * Phase 5C: Enhanced error handling with safety filter detection
    */
   private async startOperation(
     model: string,
@@ -482,6 +598,17 @@ Output ONLY the enhanced prompt, no explanations.`;
 
     if (!response.ok) {
       const errorText = await response.text();
+
+      // Phase 5C: Check for safety filter errors
+      const safetyError = this.parseSafetyError(errorText);
+      if (safetyError) {
+        const error = new Error(
+          `${safetyError.message}. ${safetyError.suggestion}`
+        ) as Error & { safetyError: VeoSafetyError };
+        error.safetyError = safetyError;
+        throw error;
+      }
+
       throw new Error(`Veo API error: ${response.status} - ${errorText}`);
     }
 
@@ -580,5 +707,130 @@ Output ONLY the enhanced prompt, no explanations.`;
 
   private sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Phase 5C: Handle output mode (base64 vs GCS URL)
+   */
+  private async handleOutput(
+    videoData: Buffer,
+    options: VeoVideoOptions
+  ): Promise<{ videoData: Buffer; videoUrl?: string; expiresAt?: string }> {
+    if (options.outputMode !== 'url' || !options.gcsBucket) {
+      return { videoData };
+    }
+
+    // Upload to GCS and return signed URL
+    const { signedUrl, expiresAt } = await this.uploadToGcs(
+      videoData,
+      options.gcsBucket,
+      options.gcsPathPrefix || 'veo-videos',
+      options.signedUrlExpirationHours || 24
+    );
+
+    return {
+      videoData,
+      videoUrl: signedUrl,
+      expiresAt,
+    };
+  }
+
+  /**
+   * Phase 5C: Upload video to GCS and return signed URL
+   */
+  private async uploadToGcs(
+    videoData: Buffer,
+    bucketName: string,
+    pathPrefix: string,
+    expirationHours: number
+  ): Promise<{ signedUrl: string; expiresAt: string; gcsPath: string }> {
+    const { Storage } = await import('@google-cloud/storage');
+
+    // Use the same auth as the main client
+    const storage = new Storage({
+      projectId: this.projectId,
+      authClient: this.auth,
+    });
+
+    const bucket = storage.bucket(bucketName);
+    const timestamp = Date.now();
+    const filename = `${pathPrefix}/${timestamp}-video.mp4`;
+    const file = bucket.file(filename);
+
+    // Upload the video
+    await file.save(videoData, {
+      contentType: 'video/mp4',
+      metadata: {
+        cacheControl: 'public, max-age=31536000',
+      },
+    });
+
+    // Generate signed URL
+    const expiresAt = new Date(Date.now() + expirationHours * 60 * 60 * 1000);
+    const [signedUrl] = await file.getSignedUrl({
+      action: 'read',
+      expires: expiresAt,
+    });
+
+    return {
+      signedUrl,
+      expiresAt: expiresAt.toISOString(),
+      gcsPath: `gs://${bucketName}/${filename}`,
+    };
+  }
+
+  /**
+   * Phase 5C: Parse safety filter errors from API response
+   */
+  private parseSafetyError(errorText: string): VeoSafetyError | null {
+    const safetyReasons: Record<string, { message: string; suggestion: string }> = {
+      'SAFETY_REASON_VULGARITY': {
+        message: 'Le prompt contient du contenu vulgaire',
+        suggestion: 'Reformulez le prompt pour éviter le langage grossier',
+      },
+      'SAFETY_REASON_VIOLENCE': {
+        message: 'Le prompt contient du contenu violent',
+        suggestion: 'Reformulez le prompt pour éviter les éléments violents',
+      },
+      'SAFETY_REASON_SEXUAL': {
+        message: 'Le prompt contient du contenu sexuel',
+        suggestion: 'Reformulez le prompt pour éviter le contenu sexuel explicite',
+      },
+      'SAFETY_REASON_DANGEROUS': {
+        message: 'Le prompt contient du contenu dangereux',
+        suggestion: 'Reformulez le prompt pour éviter les activités dangereuses',
+      },
+      'SAFETY_REASON_HARASSMENT': {
+        message: 'Le prompt contient du harcèlement',
+        suggestion: 'Reformulez le prompt pour éviter le contenu offensant',
+      },
+      'SAFETY_REASON_HATE': {
+        message: 'Le prompt contient du contenu haineux',
+        suggestion: 'Reformulez le prompt pour éviter le discours de haine',
+      },
+    };
+
+    for (const [reason, details] of Object.entries(safetyReasons)) {
+      if (errorText.includes(reason)) {
+        return {
+          code: 'SAFETY_BLOCKED',
+          reason,
+          message: details.message,
+          suggestion: details.suggestion,
+        };
+      }
+    }
+
+    // Generic safety error
+    if (errorText.toLowerCase().includes('safety') || errorText.toLowerCase().includes('blocked')) {
+      return {
+        code: 'SAFETY_BLOCKED',
+        reason: 'SAFETY_REASON_UNKNOWN',
+        message: 'Le prompt a été bloqué par les filtres de sécurité',
+        suggestion: 'Reformulez le prompt pour éviter le contenu sensible',
+      };
+    }
+
+    return null;
   }
 }

--- a/docs/n8n/veo-video-mcp-server.md
+++ b/docs/n8n/veo-video-mcp-server.md
@@ -30,13 +30,18 @@ Generate a video from a text prompt.
 {
   "operation": "generateFromText",
   "prompt": "A robot walking through a futuristic city at sunset",
+  "negativePrompt": "blurry, low quality, text, watermark",
   "model": "veo-3.1-generate-001",
   "durationSeconds": 6,
   "aspectRatio": "16:9",
   "resolution": "1080p",
+  "fps": 24,
+  "seed": 42,
   "generateAudio": true,
   "enhancePrompt": true,
-  "preset": "cinematic"
+  "preset": "cinematic",
+  "safetySetting": "block_medium_and_above",
+  "outputMode": "base64"
 }
 ```
 
@@ -63,16 +68,25 @@ Generate videos longer than 8 seconds by automatically chaining clips.
 {
   "operation": "generateLongVideo",
   "prompt": "A drone flying over a mountain landscape",
+  "negativePrompt": "low resolution, text, watermark, blurry",
   "targetDuration": 30,
   "model": "veo-3.1-generate-001",
   "aspectRatio": "16:9",
-  "resolution": "1080p"
+  "resolution": "1080p",
+  "fps": 24,
+  "seed": 42,
+  "outputMode": "url",
+  "gcsBucket": "my-videos-bucket",
+  "gcsPathPrefix": "veo-videos",
+  "signedUrlExpirationHours": 24
 }
 ```
 
 **Note**: The API will automatically calculate the optimal clip sequence. For example:
 - 30 seconds = 8s + 8s + 8s + 6s (4 API calls)
 - 20 seconds = 8s + 8s + 4s (3 API calls)
+
+**Temporal Coherence**: When `seed` is provided (or auto-generated), the same seed is used across all clips to maintain visual consistency. This prevents characters from changing appearance or scenes from drifting between clips.
 
 ### 4. Extend Video
 
@@ -128,6 +142,24 @@ Enhance a prompt using Gemini AI for better video generation results.
 | `preset` | string | `none` | Preset style to apply |
 | `personGeneration` | string | `allow_adult` | `allow_adult` or `dont_allow` |
 
+### Phase 5C: Advanced Control Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `seed` | integer | `0` (random) | Seed for reproducibility. Same seed = same visual base. Critical for long videos. |
+| `negativePrompt` | string | `null` | Elements to exclude from generation (e.g., "blurry, text, watermark, distorted limbs") |
+| `fps` | integer | `24` | Frames per second: `24` (cinematic) or `30` (TV/corporate) |
+| `safetySetting` | string | `block_medium_and_above` | Safety filter level: `block_low_and_above`, `block_medium_and_above`, `block_only_high` |
+
+### Phase 5C: Output Mode Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `outputMode` | string | `base64` | `base64` (inline) or `url` (GCS signed URL). Recommended: `url` for videos > 10s |
+| `gcsBucket` | string | - | Google Cloud Storage bucket name (required if outputMode=url) |
+| `gcsPathPrefix` | string | `veo-videos` | Path prefix in the GCS bucket |
+| `signedUrlExpirationHours` | number | `24` | Signed URL validity duration in hours |
+
 ### Duration Parameters
 
 | Parameter | Operation | Values | Description |
@@ -169,7 +201,9 @@ Available presets that automatically configure prompt styling and defaults:
     "durationSeconds": 6,
     "resolution": "1080p",
     "aspectRatio": "16:9",
-    "hasAudio": true
+    "hasAudio": true,
+    "fps": 24,
+    "seedUsed": 42
   },
   "videoBase64": "<base64-encoded-video>",
   "model": "veo-3.1-generate-001",
@@ -178,6 +212,28 @@ Available presets that automatically configure prompt styling and defaults:
   "metadata": {
     "processedAt": "2024-01-15T10:30:00.000Z"
   }
+}
+```
+
+### Response with GCS URL (outputMode: "url")
+
+When using `outputMode: "url"`, the response includes a signed URL instead of base64:
+
+```json
+{
+  "success": true,
+  "operation": "generateFromText",
+  "video": {
+    "format": "mp4",
+    "durationSeconds": 24,
+    "fps": 24,
+    "seedUsed": 42
+  },
+  "videoUrl": "https://storage.googleapis.com/my-bucket/veo-videos/1702815600-video.mp4?X-Goog-Signature=...",
+  "expiresAt": "2024-01-16T10:30:00.000Z",
+  "videoBase64": "<base64-encoded-video>",
+  "model": "veo-3.1-generate-001",
+  "generationTimeSeconds": 180
 }
 ```
 
@@ -191,14 +247,20 @@ Additional fields for `generateLongVideo`:
     "format": "mp4",
     "durationSeconds": 30,
     "clipCount": 4,
-    "clipDurations": [8, 8, 8, 6]
+    "clipDurations": [8, 8, 8, 6],
+    "fps": 24,
+    "seedUsed": 42
   },
+  "videoUrl": "https://storage.googleapis.com/my-bucket/veo-videos/final.mp4",
+  "expiresAt": "2024-01-16T10:30:00.000Z",
   "metadata": {
     "targetDuration": 30,
     "actualDuration": 30
   }
 }
 ```
+
+**Note**: For long videos, the same `seed` is used across all clips to maintain visual coherence.
 
 ## Error Handling
 
@@ -209,6 +271,32 @@ Errors are returned with a descriptive message:
   "error": "Missing required input. Provide 'prompt' for most operations or 'sourceVideo' for extendVideo"
 }
 ```
+
+### Safety Filter Errors (Phase 5C)
+
+When content is blocked by Google's safety filters, a detailed error is returned:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "SAFETY_BLOCKED",
+    "reason": "SAFETY_REASON_VIOLENCE",
+    "message": "Le prompt contient du contenu violent",
+    "suggestion": "Reformulez le prompt pour éviter les éléments violents"
+  }
+}
+```
+
+**Safety Reasons**:
+| Reason | Description |
+|--------|-------------|
+| `SAFETY_REASON_VULGARITY` | Vulgar or profane content |
+| `SAFETY_REASON_VIOLENCE` | Violent content |
+| `SAFETY_REASON_SEXUAL` | Sexual content |
+| `SAFETY_REASON_DANGEROUS` | Dangerous activities |
+| `SAFETY_REASON_HARASSMENT` | Harassment or offensive content |
+| `SAFETY_REASON_HATE` | Hate speech |
 
 ## Timing Considerations
 
@@ -224,6 +312,10 @@ Errors are returned with a descriptive message:
 3. **Choose Appropriate Duration**: Longer clips use more resources
 4. **Use Fast Model for Drafts**: `veo-3.1-fast-generate-001` for quick iterations
 5. **Portrait for Social**: Use `9:16` aspect ratio for social media content
+6. **Use GCS for Long Videos**: Set `outputMode: "url"` for videos > 10 seconds to avoid base64 memory issues
+7. **Set Seed for Reproducibility**: Use a fixed `seed` when iterating on prompts to compare variations
+8. **Use Negative Prompt**: Exclude common artifacts with `negativePrompt: "blurry, text, watermark, distorted"`
+9. **Choose FPS Wisely**: 24fps for cinematic feel, 30fps for corporate/TV content
 
 ## Example: Full Workflow
 
@@ -264,3 +356,12 @@ The workflow requires `googleVertexAiApi` credentials configured in n8n with:
 - `projectId`: GCP Project ID
 - `location`: Region (default: `us-central1`)
 - `serviceAccountKey`: Service account JSON key (optional if using default credentials)
+
+### GCS Upload (for outputMode: "url")
+
+If using `outputMode: "url"`, the service account must have these additional permissions:
+- `storage.objects.create` on the target bucket
+- `storage.objects.get` for signed URL generation
+- `iam.serviceAccounts.signBlob` for signing URLs
+
+Example IAM roles: `Storage Object Creator` + `Storage Object Viewer`


### PR DESCRIPTION
## Summary

Implementation of Phase 5C Veo Video improvements based on Gemini team feedback (`docs/issues/reponse_video_neo.md`):

- **Seed parameter**: For reproducibility across iterations - same seed = same visual base
- **Negative prompt**: Exclude visual artifacts (e.g., "blurry, text, watermark, distorted limbs")
- **FPS control**: 24fps (cinematic) or 30fps (corporate/TV)
- **Safety filter settings**: Configurable content filtering with detailed error messages
- **GCS output mode**: Upload videos to Google Cloud Storage with signed URLs (recommended for >10s videos)
- **Temporal coherence**: Same seed used across all clips for long video generation to prevent visual drift

## Changes

### VeoVideoClient.ts
- Added `seed`, `negativePrompt`, `fps`, `safetySetting` to VeoVideoOptions
- Added `outputMode`, `gcsBucket`, `gcsPathPrefix`, `signedUrlExpirationHours` for GCS upload
- Added `VeoSafetyError` interface with French error messages
- Implemented `handleOutput()` for base64/GCS output handling
- Implemented `uploadToGcs()` with signed URL generation
- Implemented `parseSafetyError()` for safety filter error detection
- Updated `generateLongVideo()` with coherence seed across all clips

### VeoVideo.node.ts
- Added UI fields for all Phase 5C parameters
- Conditional display for GCS options when outputMode="url"
- Updated all operations to pass new parameters

### Documentation
- Updated `docs/n8n/veo-video-mcp-server.md` with Phase 5C parameters
- Added safety filter error documentation
- Added GCS permissions requirements
- Updated examples with new parameters

## Test plan

- [ ] Build passes (verified)
- [ ] Test generateFromText with seed parameter
- [ ] Test negativePrompt excludes specified elements
- [ ] Test fps parameter affects video output
- [ ] Test outputMode="url" uploads to GCS
- [ ] Test safety filter returns detailed error messages
- [ ] Test long video uses same seed across clips

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)