### PR TITLE
fix(ocr): migrate to Mistral OCR API v1 and add Google Drive OCR tool

### DIFF
--- a/workflows/mcp-tools/get_image_ocr_tool.json
+++ b/workflows/mcp-tools/get_image_ocr_tool.json
@@ -70,7 +70,7 @@
     },
     {
       "id": "mistral-ocr",
-      "name": "Mistral Vision OCR",
+      "name": "Mistral OCR API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
@@ -79,7 +79,7 @@
       ],
       "parameters": {
         "method": "POST",
-        "url": "https://api.mistral.ai/v1/chat/completions",
+        "url": "https://api.mistral.ai/v1/ocr",
         "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
@@ -96,9 +96,9 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"pixtral-12b-2409\", \"messages\": [{ \"role\": \"user\", \"content\": [{ \"type\": \"text\", \"text\": $json.body.prompt || \"Extract all text from this image. Return the text exactly as it appears, preserving formatting where possible. If there are multiple columns or sections, process them in reading order.\" }, { \"type\": \"image_url\", \"image_url\": { \"url\": $json.body.image_url || ('data:image/' + ($binary.data?.mimeType?.split('/')[1] || 'png') + ';base64,' + $binary.data?.data) } }] }], \"max_tokens\": $json.body.max_tokens || 4096 } }}",
+        "jsonBody": "={{ { \"model\": \"mistral-ocr-latest\", \"document\": { \"type\": \"image_url\", \"image_url\": $json.body.image_url || ('data:image/' + ($binary.data?.mimeType?.split('/')[1] || 'png') + ';base64,' + $binary.data?.data) }, \"include_image_base64\": $json.body.include_images || false } }}",
         "options": {
-          "timeout": 60000
+          "timeout": 120000
         }
       },
       "onError": "continueRegularOutput"
@@ -114,7 +114,7 @@
       ],
       "parameters": {
         "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.choices?.[0]?.message?.content || '', \"model\": 'pixtral-12b-2409', \"source\": $('Webhook').first().json.body.image_url ? 'url' : 'binary' }, \"meta\": { \"provider\": \"mistral\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0 } } } }}"
+        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.pages?.map(p => p.markdown).join('\\n\\n') || '', \"pages\": $json.pages || [], \"model\": $json.model || 'mistral-ocr-latest', \"source\": $('Webhook').first().json.body.image_url ? 'url' : 'binary' }, \"meta\": { \"provider\": \"mistral\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"pages_processed\": $json.usage_info?.pages_processed || 1, \"doc_size_bytes\": $json.usage_info?.doc_size_bytes || 0 } } } }}"
       }
     },
     {
@@ -145,7 +145,7 @@
         "color": 6,
         "width": 550,
         "height": 240,
-        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**Parameters:**\n- `mistral_api_key` (required): Mistral API key\n- `image_url` (string): URL of image to process\n- OR upload binary image file\n- `prompt` (optional): Custom extraction instructions\n- `max_tokens` (optional): Max output tokens (default: 4096)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Extracted text from image\n\n**Note:** Uses Mistral Pixtral vision model for OCR"
+        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**Model:** mistral-ocr-latest (Mistral OCR API v1)\n\n**Parameters:**\n- `mistral_api_key` (required): Mistral API key\n- `image_url` (string): URL of image to process\n- OR upload binary image file\n- `include_images` (optional): Include base64 images in response\n- `execution_mode` (optional): online | offline\n\n**Returns:** Extracted text (markdown) + pages array\n\n**API:** https://api.mistral.ai/v1/ocr"
       }
     }
   ],

--- a/workflows/mcp-tools/google_drive_ocr_tool.json
+++ b/workflows/mcp-tools/google_drive_ocr_tool.json
@@ -1,0 +1,406 @@
+{
+  "name": "MCP - Google Drive OCR",
+  "nodes": [
+    {
+      "id": "webhook-drive-ocr",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "google-drive-ocr-webhook",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "google-drive-ocr",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [460, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.body.google_access_token }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isNotEmpty"
+              }
+            },
+            {
+              "leftValue": "={{ $json.body.file_id || $json.body.folder_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isNotEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "error-no-input",
+      "name": "Error: Missing Input",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [700, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameters. Provide google_access_token and either file_id or folder_id.\", \"status\": \"BAD_REQUEST\" } } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    },
+    {
+      "id": "route-operation",
+      "name": "Route Operation",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [700, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.body.file_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isNotEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "list-drive-files",
+      "name": "List Drive Files",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 100],
+      "parameters": {
+        "method": "GET",
+        "url": "=https://www.googleapis.com/drive/v3/files",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Webhook').first().json.body.google_access_token }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "q",
+              "value": "='\"{{ $('Webhook').first().json.body.folder_id }}\" in parents and (mimeType=\"image/png\" or mimeType=\"image/jpeg\" or mimeType=\"application/pdf\")'"
+            },
+            {
+              "name": "fields",
+              "value": "files(id,name,mimeType,size,createdTime)"
+            },
+            {
+              "name": "pageSize",
+              "value": "={{ $('Webhook').first().json.body.max_files || 100 }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "download-file",
+      "name": "Download File",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 300],
+      "parameters": {
+        "method": "GET",
+        "url": "=https://www.googleapis.com/drive/v3/files/{{ $('Webhook').first().json.body.file_id }}?alt=media",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Webhook').first().json.body.google_access_token }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "file"
+            }
+          },
+          "timeout": 60000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "get-file-metadata",
+      "name": "Get File Metadata",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 500],
+      "parameters": {
+        "method": "GET",
+        "url": "=https://www.googleapis.com/drive/v3/files/{{ $('Webhook').first().json.body.file_id }}",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Webhook').first().json.body.google_access_token }}"
+            }
+          ]
+        },
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "fields",
+              "value": "id,name,mimeType,size"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 15000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "mistral-ocr",
+      "name": "Mistral OCR API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1180, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.mistral.ai/v1/ocr",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $('Webhook').first().json.body.mistral_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ { \"model\": \"mistral-ocr-latest\", \"document\": { \"type\": \"image_url\", \"image_url\": 'data:' + ($('Get File Metadata').first().json.mimeType || 'image/png') + ';base64,' + $binary.data.data }, \"include_image_base64\": $('Webhook').first().json.body.include_images || false } }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "format-list-output",
+      "name": "Format List Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1180, 100],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ { \"success\": true, \"operation\": \"list_files\", \"data\": { \"files\": $json.files || [], \"folder_id\": $('Webhook').first().json.body.folder_id }, \"meta\": { \"provider\": \"google_drive\", \"count\": ($json.files || []).length } } }}"
+      }
+    },
+    {
+      "id": "format-ocr-output",
+      "name": "Format OCR Output",
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [1420, 300],
+      "parameters": {
+        "mode": "raw",
+        "jsonOutput": "={{ { \"success\": true, \"operation\": \"ocr\", \"data\": { \"text\": $json.pages?.map(p => p.markdown).join('\\n\\n') || '', \"pages\": $json.pages || [], \"file\": { \"id\": $('Webhook').first().json.body.file_id, \"name\": $('Get File Metadata').first().json.name, \"mimeType\": $('Get File Metadata').first().json.mimeType } }, \"meta\": { \"provider\": \"mistral\", \"model\": $json.model || 'mistral-ocr-latest', \"usage\": { \"pages_processed\": $json.usage_info?.pages_processed || 1, \"doc_size_bytes\": $json.usage_info?.doc_size_bytes || 0 } } } }}"
+      }
+    },
+    {
+      "id": "respond-list",
+      "name": "Respond List",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1420, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-ocr",
+      "name": "Respond OCR",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1,
+      "position": [1660, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "sticky-note-doc",
+      "name": "API Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [240, 60],
+      "parameters": {
+        "color": 6,
+        "width": 600,
+        "height": 280,
+        "content": "## MCP - Google Drive OCR\n\n**Endpoint:** POST /webhook/google-drive-ocr\n\n**Parameters:**\n- `google_access_token` (required): Google OAuth2 access token\n- `mistral_api_key` (required for OCR): Mistral API key\n- `folder_id` (string): List files in folder\n- `file_id` (string): Process specific file with OCR\n- `max_files` (int): Max files to list (default: 100)\n- `include_images` (bool): Include base64 images in OCR response\n\n**Operations:**\n- List files: provide `folder_id`\n- OCR file: provide `file_id` + `mistral_api_key`\n\n**API:** Mistral OCR (mistral-ocr-latest) + Google Drive v3"
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Route Operation",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Error: Missing Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route Operation": {
+      "main": [
+        [
+          {
+            "node": "Download File",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Get File Metadata",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "List Drive Files",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "List Drive Files": {
+      "main": [
+        [
+          {
+            "node": "Format List Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download File": {
+      "main": [
+        [
+          {
+            "node": "Mistral OCR API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mistral OCR API": {
+      "main": [
+        [
+          {
+            "node": "Format OCR Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format List Output": {
+      "main": [
+        [
+          {
+            "node": "Respond List",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format OCR Output": {
+      "main": [
+        [
+          {
+            "node": "Respond OCR",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Migrate `get_image_ocr_tool` from Pixtral vision model to dedicated Mistral OCR API (`/v1/ocr`)
- Add new `google_drive_ocr_tool` for OCR on Google Drive files with dynamic credentials via MCP server
- Fix Switch node configuration error ("Could not find property option") by using IF node

## Changes

### get_image_ocr_tool.json
- Endpoint: `/v1/chat/completions` → `/v1/ocr`
- Model: `pixtral-12b-2409` → `mistral-ocr-latest`
- Request format: `messages` → `document`
- Response parsing: `choices[].message.content` → `pages[].markdown`

### google_drive_ocr_tool.json (NEW)
- Dynamic Google OAuth2 token via `google_access_token` in request body
- Dynamic Mistral API key via `mistral_api_key` in request body
- Two operations: list files (folder_id) or OCR file (file_id)
- Uses Google Drive API v3 + Mistral OCR API

## Test plan
- [ ] Test OCR with image URL
- [ ] Test OCR with binary upload
- [ ] Test Google Drive file listing
- [ ] Test Google Drive file OCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)