### PR TITLE
feat(mcp): add Google Maps API integration workflow

### DIFF
--- a/workflows/mcp-tools/MCP_Google_Maps.json
+++ b/workflows/mcp-tools/MCP_Google_Maps.json
@@ -21,47 +21,215 @@
       "type": "n8n-nodes-base.switch",
       "position": [220, 300],
       "parameters": {
-        "dataType": "string",
-        "value1": "={{ $json.body.operation }}",
         "rules": {
-          "rules": [
+          "values": [
             {
-              "value2": "geocode",
-              "output": 0
+              "outputKey": "geocode",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-geocode",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "geocode"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "reverse_geocode",
-              "output": 1
+              "outputKey": "reverse_geocode",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-reverse-geocode",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "reverse_geocode"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "directions",
-              "output": 2
+              "outputKey": "directions",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-directions",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "directions"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "search_places",
-              "output": 3
+              "outputKey": "search_places",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-search-places",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "search_places"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "place_details",
-              "output": 4
+              "outputKey": "place_details",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-place-details",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "place_details"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "air_quality",
-              "output": 5
+              "outputKey": "air_quality",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-air-quality",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "air_quality"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "pollen",
-              "output": 6
+              "outputKey": "pollen",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-pollen",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "pollen"
+                  }
+                ]
+              },
+              "renameOutput": true
             },
             {
-              "value2": "timezone",
-              "output": 7
+              "outputKey": "timezone",
+              "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
+                "conditions": [
+                  {
+                    "id": "cond-timezone",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
+                    "leftValue": "={{ $json.body.operation }}",
+                    "rightValue": "timezone"
+                  }
+                ]
+              },
+              "renameOutput": true
             }
           ]
         },
-        "fallbackOutput": 8
+        "options": {
+          "fallbackOutput": "extra"
+        }
       },
-      "typeVersion": 3
+      "typeVersion": 3.2
     },
     {
       "id": "http-geocode",
@@ -428,7 +596,7 @@
     }
   ],
   "connections": {
-    "webhook-trigger": {
+    "Webhook Trigger": {
       "main": [
         [
           {
@@ -439,7 +607,7 @@
         ]
       ]
     },
-    "switch-operation": {
+    "Route Operation": {
       "main": [
         [
           {
@@ -506,7 +674,7 @@
         ]
       ]
     },
-    "http-geocode": {
+    "Geocode Address": {
       "main": [
         [
           {
@@ -517,7 +685,7 @@
         ]
       ]
     },
-    "http-reverse-geocode": {
+    "Reverse Geocode": {
       "main": [
         [
           {
@@ -528,7 +696,7 @@
         ]
       ]
     },
-    "http-directions": {
+    "Get Directions": {
       "main": [
         [
           {
@@ -539,7 +707,7 @@
         ]
       ]
     },
-    "http-search-places": {
+    "Search Places": {
       "main": [
         [
           {
@@ -550,7 +718,7 @@
         ]
       ]
     },
-    "http-place-details": {
+    "Get Place Details": {
       "main": [
         [
           {
@@ -561,7 +729,7 @@
         ]
       ]
     },
-    "http-air-quality": {
+    "Get Air Quality": {
       "main": [
         [
           {
@@ -572,7 +740,7 @@
         ]
       ]
     },
-    "http-pollen": {
+    "Get Pollen Data": {
       "main": [
         [
           {
@@ -583,7 +751,7 @@
         ]
       ]
     },
-    "http-timezone": {
+    "Get Timezone": {
       "main": [
         [
           {
@@ -594,7 +762,7 @@
         ]
       ]
     },
-    "set-error-response": {
+    "Invalid Operation Error": {
       "main": [
         [
           {
@@ -605,7 +773,7 @@
         ]
       ]
     },
-    "merge-responses": {
+    "Merge Responses": {
       "main": [
         [
           {

--- a/workflows/mcp-tools/MCP_Google_Maps.json
+++ b/workflows/mcp-tools/MCP_Google_Maps.json
@@ -1,0 +1,626 @@
+{
+  "name": "MCP - Google Maps",
+  "nodes": [
+    {
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "position": [0, 300],
+      "webhookId": "mcp-google-maps",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "mcp-google-maps",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "typeVersion": 2
+    },
+    {
+      "id": "switch-operation",
+      "name": "Route Operation",
+      "type": "n8n-nodes-base.switch",
+      "position": [220, 300],
+      "parameters": {
+        "dataType": "string",
+        "value1": "={{ $json.body.operation }}",
+        "rules": {
+          "rules": [
+            {
+              "value2": "geocode",
+              "output": 0
+            },
+            {
+              "value2": "reverse_geocode",
+              "output": 1
+            },
+            {
+              "value2": "directions",
+              "output": 2
+            },
+            {
+              "value2": "search_places",
+              "output": 3
+            },
+            {
+              "value2": "place_details",
+              "output": 4
+            },
+            {
+              "value2": "air_quality",
+              "output": 5
+            },
+            {
+              "value2": "pollen",
+              "output": 6
+            },
+            {
+              "value2": "timezone",
+              "output": 7
+            }
+          ]
+        },
+        "fallbackOutput": 8
+      },
+      "typeVersion": 3
+    },
+    {
+      "id": "http-geocode",
+      "name": "Geocode Address",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, -100],
+      "parameters": {
+        "method": "GET",
+        "url": "https://maps.googleapis.com/maps/api/geocode/json",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "address",
+              "value": "={{ $json.body.address }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            },
+            {
+              "name": "language",
+              "value": "={{ $json.body.language || 'fr' }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-reverse-geocode",
+      "name": "Reverse Geocode",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 0],
+      "parameters": {
+        "method": "GET",
+        "url": "https://maps.googleapis.com/maps/api/geocode/json",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "latlng",
+              "value": "={{ $json.body.latitude }},{{ $json.body.longitude }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            },
+            {
+              "name": "language",
+              "value": "={{ $json.body.language || 'fr' }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-directions",
+      "name": "Get Directions",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 100],
+      "parameters": {
+        "method": "GET",
+        "url": "https://maps.googleapis.com/maps/api/directions/json",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "origin",
+              "value": "={{ $json.body.origin }}"
+            },
+            {
+              "name": "destination",
+              "value": "={{ $json.body.destination }}"
+            },
+            {
+              "name": "mode",
+              "value": "={{ $json.body.mode || 'driving' }}"
+            },
+            {
+              "name": "language",
+              "value": "={{ $json.body.language || 'fr' }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-search-places",
+      "name": "Search Places",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "https://maps.googleapis.com/maps/api/place/textsearch/json",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "query",
+              "value": "={{ $json.body.query }}"
+            },
+            {
+              "name": "location",
+              "value": "={{ $json.body.latitude }},{{ $json.body.longitude }}"
+            },
+            {
+              "name": "radius",
+              "value": "={{ $json.body.radius || 5000 }}"
+            },
+            {
+              "name": "language",
+              "value": "={{ $json.body.language || 'fr' }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-place-details",
+      "name": "Get Place Details",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 300],
+      "parameters": {
+        "method": "GET",
+        "url": "https://maps.googleapis.com/maps/api/place/details/json",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "place_id",
+              "value": "={{ $json.body.place_id }}"
+            },
+            {
+              "name": "fields",
+              "value": "={{ $json.body.fields || 'name,formatted_address,geometry,rating,opening_hours,formatted_phone_number,website' }}"
+            },
+            {
+              "name": "language",
+              "value": "={{ $json.body.language || 'fr' }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-air-quality",
+      "name": "Get Air Quality",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 400],
+      "parameters": {
+        "method": "POST",
+        "url": "=https://airquality.googleapis.com/v1/currentConditions:lookup?key={{ $json.body.api_key }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ location: { latitude: Number($json.body.latitude), longitude: Number($json.body.longitude) }, extraComputations: ['HEALTH_RECOMMENDATIONS', 'DOMINANT_POLLUTANT_CONCENTRATION', 'POLLUTANT_CONCENTRATION', 'LOCAL_AQI', 'POLLUTANT_ADDITIONAL_INFO'] }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "responseFormat": "json"
+            }
+          }
+        }
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-pollen",
+      "name": "Get Pollen Data",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 500],
+      "parameters": {
+        "method": "GET",
+        "url": "https://pollen.googleapis.com/v1/forecast:lookup",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "location.latitude",
+              "value": "={{ $json.body.latitude }}"
+            },
+            {
+              "name": "location.longitude",
+              "value": "={{ $json.body.longitude }}"
+            },
+            {
+              "name": "days",
+              "value": "={{ $json.body.days || 5 }}"
+            },
+            {
+              "name": "languageCode",
+              "value": "={{ $json.body.language || 'fr' }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "http-timezone",
+      "name": "Get Timezone",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [500, 600],
+      "parameters": {
+        "method": "GET",
+        "url": "https://maps.googleapis.com/maps/api/timezone/json",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "location",
+              "value": "={{ $json.body.latitude }},{{ $json.body.longitude }}"
+            },
+            {
+              "name": "timestamp",
+              "value": "={{ $json.body.timestamp || Math.floor(Date.now() / 1000) }}"
+            },
+            {
+              "name": "key",
+              "value": "={{ $json.body.api_key }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 4.2
+    },
+    {
+      "id": "set-error-response",
+      "name": "Invalid Operation Error",
+      "type": "n8n-nodes-base.set",
+      "position": [500, 700],
+      "parameters": {
+        "mode": "manual",
+        "duplicateItem": false,
+        "assignments": {
+          "assignments": [
+            {
+              "id": "error-code",
+              "name": "error.code",
+              "type": "number",
+              "value": 400
+            },
+            {
+              "id": "error-message",
+              "name": "error.message",
+              "type": "string",
+              "value": "={{ 'Invalid operation: ' + $json.body.operation + '. Valid operations: geocode, reverse_geocode, directions, search_places, place_details, air_quality, pollen, timezone' }}"
+            },
+            {
+              "id": "error-status",
+              "name": "error.status",
+              "type": "string",
+              "value": "BAD_REQUEST"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "typeVersion": 3.4
+    },
+    {
+      "id": "merge-responses",
+      "name": "Merge Responses",
+      "type": "n8n-nodes-base.merge",
+      "position": [760, 300],
+      "parameters": {
+        "mode": "chooseBranch",
+        "output": "empty"
+      },
+      "typeVersion": 3
+    },
+    {
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "position": [980, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "typeVersion": 1.1
+    },
+    {
+      "id": "sticky-note-main",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [-300, -100],
+      "parameters": {
+        "color": 6,
+        "width": 280,
+        "height": 600,
+        "content": "## MCP Google Maps Tools\n\n**Endpoint:** POST `/webhook/mcp-google-maps`\n\n**GitHub Issue:** #137\n\n---\n\n### Operations disponibles:\n\n1. **geocode** - Adresse -> Coordonnees\n2. **reverse_geocode** - Coordonnees -> Adresse\n3. **directions** - Calcul d'itineraire\n4. **search_places** - Recherche de lieux\n5. **place_details** - Details d'un lieu\n6. **air_quality** - Qualite de l'air\n7. **pollen** - Donnees pollen\n8. **timezone** - Fuseau horaire\n\n---\n\n### Parametres requis:\n\n- `operation`: string\n- `api_key`: string (cle API Google Maps)\n\n### Parametres selon operation:\n\nVoir documentation complete dans `docs/issues/google-maps-api-integration.md`"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-note-geocode",
+      "name": "Geocoding",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [420, -200],
+      "parameters": {
+        "color": 3,
+        "width": 260,
+        "height": 80,
+        "content": "### Geocode\n`address` -> `{lat, lng}`"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-note-directions",
+      "name": "Directions",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [420, 40],
+      "parameters": {
+        "color": 3,
+        "width": 260,
+        "height": 80,
+        "content": "### Directions\n`origin, destination` -> itineraire"
+      },
+      "typeVersion": 1
+    },
+    {
+      "id": "sticky-note-environment",
+      "name": "Air Quality & Pollen",
+      "type": "n8n-nodes-base.stickyNote",
+      "position": [420, 340],
+      "parameters": {
+        "color": 2,
+        "width": 260,
+        "height": 80,
+        "content": "### Environnement\nQualite de l'air et donnees pollen"
+      },
+      "typeVersion": 1
+    }
+  ],
+  "connections": {
+    "webhook-trigger": {
+      "main": [
+        [
+          {
+            "node": "Route Operation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "switch-operation": {
+      "main": [
+        [
+          {
+            "node": "Geocode Address",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Reverse Geocode",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Directions",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Search Places",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Place Details",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Air Quality",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Pollen Data",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Timezone",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Invalid Operation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-geocode": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-reverse-geocode": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-directions": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-search-places": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-place-details": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-air-quality": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-pollen": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "http-timezone": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "set-error-response": {
+      "main": [
+        [
+          {
+            "node": "Merge Responses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "merge-responses": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "saveManualExecutions": true,
+    "callerPolicy": "workflowsFromSameOwner",
+    "timezone": "Europe/Paris"
+  }
+}


### PR DESCRIPTION
## Summary

- Add MCP - Google Maps workflow with 8 operations for geolocation and environment services
- Workflow uses HTTP Request nodes to call Google Maps APIs
- API key passed dynamically in each request for flexibility

### Operations disponibles

| Opération | API | Description |
|-----------|-----|-------------|
| `geocode` | Geocoding | Adresse → Coordonnées |
| `reverse_geocode` | Geocoding | Coordonnées → Adresse |
| `directions` | Directions | Calcul d'itinéraire |
| `search_places` | Places | Recherche de lieux |
| `place_details` | Places | Détails d'un lieu |
| `air_quality` | Air Quality | Qualité de l'air |
| `pollen` | Pollen | Données pollen |
| `timezone` | Time Zone | Fuseau horaire |

### Utilisation

```bash
curl -X POST http://pi6.local:5678/webhook/mcp-google-maps \
  -H "Content-Type: application/json" \
  -d '{"operation": "geocode", "address": "Paris", "api_key": "YOUR_KEY"}'
```

## Test plan

- [ ] Importer le workflow dans n8n
- [ ] Activer le workflow
- [ ] Tester l'opération `geocode` avec une adresse
- [ ] Tester l'opération `directions` avec origin/destination
- [ ] Tester l'opération `air_quality` avec des coordonnées

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)