### PR TITLE
feat(torah): Torah Translation Workflows & Registry

### DIFF
--- a/docs/issues/001-discord-webhook-setup.md
+++ b/docs/issues/001-discord-webhook-setup.md
@@ -1,0 +1,138 @@
+# Issue #001: Configuration Webhook Discord pour notifications traduction
+
+**Date**: 2024-12-28
+**Statut**: TODO
+**Priorité**: Haute
+**Projet**: Torah Translation Workflows
+
+---
+
+## Description
+
+Configurer un webhook Discord pour recevoir les notifications du pipeline de traduction Torah. Ce webhook sera utilisé par les workflows n8n pour notifier :
+- Démarrage d'un batch de traduction
+- Progression (page X/Y traduite)
+- Alertes qualité (traductions avec score < seuil)
+- Demandes de validation humaine
+- Fin de traduction + lien PDF
+
+---
+
+## Guide de configuration
+
+### 1. Créer le webhook dans Discord
+
+1. Ouvrir Discord et aller dans le serveur cible
+2. Clic droit sur le channel de notifications → **Modifier le salon**
+3. Onglet **Intégrations** → **Webhooks** → **Nouveau webhook**
+4. Configurer :
+   - **Nom**: `Torah Translator Bot`
+   - **Avatar**: (optionnel) icône du projet
+5. **Copier l'URL du webhook**
+
+### 2. Format de l'URL
+
+```
+https://discord.com/api/webhooks/{webhook_id}/{webhook_token}
+```
+
+### 3. Tester le webhook
+
+```bash
+curl -X POST "https://discord.com/api/webhooks/VOTRE_ID/VOTRE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "Test webhook Torah Translator",
+    "embeds": [{
+      "title": "Test de notification",
+      "description": "Si vous voyez ce message, le webhook fonctionne !",
+      "color": 5814783
+    }]
+  }'
+```
+
+### 4. Configuration dans n8n
+
+#### Option A: Variable d'environnement (recommandé)
+```bash
+# Dans .env de n8n
+DISCORD_TORAH_WEBHOOK=https://discord.com/api/webhooks/...
+```
+
+#### Option B: Credential n8n
+1. Settings → Credentials → Add Credential
+2. Type: Discord Webhook
+3. Sauvegarder l'URL
+
+### 5. Utilisation dans les workflows
+
+```json
+{
+  "type": "n8n-nodes-base.discord",
+  "parameters": {
+    "webhookUri": "={{ $env.DISCORD_TORAH_WEBHOOK }}",
+    "text": "{{ $json.message }}",
+    "options": {
+      "embeds": [{
+        "title": "{{ $json.title }}",
+        "description": "{{ $json.description }}",
+        "color": "{{ $json.color }}"
+      }]
+    }
+  }
+}
+```
+
+---
+
+## Types de notifications à implémenter
+
+| Type | Couleur | Exemple |
+|------|---------|---------|
+| Démarrage | Bleu (3447003) | "Traduction lancée: Sukkah 2a-10b" |
+| Progression | Gris (9807270) | "Page 5/50 traduite - Score: 0.94" |
+| Succès | Vert (5763719) | "Traduction terminée !" |
+| Alerte qualité | Orange (15105570) | "Score faible: 0.72 - Révision requise" |
+| Erreur | Rouge (15548997) | "Erreur API: timeout" |
+| Validation | Violet (10181046) | "Validation requise pour Sukkah 3a" |
+
+---
+
+## Exemple de message enrichi (embed)
+
+```json
+{
+  "embeds": [{
+    "title": "Traduction terminée",
+    "description": "Sukkah 2a-10b traduit avec succès",
+    "color": 5763719,
+    "fields": [
+      {"name": "Pages", "value": "50", "inline": true},
+      {"name": "Commentaires", "value": "1,234", "inline": true},
+      {"name": "Score moyen", "value": "0.91", "inline": true},
+      {"name": "Temps", "value": "45 min", "inline": true}
+    ],
+    "footer": {"text": "Torah Translator | Claude 3.5 + GPT-4o"},
+    "timestamp": "2024-12-28T12:00:00.000Z"
+  }]
+}
+```
+
+---
+
+## Tâches
+
+- [ ] Créer le channel Discord dédié
+- [ ] Créer le webhook
+- [ ] Tester avec curl
+- [ ] Ajouter l'URL dans les variables d'environnement n8n
+- [ ] Créer le workflow de notification de base
+- [ ] Tester l'intégration complète
+
+---
+
+## Liens utiles
+
+- [Documentation Discord Webhooks](https://discord.com/developers/docs/resources/webhook)
+- [n8n Discord Node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.discord/)
+- [Embed Visualizer](https://leovoel.github.io/embed-visualizer/)

--- a/docs/issues/002-discord-bot-setup.md
+++ b/docs/issues/002-discord-bot-setup.md
@@ -1,0 +1,182 @@
+# Issue #002: Création d'un Bot Discord pour recherche interactive
+
+**Date**: 2024-12-28
+**Statut**: TODO
+**Priorité**: Moyenne
+**Projet**: Torah Translation Workflows
+**Dépend de**: Issue #001 (Webhook Discord)
+
+---
+
+## Description
+
+Créer un bot Discord qui permet aux utilisateurs de demander des commentaires talmudiques en langage naturel directement dans un channel Discord.
+
+**Exemple d'utilisation:**
+```
+Utilisateur: "Souccah 28b Rashi"
+Bot: 📚 Rashi sur Sukkah 28b
+     ─────────────────────
+     1. "פירוש ראשון..."
+     2. "פירוש שני..."
+```
+
+---
+
+## Différence Webhook vs Bot
+
+| Webhook | Bot |
+|---------|-----|
+| Envoie des messages uniquement | Peut lire ET envoyer des messages |
+| Pas besoin de serveur | Nécessite un token et des permissions |
+| Déclenché par appel HTTP | Déclenché par événements Discord |
+| Simple à configurer | Plus complexe mais plus puissant |
+
+---
+
+## Guide de création du Bot Discord
+
+### Étape 1: Créer l'application Discord
+
+1. Aller sur https://discord.com/developers/applications
+2. Cliquer sur **"New Application"**
+3. Nom: `Torah Commentary Bot`
+4. Cliquer sur **"Create"**
+
+### Étape 2: Configurer le Bot
+
+1. Dans le menu gauche, cliquer sur **"Bot"**
+2. Cliquer sur **"Add Bot"** → **"Yes, do it!"**
+3. Configurer:
+   - **Username**: `Torah Commentary Bot`
+   - **Icon**: (optionnel) ajouter une icône
+4. **IMPORTANT**: Dans "Privileged Gateway Intents", activer:
+   - ✅ **MESSAGE CONTENT INTENT** (pour lire les messages)
+   - ✅ **SERVER MEMBERS INTENT** (optionnel)
+
+### Étape 3: Récupérer le Token
+
+1. Dans la section **"Bot"**, cliquer sur **"Reset Token"**
+2. **Copier et sauvegarder le token** (il ne sera plus visible après)
+3. Format: `MTQ1NDg3MjcwMTMzMTE3NzYwNg.XXXXXX.XXXXXXXXXXXXXXXX`
+
+⚠️ **ATTENTION**: Ne jamais partager ce token ! Il donne un accès total au bot.
+
+### Étape 4: Configurer les permissions
+
+1. Aller dans **"OAuth2"** → **"URL Generator"**
+2. Cocher les scopes:
+   - ✅ `bot`
+   - ✅ `applications.commands` (pour les slash commands)
+3. Cocher les permissions bot:
+   - ✅ `Read Messages/View Channels`
+   - ✅ `Send Messages`
+   - ✅ `Embed Links`
+   - ✅ `Read Message History`
+   - ✅ `Use Slash Commands`
+4. Copier l'URL générée
+
+### Étape 5: Inviter le bot sur le serveur
+
+1. Ouvrir l'URL générée dans un navigateur
+2. Sélectionner le serveur Discord cible
+3. Cliquer sur **"Authorize"**
+4. Compléter le captcha
+
+### Étape 6: Configurer dans n8n
+
+#### Option A: Credential n8n (recommandé)
+1. Dans n8n: **Settings** → **Credentials** → **Add Credential**
+2. Type: **Discord Bot API**
+3. Coller le **Bot Token**
+4. Sauvegarder
+
+#### Option B: Variable d'environnement
+```bash
+# Dans .env de n8n
+DISCORD_BOT_TOKEN=MTQ1NDg3MjcwMTMzMTE3NzYwNg.XXXXXX.XXXXXXXXXXXXXXXX
+```
+
+---
+
+## Architecture du workflow n8n
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Discord Trigger                                                  │
+│ - Event: Message Create                                          │
+│ - Channel: #torah-bot (ou tous)                                  │
+│ - Filtre: messages commençant par "!" ou mentionnant le bot     │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ LLM - Extraction d'intention                                     │
+│ Prompt: "Extrais la référence talmudique et le commentateur     │
+│          du message suivant: {message}"                          │
+│ Output: { traite, page, commentator, action }                    │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ HTTP Request - API Backend                                       │
+│ GET http://pi6.local:3031/api/talmud/text/{traite}/{page}       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Code - Filtrer et formater                                       │
+│ - Filtrer par commentateur                                       │
+│ - Formater pour Discord (embeds)                                 │
+│ - Limiter à 2000 caractères                                      │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Discord - Send Message                                           │
+│ - Répondre dans le même channel                                  │
+│ - Utiliser des embeds pour le formatage                          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Exemples de requêtes supportées
+
+| Message utilisateur | Interprétation |
+|---------------------|----------------|
+| `Sukkah 28b Rashi` | Traité: Sukkah, Page: 28b, Commentateur: Rashi |
+| `!rashi souccah 10a` | Traité: Sukkah, Page: 10a, Commentateur: Rashi |
+| `Berakhot 2a tous les commentaires` | Traité: Berakhot, Page: 2a, Tous commentateurs |
+| `@Torah Bot Pesachim 5b Tosafot` | Traité: Pesachim, Page: 5b, Commentateur: Tosafot |
+
+---
+
+## Tâches
+
+- [ ] Créer l'application Discord Developer
+- [ ] Configurer le bot avec les permissions
+- [ ] Récupérer et sauvegarder le token
+- [ ] Inviter le bot sur le serveur
+- [ ] Ajouter le token dans n8n credentials
+- [ ] Créer le workflow n8n
+- [ ] Tester avec des requêtes simples
+- [ ] Ajouter la gestion d'erreurs
+
+---
+
+## Sécurité
+
+- Ne jamais commiter le token dans le code
+- Utiliser les credentials n8n ou variables d'environnement
+- Limiter les permissions au minimum nécessaire
+- Restreindre le bot à des channels spécifiques si possible
+
+---
+
+## Liens utiles
+
+- [Discord Developer Portal](https://discord.com/developers/applications)
+- [Discord.js Guide](https://discordjs.guide/)
+- [n8n Discord Node](https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.discord/)
+- [Discord API Documentation](https://discord.com/developers/docs/intro)

--- a/workflows/Torah/torah-batch-translation.json
+++ b/workflows/Torah/torah-batch-translation.json
@@ -12,6 +12,7 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [250, 300],
+      "webhookId": "torah-batch-translate",
       "notes": "Payload: {book: 'Sukkah', chapter_start: '2a', chapter_end: '10b', config: {...}}"
     },
     {

--- a/workflows/Torah/torah-batch-translation.json
+++ b/workflows/Torah/torah-batch-translation.json
@@ -1,0 +1,469 @@
+{
+  "name": "Torah Batch Translation with Commentaries",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-batch-translate",
+        "options": {}
+      },
+      "id": "webhook-batch",
+      "name": "Batch Translation Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "notes": "Payload: {book: 'Sukkah', chapter_start: '2a', chapter_end: '10b', config: {...}}"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider et preparer les parametres de batch\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Configuration par defaut\nconst defaultConfig = {\n  target_language: 'fr',\n  translator: { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022' },\n  reviewer: { provider: 'openai', model: 'gpt-4o' },\n  apply_grammalecte: true,\n  include_commentaries: true,\n  max_commentaries_per_text: 10\n};\n\nconst config = { ...defaultConfig, ...body.config };\n\n// Validation\nconst errors = [];\nif (!body.book && !body.source_text_ids) {\n  errors.push('Specify either \"book\" (e.g., \"Sukkah\") or \"source_text_ids\" array');\n}\n\nif (body.book && !['Sukkah', 'Berakhot', 'Pesachim', 'Shabbat', 'Eruvin', 'Bekhorot'].includes(body.book)) {\n  errors.push('Invalid book. Available: Sukkah, Berakhot, Pesachim, Shabbat, Eruvin, Bekhorot');\n}\n\nconst result = {\n  valid: errors.length === 0,\n  errors: errors,\n  params: {\n    book: body.book || null,\n    chapter_start: body.chapter_start || '2a',\n    chapter_end: body.chapter_end || null,\n    source_text_ids: body.source_text_ids || [],\n    config: config,\n    batch_id: `batch_${Date.now()}`\n  }\n};\n\nreturn [{ json: result }];"
+      },
+      "id": "validate-batch-params",
+      "name": "Validate Batch Parameters",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "is-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Parameters Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=http://pi6.local:3031/api/source-texts?book={{ $json.params.book }}&limit=100",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "fetch-source-texts",
+      "name": "API - Fetch Source Texts",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 200],
+      "notes": "Recupere tous les textes sources du livre"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Preparer les items pour le traitement batch\nconst apiResponse = $input.first().json;\nconst params = $('Validate Batch Parameters').first().json.params;\n\n// Extraire les textes de la reponse API\nlet texts = [];\nif (apiResponse.items) {\n  texts = apiResponse.items;\n} else if (apiResponse.source_texts) {\n  texts = apiResponse.source_texts;\n} else if (Array.isArray(apiResponse)) {\n  texts = apiResponse;\n}\n\n// Filtrer par plage de chapitres si specifie\nif (params.chapter_start || params.chapter_end) {\n  const parseRef = (ref) => {\n    const match = ref.match(/(\\d+)([ab])/i);\n    if (!match) return { num: 0, side: 'a' };\n    return { num: parseInt(match[1]), side: match[2].toLowerCase() };\n  };\n  \n  const start = params.chapter_start ? parseRef(params.chapter_start) : { num: 0, side: 'a' };\n  const end = params.chapter_end ? parseRef(params.chapter_end) : { num: 999, side: 'b' };\n  \n  texts = texts.filter(t => {\n    const ref = parseRef(t.reference || t.ref || '');\n    const startVal = start.num * 2 + (start.side === 'b' ? 1 : 0);\n    const endVal = end.num * 2 + (end.side === 'b' ? 1 : 0);\n    const refVal = ref.num * 2 + (ref.side === 'b' ? 1 : 0);\n    return refVal >= startVal && refVal <= endVal;\n  });\n}\n\n// Limiter le nombre de textes si trop grand\nconst maxTexts = 50;\nif (texts.length > maxTexts) {\n  texts = texts.slice(0, maxTexts);\n}\n\n// Creer les items de batch\nconst batchItems = texts.map((text, index) => ({\n  json: {\n    source_text_id: text.uuid || text.id,\n    reference: text.reference || text.ref,\n    book: params.book,\n    index: index + 1,\n    total: texts.length,\n    batch_id: params.batch_id,\n    config: params.config\n  }\n}));\n\n// Si aucun texte, retourner un item vide avec erreur\nif (batchItems.length === 0) {\n  return [{ json: { error: 'Aucun texte trouve pour les criteres specifies', texts_count: 0 } }];\n}\n\nreturn batchItems;"
+      },
+      "id": "prepare-batch-items",
+      "name": "Prepare Batch Items",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1130, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Traduction Batch Demarree\",\n    \"description\": \"Batch ID: {{ $('Validate Batch Parameters').first().json.params.batch_id }}\",\n    \"color\": 3447003,\n    \"fields\": [\n      {\"name\": \"Livre\", \"value\": \"{{ $('Validate Batch Parameters').first().json.params.book || 'Selection' }}\", \"inline\": true},\n      {\"name\": \"Textes\", \"value\": \"{{ $json.length || $input.all().length }}\", \"inline\": true},\n      {\"name\": \"Langue\", \"value\": \"{{ $('Validate Batch Parameters').first().json.params.config.target_language }}\", \"inline\": true},\n      {\"name\": \"Provider\", \"value\": \"{{ $('Validate Batch Parameters').first().json.params.config.translator.provider }}\", \"inline\": true}\n    ],\n    \"footer\": {\"text\": \"Torah Batch Translator\"},\n    \"timestamp\": \"{{ new Date().toISOString() }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-batch-start",
+      "name": "Discord - Batch Start",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1350, 200]
+    },
+    {
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      },
+      "id": "batch-loop",
+      "name": "Process Texts",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [1570, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://pi6.local:3031/api/translate-with-comments",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"reference\": {\n    \"table\": \"source_texts\",\n    \"uuid\": \"{{ $json.source_text_id }}\"\n  },\n  \"target_language\": \"{{ $json.config.target_language }}\",\n  \"translator\": {{ JSON.stringify($json.config.translator) }},\n  \"reviewer\": {{ JSON.stringify($json.config.reviewer) }},\n  \"apply_grammalecte\": {{ $json.config.apply_grammalecte }},\n  \"max_commentaries\": {{ $json.config.max_commentaries_per_text || 10 }}\n}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "translate-text",
+      "name": "API - Translate Text",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1790, 200],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "// Gerer le resultat de traduction\nconst input = $input.first().json;\nconst batchItem = $('Process Texts').item.json;\n\nconst result = {\n  source_text_id: batchItem.source_text_id,\n  reference: batchItem.reference,\n  index: batchItem.index,\n  total: batchItem.total,\n  success: !input.error && !input.detail,\n  error: input.error || input.detail || null,\n  translation_id: input.translation_id || null,\n  comments_translated: input.comments_count || 0,\n  tokens_used: input.tokens_used || 0\n};\n\nreturn [{ json: result }];"
+      },
+      "id": "process-result",
+      "name": "Process Translation Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2010, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-progress",
+              "leftValue": "={{ $json.index % 5 }}",
+              "rightValue": 0,
+              "operator": {
+                "type": "number",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "should-notify",
+      "name": "Notify Every 5?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2230, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"content\": \"Progression: {{ $json.index }}/{{ $json.total }} textes traites ({{ Math.round($json.index / $json.total * 100) }}%)\"\n}",
+        "options": {}
+      },
+      "id": "discord-progress",
+      "name": "Discord - Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2450, 120]
+    },
+    {
+      "parameters": {
+        "mode": "passthrough"
+      },
+      "id": "merge-after-notify",
+      "name": "Continue",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [2670, 200]
+    },
+    {
+      "parameters": {
+        "aggregate": "aggregateAllItemData",
+        "options": {}
+      },
+      "id": "aggregate-results",
+      "name": "Aggregate All Results",
+      "type": "n8n-nodes-base.aggregate",
+      "typeVersion": 1,
+      "position": [2890, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Calculer les statistiques finales\nconst results = $input.first().json.data || [];\n\nconst stats = {\n  batch_id: results[0]?.batch_id || 'unknown',\n  total_texts: results.length,\n  successful: results.filter(r => r.success).length,\n  failed: results.filter(r => !r.success).length,\n  total_comments_translated: results.reduce((sum, r) => sum + (r.comments_translated || 0), 0),\n  total_tokens: results.reduce((sum, r) => sum + (r.tokens_used || 0), 0),\n  errors: results.filter(r => r.error).map(r => ({ ref: r.reference, error: r.error }))\n};\n\nstats.success_rate = stats.total_texts > 0 \n  ? Math.round(stats.successful / stats.total_texts * 100) \n  : 0;\n\nreturn [{ json: { stats, results } }];"
+      },
+      "id": "calculate-final-stats",
+      "name": "Calculate Final Statistics",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3110, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Traduction Batch Terminee\",\n    \"description\": \"Batch ID: {{ $json.stats.batch_id }}\",\n    \"color\": {{ $json.stats.failed === 0 ? 5763719 : 15105570 }},\n    \"fields\": [\n      {\"name\": \"Textes traduits\", \"value\": \"{{ $json.stats.successful }}/{{ $json.stats.total_texts }}\", \"inline\": true},\n      {\"name\": \"Taux de succes\", \"value\": \"{{ $json.stats.success_rate }}%\", \"inline\": true},\n      {\"name\": \"Commentaires\", \"value\": \"{{ $json.stats.total_comments_translated }}\", \"inline\": true},\n      {\"name\": \"Tokens utilises\", \"value\": \"{{ $json.stats.total_tokens.toLocaleString() }}\", \"inline\": true}\n    ],\n    \"footer\": {\"text\": \"Torah Batch Translator\"},\n    \"timestamp\": \"{{ new Date().toISOString() }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-batch-complete",
+      "name": "Discord - Batch Complete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3330, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, stats: $json.stats } }}",
+        "options": {}
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [3550, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Erreur Batch Translation\",\n    \"description\": \"{{ $json.errors.join(', ') }}\",\n    \"color\": 15548997,\n    \"footer\": {\"text\": \"Torah Batch Translator\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-error",
+      "name": "Discord - Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, errors: $json.errors } }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1130, 420]
+    }
+  ],
+  "connections": {
+    "Batch Translation Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Batch Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Batch Parameters": {
+      "main": [
+        [
+          {
+            "node": "Parameters Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parameters Valid?": {
+      "main": [
+        [
+          {
+            "node": "API - Fetch Source Texts",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord - Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Fetch Source Texts": {
+      "main": [
+        [
+          {
+            "node": "Prepare Batch Items",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Batch Items": {
+      "main": [
+        [
+          {
+            "node": "Discord - Batch Start",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Batch Start": {
+      "main": [
+        [
+          {
+            "node": "Process Texts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Texts": {
+      "main": [
+        [
+          {
+            "node": "API - Translate Text",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Aggregate All Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Translate Text": {
+      "main": [
+        [
+          {
+            "node": "Process Translation Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Translation Result": {
+      "main": [
+        [
+          {
+            "node": "Notify Every 5?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Notify Every 5?": {
+      "main": [
+        [
+          {
+            "node": "Discord - Progress",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Continue",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Discord - Progress": {
+      "main": [
+        [
+          {
+            "node": "Continue",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Continue": {
+      "main": [
+        [
+          {
+            "node": "Process Texts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate All Results": {
+      "main": [
+        [
+          {
+            "node": "Calculate Final Statistics",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Calculate Final Statistics": {
+      "main": [
+        [
+          {
+            "node": "Discord - Batch Complete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Batch Complete": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah/torah-batch-translation.json
+++ b/workflows/Torah/torah-batch-translation.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "torah-batch-translate",
+        "responseMode": "responseNode",
         "options": {}
       },
       "id": "webhook-batch",

--- a/workflows/Torah/torah-batch-translation.json
+++ b/workflows/Torah/torah-batch-translation.json
@@ -12,7 +12,10 @@
       "name": "Batch Translation Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [250, 300],
+      "position": [
+        250,
+        300
+      ],
       "webhookId": "torah-batch-translate",
       "notes": "Payload: {book: 'Sukkah', chapter_start: '2a', chapter_end: '10b', config: {...}}"
     },
@@ -24,7 +27,10 @@
       "name": "Validate Batch Parameters",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [470, 300]
+      "position": [
+        470,
+        300
+      ]
     },
     {
       "parameters": {
@@ -52,8 +58,11 @@
       "id": "check-valid",
       "name": "Parameters Valid?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [690, 300]
+      "typeVersion": 2.2,
+      "position": [
+        690,
+        300
+      ]
     },
     {
       "parameters": {
@@ -67,7 +76,10 @@
       "name": "API - Fetch Source Texts",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [910, 200],
+      "position": [
+        910,
+        200
+      ],
       "notes": "Recupere tous les textes sources du livre"
     },
     {
@@ -78,7 +90,10 @@
       "name": "Prepare Batch Items",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1130, 200]
+      "position": [
+        1130,
+        200
+      ]
     },
     {
       "parameters": {
@@ -93,7 +108,10 @@
       "name": "Discord - Batch Start",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1350, 200]
+      "position": [
+        1350,
+        200
+      ]
     },
     {
       "parameters": {
@@ -104,7 +122,10 @@
       "name": "Process Texts",
       "type": "n8n-nodes-base.splitInBatches",
       "typeVersion": 3,
-      "position": [1570, 200]
+      "position": [
+        1570,
+        200
+      ]
     },
     {
       "parameters": {
@@ -121,7 +142,10 @@
       "name": "API - Translate Text",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1790, 200],
+      "position": [
+        1790,
+        200
+      ],
       "continueOnFail": true
     },
     {
@@ -132,7 +156,10 @@
       "name": "Process Translation Result",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2010, 200]
+      "position": [
+        2010,
+        200
+      ]
     },
     {
       "parameters": {
@@ -160,8 +187,11 @@
       "id": "should-notify",
       "name": "Notify Every 5?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [2230, 200]
+      "typeVersion": 2.2,
+      "position": [
+        2230,
+        200
+      ]
     },
     {
       "parameters": {
@@ -176,7 +206,10 @@
       "name": "Discord - Progress",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2450, 120]
+      "position": [
+        2450,
+        120
+      ]
     },
     {
       "parameters": {
@@ -186,7 +219,10 @@
       "name": "Continue",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [2670, 200]
+      "position": [
+        2670,
+        200
+      ]
     },
     {
       "parameters": {
@@ -197,7 +233,10 @@
       "name": "Aggregate All Results",
       "type": "n8n-nodes-base.aggregate",
       "typeVersion": 1,
-      "position": [2890, 200]
+      "position": [
+        2890,
+        200
+      ]
     },
     {
       "parameters": {
@@ -207,7 +246,10 @@
       "name": "Calculate Final Statistics",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [3110, 200]
+      "position": [
+        3110,
+        200
+      ]
     },
     {
       "parameters": {
@@ -222,7 +264,10 @@
       "name": "Discord - Batch Complete",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [3330, 200]
+      "position": [
+        3330,
+        200
+      ]
     },
     {
       "parameters": {
@@ -234,7 +279,10 @@
       "name": "Respond Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [3550, 200]
+      "position": [
+        3550,
+        200
+      ]
     },
     {
       "parameters": {
@@ -249,7 +297,10 @@
       "name": "Discord - Error",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [910, 420]
+      "position": [
+        910,
+        420
+      ]
     },
     {
       "parameters": {
@@ -263,7 +314,10 @@
       "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1130, 420]
+      "position": [
+        1130,
+        420
+      ]
     }
   ],
   "connections": {

--- a/workflows/Torah/torah-discord-bot-commentary.json
+++ b/workflows/Torah/torah-discord-bot-commentary.json
@@ -12,6 +12,7 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [250, 300],
+      "webhookId": "torah-discord-message",
       "notes": "Recoit les messages Discord. Payload: {message: 'Sukkah 10a Rashi'}"
     },
     {

--- a/workflows/Torah/torah-discord-bot-commentary.json
+++ b/workflows/Torah/torah-discord-bot-commentary.json
@@ -1,0 +1,224 @@
+{
+  "name": "Torah Discord Bot - Commentary Search",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-discord-message",
+        "options": {}
+      },
+      "id": "webhook-discord",
+      "name": "Discord Message Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "notes": "Recoit les messages Discord. Payload: {message: 'Sukkah 10a Rashi'}"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraction d'intention simple via regex (sans LLM)\nconst input = $input.first().json;\nconst message = (input.body?.message || input.message || '').toLowerCase();\n\n// Patterns pour les traites\nconst traitePatterns = {\n  'sukkah': 'Sukkah', 'souccah': 'Sukkah', 'sukka': 'Sukkah', 'soucca': 'Sukkah',\n  'berakhot': 'Berakhot', 'berachot': 'Berakhot', 'brachot': 'Berakhot', 'brakhot': 'Berakhot',\n  'pesachim': 'Pesachim', 'pessahim': 'Pesachim', 'pessachim': 'Pesachim',\n  'shabbat': 'Shabbat', 'shabat': 'Shabbat', 'chabbat': 'Shabbat',\n  'eruvin': 'Eruvin', 'erouvin': 'Eruvin', 'eiruvin': 'Eruvin',\n  'bekhorot': 'Bekhorot', 'bechorot': 'Bekhorot'\n};\n\n// Patterns pour les commentateurs\nconst commentatorPatterns = {\n  'rashi': 'Rashi', 'rachi': 'Rashi',\n  'tosafot': 'Tosafot', 'tossafot': 'Tosafot', 'tosfot': 'Tosafot',\n  'steinsaltz': 'Steinsaltz', 'steinzaltz': 'Steinsaltz',\n  'ritva': 'Ritva',\n  'meiri': 'Meiri',\n  'rashash': 'Rashash',\n  'rosh': 'Rosh',\n  'maharam': 'Maharam',\n  'all': 'all', 'tous': 'all', 'tout': 'all'\n};\n\nlet intent = { traite: null, page: null, commentator: 'all', action: 'get_commentary' };\nlet error = null;\n\n// Chercher le traite\nfor (const [pattern, name] of Object.entries(traitePatterns)) {\n  if (message.includes(pattern)) {\n    intent.traite = name;\n    break;\n  }\n}\n\n// Chercher la page (format: 10a, 28b, 2a, etc.)\nconst pageMatch = message.match(/\\b(\\d{1,3}[ab])\\b/);\nif (pageMatch) {\n  intent.page = pageMatch[1];\n}\n\n// Chercher le commentateur\nfor (const [pattern, name] of Object.entries(commentatorPatterns)) {\n  if (message.includes(pattern)) {\n    intent.commentator = name;\n    break;\n  }\n}\n\n// Validation\nif (!intent.traite) {\n  error = 'Traite non reconnu. Traites disponibles: Sukkah, Berakhot, Pesachim, Shabbat, Eruvin, Bekhorot';\n} else if (!intent.page) {\n  error = 'Page non reconnue. Format attendu: 10a, 28b, 2a, etc.';\n}\n\nreturn [{ json: { intent, error, originalMessage: message } }];"
+      },
+      "id": "extract-intent",
+      "name": "Extract Intent (Regex)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "no-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-intent",
+      "name": "Intent Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=http://pi6.local:3031/api/talmud/text/{{ $json.intent.traite }}/{{ $json.intent.page }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "get-talmud-text",
+      "name": "API - Get Talmud Text",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater les commentaires pour Discord\nconst input = $input.first().json;\nconst intent = $('Extract Intent (Regex)').first().json.intent;\n\nlet commentaries = input.commentaries || [];\nconst sourceText = input.source_text || input;\n\n// Filtrer par commentateur si specifie\nif (intent.commentator && intent.commentator.toLowerCase() !== 'all') {\n  const targetCommentator = intent.commentator.toLowerCase();\n  commentaries = commentaries.filter(c => {\n    const name = (c.commentator || '').toLowerCase();\n    return name.includes(targetCommentator) || targetCommentator.includes(name);\n  });\n}\n\n// Limiter le nombre de commentaires\nconst maxComments = 5;\nconst displayedComments = commentaries.slice(0, maxComments);\n\n// Construire le titre\nlet title = `${intent.traite} ${intent.page}`;\nif (intent.commentator && intent.commentator.toLowerCase() !== 'all') {\n  title += ` - ${intent.commentator}`;\n}\n\n// Description\nlet description = '';\nif (displayedComments.length === 0) {\n  description = 'Aucun commentaire trouve pour cette recherche.';\n} else {\n  description = `${commentaries.length} commentaire(s) trouve(s)`;\n  if (commentaries.length > maxComments) {\n    description += ` (affichage des ${maxComments} premiers)`;\n  }\n}\n\n// Creer les fields pour les commentaires\nconst fields = displayedComments.map((c, i) => {\n  let text = c.text || c.hebrew_text || '';\n  // Limiter la taille du texte pour Discord\n  if (text.length > 300) {\n    text = text.substring(0, 300) + '...';\n  }\n  return {\n    name: `${c.commentator || 'Commentaire'} (seg. ${c.segment || i+1})`,\n    value: text || '(texte non disponible)',\n    inline: false\n  };\n});\n\n// Ajouter la reference\nif (sourceText && sourceText.reference) {\n  fields.unshift({\n    name: 'Reference',\n    value: sourceText.reference,\n    inline: true\n  });\n}\n\nconst embed = {\n  title: title,\n  description: description,\n  color: 10181046,\n  fields: fields.slice(0, 10),\n  footer: { text: 'Torah Commentary Bot' },\n  timestamp: new Date().toISOString()\n};\n\nreturn [{ json: { embed, stats: { total: commentaries.length, displayed: displayedComments.length } } }];"
+      },
+      "id": "format-response",
+      "name": "Format for Discord",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1130, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{{ JSON.stringify($json.embed) }}]\n}",
+        "options": {}
+      },
+      "id": "discord-send-result",
+      "name": "Discord - Send Result",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1350, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Erreur\",\n    \"description\": \"{{ $json.error || 'Erreur inconnue' }}\\n\\nEssayez un format comme:\\n- Sukkah 28b Rashi\\n- Berakhot 2a tous\\n- Pesachim 10a Tosafot\",\n    \"color\": 15548997,\n    \"footer\": {\"text\": \"Torah Commentary Bot\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-send-error",
+      "name": "Discord - Send Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, stats: $json.stats } }}",
+        "options": {}
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1570, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {}
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1130, 420]
+    }
+  ],
+  "connections": {
+    "Discord Message Webhook": {
+      "main": [
+        [
+          {
+            "node": "Extract Intent (Regex)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Intent (Regex)": {
+      "main": [
+        [
+          {
+            "node": "Intent Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Intent Valid?": {
+      "main": [
+        [
+          {
+            "node": "API - Get Talmud Text",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord - Send Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Get Talmud Text": {
+      "main": [
+        [
+          {
+            "node": "Format for Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format for Discord": {
+      "main": [
+        [
+          {
+            "node": "Discord - Send Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Send Result": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Send Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah/torah-discord-bot-commentary.json
+++ b/workflows/Torah/torah-discord-bot-commentary.json
@@ -36,12 +36,21 @@
           },
           "conditions": [
             {
-              "id": "no-error",
-              "leftValue": "={{ $json.error }}",
+              "id": "check-traite",
+              "leftValue": "={{ $json.intent.traite }}",
               "rightValue": "",
               "operator": {
                 "type": "string",
-                "operation": "isEmpty"
+                "operation": "exists"
+              }
+            },
+            {
+              "id": "check-page",
+              "leftValue": "={{ $json.intent.page }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
               }
             }
           ],
@@ -52,7 +61,7 @@
       "id": "check-intent",
       "name": "Intent Valid?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
+      "typeVersion": 2.2,
       "position": [690, 300]
     },
     {

--- a/workflows/Torah/torah-discord-bot-commentary.json
+++ b/workflows/Torah/torah-discord-bot-commentary.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "torah-discord-message",
+        "responseMode": "responseNode",
         "options": {}
       },
       "id": "webhook-discord",

--- a/workflows/Torah/torah-pdf-generation.json
+++ b/workflows/Torah/torah-pdf-generation.json
@@ -12,6 +12,7 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [250, 300],
+      "webhookId": "torah-generate-pdf",
       "notes": "Payload: {book: 'Sukkah', chapter_start: '2a', chapter_end: '10b', format: 'bilingual', include_commentaries: true}"
     },
     {

--- a/workflows/Torah/torah-pdf-generation.json
+++ b/workflows/Torah/torah-pdf-generation.json
@@ -1,0 +1,476 @@
+{
+  "name": "Torah PDF Generation",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-generate-pdf",
+        "options": {}
+      },
+      "id": "webhook-pdf",
+      "name": "Generate PDF Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "notes": "Payload: {book: 'Sukkah', chapter_start: '2a', chapter_end: '10b', format: 'bilingual', include_commentaries: true}"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider et preparer les parametres PDF\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Configuration par defaut\nconst defaultConfig = {\n  format: 'bilingual',\n  page_size: 'A4',\n  include_commentaries: true,\n  include_source: true,\n  include_translation: true,\n  font_size: 12,\n  rtl_support: true,\n  max_commentaries_per_page: 5,\n  output_format: 'pdf'\n};\n\nconst config = { ...defaultConfig, ...body.config };\n\n// Validation\nconst errors = [];\nif (!body.book && !body.translation_ids) {\n  errors.push('Specify either \"book\" (e.g., \"Sukkah\") or \"translation_ids\" array');\n}\n\nconst validFormats = ['bilingual', 'source_only', 'translation_only', 'academic', 'annotated'];\nif (!validFormats.includes(config.format)) {\n  errors.push(`Invalid format. Use: ${validFormats.join(', ')}`);\n}\n\nconst result = {\n  valid: errors.length === 0,\n  errors: errors,\n  params: {\n    book: body.book || null,\n    chapter_start: body.chapter_start || '2a',\n    chapter_end: body.chapter_end || null,\n    translation_ids: body.translation_ids || [],\n    config: config,\n    job_id: `pdf_${Date.now()}`\n  }\n};\n\nreturn [{ json: result }];"
+      },
+      "id": "validate-pdf-params",
+      "name": "Validate PDF Parameters",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "is-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-params-valid",
+      "name": "Parameters Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Generation PDF Demarree\",\n    \"description\": \"Preparation du document en cours...\",\n    \"color\": 3447003,\n    \"fields\": [\n      {\"name\": \"Job ID\", \"value\": \"`{{ $json.params.job_id }}`\", \"inline\": true},\n      {\"name\": \"Livre\", \"value\": \"{{ $json.params.book || 'Selection' }}\", \"inline\": true},\n      {\"name\": \"Format\", \"value\": \"{{ $json.params.config.format }}\", \"inline\": true},\n      {\"name\": \"Commentaires\", \"value\": \"{{ $json.params.config.include_commentaries ? 'Oui' : 'Non' }}\", \"inline\": true}\n    ],\n    \"footer\": {\"text\": \"Torah PDF Generator\"},\n    \"timestamp\": \"{{ new Date().toISOString() }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-pdf-start",
+      "name": "Discord - PDF Start",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=http://pi6.local:3031/api/translations?book={{ $('Validate PDF Parameters').first().json.params.book }}&status=approved&limit=100",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "fetch-translations",
+      "name": "API - Fetch Translations",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1130, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Preparer les donnees pour la generation PDF\nconst apiResponse = $input.first().json;\nconst params = $('Validate PDF Parameters').first().json.params;\n\n// Extraire les traductions\nlet translations = [];\nif (apiResponse.items) {\n  translations = apiResponse.items;\n} else if (apiResponse.translations) {\n  translations = apiResponse.translations;\n} else if (Array.isArray(apiResponse)) {\n  translations = apiResponse;\n}\n\n// Filtrer par plage de chapitres si specifie\nif (params.chapter_start || params.chapter_end) {\n  const parseRef = (ref) => {\n    const match = (ref || '').match(/(\\d+)([ab])/i);\n    if (!match) return { num: 0, side: 'a' };\n    return { num: parseInt(match[1]), side: match[2].toLowerCase() };\n  };\n  \n  const start = params.chapter_start ? parseRef(params.chapter_start) : { num: 0, side: 'a' };\n  const end = params.chapter_end ? parseRef(params.chapter_end) : { num: 999, side: 'b' };\n  \n  translations = translations.filter(t => {\n    const ref = parseRef(t.reference || t.ref || '');\n    const startVal = start.num * 2 + (start.side === 'b' ? 1 : 0);\n    const endVal = end.num * 2 + (end.side === 'b' ? 1 : 0);\n    const refVal = ref.num * 2 + (ref.side === 'b' ? 1 : 0);\n    return refVal >= startVal && refVal <= endVal;\n  });\n}\n\n// Trier par reference\ntranslations.sort((a, b) => {\n  const refA = (a.reference || '').match(/(\\d+)([ab])/i) || [0, 0, 'a'];\n  const refB = (b.reference || '').match(/(\\d+)([ab])/i) || [0, 0, 'a'];\n  const numA = parseInt(refA[1]) * 2 + (refA[2] === 'b' ? 1 : 0);\n  const numB = parseInt(refB[1]) * 2 + (refB[2] === 'b' ? 1 : 0);\n  return numA - numB;\n});\n\nif (translations.length === 0) {\n  return [{ json: { error: 'Aucune traduction approuvee trouvee', translations_count: 0 } }];\n}\n\nreturn [{\n  json: {\n    translations_count: translations.length,\n    translation_ids: translations.map(t => t.uuid || t.id),\n    references: translations.map(t => t.reference),\n    job_id: params.job_id,\n    config: params.config,\n    book: params.book\n  }\n}];"
+      },
+      "id": "prepare-pdf-data",
+      "name": "Prepare PDF Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1350, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-translations",
+              "leftValue": "={{ $json.translations_count }}",
+              "rightValue": 0,
+              "operator": {
+                "type": "number",
+                "operation": "gt"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "has-data",
+      "name": "Has Translations?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1570, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://pi6.local:3031/api/pdf/generate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"translation_ids\": {{ JSON.stringify($json.translation_ids) }},\n  \"format\": \"{{ $json.config.format }}\",\n  \"options\": {\n    \"page_size\": \"{{ $json.config.page_size }}\",\n    \"include_source\": {{ $json.config.include_source }},\n    \"include_translation\": {{ $json.config.include_translation }},\n    \"include_commentaries\": {{ $json.config.include_commentaries }},\n    \"font_size\": {{ $json.config.font_size }},\n    \"rtl_support\": {{ $json.config.rtl_support }},\n    \"max_commentaries_per_page\": {{ $json.config.max_commentaries_per_page }}\n  },\n  \"metadata\": {\n    \"title\": \"{{ $json.book || 'Torah' }} - Traduction Bilingue\",\n    \"author\": \"Torah Translation Project\",\n    \"job_id\": \"{{ $json.job_id }}\"\n  }\n}",
+        "options": {
+          "timeout": 600000
+        }
+      },
+      "id": "generate-pdf-api",
+      "name": "API - Generate PDF",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1790, 120],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "jsCode": "// Traiter le resultat de generation PDF\nconst input = $input.first().json;\nconst pdfData = $('Prepare PDF Data').first().json;\n\nconst result = {\n  success: !input.error && !input.detail && (input.pdf_url || input.file_path),\n  job_id: pdfData.job_id,\n  pdf_url: input.pdf_url || null,\n  file_path: input.file_path || null,\n  file_size: input.file_size || null,\n  pages: input.pages || null,\n  translations_included: pdfData.translations_count,\n  error: input.error || input.detail || null,\n  generated_at: new Date().toISOString()\n};\n\n// Construire l'URL de telechargement\nif (result.file_path && !result.pdf_url) {\n  result.pdf_url = `http://pi6.local:3031/api/pdf/download/${pdfData.job_id}`;\n}\n\nreturn [{ json: result }];"
+      },
+      "id": "process-pdf-result",
+      "name": "Process PDF Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2010, 120]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "pdf-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "pdf-success",
+      "name": "PDF Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [2230, 120]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"PDF Genere avec Succes\",\n    \"description\": \"Votre document est pret au telechargement.\",\n    \"color\": 5763719,\n    \"fields\": [\n      {\"name\": \"Job ID\", \"value\": \"`{{ $json.job_id }}`\", \"inline\": true},\n      {\"name\": \"Pages\", \"value\": \"{{ $json.pages || 'N/A' }}\", \"inline\": true},\n      {\"name\": \"Traductions\", \"value\": \"{{ $json.translations_included }}\", \"inline\": true},\n      {\"name\": \"Telechargement\", \"value\": \"[Telecharger le PDF]({{ $json.pdf_url }})\", \"inline\": false}\n    ],\n    \"footer\": {\"text\": \"Torah PDF Generator\"},\n    \"timestamp\": \"{{ $json.generated_at }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-pdf-success",
+      "name": "Discord - PDF Success",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2450, 40]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, job_id: $json.job_id, pdf_url: $json.pdf_url, pages: $json.pages, translations: $json.translations_included } }}",
+        "options": {}
+      },
+      "id": "respond-pdf-success",
+      "name": "Respond - PDF Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2670, 40]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Erreur Generation PDF\",\n    \"description\": \"{{ $json.error || 'Erreur inconnue lors de la generation' }}\",\n    \"color\": 15548997,\n    \"fields\": [\n      {\"name\": \"Job ID\", \"value\": \"`{{ $json.job_id }}`\", \"inline\": true}\n    ],\n    \"footer\": {\"text\": \"Torah PDF Generator\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-pdf-error",
+      "name": "Discord - PDF Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2450, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, job_id: $json.job_id, error: $json.error } }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "respond-pdf-error",
+      "name": "Respond - PDF Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2670, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Aucune Traduction Disponible\",\n    \"description\": \"Aucune traduction approuvee n'a ete trouvee pour les criteres specifies.\",\n    \"color\": 15105570,\n    \"footer\": {\"text\": \"Torah PDF Generator\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-no-data",
+      "name": "Discord - No Data",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1790, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: 'No approved translations found' } }}",
+        "options": {
+          "responseCode": 404
+        }
+      },
+      "id": "respond-no-data",
+      "name": "Respond - No Data",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2010, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Erreur de Validation PDF\",\n    \"description\": \"{{ $json.errors.join(', ') }}\",\n    \"color\": 15548997,\n    \"footer\": {\"text\": \"Torah PDF Generator\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-validation-error",
+      "name": "Discord - Validation Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, errors: $json.errors } }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond - Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1130, 420]
+    }
+  ],
+  "connections": {
+    "Generate PDF Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate PDF Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate PDF Parameters": {
+      "main": [
+        [
+          {
+            "node": "Parameters Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parameters Valid?": {
+      "main": [
+        [
+          {
+            "node": "Discord - PDF Start",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord - Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - PDF Start": {
+      "main": [
+        [
+          {
+            "node": "API - Fetch Translations",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Fetch Translations": {
+      "main": [
+        [
+          {
+            "node": "Prepare PDF Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare PDF Data": {
+      "main": [
+        [
+          {
+            "node": "Has Translations?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Translations?": {
+      "main": [
+        [
+          {
+            "node": "API - Generate PDF",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord - No Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Generate PDF": {
+      "main": [
+        [
+          {
+            "node": "Process PDF Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process PDF Result": {
+      "main": [
+        [
+          {
+            "node": "PDF Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "PDF Success?": {
+      "main": [
+        [
+          {
+            "node": "Discord - PDF Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord - PDF Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - PDF Success": {
+      "main": [
+        [
+          {
+            "node": "Respond - PDF Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - PDF Error": {
+      "main": [
+        [
+          {
+            "node": "Respond - PDF Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - No Data": {
+      "main": [
+        [
+          {
+            "node": "Respond - No Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond - Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah/torah-pdf-generation.json
+++ b/workflows/Torah/torah-pdf-generation.json
@@ -12,7 +12,10 @@
       "name": "Generate PDF Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [250, 300],
+      "position": [
+        250,
+        300
+      ],
       "webhookId": "torah-generate-pdf",
       "notes": "Payload: {book: 'Sukkah', chapter_start: '2a', chapter_end: '10b', format: 'bilingual', include_commentaries: true}"
     },
@@ -24,7 +27,10 @@
       "name": "Validate PDF Parameters",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [470, 300]
+      "position": [
+        470,
+        300
+      ]
     },
     {
       "parameters": {
@@ -52,8 +58,11 @@
       "id": "check-params-valid",
       "name": "Parameters Valid?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [690, 300]
+      "typeVersion": 2.2,
+      "position": [
+        690,
+        300
+      ]
     },
     {
       "parameters": {
@@ -68,7 +77,10 @@
       "name": "Discord - PDF Start",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [910, 200]
+      "position": [
+        910,
+        200
+      ]
     },
     {
       "parameters": {
@@ -82,7 +94,10 @@
       "name": "API - Fetch Translations",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1130, 200]
+      "position": [
+        1130,
+        200
+      ]
     },
     {
       "parameters": {
@@ -92,7 +107,10 @@
       "name": "Prepare PDF Data",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1350, 200]
+      "position": [
+        1350,
+        200
+      ]
     },
     {
       "parameters": {
@@ -120,8 +138,11 @@
       "id": "has-data",
       "name": "Has Translations?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [1570, 200]
+      "typeVersion": 2.2,
+      "position": [
+        1570,
+        200
+      ]
     },
     {
       "parameters": {
@@ -138,7 +159,10 @@
       "name": "API - Generate PDF",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1790, 120],
+      "position": [
+        1790,
+        120
+      ],
       "continueOnFail": true
     },
     {
@@ -149,7 +173,10 @@
       "name": "Process PDF Result",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2010, 120]
+      "position": [
+        2010,
+        120
+      ]
     },
     {
       "parameters": {
@@ -177,8 +204,11 @@
       "id": "pdf-success",
       "name": "PDF Success?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [2230, 120]
+      "typeVersion": 2.2,
+      "position": [
+        2230,
+        120
+      ]
     },
     {
       "parameters": {
@@ -193,7 +223,10 @@
       "name": "Discord - PDF Success",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2450, 40]
+      "position": [
+        2450,
+        40
+      ]
     },
     {
       "parameters": {
@@ -205,7 +238,10 @@
       "name": "Respond - PDF Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [2670, 40]
+      "position": [
+        2670,
+        40
+      ]
     },
     {
       "parameters": {
@@ -220,7 +256,10 @@
       "name": "Discord - PDF Error",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2450, 200]
+      "position": [
+        2450,
+        200
+      ]
     },
     {
       "parameters": {
@@ -234,7 +273,10 @@
       "name": "Respond - PDF Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [2670, 200]
+      "position": [
+        2670,
+        200
+      ]
     },
     {
       "parameters": {
@@ -249,7 +291,10 @@
       "name": "Discord - No Data",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1790, 300]
+      "position": [
+        1790,
+        300
+      ]
     },
     {
       "parameters": {
@@ -263,7 +308,10 @@
       "name": "Respond - No Data",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [2010, 300]
+      "position": [
+        2010,
+        300
+      ]
     },
     {
       "parameters": {
@@ -278,7 +326,10 @@
       "name": "Discord - Validation Error",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [910, 420]
+      "position": [
+        910,
+        420
+      ]
     },
     {
       "parameters": {
@@ -292,7 +343,10 @@
       "name": "Respond - Validation Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1130, 420]
+      "position": [
+        1130,
+        420
+      ]
     }
   ],
   "connections": {

--- a/workflows/Torah/torah-pdf-generation.json
+++ b/workflows/Torah/torah-pdf-generation.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "torah-generate-pdf",
+        "responseMode": "responseNode",
         "options": {}
       },
       "id": "webhook-pdf",

--- a/workflows/Torah/torah-registry.json
+++ b/workflows/Torah/torah-registry.json
@@ -1,0 +1,107 @@
+{
+  "name": "Torah - Registry",
+  "nodes": [
+    {
+      "parameters": {
+        "path": "torah-registry",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-registry",
+      "name": "Webhook Registry",
+      "type": "n8n-nodes-base.webhook",
+      "position": [304, 304],
+      "webhookId": "torah-registry",
+      "typeVersion": 2
+    },
+    {
+      "parameters": {
+        "url": "http://pi6.local:5678/api/v1/workflows?active=true&limit=250",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "http-get-workflows",
+      "name": "Get Active Workflows",
+      "type": "n8n-nodes-base.httpRequest",
+      "position": [512, 304],
+      "typeVersion": 4.2,
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "aHxvULwe4es6Gnmh",
+          "name": "Header Auth account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================================================\n// TORAH REGISTRY - Build Registry with Metadata\n// ============================================================================\n\n// Torah Workflow Metadata\nconst torahMetadata = {\n  \"torah-discord-message\": {\n    \"label\": \"Discord Commentary Bot\",\n    \"icon\": \"💬\",\n    \"description\": \"Recherche de commentaires talmudiques via Discord\",\n    \"tags\": [\"discord\", \"talmud\", \"commentaires\"],\n    \"scope\": \"user\",\n    \"example\": \"Sukkah 28b Rashi\"\n  },\n  \"torah-translate\": {\n    \"label\": \"Translation Orchestrator\",\n    \"icon\": \"🎯\",\n    \"description\": \"Orchestration du pipeline de traduction Torah\",\n    \"tags\": [\"traduction\", \"orchestration\"],\n    \"scope\": \"system\"\n  },\n  \"torah-batch-translate\": {\n    \"label\": \"Batch Translation\",\n    \"icon\": \"📚\",\n    \"description\": \"Traduction en lot avec extraction de commentaires\",\n    \"tags\": [\"traduction\", \"batch\", \"commentaires\"],\n    \"scope\": \"user\"\n  },\n  \"torah-submit-review\": {\n    \"label\": \"Review Submission\",\n    \"icon\": \"✅\",\n    \"description\": \"Soumission de traductions pour révision\",\n    \"tags\": [\"revision\", \"validation\"],\n    \"scope\": \"user\"\n  },\n  \"torah-review-action\": {\n    \"label\": \"Review Action\",\n    \"icon\": \"📝\",\n    \"description\": \"Actions de validation (approuver/rejeter/modifier)\",\n    \"tags\": [\"revision\", \"validation\"],\n    \"scope\": \"user\"\n  },\n  \"torah-generate-pdf\": {\n    \"label\": \"PDF Generator\",\n    \"icon\": \"📄\",\n    \"description\": \"Génération de PDF avec traductions et commentaires\",\n    \"tags\": [\"pdf\", \"export\", \"document\"],\n    \"scope\": \"user\"\n  }\n};\n\n// ============================================================================\n// BUILD REGISTRY\n// ============================================================================\n\nconst workflows = $input.first().json.data || [];\n\n// Filter active Torah workflows (excluding this registry)\nconst torahWorkflows = workflows.filter(w => \n  w.active && \n  w.name.startsWith('Torah') && \n  w.name !== 'Torah - Registry'\n);\n\n// Build tools object\nconst tools = {};\n\nfor (const workflow of torahWorkflows) {\n  // Find all webhook nodes in the workflow\n  const webhookNodes = workflow.nodes?.filter(n => n.type === 'n8n-nodes-base.webhook') || [];\n  \n  for (const webhookNode of webhookNodes) {\n    const webhookPath = webhookNode.parameters?.path || webhookNode.webhookId;\n    const toolName = webhookPath;\n    \n    // Get metadata\n    const meta = torahMetadata[toolName] || {};\n    \n    tools[toolName] = {\n      name: workflow.name,\n      label: meta.label || workflow.name.replace('Torah ', ''),\n      icon: meta.icon || '📜',\n      description: meta.description || `Torah Tool: ${workflow.name}`,\n      tags: meta.tags || ['torah'],\n      scope: meta.scope || 'user',\n      workflow_id: workflow.id,\n      endpoint: `/webhook/${webhookPath}`,\n      webhook_url: `http://pi6.local:5678/webhook/${webhookPath}`,\n      method: webhookNode.parameters?.httpMethod || 'POST',\n      active: workflow.active,\n      example: meta.example || null\n    };\n  }\n}\n\n// Build final registry response\nconst registry = {\n  version: \"1.0\",\n  updated_at: new Date().toISOString(),\n  n8n: {\n    host: \"pi6.local\",\n    port: 5678,\n    protocol: \"http\",\n    webhook_base: \"http://pi6.local:5678/webhook\"\n  },\n  scopes: {\n    user: \"Endpoint accessible par l'utilisateur\",\n    system: \"Endpoint interne pour orchestration\"\n  },\n  total_tools: Object.keys(tools).length,\n  tools: tools\n};\n\nreturn { json: registry };"
+      },
+      "id": "code-registry",
+      "name": "Build Registry",
+      "type": "n8n-nodes-base.code",
+      "position": [704, 304],
+      "typeVersion": 2
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-registry",
+      "name": "Respond Registry",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "position": [912, 304],
+      "typeVersion": 1.1
+    }
+  ],
+  "connections": {
+    "Webhook Registry": {
+      "main": [
+        [
+          {
+            "node": "Get Active Workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Active Workflows": {
+      "main": [
+        [
+          {
+            "node": "Build Registry",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Registry": {
+      "main": [
+        [
+          {
+            "node": "Respond Registry",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah/torah-review-validation.json
+++ b/workflows/Torah/torah-review-validation.json
@@ -12,6 +12,7 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [250, 200],
+      "webhookId": "torah-submit-review",
       "notes": "Soumet une traduction pour revision. Payload: {translation_id, source_text, translation, commentaries: [{...}]}"
     },
     {
@@ -25,6 +26,7 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [250, 500],
+      "webhookId": "torah-review-action",
       "notes": "Action de revision. Payload: {translation_id, action: 'approve'|'reject'|'retranslate', feedback?: string, reviewer?: string}"
     },
     {

--- a/workflows/Torah/torah-review-validation.json
+++ b/workflows/Torah/torah-review-validation.json
@@ -12,7 +12,10 @@
       "name": "Submit for Review",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [250, 200],
+      "position": [
+        250,
+        200
+      ],
       "webhookId": "torah-submit-review",
       "notes": "Soumet une traduction pour revision. Payload: {translation_id, source_text, translation, commentaries: [{...}]}"
     },
@@ -27,7 +30,10 @@
       "name": "Review Action",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [250, 500],
+      "position": [
+        250,
+        500
+      ],
       "webhookId": "torah-review-action",
       "notes": "Action de revision. Payload: {translation_id, action: 'approve'|'reject'|'retranslate', feedback?: string, reviewer?: string}"
     },
@@ -39,7 +45,10 @@
       "name": "Prepare Review Data",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [470, 200]
+      "position": [
+        470,
+        200
+      ]
     },
     {
       "parameters": {
@@ -54,7 +63,10 @@
       "name": "Discord - Review Embed",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [690, 200]
+      "position": [
+        690,
+        200
+      ]
     },
     {
       "parameters": {
@@ -69,7 +81,10 @@
       "name": "Discord - Actions Help",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [910, 200]
+      "position": [
+        910,
+        200
+      ]
     },
     {
       "parameters": {
@@ -81,7 +96,10 @@
       "name": "Respond - Submitted",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1130, 200]
+      "position": [
+        1130,
+        200
+      ]
     },
     {
       "parameters": {
@@ -91,7 +109,10 @@
       "name": "Process Review Action",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [470, 500]
+      "position": [
+        470,
+        500
+      ]
     },
     {
       "parameters": {
@@ -119,8 +140,11 @@
       "id": "check-action-valid",
       "name": "Action Valid?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [690, 500]
+      "typeVersion": 2.2,
+      "position": [
+        690,
+        500
+      ]
     },
     {
       "parameters": {
@@ -137,7 +161,10 @@
       "name": "API - Update Status",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [910, 400],
+      "position": [
+        910,
+        400
+      ],
       "continueOnFail": true
     },
     {
@@ -153,7 +180,10 @@
       "name": "Discord - Action Result",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1130, 400]
+      "position": [
+        1130,
+        400
+      ]
     },
     {
       "parameters": {
@@ -181,8 +211,11 @@
       "id": "check-retranslate",
       "name": "Needs Retranslation?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [1350, 400]
+      "typeVersion": 2.2,
+      "position": [
+        1350,
+        400
+      ]
     },
     {
       "parameters": {
@@ -199,7 +232,10 @@
       "name": "Trigger Retranslation",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1570, 320],
+      "position": [
+        1570,
+        320
+      ],
       "continueOnFail": true
     },
     {
@@ -212,7 +248,10 @@
       "name": "Respond - Action Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1790, 400]
+      "position": [
+        1790,
+        400
+      ]
     },
     {
       "parameters": {
@@ -226,7 +265,10 @@
       "name": "Respond - Action Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [910, 620]
+      "position": [
+        910,
+        620
+      ]
     }
   ],
   "connections": {

--- a/workflows/Torah/torah-review-validation.json
+++ b/workflows/Torah/torah-review-validation.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "torah-submit-review",
+        "responseMode": "responseNode",
         "options": {}
       },
       "id": "webhook-submit",
@@ -19,6 +20,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "torah-review-action",
+        "responseMode": "responseNode",
         "options": {}
       },
       "id": "webhook-action",

--- a/workflows/Torah/torah-review-validation.json
+++ b/workflows/Torah/torah-review-validation.json
@@ -1,0 +1,368 @@
+{
+  "name": "Torah Review and Validation",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-submit-review",
+        "options": {}
+      },
+      "id": "webhook-submit",
+      "name": "Submit for Review",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 200],
+      "notes": "Soumet une traduction pour revision. Payload: {translation_id, source_text, translation, commentaries: [{...}]}"
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-review-action",
+        "options": {}
+      },
+      "id": "webhook-action",
+      "name": "Review Action",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 500],
+      "notes": "Action de revision. Payload: {translation_id, action: 'approve'|'reject'|'retranslate', feedback?: string, reviewer?: string}"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Preparer la traduction pour revision Discord\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst translation_id = body.translation_id || `tr_${Date.now()}`;\nconst reference = body.reference || 'Unknown Reference';\n\n// Construire le texte source (tronque si trop long)\nlet sourceText = body.source_text || body.hebrew_text || '';\nif (sourceText.length > 500) {\n  sourceText = sourceText.substring(0, 500) + '...';\n}\n\n// Construire la traduction (tronque si trop long)\nlet translationText = body.translation || body.translated_text || '';\nif (translationText.length > 800) {\n  translationText = translationText.substring(0, 800) + '...';\n}\n\n// Commentaires traduits\nconst commentaries = body.commentaries || [];\nconst commentaryFields = commentaries.slice(0, 3).map((c, i) => ({\n  name: c.commentator || `Commentaire ${i + 1}`,\n  value: (c.translation || c.text || '').substring(0, 200) + (c.translation?.length > 200 ? '...' : ''),\n  inline: false\n}));\n\n// URLs de callback pour les actions\nconst baseUrl = 'http://pi6.local:5678/webhook/torah-review-action';\nconst approveUrl = `${baseUrl}?translation_id=${translation_id}&action=approve`;\nconst rejectUrl = `${baseUrl}?translation_id=${translation_id}&action=reject`;\nconst retranslateUrl = `${baseUrl}?translation_id=${translation_id}&action=retranslate`;\n\nreturn [{\n  json: {\n    translation_id,\n    reference,\n    sourceText,\n    translationText,\n    commentaryFields,\n    commentariesCount: commentaries.length,\n    approveUrl,\n    rejectUrl,\n    retranslateUrl,\n    submittedAt: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "prepare-review",
+      "name": "Prepare Review Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [470, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Revision Requise: {{ $json.reference }}\",\n    \"description\": \"Une nouvelle traduction necessite votre revision.\",\n    \"color\": 15844367,\n    \"fields\": [\n      {\"name\": \"ID\", \"value\": \"`{{ $json.translation_id }}`\", \"inline\": true},\n      {\"name\": \"Commentaires\", \"value\": \"{{ $json.commentariesCount }}\", \"inline\": true},\n      {\"name\": \"Texte Source (Hebreu)\", \"value\": \"{{ $json.sourceText || '(non disponible)' }}\", \"inline\": false},\n      {\"name\": \"Traduction\", \"value\": \"{{ $json.translationText || '(non disponible)' }}\", \"inline\": false}\n    ],\n    \"footer\": {\"text\": \"Torah Review System\"},\n    \"timestamp\": \"{{ $json.submittedAt }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-review-embed",
+      "name": "Discord - Review Embed",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"content\": \"**Actions disponibles pour `{{ $json.translation_id }}`:**\\n\\nPour valider, utilisez curl ou un client HTTP:\\n```bash\\ncurl -X POST 'http://pi6.local:5678/webhook/torah-review-action' \\\\\\n  -H 'Content-Type: application/json' \\\\\\n  -d '{\\\"translation_id\\\": \\\"{{ $json.translation_id }}\\\", \\\"action\\\": \\\"approve\\\", \\\"reviewer\\\": \\\"VotreNom\\\"}'\\n```\\n\\nActions: `approve` | `reject` | `retranslate`\"\n}",
+        "options": {}
+      },
+      "id": "discord-actions-help",
+      "name": "Discord - Actions Help",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, translation_id: $json.translation_id, message: 'Submitted for review' } }}",
+        "options": {}
+      },
+      "id": "respond-submitted",
+      "name": "Respond - Submitted",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1130, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Traiter l'action de revision\nconst input = $input.first().json;\nconst body = input.body || input;\nconst query = input.query || {};\n\n// Supporter les parametres en body ou query string\nconst translation_id = body.translation_id || query.translation_id;\nconst action = body.action || query.action;\nconst feedback = body.feedback || query.feedback || '';\nconst reviewer = body.reviewer || query.reviewer || 'Anonymous';\n\n// Validation\nconst validActions = ['approve', 'reject', 'retranslate'];\nif (!translation_id) {\n  return [{ json: { error: 'translation_id required', valid: false } }];\n}\nif (!validActions.includes(action)) {\n  return [{ json: { error: `Invalid action. Use: ${validActions.join(', ')}`, valid: false } }];\n}\n\n// Mapping des statuts\nconst statusMap = {\n  'approve': { status: 'approved', color: 5763719, emoji: '' },\n  'reject': { status: 'rejected', color: 15548997, emoji: '' },\n  'retranslate': { status: 'pending_retranslation', color: 15105570, emoji: '' }\n};\n\nconst result = statusMap[action];\n\nreturn [{\n  json: {\n    valid: true,\n    translation_id,\n    action,\n    status: result.status,\n    color: result.color,\n    emoji: result.emoji,\n    feedback,\n    reviewer,\n    processedAt: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "process-action",
+      "name": "Process Review Action",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [470, 500]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "is-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-action-valid",
+      "name": "Action Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 500]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "=http://pi6.local:3031/api/translations/{{ $json.translation_id }}/status",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"status\": \"{{ $json.status }}\",\n  \"reviewer\": \"{{ $json.reviewer }}\",\n  \"feedback\": \"{{ $json.feedback }}\",\n  \"reviewed_at\": \"{{ $json.processedAt }}\"\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "update-status-api",
+      "name": "API - Update Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 400],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"{{ $('Process Review Action').first().json.emoji }} Revision: {{ $('Process Review Action').first().json.action | capitalize }}\",\n    \"description\": \"Traduction `{{ $('Process Review Action').first().json.translation_id }}` {{ $('Process Review Action').first().json.action === 'approve' ? 'approuvee' : ($('Process Review Action').first().json.action === 'reject' ? 'rejetee' : 'a re-traduire') }}\",\n    \"color\": {{ $('Process Review Action').first().json.color }},\n    \"fields\": [\n      {\"name\": \"Reviseur\", \"value\": \"{{ $('Process Review Action').first().json.reviewer }}\", \"inline\": true},\n      {\"name\": \"Statut\", \"value\": \"{{ $('Process Review Action').first().json.status }}\", \"inline\": true},\n      {\"name\": \"Feedback\", \"value\": \"{{ $('Process Review Action').first().json.feedback || '(aucun)' }}\", \"inline\": false}\n    ],\n    \"footer\": {\"text\": \"Torah Review System\"},\n    \"timestamp\": \"{{ $('Process Review Action').first().json.processedAt }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-action-result",
+      "name": "Discord - Action Result",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1130, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "needs-retranslate",
+              "leftValue": "={{ $('Process Review Action').first().json.action }}",
+              "rightValue": "retranslate",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-retranslate",
+      "name": "Needs Retranslation?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1350, 400]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://pi6.local:5678/webhook/torah-translate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"source_text_ids\": [\"{{ $('Process Review Action').first().json.translation_id }}\"],\n  \"config\": {\n    \"target_language\": \"fr\",\n    \"translator\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\" },\n    \"reviewer\": { \"provider\": \"openai\", \"model\": \"gpt-4o\" }\n  },\n  \"retry_reason\": \"{{ $('Process Review Action').first().json.feedback || 'Retranslation requested' }}\"\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "trigger-retranslation",
+      "name": "Trigger Retranslation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1570, 320],
+      "continueOnFail": true
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, translation_id: $('Process Review Action').first().json.translation_id, action: $('Process Review Action').first().json.action, status: $('Process Review Action').first().json.status } }}",
+        "options": {}
+      },
+      "id": "respond-action-success",
+      "name": "Respond - Action Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1790, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-action-error",
+      "name": "Respond - Action Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 620]
+    }
+  ],
+  "connections": {
+    "Submit for Review": {
+      "main": [
+        [
+          {
+            "node": "Prepare Review Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Review Data": {
+      "main": [
+        [
+          {
+            "node": "Discord - Review Embed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Review Embed": {
+      "main": [
+        [
+          {
+            "node": "Discord - Actions Help",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Actions Help": {
+      "main": [
+        [
+          {
+            "node": "Respond - Submitted",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Review Action": {
+      "main": [
+        [
+          {
+            "node": "Process Review Action",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Review Action": {
+      "main": [
+        [
+          {
+            "node": "Action Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Action Valid?": {
+      "main": [
+        [
+          {
+            "node": "API - Update Status",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond - Action Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Update Status": {
+      "main": [
+        [
+          {
+            "node": "Discord - Action Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Action Result": {
+      "main": [
+        [
+          {
+            "node": "Needs Retranslation?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Needs Retranslation?": {
+      "main": [
+        [
+          {
+            "node": "Trigger Retranslation",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond - Action Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Trigger Retranslation": {
+      "main": [
+        [
+          {
+            "node": "Respond - Action Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah/torah-translation-orchestrator.json
+++ b/workflows/Torah/torah-translation-orchestrator.json
@@ -12,7 +12,10 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [250, 300],
+      "position": [
+        250,
+        300
+      ],
       "webhookId": "torah-translate"
     },
     {
@@ -41,8 +44,11 @@
       "id": "validate-params",
       "name": "Validate Parameters",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [470, 300]
+      "typeVersion": 2.2,
+      "position": [
+        470,
+        300
+      ]
     },
     {
       "parameters": {
@@ -57,7 +63,10 @@
       "name": "Discord - Start",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [690, 200]
+      "position": [
+        690,
+        200
+      ]
     },
     {
       "parameters": {
@@ -72,7 +81,10 @@
       "name": "Discord - Validation Error",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [690, 420]
+      "position": [
+        690,
+        420
+      ]
     },
     {
       "parameters": {
@@ -82,7 +94,10 @@
       "name": "Prepare Batch Items",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [910, 200]
+      "position": [
+        910,
+        200
+      ]
     },
     {
       "parameters": {
@@ -93,7 +108,10 @@
       "name": "Process One by One",
       "type": "n8n-nodes-base.splitInBatches",
       "typeVersion": 3,
-      "position": [1130, 200]
+      "position": [
+        1130,
+        200
+      ]
     },
     {
       "parameters": {
@@ -110,7 +128,10 @@
       "name": "API - Translate with Comments",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1350, 200]
+      "position": [
+        1350,
+        200
+      ]
     },
     {
       "parameters": {
@@ -125,7 +146,10 @@
       "name": "Discord - Progress",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1570, 200]
+      "position": [
+        1570,
+        200
+      ]
     },
     {
       "parameters": {
@@ -136,7 +160,10 @@
       "name": "Aggregate Results",
       "type": "n8n-nodes-base.aggregate",
       "typeVersion": 1,
-      "position": [1790, 200]
+      "position": [
+        1790,
+        200
+      ]
     },
     {
       "parameters": {
@@ -146,7 +173,10 @@
       "name": "Calculate Statistics",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2010, 200]
+      "position": [
+        2010,
+        200
+      ]
     },
     {
       "parameters": {
@@ -161,7 +191,10 @@
       "name": "Discord - Complete",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2230, 200]
+      "position": [
+        2230,
+        200
+      ]
     },
     {
       "parameters": {
@@ -173,7 +206,10 @@
       "name": "Respond to Webhook",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [2450, 200]
+      "position": [
+        2450,
+        200
+      ]
     },
     {
       "parameters": {
@@ -187,7 +223,10 @@
       "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [910, 420]
+      "position": [
+        910,
+        420
+      ]
     }
   ],
   "connections": {

--- a/workflows/Torah/torah-translation-orchestrator.json
+++ b/workflows/Torah/torah-translation-orchestrator.json
@@ -1,0 +1,331 @@
+{
+  "name": "Torah Translation Orchestrator",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-translate",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "condition-source-texts",
+              "leftValue": "={{ $json.source_text_ids }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "validate-params",
+      "name": "Validate Parameters",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Traduction demarree\",\n    \"description\": \"Pipeline de traduction lance pour {{ $json.book || 'Textes selectionnes' }}\",\n    \"color\": 3447003,\n    \"fields\": [\n      {\"name\": \"Textes\", \"value\": \"{{ $json.source_text_ids.length }}\", \"inline\": true},\n      {\"name\": \"Langue cible\", \"value\": \"{{ $json.config.target_language || 'fr' }}\", \"inline\": true},\n      {\"name\": \"Provider\", \"value\": \"{{ $json.config.translator.provider || 'claude' }}\", \"inline\": true}\n    ],\n    \"footer\": {\"text\": \"Torah Translator Bot\"},\n    \"timestamp\": \"{{ new Date().toISOString() }}\"\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-start",
+      "name": "Discord - Start",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Erreur de validation\",\n    \"description\": \"Les parametres de la requete sont invalides.\",\n    \"color\": 15548997,\n    \"footer\": {\"text\": \"Torah Translator Bot\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-error-validation",
+      "name": "Discord - Validation Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 420]
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\n\nconst config = input.config || {\n  target_language: 'fr',\n  translator: { provider: 'anthropic', model: 'claude-3-5-sonnet-20241022' },\n  reviewer: { provider: 'openai', model: 'gpt-4o' }\n};\n\nconst items = input.source_text_ids.map((id, index) => ({\n  json: {\n    source_text_id: id,\n    index: index + 1,\n    total: input.source_text_ids.length,\n    config: config,\n    book: input.book || 'Unknown'\n  }\n}));\n\nreturn items;"
+      },
+      "id": "prepare-batch",
+      "name": "Prepare Batch Items",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [910, 200]
+    },
+    {
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      },
+      "id": "split-batches",
+      "name": "Process One by One",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [1130, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://pi6.local:3031/api/translate-with-comments",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"reference\": {\n    \"table\": \"source_texts\",\n    \"uuid\": \"{{ $json.source_text_id }}\"\n  },\n  \"target_language\": \"{{ $json.config.target_language }}\",\n  \"translator\": {{ JSON.stringify($json.config.translator) }},\n  \"reviewer\": {{ JSON.stringify($json.config.reviewer) }},\n  \"apply_grammalecte\": true\n}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "translate-api",
+      "name": "API - Translate with Comments",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1350, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"content\": \"Page {{ $('Process One by One').item.json.index }}/{{ $('Process One by One').item.json.total }} traduite - {{ $json.comments_count || 0 }} commentaires\"\n}",
+        "options": {}
+      },
+      "id": "discord-progress",
+      "name": "Discord - Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1570, 200]
+    },
+    {
+      "parameters": {
+        "aggregate": "aggregateAllItemData",
+        "options": {}
+      },
+      "id": "aggregate-results",
+      "name": "Aggregate Results",
+      "type": "n8n-nodes-base.aggregate",
+      "typeVersion": 1,
+      "position": [1790, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "const results = $input.first().json.data || [];\n\nconst stats = {\n  total_texts: results.length,\n  successful: results.filter(r => r.success).length,\n  failed: results.filter(r => !r.success).length,\n  total_comments: results.reduce((sum, r) => sum + (r.comments_count || 0), 0)\n};\n\nreturn [{ json: { stats, results } }];"
+      },
+      "id": "calculate-stats",
+      "name": "Calculate Statistics",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2010, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://discord.com/api/webhooks/1454872701331177606/0qZXNfqF45UU9epTnYbXJMd3nCWtUwfMU1p_E6sTQbnP7Ik-jzxW1Duq2jjHuMHPDC6o",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Traduction terminee\",\n    \"description\": \"Pipeline complete avec succes\",\n    \"color\": 5763719,\n    \"fields\": [\n      {\"name\": \"Textes\", \"value\": \"{{ $json.stats.successful }}/{{ $json.stats.total_texts }}\", \"inline\": true},\n      {\"name\": \"Commentaires\", \"value\": \"{{ $json.stats.total_comments }}\", \"inline\": true}\n    ],\n    \"footer\": {\"text\": \"Torah Translator Bot\"}\n  }]\n}",
+        "options": {}
+      },
+      "id": "discord-complete",
+      "name": "Discord - Complete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2230, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, stats: $json.stats } }}",
+        "options": {}
+      },
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2450, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: 'Invalid parameters' } }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 420]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Parameters": {
+      "main": [
+        [
+          {
+            "node": "Discord - Start",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord - Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Start": {
+      "main": [
+        [
+          {
+            "node": "Prepare Batch Items",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Batch Items": {
+      "main": [
+        [
+          {
+            "node": "Process One by One",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process One by One": {
+      "main": [
+        [
+          {
+            "node": "API - Translate with Comments",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Aggregate Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API - Translate with Comments": {
+      "main": [
+        [
+          {
+            "node": "Discord - Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Progress": {
+      "main": [
+        [
+          {
+            "node": "Process One by One",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate Results": {
+      "main": [
+        [
+          {
+            "node": "Calculate Statistics",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Calculate Statistics": {
+      "main": [
+        [
+          {
+            "node": "Discord - Complete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord - Complete": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah/torah-translation-orchestrator.json
+++ b/workflows/Torah/torah-translation-orchestrator.json
@@ -5,6 +5,7 @@
       "parameters": {
         "httpMethod": "POST",
         "path": "torah-translate",
+        "responseMode": "responseNode",
         "options": {}
       },
       "id": "webhook-trigger",

--- a/workflows/Torah/torah-translation-orchestrator.json
+++ b/workflows/Torah/torah-translation-orchestrator.json
@@ -11,7 +11,8 @@
       "name": "Webhook Trigger",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [250, 300]
+      "position": [250, 300],
+      "webhookId": "torah-translate"
     },
     {
       "parameters": {


### PR DESCRIPTION
## Summary

- Ajout de 6 workflows n8n pour la traduction Torah avec notifications Discord
- Création d'un Torah Registry similaire au MCP Registry

## Workflows ajoutés

| Workflow | Endpoint | Description |
|----------|----------|-------------|
| Torah Discord Bot | `/webhook/torah-discord-message` | Recherche de commentaires talmudiques |
| Torah Translation Orchestrator | `/webhook/torah-translate` | Pipeline de traduction |
| Torah Batch Translation | `/webhook/torah-batch-translate` | Traduction en lot |
| Torah Review and Validation | `/webhook/torah-submit-review` | Soumission pour révision |
| Torah PDF Generation | `/webhook/torah-generate-pdf` | Génération de PDF |
| Torah Registry | `/webhook/torah-registry` | Liste tous les workflows Torah actifs |

## Fixes appliqués

- Ajout de `webhookId` pour l'enregistrement correct des webhooks
- Ajout de `responseMode: responseNode` pour les webhooks avec réponse
- Mise à jour des IF nodes en `typeVersion: 2.2` avec opérateur `exists`

## Test plan

- [x] Tester `/webhook/torah-discord-message` avec `{"message": "Sukkah 28b Rashi"}`
- [x] Vérifier `/webhook/torah-registry` retourne les 6 outils
- [ ] Tester les autres endpoints avec l'API Torah

🤖 Generated with [Claude Code](https://claude.com/claude-code)