### PR TITLE
feat(torah): add translation workflow v3 with cache support

### DIFF
--- a/docs/issues/N8N_TRANSLATION_API.md
+++ b/docs/issues/N8N_TRANSLATION_API.md
@@ -1,0 +1,441 @@
+# API Traduction - Guide pour n8n
+
+Documentation pour l'intégration n8n avec le système de traduction Torah Solutions.
+
+---
+
+## 1. URL de Base
+
+```
+Production : http://torah.solutions:3031
+Développement : http://localhost:3031
+```
+
+---
+
+## 2. Endpoints de Traduction
+
+### 2.1 Traduire un texte (Endpoint principal)
+
+**POST** `/api/translate`
+
+Traduit un texte ou document avec choix du modèle LLM.
+
+#### Requête
+
+```json
+{
+  "type": "text",
+  "text": "בְּרֵאשִׁית בָּרָא אֱלֹהִים",
+  "source_language": "he",
+  "target_language": "fr",
+  "provider": "openai",
+  "model": "gpt-4o-mini",
+  "preserve_formatting": true,
+  "quality_check": true,
+  "context": "Texte de la Torah, Genèse"
+}
+```
+
+#### Paramètres
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `type` | string | Oui | `"text"` ou `"document"` |
+| `text` | string | Oui* | Texte à traduire (si type=text) |
+| `document_url` | string | Oui* | URL du document (si type=document) |
+| `document_id` | string | Oui* | UUID du document en BDD |
+| `source_language` | string | Oui | Code ISO langue source (`he`, `en`, `fr`) |
+| `target_language` | string | Oui | Code ISO langue cible |
+| `provider` | string | Non | `openai`, `claude`, `gemini`, `mistral` |
+| `model` | string | Non | Modèle spécifique (voir liste ci-dessous) |
+| `context` | string | Non | Contexte pour améliorer la traduction |
+| `quality_check` | boolean | Non | Activer la vérification qualité |
+| `glossary` | object | Non | Glossaire personnalisé `{"terme": "traduction"}` |
+
+#### Modèles disponibles
+
+| Provider | Modèles |
+|----------|---------|
+| OpenAI | `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`, `gpt-3.5-turbo` |
+| Claude | `claude-3-opus-20240229`, `claude-3-sonnet-20240229`, `claude-3-haiku-20240307` |
+| Gemini | `gemini-pro`, `gemini-pro-vision` |
+| Mistral | `mistral-large-latest`, `mistral-medium-latest`, `mistral-small-latest` |
+
+#### Réponse
+
+```json
+{
+  "translation_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "completed",
+  "type": "text",
+  "translated_text": "Au commencement, Dieu créa",
+  "source_language": "he",
+  "target_language": "fr",
+  "provider": "openai",
+  "model": "gpt-4o-mini",
+  "character_count": 28,
+  "token_count": 15,
+  "processing_time": 1.23,
+  "quality_score": 0.95
+}
+```
+
+---
+
+### 2.2 Traduire avec référence BDD (Optimisé)
+
+**POST** `/api/mcp/translate`
+
+Endpoint optimisé pour traduire directement depuis la base de données.
+
+#### Requête
+
+```json
+{
+  "reference": {
+    "table": "source_texts",
+    "uuid": "29428246-00aa-4755-b402-8e3d8ae4fd52"
+  },
+  "target_language": "fr",
+  "translator": {
+    "provider": "openai",
+    "model": "gpt-4o"
+  },
+  "reviewer": {
+    "provider": "anthropic",
+    "model": "claude-3-5-sonnet"
+  },
+  "apply_grammalecte": true,
+  "translator_prompt": "Traduire ce texte rabbinique avec fidélité",
+  "reviewer_prompt": "Vérifier la cohérence terminologique"
+}
+```
+
+#### Formats de référence supportés
+
+```json
+// Format 1: Table + UUID
+{"table": "source_texts", "uuid": "uuid-value"}
+
+// Format 2: Table + ID
+{"table": "commentary_details", "id": "uuid-value"}
+
+// Format 3: Texte personnalisé
+{"type": "custom_text", "id": "Le texte à traduire"}
+
+// Format 4: Legacy
+{"type": "database", "table": "source_texts", "id": "uuid-value"}
+```
+
+#### Réponse
+
+```json
+{
+  "success": true,
+  "translation": "Texte traduit...",
+  "revision": "Texte révisé...",
+  "metadata": {
+    "processing_time": 2.45,
+    "translator_model": "gpt-4o",
+    "reviewer_model": "claude-3-5-sonnet",
+    "grammalecte_applied": true
+  }
+}
+```
+
+---
+
+### 2.3 Statut d'une traduction
+
+**GET** `/api/translate/{translation_id}/status`
+
+Vérifie le statut d'une traduction asynchrone.
+
+#### Réponse
+
+```json
+{
+  "translation_id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "processing",
+  "progress": 45.5,
+  "current_step": "Traduction en cours",
+  "error": null
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| `pending` | En attente de traitement |
+| `processing` | Traduction en cours |
+| `completed` | Terminé avec succès |
+| `failed` | Échec de la traduction |
+
+---
+
+### 2.4 Annuler une traduction
+
+**POST** `/api/translate/{translation_id}/cancel`
+
+---
+
+### 2.5 Télécharger un document traduit
+
+**GET** `/api/translate/{translation_id}/download`
+
+Retourne le fichier traduit (PDF, DOCX, etc.)
+
+---
+
+## 3. Structure des Données en Base
+
+### Tables PostgreSQL
+
+#### `translation_projects` - Projets de traduction
+
+| Colonne | Type | Description |
+|---------|------|-------------|
+| `id` | UUID | Identifiant unique |
+| `name` | VARCHAR(255) | Nom du projet |
+| `sefaria_ref` | VARCHAR(255) | Référence Sefaria |
+| `source_language` | VARCHAR(10) | Langue source (défaut: `he`) |
+| `target_language` | VARCHAR(10) | Langue cible (défaut: `fr`) |
+| `status` | VARCHAR(50) | `draft`, `in_progress`, `completed` |
+| `created_by` | UUID | FK vers users |
+| `extra_data` | JSON | Métadonnées additionnelles |
+| `created_at` | TIMESTAMP | Date de création |
+| `updated_at` | TIMESTAMP | Date de modification |
+
+#### `source_texts` - Textes sources
+
+| Colonne | Type | Description |
+|---------|------|-------------|
+| `id` | UUID | Identifiant unique |
+| `project_id` | UUID | FK vers translation_projects |
+| `reference` | VARCHAR(255) | Référence du texte |
+| `text` | TEXT | Texte source |
+| `hebrew_text` | TEXT | Texte hébreu original |
+| `position` | INTEGER | Position dans le projet |
+| `extra_data` | JSON | Métadonnées |
+
+#### `translations` - Traductions (versionnées)
+
+| Colonne | Type | Description |
+|---------|------|-------------|
+| `id` | UUID | Identifiant unique |
+| `source_text_id` | UUID | FK vers source_texts |
+| `version` | INTEGER | Numéro de version |
+| `translated_text` | TEXT | **Texte traduit** |
+| `provider` | VARCHAR(50) | Provider LLM utilisé |
+| `model` | VARCHAR(100) | Modèle utilisé |
+| `quality_score` | FLOAT | Score qualité (0-1) |
+| `confidence_score` | FLOAT | Score de confiance |
+| `is_current` | BOOLEAN | Version courante |
+| `input_tokens` | INTEGER | Tokens consommés (entrée) |
+| `output_tokens` | INTEGER | Tokens consommés (sortie) |
+| `cost_estimate` | FLOAT | Coût estimé |
+| `extra_data` | JSON | Métadonnées |
+
+#### `corrections` - Corrections
+
+| Colonne | Type | Description |
+|---------|------|-------------|
+| `id` | UUID | Identifiant unique |
+| `translation_id` | UUID | FK vers translations |
+| `original_text` | TEXT | Texte original |
+| `corrected_text` | TEXT | Texte corrigé |
+| `correction_reason` | TEXT | Raison de la correction |
+| `correction_type` | VARCHAR(50) | `manual`, `automatic`, `llm_suggested` |
+
+#### `commentaries` - Commentaires
+
+| Colonne | Type | Description |
+|---------|------|-------------|
+| `id` | UUID | Identifiant unique |
+| `source_text_id` | UUID | FK vers source_texts |
+| `reference` | VARCHAR(255) | Référence |
+| `text` | TEXT | Texte du commentaire |
+| `hebrew_text` | TEXT | Texte hébreu |
+| `category` | VARCHAR(100) | Catégorie (Rachi, Tosafot...) |
+| `author` | VARCHAR(255) | Auteur |
+
+---
+
+## 4. Requêtes SQL Utiles
+
+### Récupérer une traduction par texte source
+
+```sql
+SELECT
+    t.id,
+    t.translated_text,
+    t.version,
+    t.provider,
+    t.model,
+    t.quality_score,
+    t.created_at
+FROM translations t
+JOIN source_texts st ON t.source_text_id = st.id
+WHERE st.text ILIKE '%recherche%'
+  AND t.is_current = true
+ORDER BY t.created_at DESC;
+```
+
+### Récupérer toutes les traductions d'un projet
+
+```sql
+SELECT
+    st.reference,
+    st.text as source_text,
+    st.hebrew_text,
+    t.translated_text,
+    t.provider,
+    t.model,
+    t.quality_score
+FROM translation_projects tp
+JOIN source_texts st ON st.project_id = tp.id
+LEFT JOIN translations t ON t.source_text_id = st.id AND t.is_current = true
+WHERE tp.id = 'project-uuid'
+ORDER BY st.position;
+```
+
+### Vérifier si une traduction existe
+
+```sql
+SELECT EXISTS(
+    SELECT 1
+    FROM translations t
+    JOIN source_texts st ON t.source_text_id = st.id
+    WHERE st.text = 'texte original'
+      AND t.is_current = true
+) as translation_exists;
+```
+
+---
+
+## 5. Exemples d'Intégration n8n
+
+### Workflow 1: Traduire un texte simple
+
+```json
+{
+  "nodes": [
+    {
+      "name": "HTTP Request",
+      "type": "n8n-nodes-base.httpRequest",
+      "parameters": {
+        "method": "POST",
+        "url": "http://localhost:3031/api/translate",
+        "body": {
+          "type": "text",
+          "text": "{{ $json.hebrew_text }}",
+          "source_language": "he",
+          "target_language": "fr",
+          "provider": "openai",
+          "model": "gpt-4o-mini"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Workflow 2: Traduire depuis la BDD
+
+```json
+{
+  "nodes": [
+    {
+      "name": "HTTP Request",
+      "type": "n8n-nodes-base.httpRequest",
+      "parameters": {
+        "method": "POST",
+        "url": "http://localhost:3031/api/mcp/translate",
+        "body": {
+          "reference": {
+            "table": "source_texts",
+            "uuid": "{{ $json.source_text_id }}"
+          },
+          "target_language": "fr",
+          "translator": {
+            "provider": "openai",
+            "model": "gpt-4o"
+          },
+          "reviewer": {
+            "provider": "anthropic",
+            "model": "claude-3-5-sonnet"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+### Workflow 3: Vérifier le statut
+
+```json
+{
+  "nodes": [
+    {
+      "name": "HTTP Request",
+      "type": "n8n-nodes-base.httpRequest",
+      "parameters": {
+        "method": "GET",
+        "url": "http://localhost:3031/api/translate/{{ $json.translation_id }}/status"
+      }
+    },
+    {
+      "name": "IF",
+      "type": "n8n-nodes-base.if",
+      "parameters": {
+        "conditions": {
+          "string": [
+            {
+              "value1": "{{ $json.status }}",
+              "value2": "completed"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+```
+
+---
+
+## 6. Authentification
+
+L'API nécessite une authentification. Ajouter le header :
+
+```
+Authorization: Bearer <token>
+```
+
+Pour obtenir un token, contacter l'administrateur.
+
+---
+
+## 7. Codes d'Erreur
+
+| Code | Description |
+|------|-------------|
+| 400 | Requête invalide (paramètres manquants) |
+| 401 | Non authentifié |
+| 403 | Non autorisé |
+| 404 | Ressource non trouvée |
+| 429 | Rate limit dépassé |
+| 500 | Erreur serveur |
+
+---
+
+## 8. Contact
+
+- **API Documentation Swagger** : http://localhost:3031/api/docs
+- **Repository** : torah.solutions.api
+- **Support** : équipe backend
+
+---
+
+*Dernière mise à jour : 28 décembre 2025*

--- a/docs/issues/TORAH_BOT_INTEGRATION.md
+++ b/docs/issues/TORAH_BOT_INTEGRATION.md
@@ -1,0 +1,313 @@
+# Intégration Torah Bot - Workflow Traduction
+
+Documentation pour l'équipe **torah.bot** sur l'utilisation du workflow de traduction n8n.
+
+---
+
+## Endpoint
+
+```
+POST http://pi6.local:5678/webhook/torah-discord-translate
+```
+
+---
+
+## Paramètres de la requête
+
+### Requis
+
+| Paramètre | Type | Description |
+|-----------|------|-------------|
+| `text` | string | Texte hébreu/araméen à traduire |
+| `api_key` | string | Clé API Anthropic (Claude) |
+| `openai_api_key` | string | Clé API OpenAI (GPT-4o) |
+
+### Optionnels (recommandés pour le cache)
+
+| Paramètre | Type | Description |
+|-----------|------|-------------|
+| `target_language` | string | Langue cible : `fr` (défaut), `en`, `es` |
+| `source_text_id` | UUID | ID du texte source (depuis API Talmud) - **priorité 1** |
+| `commentary_id` | UUID | ID du commentaire (depuis API Talmud) - **priorité 1** |
+| `context.traite` | string | Nom du traité (ex: `Sukkah`) |
+| `context.page` | string | Page (ex: `28a`) |
+| `context.commentator` | string | Commentateur (ex: `Rashi`) |
+| `discord.webhook_url` | string | URL webhook Discord pour notification |
+
+---
+
+## Exemple d'appel complet
+
+```json
+{
+  "text": "בר ממטללא - אם ירצה דמצטער הוא",
+  "api_key": "sk-ant-api03-xxx",
+  "openai_api_key": "sk-xxx",
+  "target_language": "fr",
+  "source_text_id": "29428246-00aa-4755-b402-8e3d8ae4fd52",
+  "context": {
+    "traite": "Sukkah",
+    "page": "28a",
+    "commentator": "Rashi"
+  },
+  "discord": {
+    "webhook_url": "https://discord.com/api/webhooks/xxx/yyy"
+  }
+}
+```
+
+---
+
+## Flux du workflow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                                                             │
+│  1. CACHE CHECK (si source_text_id ou commentary_id fourni)                │
+│     GET /api/translations/search?source_text_id=xxx&target_language=fr     │
+│                                                                             │
+│     ├── Cache HIT  → Retourne traduction en ~50ms                          │
+│     │                                                                       │
+│     └── Cache MISS → Continue vers étape 2                                 │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  2. TRADUCTION (Claude Sonnet 4)                                           │
+│     - Traduit le texte hébreu/araméen                                      │
+│     - ~2-3 secondes                                                         │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  3. VERIFICATION (GPT-4o)                                                  │
+│     - Vérifie la traduction                                                │
+│     - Corrige si nécessaire                                                │
+│     - Attribue un score de confiance (0.0-1.0)                             │
+│     - ~2-3 secondes                                                         │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  4. SAUVEGARDE                                                             │
+│     POST /api/translations                                                 │
+│     - Stocke en BDD pour le cache                                          │
+│                                                                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  5. DISCORD (optionnel)                                                    │
+│     - Envoie embed si webhook_url fourni                                   │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Format de réponse
+
+### Succès (cache hit)
+
+```json
+{
+  "success": true,
+  "cached": true,
+  "translation": {
+    "original": "בר ממטללא - אם ירצה דמצטער הוא",
+    "translated": "Celui qui est sous la couverture - s'il le désire, c'est qu'il souffre",
+    "source_language": "he",
+    "target_language": "fr",
+    "quality_score": 0.92
+  },
+  "verification": {
+    "approved": true,
+    "confidence": 0.92,
+    "issues": [],
+    "notes": "Traduction depuis le cache"
+  },
+  "metadata": {
+    "traite": "Sukkah",
+    "page": "28a",
+    "commentator": "Rashi",
+    "source": "cache",
+    "cached_at": "2025-12-28T15:30:00Z",
+    "processing_time_ms": 45
+  }
+}
+```
+
+### Succès (nouvelle traduction)
+
+```json
+{
+  "success": true,
+  "cached": false,
+  "translation": {
+    "original": "בר ממטללא - אם ירצה דמצטער הוא",
+    "translated": "Celui qui est sous la couverture - s'il le désire, c'est qu'il souffre",
+    "source_language": "he",
+    "target_language": "fr",
+    "quality_score": 0.95
+  },
+  "verification": {
+    "approved": true,
+    "confidence": 0.95,
+    "issues": [],
+    "notes": "Traduction fidèle au contexte talmudique"
+  },
+  "alternatives": null,
+  "metadata": {
+    "traite": "Sukkah",
+    "page": "28a",
+    "commentator": "Rashi",
+    "source_text_id": "29428246-00aa-4755-b402-8e3d8ae4fd52",
+    "models_used": ["claude-sonnet-4-20250514", "gpt-4o"],
+    "source": "generated",
+    "processing_time_ms": 5230,
+    "tokens": {
+      "claude": {"input_tokens": 150, "output_tokens": 80},
+      "gpt4o": {"prompt_tokens": 200, "completion_tokens": 100}
+    }
+  }
+}
+```
+
+### Succès avec désaccord (2 versions)
+
+Si GPT-4o corrige significativement Claude (`confidence < 0.6`), les deux versions sont retournées :
+
+```json
+{
+  "success": true,
+  "cached": false,
+  "translation": {
+    "translated": "Version corrigée par GPT-4o...",
+    "quality_score": 0.55
+  },
+  "verification": {
+    "approved": false,
+    "confidence": 0.55,
+    "issues": ["Terme mal traduit", "Contexte non respecté"]
+  },
+  "alternatives": {
+    "claude_translation": "Version originale Claude...",
+    "gpt4o_translation": "Version corrigée GPT-4o..."
+  }
+}
+```
+
+### Erreur
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 400,
+    "message": "Le champ \"text\" est requis",
+    "status": "BAD_REQUEST"
+  }
+}
+```
+
+---
+
+## Intégration recommandée dans torah.bot
+
+### 1. Récupérer le texte avec l'UUID
+
+```python
+# Appel API Talmud
+response = requests.get(f"http://localhost:3031/api/talmud/text/Sukkah/28a")
+data = response.json()
+
+# Extraire l'UUID pour le cache
+source_text_id = data["id"]
+commentaries = data["commentaries"]  # [{id, commentator, text, ...}]
+```
+
+### 2. Appeler le workflow de traduction
+
+```python
+def translate_text(text, source_text_id=None, commentary_id=None, context=None):
+    payload = {
+        "text": text,
+        "api_key": os.getenv("ANTHROPIC_API_KEY"),
+        "openai_api_key": os.getenv("OPENAI_API_KEY"),
+        "target_language": "fr",
+    }
+
+    # Ajouter UUID si disponible (optimise le cache)
+    if source_text_id:
+        payload["source_text_id"] = source_text_id
+    if commentary_id:
+        payload["commentary_id"] = commentary_id
+    if context:
+        payload["context"] = context
+
+    response = requests.post(
+        "http://pi6.local:5678/webhook/torah-discord-translate",
+        json=payload
+    )
+    return response.json()
+```
+
+### 3. Exemple complet
+
+```python
+# Utilisateur demande "Sukkah 28a"
+talmud = get_talmud_text("Sukkah", "28a")
+
+# Utilisateur sélectionne Rashi
+rashi = next(c for c in talmud["commentaries"] if c["commentator"] == "Rashi")
+
+# Utilisateur sélectionne une phrase
+phrase = "בר ממטללא - אם ירצה דמצטער הוא"
+
+# Traduction avec tous les UUIDs pour le cache
+result = translate_text(
+    text=phrase,
+    commentary_id=rashi["id"],
+    context={
+        "traite": "Sukkah",
+        "page": "28a",
+        "commentator": "Rashi"
+    }
+)
+
+if result["success"]:
+    if result["cached"]:
+        print(f"📦 Cache ({result['metadata']['processing_time_ms']}ms)")
+    else:
+        print(f"✨ Nouvelle traduction ({result['metadata']['processing_time_ms']}ms)")
+
+    print(f"Traduction: {result['translation']['translated']}")
+    print(f"Score: {result['translation']['quality_score']*100:.0f}%")
+```
+
+---
+
+## Temps de réponse attendus
+
+| Scénario | Temps |
+|----------|-------|
+| Cache hit | ~50-100ms |
+| Cache miss (traduction complète) | ~5-8 secondes |
+
+---
+
+## Codes d'erreur
+
+| Code | Signification |
+|------|---------------|
+| 200 | Succès |
+| 400 | Paramètres manquants ou invalides |
+| 401 | Clé API invalide (Claude ou OpenAI) |
+| 500 | Erreur serveur |
+
+---
+
+## Contact
+
+- **Workflow n8n** : `torah-discord-translate` (ID: à confirmer après import)
+- **API Torah** : `http://localhost:3031`
+- **Documentation API** : `docs/issues/N8N_TRANSLATION_API.md`
+
+---
+
+*Dernière mise à jour : 28 décembre 2025*

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -4,6 +4,7 @@ module.exports = {
       name: 'n8n',
       script: 'n8n',
       args: 'start',
+      cwd: '/home/fsebb/n8n-workflows',
 
       // Environnement
       env: {
@@ -15,8 +16,8 @@ module.exports = {
         N8N_PORT: 5678,
         N8N_PROTOCOL: 'http',
 
-        // Mode API uniquement (sans frontend) - décommenter si souhaité
-        // N8N_DISABLE_UI: 'true',
+        // Custom nodes
+        N8N_CUSTOM_EXTENSIONS: '/home/fsebb/n8n-workflows/custom-nodes/n8n-nodes-gmail-dynamic',
 
         // Performance SQLite
         DB_SQLITE_POOL_SIZE: 4,
@@ -32,25 +33,38 @@ module.exports = {
         N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: 'true',
         N8N_SECURE_COOKIE: 'false',
 
-        // Gestion des utilisateurs activée (nécessaire pour l'UI)
-        // N8N_USER_MANAGEMENT_DISABLED: 'true',
-
         // Activer l'API publique
         N8N_PUBLIC_API_DISABLED: 'false',
 
         // Allégement / Mode offline
         N8N_DIAGNOSTICS_ENABLED: 'false',
         N8N_HIRING_BANNER_ENABLED: 'false',
-        N8N_VERSION_NOTIFICATIONS_ENABLED: 'false',  // Pas de check de version
-        N8N_TEMPLATES_ENABLED: 'false',              // Pas de templates depuis api.n8n.io
+        N8N_VERSION_NOTIFICATIONS_ENABLED: 'false',
+        N8N_TEMPLATES_ENABLED: 'false',
 
-        // Webhook URL (remplacer par ton IP/domaine)
+        // Webhook URL
         WEBHOOK_URL: 'http://pi6.local:5678/',
+      },
 
-        // Authentification basique (recommandé si accès externe)
-        // N8N_BASIC_AUTH_ACTIVE: 'true',
-        // N8N_BASIC_AUTH_USER: 'admin',
-        // N8N_BASIC_AUTH_PASSWORD: 'change_this_password',
+      // Environnement production (moins de logs)
+      env_production: {
+        N8N_LOG_LEVEL: 'info',
+        N8N_HOST: '0.0.0.0',
+        N8N_PORT: 5678,
+        N8N_PROTOCOL: 'http',
+        N8N_CUSTOM_EXTENSIONS: '/home/fsebb/n8n-workflows/custom-nodes/n8n-nodes-gmail-dynamic',
+        DB_SQLITE_POOL_SIZE: 4,
+        N8N_RUNNERS_ENABLED: 'true',
+        N8N_BLOCK_ENV_ACCESS_IN_NODE: 'false',
+        N8N_GIT_NODE_DISABLE_BARE_REPOS: 'true',
+        N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: 'true',
+        N8N_SECURE_COOKIE: 'false',
+        N8N_PUBLIC_API_DISABLED: 'false',
+        N8N_DIAGNOSTICS_ENABLED: 'false',
+        N8N_HIRING_BANNER_ENABLED: 'false',
+        N8N_VERSION_NOTIFICATIONS_ENABLED: 'false',
+        N8N_TEMPLATES_ENABLED: 'false',
+        WEBHOOK_URL: 'http://pi6.local:5678/',
       },
 
       // Redémarrage automatique
@@ -58,15 +72,21 @@ module.exports = {
       watch: false,
       max_memory_restart: '500M',
 
-      // Logs
-      error_file: '/home/fsebb/.n8n/logs/n8n-error.log',
-      out_file: '/home/fsebb/.n8n/logs/n8n-out.log',
+      // Logs - dans le dossier du projet
+      error_file: '/home/fsebb/n8n-workflows/logs/n8n-error.log',
+      out_file: '/home/fsebb/n8n-workflows/logs/n8n-out.log',
+      combine_logs: true,
+      merge_logs: true,
       log_date_format: 'YYYY-MM-DD HH:mm:ss',
 
       // Gestion des crashes
       min_uptime: '10s',
       max_restarts: 10,
       restart_delay: 5000,
+
+      // Graceful shutdown
+      kill_timeout: 5000,
+      listen_timeout: 10000,
     }
   ]
 };

--- a/scripts/test/test_torah_translate.sh
+++ b/scripts/test/test_torah_translate.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script de test pour le workflow Torah Discord Translation v2
+# Usage: ./test_torah_translate.sh <anthropic_api_key> <openai_api_key> [text] [target_language]
+
+ANTHROPIC_KEY="${1:-}"
+OPENAI_KEY="${2:-}"
+TEXT="${3:-בר ממטללא - אם ירצה דמצטער הוא}"
+TARGET_LANG="${4:-fr}"
+WEBHOOK_URL="http://pi6.local:5678/webhook/torah-discord-translate"
+
+if [ -z "$ANTHROPIC_KEY" ] || [ -z "$OPENAI_KEY" ]; then
+    echo "Usage: $0 <anthropic_api_key> <openai_api_key> [text] [target_language]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 sk-ant-xxx sk-xxx"
+    echo "  $0 sk-ant-xxx sk-xxx 'בר ממטללא' fr"
+    echo ""
+    echo "Test validation (sans clés):"
+    curl -s -X POST "$WEBHOOK_URL" \
+        -H "Content-Type: application/json" \
+        -d '{"text":"","api_key":"","openai_api_key":""}' | jq .
+    exit 1
+fi
+
+echo "=== Torah Discord Translation v2 ==="
+echo "Pipeline: Claude Sonnet 4 → GPT-4o Verifier"
+echo "Text: $TEXT"
+echo "Target: $TARGET_LANG"
+echo ""
+
+curl -s -X POST "$WEBHOOK_URL" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"text\": \"$TEXT\",
+        \"api_key\": \"$ANTHROPIC_KEY\",
+        \"openai_api_key\": \"$OPENAI_KEY\",
+        \"target_language\": \"$TARGET_LANG\",
+        \"context\": {
+            \"traite\": \"Sukkah\",
+            \"page\": \"28b\",
+            \"commentator\": \"Rashi\"
+        }
+    }" | jq .

--- a/workflows/Torah/torah-discord-translate.json
+++ b/workflows/Torah/torah-discord-translate.json
@@ -1,0 +1,692 @@
+{
+  "name": "Torah Discord Translation",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Discord Translation v3 (avec Cache)\n\n**Endpoint:** POST /webhook/torah-discord-translate\n\n**Required:**\n- `text`: Texte hébreu/araméen à traduire\n- `api_key`: Clé API Anthropic (Claude)\n- `openai_api_key`: Clé API OpenAI (GPT-4o)\n\n**Optional:**\n- `target_language`: fr (défaut), en, es\n- `source_text_id`: UUID du texte source (cache optimisé)\n- `commentary_id`: UUID du commentaire\n- `context`: { traite, page, commentator }\n- `discord.webhook_url`: URL webhook Discord\n\n**Pipeline:**\n1. Check Cache (API Torah)\n2. Si cache miss → Claude Sonnet 4 + GPT-4o\n3. Sauvegarde en BDD",
+        "height": 420,
+        "width": 320,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-discord-translate",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-discord-translate"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validation et préparation des données\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst startTime = Date.now();\n\n// Extraction des paramètres\nconst text = body.text || '';\nconst apiKey = body.api_key || '';\nconst openaiApiKey = body.openai_api_key || '';\nconst targetLanguage = body.target_language || 'fr';\nconst sourceTextId = body.source_text_id || null;\nconst commentaryId = body.commentary_id || null;\nconst context = body.context || {};\nconst discord = body.discord || {};\n\n// Validation\nconst errors = [];\nif (!text || text.trim().length === 0) {\n  errors.push('Le champ \"text\" est requis');\n}\nif (!apiKey || apiKey.trim().length === 0) {\n  errors.push('Le champ \"api_key\" (Anthropic) est requis');\n}\nif (!openaiApiKey || openaiApiKey.trim().length === 0) {\n  errors.push('Le champ \"openai_api_key\" est requis');\n}\n\n// Mapping langues\nconst languageNames = {\n  'fr': 'français',\n  'en': 'English',\n  'es': 'español',\n  'he': 'hébreu',\n  'ar': 'araméen'\n};\n\nconst targetLangName = languageNames[targetLanguage] || 'français';\n\n// Construction du contexte pour le prompt\nlet contextInfo = '';\nif (context.traite || context.page || context.commentator) {\n  contextInfo = `\\n\\nContexte: ${context.commentator || ''} sur ${context.traite || ''} ${context.page || ''}`.trim();\n}\n\n// Construire l'URL de recherche cache\nlet cacheSearchParams = `target_language=${targetLanguage}`;\nif (sourceTextId) {\n  cacheSearchParams += `&source_text_id=${sourceTextId}`;\n} else if (commentaryId) {\n  cacheSearchParams += `&commentary_id=${commentaryId}`;\n} else if (context.traite && context.page) {\n  cacheSearchParams += `&traite=${encodeURIComponent(context.traite)}&page=${encodeURIComponent(context.page)}`;\n  if (context.commentator) {\n    cacheSearchParams += `&commentator=${encodeURIComponent(context.commentator)}`;\n  }\n  cacheSearchParams += `&text=${encodeURIComponent(text)}&exact=true`;\n}\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    text: text,\n    apiKey: apiKey,\n    openaiApiKey: openaiApiKey,\n    targetLanguage: targetLanguage,\n    targetLangName: targetLangName,\n    sourceTextId: sourceTextId,\n    commentaryId: commentaryId,\n    contextInfo: contextInfo,\n    context: context,\n    discord: discord,\n    startTime: startTime,\n    cacheSearchParams: cacheSearchParams,\n    canSearchCache: !!(sourceTextId || commentaryId || (context.traite && context.page))\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-validation",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "can-search",
+              "leftValue": "={{ $json.canSearchCache }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-can-cache",
+      "name": "Can Search Cache?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1060, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=http://localhost:3031/api/translations/search?{{ $json.cacheSearchParams }}",
+        "options": {
+          "timeout": 5000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "search-cache",
+      "name": "Search Cache",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1280, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Vérifier si le cache a retourné une traduction\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Cache hit si status 200 et traduction trouvée\nconst cacheHit = statusCode === 200 && data.found === true && data.translations && data.translations.length > 0;\n\nif (cacheHit) {\n  const cached = data.translations[0];\n  return [{\n    json: {\n      cacheHit: true,\n      translation: cached.translated_text,\n      qualityScore: cached.quality_score || 0.9,\n      provider: cached.provider || 'cached',\n      model: cached.model || 'cached',\n      cachedAt: cached.created_at,\n      // Passer les données pour la réponse\n      originalText: prevData.text,\n      targetLanguage: prevData.targetLanguage,\n      context: prevData.context,\n      discord: prevData.discord,\n      startTime: prevData.startTime\n    }\n  }];\n}\n\n// Cache miss - passer au traducteur\nreturn [{\n  json: {\n    cacheHit: false,\n    ...prevData\n  }\n}];"
+      },
+      "id": "check-cache-result",
+      "name": "Check Cache Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1500, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cache-hit",
+              "leftValue": "={{ $json.cacheHit }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "is-cache-hit",
+      "name": "Cache Hit?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1720, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la réponse depuis le cache\nconst input = $input.first().json;\n\nconst endTime = Date.now();\nconst processingTime = endTime - input.startTime;\n\nreturn [{\n  json: {\n    success: true,\n    cached: true,\n    translation: {\n      original: input.originalText,\n      translated: input.translation,\n      source_language: 'he',\n      target_language: input.targetLanguage,\n      quality_score: input.qualityScore\n    },\n    verification: {\n      approved: true,\n      confidence: input.qualityScore,\n      issues: [],\n      notes: 'Traduction depuis le cache'\n    },\n    alternatives: null,\n    metadata: {\n      traite: input.context.traite || null,\n      page: input.context.page || null,\n      commentator: input.context.commentator || null,\n      models_used: [input.provider || 'cached'],\n      source: 'cache',\n      cached_at: input.cachedAt,\n      processing_time_ms: processingTime\n    },\n    discord: input.discord\n  }\n}];"
+      },
+      "id": "format-cache-response",
+      "name": "Format Cache Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1940, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.apiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tu es un expert en textes talmudiques et rabbiniques. Traduis le texte suivant en {{ $json.targetLangName }}.{{ $json.contextInfo }}\\n\\nTexte à traduire:\\n{{ $json.text }}\\n\\nRéponds UNIQUEMENT avec la traduction, sans commentaires ni explications supplémentaires.\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "call-claude-api",
+      "name": "Claude Sonnet 4",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1940, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire la traduction Claude et préparer pour GPT-4o\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Gestion fullResponse ou réponse directe\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Vérifier les erreurs HTTP Claude\nif (statusCode >= 400 || data.error) {\n  const errorMsg = data.error?.message || data.message || `Erreur HTTP ${statusCode}`;\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: `Erreur API Claude: ${errorMsg}`,\n        status: 'CLAUDE_API_ERROR'\n      }\n    }\n  }];\n}\n\n// Extraire la traduction de Claude\nlet claudeTranslation = '';\nif (data.content && data.content[0] && data.content[0].text) {\n  claudeTranslation = data.content[0].text.trim();\n}\n\nif (!claudeTranslation) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 500,\n        message: 'Aucune traduction retournée par Claude',\n        status: 'EMPTY_CLAUDE_RESPONSE'\n      }\n    }\n  }];\n}\n\n// Préparer les données pour GPT-4o\nreturn [{\n  json: {\n    claudeTranslation: claudeTranslation,\n    originalText: prevData.text,\n    targetLanguage: prevData.targetLanguage,\n    targetLangName: prevData.targetLangName,\n    sourceTextId: prevData.sourceTextId,\n    commentaryId: prevData.commentaryId,\n    context: prevData.context,\n    contextInfo: prevData.contextInfo,\n    openaiApiKey: prevData.openaiApiKey,\n    discord: prevData.discord,\n    startTime: prevData.startTime,\n    claudeUsage: {\n      input_tokens: data.usage?.input_tokens || 0,\n      output_tokens: data.usage?.output_tokens || 0\n    }\n  }\n}];"
+      },
+      "id": "extract-claude-response",
+      "name": "Extract Claude Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2160, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-claude-success",
+              "leftValue": "={{ $json.claudeTranslation }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-claude-success",
+      "name": "Claude OK?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2380, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o\",\n  \"temperature\": 0.1,\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un expert en hébreu biblique, araméen talmudique et textes rabbiniques. Tu vérifies et améliores des traductions. Réponds UNIQUEMENT en JSON valide.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Vérifie cette traduction et évalue sa qualité.\\n\\nTexte original (hébreu/araméen):\\n{{ $json.originalText }}\\n\\nTraduction proposée ({{ $json.targetLangName }}):\\n{{ $json.claudeTranslation }}{{ $json.contextInfo ? '\\n\\n' + $json.contextInfo : '' }}\\n\\nRéponds en JSON avec:\\n{\\n  \\\"approved\\\": true/false (la traduction est-elle correcte?),\\n  \\\"confidence\\\": 0.0-1.0 (niveau de confiance),\\n  \\\"corrected_translation\\\": \\\"...\\\" (traduction corrigée si besoin, sinon null),\\n  \\\"issues\\\": [\\\"...\\\"](liste des problèmes détectés, vide si aucun),\\n  \\\"notes\\\": \\\"...\\\" (commentaires optionnels sur la traduction)\\n}\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "call-gpt4o-verify",
+      "name": "GPT-4o Verify",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2600, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater et préparer sauvegarde en BDD\nconst gptResponse = $input.first().json;\nconst claudeData = $('Extract Claude Response').first().json;\n\nconst endTime = Date.now();\nconst processingTime = endTime - claudeData.startTime;\n\n// Parser la réponse GPT-4o\nconst gptData = gptResponse.body || gptResponse;\nconst gptStatusCode = gptResponse.statusCode || 200;\n\n// Valeurs par défaut si GPT-4o échoue\nlet verification = {\n  approved: true,\n  confidence: 0.7,\n  corrected_translation: null,\n  issues: [],\n  notes: 'Vérification GPT-4o non disponible'\n};\n\nlet gptUsage = { prompt_tokens: 0, completion_tokens: 0 };\nlet verifierError = null;\n\nif (gptStatusCode >= 400 || gptData.error) {\n  verifierError = gptData.error?.message || 'Erreur API GPT-4o';\n} else if (gptData.choices && gptData.choices[0]?.message?.content) {\n  try {\n    verification = JSON.parse(gptData.choices[0].message.content);\n    gptUsage = gptData.usage || gptUsage;\n  } catch (e) {\n    verifierError = 'Erreur parsing JSON GPT-4o';\n  }\n}\n\n// Déterminer la traduction finale\nconst hasSignificantDisagreement = !verification.approved && verification.confidence < 0.6;\nconst finalTranslation = verification.corrected_translation || claudeData.claudeTranslation;\n\n// Construire la réponse\nconst response = {\n  success: true,\n  cached: false,\n  translation: {\n    original: claudeData.originalText,\n    translated: finalTranslation,\n    source_language: 'he',\n    target_language: claudeData.targetLanguage,\n    quality_score: verification.confidence\n  },\n  verification: {\n    approved: verification.approved,\n    confidence: verification.confidence,\n    issues: verification.issues || [],\n    notes: verification.notes || null,\n    verifier_error: verifierError\n  },\n  alternatives: hasSignificantDisagreement ? {\n    claude_translation: claudeData.claudeTranslation,\n    gpt4o_translation: verification.corrected_translation\n  } : null,\n  metadata: {\n    traite: claudeData.context.traite || null,\n    page: claudeData.context.page || null,\n    commentator: claudeData.context.commentator || null,\n    source_text_id: claudeData.sourceTextId || null,\n    commentary_id: claudeData.commentaryId || null,\n    models_used: ['claude-sonnet-4-20250514', 'gpt-4o'],\n    source: 'generated',\n    processing_time_ms: processingTime,\n    tokens: {\n      claude: claudeData.claudeUsage,\n      gpt4o: gptUsage\n    }\n  },\n  discord: claudeData.discord,\n  // Données pour sauvegarde\n  _saveData: {\n    text: claudeData.originalText,\n    translated_text: finalTranslation,\n    source_text_id: claudeData.sourceTextId,\n    commentary_id: claudeData.commentaryId,\n    traite: claudeData.context.traite,\n    page: claudeData.context.page,\n    commentator: claudeData.context.commentator,\n    target_language: claudeData.targetLanguage,\n    quality_score: verification.confidence,\n    provider: 'claude+gpt4o',\n    model: 'claude-sonnet-4+gpt-4o'\n  }\n};\n\nreturn [{ json: response }];"
+      },
+      "id": "format-final-response",
+      "name": "Format Final Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2820, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://localhost:3031/api/translations",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json._saveData) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "save-to-cache",
+      "name": "Save to Cache",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3040, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Nettoyer la réponse (supprimer _saveData)\nconst input = $input.first().json;\nconst prevResponse = $('Format Final Response').first().json;\n\n// Supprimer les données internes\nconst response = { ...prevResponse };\ndelete response._saveData;\n\nreturn [{ json: response }];"
+      },
+      "id": "clean-response",
+      "name": "Clean Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3260, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            },
+            {
+              "id": "check-discord-url",
+              "leftValue": "={{ $json.discord?.webhook_url }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-discord",
+      "name": "Send to Discord?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [3480, 50]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.discord.webhook_url }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"Traduction {{ $json.metadata.commentator ? $json.metadata.commentator + ' - ' : '' }}{{ $json.metadata.traite || '' }} {{ $json.metadata.page || '' }}\",\n    \"color\": {{ $json.cached ? 3447003 : ($json.verification.approved ? 5763719 : 15548997) }},\n    \"fields\": [\n      {\n        \"name\": \"Original (he)\",\n        \"value\": \"{{ $json.translation.original.substring(0, 500) }}{{ $json.translation.original.length > 500 ? '...' : '' }}\",\n        \"inline\": false\n      },\n      {\n        \"name\": \"Traduction ({{ $json.translation.target_language }})\",\n        \"value\": \"{{ $json.translation.translated.substring(0, 900) }}{{ $json.translation.translated.length > 900 ? '...' : '' }}\",\n        \"inline\": false\n      },\n      {\n        \"name\": \"Score\",\n        \"value\": \"{{ Math.round($json.translation.quality_score * 100) }}%\",\n        \"inline\": true\n      },\n      {\n        \"name\": \"Source\",\n        \"value\": \"{{ $json.cached ? '📦 Cache' : ($json.verification.approved ? '✅ Vérifié' : '⚠️ Corrigé') }}\",\n        \"inline\": true\n      },\n      {\n        \"name\": \"Temps\",\n        \"value\": \"{{ Math.round($json.metadata.processing_time_ms / 1000 * 10) / 10 }}s\",\n        \"inline\": true\n      }\n    ],\n    \"footer\": { \"text\": \"{{ $json.cached ? 'Cache Torah API' : 'Claude Sonnet 4 + GPT-4o' }}\" },\n    \"timestamp\": \"{{ new Date().toISOString() }}\"\n  }]\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "send-discord",
+      "name": "Send to Discord",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3700, -50]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [3920, 50]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Construire la réponse d'erreur de validation\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
+      },
+      "id": "build-error-response",
+      "name": "Build Error Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1060, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1280, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 500 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-claude-error",
+      "name": "Respond Claude Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2600, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Can Search Cache?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Can Search Cache?": {
+      "main": [
+        [
+          {
+            "node": "Search Cache",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Claude Sonnet 4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search Cache": {
+      "main": [
+        [
+          {
+            "node": "Check Cache Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Cache Result": {
+      "main": [
+        [
+          {
+            "node": "Cache Hit?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cache Hit?": {
+      "main": [
+        [
+          {
+            "node": "Format Cache Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Claude Sonnet 4",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Cache Response": {
+      "main": [
+        [
+          {
+            "node": "Send to Discord?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Sonnet 4": {
+      "main": [
+        [
+          {
+            "node": "Extract Claude Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Claude Response": {
+      "main": [
+        [
+          {
+            "node": "Claude OK?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude OK?": {
+      "main": [
+        [
+          {
+            "node": "GPT-4o Verify",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Claude Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GPT-4o Verify": {
+      "main": [
+        [
+          {
+            "node": "Format Final Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Final Response": {
+      "main": [
+        [
+          {
+            "node": "Save to Cache",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Save to Cache": {
+      "main": [
+        [
+          {
+            "node": "Clean Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Clean Response": {
+      "main": [
+        [
+          {
+            "node": "Send to Discord?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send to Discord?": {
+      "main": [
+        [
+          {
+            "node": "Send to Discord",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send to Discord": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "availableInMCP": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add `torah-discord-translate` workflow v3 with:
  - Cache lookup via Torah API (`GET /api/translations/search`)
  - Claude Sonnet 4 for initial translation
  - GPT-4o for verification, correction and real quality scoring
  - Save new translations to cache (`POST /api/translations`)
  - Discord embed notification support
- Add PM2 `ecosystem.config.js` for n8n service management
- Add API documentation (`docs/issues/N8N_TRANSLATION_API.md`)
- Add torah.bot integration guide (`docs/issues/TORAH_BOT_INTEGRATION.md`)
- Add test script (`scripts/test/test_torah_translate.sh`)

## Workflow Pipeline

```
Webhook → Validate → Cache Search → Hit?
                                     ↓ Yes → Return cached (50ms)
                                     ↓ No
                                Claude Sonnet 4 (translate)
                                     ↓
                                GPT-4o (verify + score)
                                     ↓
                                Save to Cache
                                     ↓
                                Discord? → Respond
```

## Dependencies

Requires API endpoints (in progress by API team):
- `GET /api/translations/search?source_text_id=xxx&target_language=fr`
- `POST /api/translations`

## Test plan

- [ ] Wait for API endpoints to be ready
- [ ] Import workflow into n8n
- [ ] Test cache miss scenario (new translation)
- [ ] Test cache hit scenario (existing translation)
- [ ] Test Discord notification
- [ ] Test error handling (invalid API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)