### PR TITLE
feat(torah): add Torah List workflow

### DIFF
--- a/workflows/Torah/torah-list.json
+++ b/workflows/Torah/torah-list.json
@@ -1,0 +1,171 @@
+{
+  "name": "Torah List",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah List API\n\n**Endpoint:**\n- GET /webhook/torah-list\n\n**Réponse:**\n```json\n{\n  \"success\": true,\n  \"items\": [\n    { \"type\": \"talmud\", \"items\": [...], \"total\": 10 },\n    { \"type\": \"text\", \"items\": [...], \"total\": 2 }\n  ],\n  \"total\": 12\n}\n```\n\n**Source:**\n- /api/talmud/traites\n- /api/texts/projects",
+        "height": 280,
+        "width": 300,
+        "color": 4
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "torah-list",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-list"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/talmud/traites",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "get-traites",
+      "name": "Get Traites",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [620, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/texts/projects",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "get-projects",
+      "name": "Get Projects",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [620, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "mode": "append"
+      },
+      "id": "merge-results",
+      "name": "Merge Results",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Récupérer les données des deux appels API\nconst items = $input.all();\n\n// Trouver les données de chaque source\nlet traitesData = { traites: [], total: 0 };\nlet projectsData = { projects: [], total: 0 };\n\nfor (const item of items) {\n  const data = item.json;\n  if (data.traites) {\n    traitesData = data;\n  } else if (data.projects) {\n    projectsData = data;\n  }\n}\n\n// Traiter les traités\nconst traites = traitesData.traites || [];\nconst traitesTotal = traitesData.total || traites.length;\n\n// Traiter les projets (extraire juste les noms)\nconst projects = projectsData.projects || [];\nconst projectNames = projects.map(p => p.name);\nconst projectsTotal = projectsData.total || projects.length;\n\n// Construire la réponse unifiée\nconst response = {\n  success: true,\n  items: [\n    {\n      type: 'talmud',\n      items: traites,\n      total: traitesTotal\n    },\n    {\n      type: 'text',\n      items: projectNames,\n      total: projectsTotal\n    }\n  ],\n  total: traitesTotal + projectsTotal\n};\n\nreturn [{ json: response }];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1060, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-webhook",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1280, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Get Traites",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Get Projects",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Traites": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Projects": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Results": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": true,
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary

Nouveau workflow **Torah List** qui combine les traités Talmud et les projets Texts.

## Endpoint

```
GET /webhook/torah-list
```

## Réponse

```json
{
  "success": true,
  "items": [
    {
      "type": "talmud",
      "items": ["Bekhorot", "Berakhot", ...],
      "total": 10
    },
    {
      "type": "text", 
      "items": ["Corpus Talmudique - Import Complet", "Second Temple"],
      "total": 2
    }
  ],
  "total": 12
}
```

## Sources API

- `/api/talmud/traites`
- `/api/texts/projects`

## Test plan

- [x] Tester `curl http://pi6.local:5678/webhook/torah-list`
- [x] Vérifier 10 traités talmud
- [x] Vérifier 2 projets texts

🤖 Generated with [Claude Code](https://claude.com/claude-code)