### PR TITLE
feat(torah): add async page translation workflows (#158)

### DIFF
--- a/workflows/Torah/torah-job-status.json
+++ b/workflows/Torah/torah-job-status.json
@@ -30,7 +30,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Extraire le job_id des query params\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst jobId = query.job_id || null;\n\nif (!jobId) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 400,\n        message: 'Le paramètre \"job_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Chemin du fichier job\nconst jobPath = `/tmp/torah-jobs/${jobId}.json`;\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId,\n    jobPath: jobPath\n  }\n}];"
+        "jsCode": "// Extraire le job_id des query params\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst jobId = query.job_id || null;\n\nif (!jobId) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 400,\n        message: 'Le paramètre \"job_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId\n  }\n}];"
       },
       "id": "parse-params",
       "name": "Parse Parameters",
@@ -69,13 +69,33 @@
     },
     {
       "parameters": {
-        "jsCode": "// Lire le fichier job\nconst input = $input.first().json;\nconst fs = require('fs');\n\nconst jobPath = input.jobPath;\nconst jobId = input.jobId;\n\n// Vérifier si le fichier existe\nif (!fs.existsSync(jobPath)) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: `Job non trouvé: ${jobId}`,\n        status: 'JOB_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Lire et parser le fichier\nlet jobData;\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  jobData = JSON.parse(content);\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 500,\n        message: 'Erreur lecture fichier job: ' + e.message,\n        status: 'JOB_READ_ERROR'\n      }\n    }\n  }];\n}\n\n// Calculer la progression\nconst current = jobData.current_segment || 0;\nconst total = jobData.segments_count || 0;\nconst percentage = total > 0 ? Math.round((current / total) * 100) : 0;\n\n// Construire la réponse selon le statut\nconst response = {\n  job_id: jobData.job_id,\n  status: jobData.status,\n  traite: jobData.traite,\n  page: jobData.page,\n  progress: {\n    current: current,\n    total: total,\n    percentage: percentage\n  },\n  started_at: jobData.started_at\n};\n\n// Ajouter les infos selon le statut\nif (jobData.status === 'in_progress') {\n  // Ajouter le segment en cours si disponible\n  if (jobData.segments && jobData.segments[current]) {\n    const currentSegmentText = jobData.segments[current];\n    response.current_segment = currentSegmentText.substring(0, 100) + (currentSegmentText.length > 100 ? '...' : '');\n  }\n}\n\nif (jobData.status === 'completed') {\n  response.completed_at = jobData.completed_at;\n  // Calculer la durée\n  if (jobData.started_at && jobData.completed_at) {\n    const start = new Date(jobData.started_at);\n    const end = new Date(jobData.completed_at);\n    response.duration_seconds = Math.round((end - start) / 1000);\n  }\n  response.translations_saved = jobData.translations?.length || current;\n}\n\nif (jobData.status === 'failed') {\n  response.error = jobData.error;\n}\n\nreturn [{ json: response }];"
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
       },
-      "id": "read-job-file",
-      "name": "Read Job File",
+      "id": "get-job-api",
+      "name": "Get Job (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la réponse du job\nconst input = $input.first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Erreur API\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Job non trouvé',\n        status: 'JOB_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Retourner la réponse telle quelle de l'API\nreturn [{ json: data }];"
+      },
+      "id": "format-job-response",
+      "name": "Format Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1060, 200]
+      "position": [1280, 200]
     },
     {
       "parameters": {
@@ -149,7 +169,7 @@
       "main": [
         [
           {
-            "node": "Read Job File",
+            "node": "Get Job (API)",
             "type": "main",
             "index": 0
           }
@@ -163,7 +183,18 @@
         ]
       ]
     },
-    "Read Job File": {
+    "Get Job (API)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
       "main": [
         [
           {

--- a/workflows/Torah/torah-job-status.json
+++ b/workflows/Torah/torah-job-status.json
@@ -1,0 +1,183 @@
+{
+  "name": "Torah Job Status",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Job Status - Check Progress\n\n**Endpoint:** GET /webhook/torah-job-status\n\n**Query Parameters:**\n- `job_id`: ID du job (ex: job_abc123)\n\n**Response (in_progress):**\n```json\n{\n  \"job_id\": \"job_abc123\",\n  \"status\": \"in_progress\",\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"progress\": {\n    \"current\": 5,\n    \"total\": 14,\n    \"percentage\": 36\n  },\n  \"started_at\": \"...\"\n}\n```\n\n**Response (completed):**\n```json\n{\n  \"job_id\": \"job_abc123\",\n  \"status\": \"completed\",\n  \"progress\": { \"current\": 14, \"total\": 14, \"percentage\": 100 },\n  \"completed_at\": \"...\",\n  \"duration_seconds\": 150,\n  \"translations_saved\": 14\n}\n```",
+        "height": 400,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "torah-job-status",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-job-status"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire le job_id des query params\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst jobId = query.job_id || null;\n\nif (!jobId) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 400,\n        message: 'Le paramètre \"job_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Chemin du fichier job\nconst jobPath = `/tmp/torah-jobs/${jobId}.json`;\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId,\n    jobPath: jobPath\n  }\n}];"
+      },
+      "id": "parse-params",
+      "name": "Parse Parameters",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Job ID Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Lire le fichier job\nconst input = $input.first().json;\nconst fs = require('fs');\n\nconst jobPath = input.jobPath;\nconst jobId = input.jobId;\n\n// Vérifier si le fichier existe\nif (!fs.existsSync(jobPath)) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: `Job non trouvé: ${jobId}`,\n        status: 'JOB_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Lire et parser le fichier\nlet jobData;\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  jobData = JSON.parse(content);\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 500,\n        message: 'Erreur lecture fichier job: ' + e.message,\n        status: 'JOB_READ_ERROR'\n      }\n    }\n  }];\n}\n\n// Calculer la progression\nconst current = jobData.current_segment || 0;\nconst total = jobData.segments_count || 0;\nconst percentage = total > 0 ? Math.round((current / total) * 100) : 0;\n\n// Construire la réponse selon le statut\nconst response = {\n  job_id: jobData.job_id,\n  status: jobData.status,\n  traite: jobData.traite,\n  page: jobData.page,\n  progress: {\n    current: current,\n    total: total,\n    percentage: percentage\n  },\n  started_at: jobData.started_at\n};\n\n// Ajouter les infos selon le statut\nif (jobData.status === 'in_progress') {\n  // Ajouter le segment en cours si disponible\n  if (jobData.segments && jobData.segments[current]) {\n    const currentSegmentText = jobData.segments[current];\n    response.current_segment = currentSegmentText.substring(0, 100) + (currentSegmentText.length > 100 ? '...' : '');\n  }\n}\n\nif (jobData.status === 'completed') {\n  response.completed_at = jobData.completed_at;\n  // Calculer la durée\n  if (jobData.started_at && jobData.completed_at) {\n    const start = new Date(jobData.started_at);\n    const end = new Date(jobData.completed_at);\n    response.duration_seconds = Math.round((end - start) / 1000);\n  }\n  response.translations_saved = jobData.translations?.length || current;\n}\n\nif (jobData.status === 'failed') {\n  response.error = jobData.error;\n}\n\nreturn [{ json: response }];"
+      },
+      "id": "read-job-file",
+      "name": "Read Job File",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1060, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? ($json.error.code || 500) : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-status",
+      "name": "Respond Status",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Parameters": {
+      "main": [
+        [
+          {
+            "node": "Job ID Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Job ID Valid?": {
+      "main": [
+        [
+          {
+            "node": "Read Job File",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Job File": {
+      "main": [
+        [
+          {
+            "node": "Respond Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": true,
+  "versionId": "1"
+}

--- a/workflows/Torah/torah-translate-page-worker.json
+++ b/workflows/Torah/torah-translate-page-worker.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Page Translation Worker\n\n**Endpoint:** POST /webhook/torah-translate-page-worker\n\n**Called by:** torah-translate-page workflow\n\n**Process:**\n1. Respond immediately (async)\n2. Loop through each segment\n3. For each segment:\n   - Claude translation (draft)\n   - GPT-4o verification\n   - Save to API\n   - Update job file progress\n4. Mark job as completed\n\n**Time:** ~7s per segment\n- Claude: ~3s\n- GPT-4o: ~3s\n- Save: ~0.5s",
+        "content": "## Torah Page Translation Worker\n\n**Endpoint:** POST /webhook/torah-translate-page-worker\n\n**Called by:** torah-translate-page workflow\n\n**Process:**\n1. Respond immediately (async)\n2. PATCH /api/jobs → in_progress\n3. Loop through each segment:\n   - Claude translation (draft)\n   - GPT-4o verification\n   - POST /api/translations/save\n   - PATCH /api/jobs (progress)\n4. PATCH /api/jobs → completed\n\n**Time:** ~7s per segment",
         "height": 340,
         "width": 320,
         "color": 3
@@ -62,13 +62,31 @@
     },
     {
       "parameters": {
-        "jsCode": "// Mettre le statut à in_progress\nconst input = $input.first().json;\nconst fs = require('fs');\n\nconst jobPath = `/tmp/torah-jobs/${input.jobId}.json`;\n\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  const jobData = JSON.parse(content);\n  jobData.status = 'in_progress';\n  jobData.updated_at = new Date().toISOString();\n  fs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n} catch (e) {\n  // Ignorer les erreurs de fichier\n}\n\nreturn [{ json: input }];"
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'in_progress' }) }}",
+        "options": {
+          "timeout": 5000
+        }
       },
       "id": "update-status-in-progress",
       "name": "Set In Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Passer les données originales\nconst prevData = $('Parse Input').first().json;\nreturn [{ json: prevData }];"
+      },
+      "id": "pass-data",
+      "name": "Pass Data",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1060, 300]
+      "position": [1280, 300]
     },
     {
       "parameters": {
@@ -236,23 +254,59 @@
     },
     {
       "parameters": {
-        "jsCode": "// Mettre à jour le fichier job avec la progression\nconst input = $input.first().json;\nconst prevData = $('Extract GPT').first().json;\nconst fs = require('fs');\n\nconst jobPath = `/tmp/torah-jobs/${prevData.jobId}.json`;\nconst segmentIndex = prevData.segmentIndex;\nconst totalSegments = prevData.totalSegments;\n\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  const jobData = JSON.parse(content);\n  \n  // Mettre à jour la progression\n  jobData.current_segment = segmentIndex + 1;\n  jobData.updated_at = new Date().toISOString();\n  \n  // Ajouter la traduction\n  if (!jobData.translations) jobData.translations = [];\n  jobData.translations.push({\n    segment_index: segmentIndex,\n    original: prevData.segmentText.substring(0, 100),\n    translation: prevData.finalTranslation.substring(0, 100),\n    confidence: prevData.confidence,\n    approved: prevData.approved\n  });\n  \n  // Vérifier si c'est le dernier segment\n  if (segmentIndex + 1 >= totalSegments) {\n    jobData.status = 'completed';\n    jobData.completed_at = new Date().toISOString();\n  }\n  \n  fs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n} catch (e) {\n  // Ignorer les erreurs\n}\n\nreturn [{ json: prevData }];"
+        "jsCode": "// Préparer les données pour la mise à jour\nconst input = $input.first().json;\nconst prevData = $('Extract GPT').first().json;\n\nconst segmentIndex = prevData.segmentIndex;\nconst totalSegments = prevData.totalSegments;\nconst isComplete = segmentIndex + 1 >= totalSegments;\n\nreturn [{\n  json: {\n    ...prevData,\n    isComplete: isComplete,\n    updatePayload: isComplete ? {\n      status: 'completed',\n      translations_saved: segmentIndex + 1\n    } : {\n      status: 'in_progress',\n      current_segment: segmentIndex + 1,\n      current_segment_text: prevData.segmentText.substring(0, 100),\n      translations_saved: segmentIndex + 1\n    }\n  }\n}];"
       },
-      "id": "update-progress",
-      "name": "Update Progress",
+      "id": "prepare-update",
+      "name": "Prepare Update",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [3040, 200]
     },
     {
       "parameters": {
-        "jsCode": "// Marquer le segment comme failed mais continuer\nconst input = $input.first().json;\nconst fs = require('fs');\n\nconst jobPath = `/tmp/torah-jobs/${input.jobId}.json`;\n\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  const jobData = JSON.parse(content);\n  \n  // Ajouter l'erreur mais continuer\n  if (!jobData.errors) jobData.errors = [];\n  jobData.errors.push({\n    segment_index: input.segmentIndex,\n    error: input.claudeError || 'Claude translation failed'\n  });\n  \n  // Mettre à jour la progression quand même\n  jobData.current_segment = input.segmentIndex + 1;\n  jobData.updated_at = new Date().toISOString();\n  \n  // Vérifier si c'est le dernier segment\n  if (input.segmentIndex + 1 >= input.totalSegments) {\n    jobData.status = 'completed';\n    jobData.completed_at = new Date().toISOString();\n  }\n  \n  fs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n} catch (e) {\n  // Ignorer\n}\n\nreturn [{ json: input }];"
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.updatePayload) }}",
+        "options": {
+          "timeout": 5000
+        }
       },
-      "id": "handle-error",
-      "name": "Handle Error",
+      "id": "update-progress-api",
+      "name": "Update Progress (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3260, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Préparer la mise à jour pour erreur\nconst input = $input.first().json;\n\nconst segmentIndex = input.segmentIndex;\nconst totalSegments = input.totalSegments;\nconst isComplete = segmentIndex + 1 >= totalSegments;\n\nreturn [{\n  json: {\n    ...input,\n    isComplete: isComplete,\n    updatePayload: isComplete ? {\n      status: 'completed',\n      translations_saved: segmentIndex\n    } : {\n      status: 'in_progress',\n      current_segment: segmentIndex + 1,\n      translations_saved: segmentIndex\n    }\n  }\n}];"
+      },
+      "id": "prepare-error-update",
+      "name": "Prepare Error Update",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [2380, 400]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.updatePayload) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-error-api",
+      "name": "Update Error (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2600, 400],
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {},
@@ -306,6 +360,17 @@
       ]
     },
     "Set In Progress": {
+      "main": [
+        [
+          {
+            "node": "Pass Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pass Data": {
       "main": [
         [
           {
@@ -367,24 +432,6 @@
         ]
       ]
     },
-    "Check Claude OK?": {
-      "main": [
-        [
-          {
-            "node": "GPT-4o Verify",
-            "type": "main",
-            "index": 0
-          }
-        ],
-        [
-          {
-            "node": "Handle Error",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
     "GPT-4o Verify": {
       "main": [
         [
@@ -411,14 +458,25 @@
       "main": [
         [
           {
-            "node": "Update Progress",
+            "node": "Prepare Update",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Update Progress": {
+    "Prepare Update": {
+      "main": [
+        [
+          {
+            "node": "Update Progress (API)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Progress (API)": {
       "main": [
         [
           {
@@ -429,7 +487,36 @@
         ]
       ]
     },
-    "Handle Error": {
+    "Check Claude OK?": {
+      "main": [
+        [
+          {
+            "node": "GPT-4o Verify",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Error Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Error Update": {
+      "main": [
+        [
+          {
+            "node": "Update Error (API)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Error (API)": {
       "main": [
         [
           {

--- a/workflows/Torah/torah-translate-page-worker.json
+++ b/workflows/Torah/torah-translate-page-worker.json
@@ -1,0 +1,460 @@
+{
+  "name": "Torah Translate Page Worker",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Page Translation Worker\n\n**Endpoint:** POST /webhook/torah-translate-page-worker\n\n**Called by:** torah-translate-page workflow\n\n**Process:**\n1. Respond immediately (async)\n2. Loop through each segment\n3. For each segment:\n   - Claude translation (draft)\n   - GPT-4o verification\n   - Save to API\n   - Update job file progress\n4. Mark job as completed\n\n**Time:** ~7s per segment\n- Claude: ~3s\n- GPT-4o: ~3s\n- Save: ~0.5s",
+        "height": 340,
+        "width": 320,
+        "color": 3
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-translate-page-worker",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-translate-page-worker"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire les données du job\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Stocker les données pour le traitement async\nreturn [{\n  json: {\n    jobId: body.job_id,\n    traite: body.traite,\n    page: body.page,\n    mode: body.mode || 'premium',\n    targetLanguage: body.target_language || 'fr',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    sourceTextId: body.source_text_id,\n    reference: body.reference,\n    segments: body.segments || [],\n    requestId: body.request_id\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ received: true, job_id: $json.jobId, segments_count: $json.segments.length }) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-immediately",
+      "name": "Respond Immediately",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Mettre le statut à in_progress\nconst input = $input.first().json;\nconst fs = require('fs');\n\nconst jobPath = `/tmp/torah-jobs/${input.jobId}.json`;\n\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  const jobData = JSON.parse(content);\n  jobData.status = 'in_progress';\n  jobData.updated_at = new Date().toISOString();\n  fs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n} catch (e) {\n  // Ignorer les erreurs de fichier\n}\n\nreturn [{ json: input }];"
+      },
+      "id": "update-status-in-progress",
+      "name": "Set In Progress",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1060, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Convertir les segments en items pour la boucle\nconst input = $input.first().json;\n\nconst items = input.segments.map((segment, index) => ({\n  json: {\n    segmentIndex: index,\n    segmentText: segment,\n    totalSegments: input.segments.length,\n    jobId: input.jobId,\n    traite: input.traite,\n    page: input.page,\n    mode: input.mode,\n    targetLanguage: input.targetLanguage,\n    apiKey: input.apiKey,\n    openaiApiKey: input.openaiApiKey,\n    sourceTextId: input.sourceTextId,\n    reference: input.reference,\n    requestId: input.requestId\n  }\n}));\n\nreturn items;"
+      },
+      "id": "split-segments",
+      "name": "Split Segments",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 300]
+    },
+    {
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      },
+      "id": "loop-segments",
+      "name": "Loop Segments",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [1500, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.apiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tu es un expert en textes talmudiques et rabbiniques. Traduis ce segment du Talmud ({{ $json.reference }}, segment {{ $json.segmentIndex + 1 }}/{{ $json.totalSegments }}) en {{ $json.targetLanguage === 'fr' ? 'français' : $json.targetLanguage }}.\\n\\nTexte à traduire:\\n{{ $json.segmentText }}\\n\\nRéponds UNIQUEMENT avec la traduction, sans commentaires ni explications.\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "call-claude",
+      "name": "Claude Translation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1720, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire la traduction Claude\nconst input = $input.first().json;\nconst prevData = $('Loop Segments').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet claudeTranslation = '';\nlet claudeError = null;\nlet claudeUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode >= 400 || data.type === 'error' || data.error) {\n  claudeError = data.error?.message || data.message || `Erreur Claude HTTP ${statusCode}`;\n} else if (data.content?.[0]?.text) {\n  claudeTranslation = data.content[0].text.trim();\n  claudeUsage = {\n    input_tokens: data.usage?.input_tokens || 0,\n    output_tokens: data.usage?.output_tokens || 0,\n    total_tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0)\n  };\n}\n\nreturn [{\n  json: {\n    ...prevData,\n    claudeTranslation: claudeTranslation,\n    claudeError: claudeError,\n    claudeUsage: claudeUsage\n  }\n}];"
+      },
+      "id": "extract-claude",
+      "name": "Extract Claude",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1940, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-claude-ok",
+              "leftValue": "={{ $json.claudeTranslation }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-claude-ok",
+      "name": "Claude OK?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2160, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'gpt-4o', temperature: 0.1, response_format: { type: 'json_object' }, messages: [{ role: 'system', content: 'Tu es un expert en textes talmudiques. Vérifie et améliore cette traduction. Réponds en JSON.' }, { role: 'user', content: 'Vérifie cette traduction du Talmud (' + $json.reference + ', segment ' + ($json.segmentIndex + 1) + '/' + $json.totalSegments + '):\\n\\nTexte original (hébreu/araméen):\\n' + $json.segmentText + '\\n\\nTraduction proposée:\\n' + $json.claudeTranslation + '\\n\\nRéponds en JSON:\\n{\\n  \"my_translation\": \"ta traduction corrigée ou identique\",\\n  \"approved\": true/false,\\n  \"confidence\": 0.0-1.0,\\n  \"issues\": []\\n}' }] }) }}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "call-gpt4o",
+      "name": "GPT-4o Verify",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2380, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire et combiner les résultats\nconst input = $input.first().json;\nconst prevData = $('Check Claude OK?').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet gptVerification = {\n  my_translation: prevData.claudeTranslation,\n  approved: true,\n  confidence: 0.8,\n  issues: []\n};\nlet gptUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode < 400 && data.choices?.[0]?.message?.content) {\n  try {\n    gptVerification = JSON.parse(data.choices[0].message.content);\n    gptUsage = {\n      input_tokens: data.usage?.prompt_tokens || 0,\n      output_tokens: data.usage?.completion_tokens || 0,\n      total_tokens: (data.usage?.prompt_tokens || 0) + (data.usage?.completion_tokens || 0)\n    };\n  } catch (e) {\n    // Garder les valeurs par défaut\n  }\n}\n\n// Déterminer la traduction finale\nconst finalTranslation = gptVerification.approved ? prevData.claudeTranslation : (gptVerification.my_translation || prevData.claudeTranslation);\n\nreturn [{\n  json: {\n    ...prevData,\n    gptVerification: gptVerification,\n    gptUsage: gptUsage,\n    finalTranslation: finalTranslation,\n    confidence: gptVerification.confidence || 0.8,\n    approved: gptVerification.approved\n  }\n}];"
+      },
+      "id": "extract-gpt",
+      "name": "Extract GPT",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2600, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/translations/save",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ text: $json.segmentText, translated_text: $json.finalTranslation, source_text_id: $json.sourceTextId, segment_index: $json.segmentIndex, traite: $json.traite, page: $json.page, source_language: 'he', target_language: $json.targetLanguage, quality_score: $json.confidence, provider: 'claude+openai', model: 'claude-sonnet-4+gpt-4o', mode: $json.mode, request_id: $json.requestId, llm_usage: [{ model: 'claude-sonnet-4-20250514', provider: 'anthropic', ...($json.claudeUsage) }, { model: 'gpt-4o', provider: 'openai', ...($json.gptUsage) }] }) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "save-translation",
+      "name": "Save Translation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2820, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Mettre à jour le fichier job avec la progression\nconst input = $input.first().json;\nconst prevData = $('Extract GPT').first().json;\nconst fs = require('fs');\n\nconst jobPath = `/tmp/torah-jobs/${prevData.jobId}.json`;\nconst segmentIndex = prevData.segmentIndex;\nconst totalSegments = prevData.totalSegments;\n\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  const jobData = JSON.parse(content);\n  \n  // Mettre à jour la progression\n  jobData.current_segment = segmentIndex + 1;\n  jobData.updated_at = new Date().toISOString();\n  \n  // Ajouter la traduction\n  if (!jobData.translations) jobData.translations = [];\n  jobData.translations.push({\n    segment_index: segmentIndex,\n    original: prevData.segmentText.substring(0, 100),\n    translation: prevData.finalTranslation.substring(0, 100),\n    confidence: prevData.confidence,\n    approved: prevData.approved\n  });\n  \n  // Vérifier si c'est le dernier segment\n  if (segmentIndex + 1 >= totalSegments) {\n    jobData.status = 'completed';\n    jobData.completed_at = new Date().toISOString();\n  }\n  \n  fs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n} catch (e) {\n  // Ignorer les erreurs\n}\n\nreturn [{ json: prevData }];"
+      },
+      "id": "update-progress",
+      "name": "Update Progress",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3040, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Marquer le segment comme failed mais continuer\nconst input = $input.first().json;\nconst fs = require('fs');\n\nconst jobPath = `/tmp/torah-jobs/${input.jobId}.json`;\n\ntry {\n  const content = fs.readFileSync(jobPath, 'utf8');\n  const jobData = JSON.parse(content);\n  \n  // Ajouter l'erreur mais continuer\n  if (!jobData.errors) jobData.errors = [];\n  jobData.errors.push({\n    segment_index: input.segmentIndex,\n    error: input.claudeError || 'Claude translation failed'\n  });\n  \n  // Mettre à jour la progression quand même\n  jobData.current_segment = input.segmentIndex + 1;\n  jobData.updated_at = new Date().toISOString();\n  \n  // Vérifier si c'est le dernier segment\n  if (input.segmentIndex + 1 >= input.totalSegments) {\n    jobData.status = 'completed';\n    jobData.completed_at = new Date().toISOString();\n  }\n  \n  fs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n} catch (e) {\n  // Ignorer\n}\n\nreturn [{ json: input }];"
+      },
+      "id": "handle-error",
+      "name": "Handle Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2380, 400]
+    },
+    {
+      "parameters": {},
+      "id": "merge-results",
+      "name": "Merge Results",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [3260, 300]
+    },
+    {
+      "parameters": {},
+      "id": "noop-end",
+      "name": "Done",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [3480, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Input": {
+      "main": [
+        [
+          {
+            "node": "Respond Immediately",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond Immediately": {
+      "main": [
+        [
+          {
+            "node": "Set In Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set In Progress": {
+      "main": [
+        [
+          {
+            "node": "Split Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Segments": {
+      "main": [
+        [
+          {
+            "node": "Loop Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Loop Segments": {
+      "main": [
+        [
+          {
+            "node": "Claude Translation",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Done",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Translation": {
+      "main": [
+        [
+          {
+            "node": "Extract Claude",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Claude": {
+      "main": [
+        [
+          {
+            "node": "Check Claude OK?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Claude OK?": {
+      "main": [
+        [
+          {
+            "node": "GPT-4o Verify",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Handle Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GPT-4o Verify": {
+      "main": [
+        [
+          {
+            "node": "Extract GPT",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract GPT": {
+      "main": [
+        [
+          {
+            "node": "Save Translation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Save Translation": {
+      "main": [
+        [
+          {
+            "node": "Update Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Progress": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Handle Error": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Results": {
+      "main": [
+        [
+          {
+            "node": "Loop Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": true,
+  "versionId": "1"
+}

--- a/workflows/Torah/torah-translate-page.json
+++ b/workflows/Torah/torah-translate-page.json
@@ -1,0 +1,375 @@
+{
+  "name": "Torah Translate Page",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Fetch page segments from API\n3. Create job file in /tmp/torah-jobs/\n4. Launch worker workflow (async)\n5. Return job_id immediately",
+        "height": 420,
+        "width": 320,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-translate-page",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-translate-page"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validation des paramètres\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst traite = body.traite || '';\nconst page = body.page || '';\nconst mode = body.mode || 'premium';\nconst targetLanguage = body.target_language || 'fr';\nconst apiKey = body.api_key || '';\nconst openaiApiKey = body.openai_api_key || '';\nconst requestId = body.request_id || null;\n\n// Validation\nconst errors = [];\nif (!traite) errors.push('Le champ \"traite\" est requis');\nif (!page) errors.push('Le champ \"page\" est requis');\nif (!apiKey) errors.push('Le champ \"api_key\" (Anthropic) est requis');\nif (!openaiApiKey) errors.push('Le champ \"openai_api_key\" est requis');\n\n// Générer un job_id unique\nconst jobId = 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    jobId: jobId,\n    traite: traite,\n    page: page,\n    mode: mode,\n    targetLanguage: targetLanguage,\n    apiKey: apiKey,\n    openaiApiKey: openaiApiKey,\n    requestId: requestId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-validation",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/talmud/text/{{ encodeURIComponent($json.traite) }}/{{ encodeURIComponent($json.page) }}",
+        "options": {
+          "timeout": 30000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "fetch-page",
+      "name": "Fetch Page Segments",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire les segments de la page\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Vérifier les erreurs\nif (statusCode >= 400 || data.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Page non trouvée',\n        status: 'PAGE_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Extraire les segments depuis extra_data.versions[0].text\nlet segments = [];\nif (data.extra_data?.versions?.[0]?.text) {\n  segments = data.extra_data.versions[0].text;\n} else if (data.segments) {\n  segments = data.segments;\n}\n\nif (segments.length === 0) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: 'Aucun segment trouvé pour cette page',\n        status: 'NO_SEGMENTS'\n      }\n    }\n  }];\n}\n\n// Estimation du temps (~7 secondes par segment)\nconst estimatedSeconds = Math.ceil(segments.length * 7);\n\nreturn [{\n  json: {\n    success: true,\n    jobId: prevData.jobId,\n    traite: prevData.traite,\n    page: prevData.page,\n    mode: prevData.mode,\n    targetLanguage: prevData.targetLanguage,\n    apiKey: prevData.apiKey,\n    openaiApiKey: prevData.openaiApiKey,\n    requestId: prevData.requestId,\n    sourceTextId: data.id || null,\n    reference: data.reference || `${prevData.traite} ${prevData.page}`,\n    segments: segments,\n    segmentsCount: segments.length,\n    estimatedSeconds: estimatedSeconds\n  }\n}];"
+      },
+      "id": "extract-segments",
+      "name": "Extract Segments",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-segments",
+      "name": "Segments Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1500, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Créer le fichier job dans /tmp/torah-jobs/\nconst input = $input.first().json;\n\nconst jobData = {\n  job_id: input.jobId,\n  status: 'started',\n  traite: input.traite,\n  page: input.page,\n  mode: input.mode,\n  target_language: input.targetLanguage,\n  reference: input.reference,\n  source_text_id: input.sourceTextId,\n  segments_count: input.segmentsCount,\n  current_segment: 0,\n  segments: input.segments,\n  translations: [],\n  started_at: new Date().toISOString(),\n  updated_at: new Date().toISOString(),\n  error: null\n};\n\n// Créer le répertoire s'il n'existe pas\nconst fs = require('fs');\nconst jobDir = '/tmp/torah-jobs';\nif (!fs.existsSync(jobDir)) {\n  fs.mkdirSync(jobDir, { recursive: true });\n}\n\n// Écrire le fichier job\nconst jobPath = `${jobDir}/${input.jobId}.json`;\nfs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n\n// Préparer les données pour le worker\nreturn [{\n  json: {\n    ...input,\n    jobPath: jobPath,\n    jobCreated: true\n  }\n}];"
+      },
+      "id": "create-job-file",
+      "name": "Create Job File",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1720, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-translate-page-worker",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, traite: $json.traite, page: $json.page, mode: $json.mode, target_language: $json.targetLanguage, api_key: $json.apiKey, openai_api_key: $json.openaiApiKey, source_text_id: $json.sourceTextId, reference: $json.reference, segments: $json.segments, request_id: $json.requestId }) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "launch-worker",
+      "name": "Launch Worker (async)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1940, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Préparer la réponse immédiate\nconst input = $('Create Job File').first().json;\n\nreturn [{\n  json: {\n    success: true,\n    job_id: input.jobId,\n    status: 'started',\n    traite: input.traite,\n    page: input.page,\n    segments_count: input.segmentsCount,\n    estimated_seconds: input.estimatedSeconds\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2160, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2380, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Construire la réponse d'erreur de validation\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
+      },
+      "id": "build-validation-error",
+      "name": "Build Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1060, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1280, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 500 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-page-error",
+      "name": "Respond Page Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1720, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Fetch Page Segments",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Page Segments": {
+      "main": [
+        [
+          {
+            "node": "Extract Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Segments": {
+      "main": [
+        [
+          {
+            "node": "Segments Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Segments Found?": {
+      "main": [
+        [
+          {
+            "node": "Create Job File",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Page Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Job File": {
+      "main": [
+        [
+          {
+            "node": "Launch Worker (async)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Launch Worker (async)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": true,
+  "versionId": "1"
+}

--- a/workflows/Torah/torah-translate-page.json
+++ b/workflows/Torah/torah-translate-page.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Fetch page segments from API\n3. Create job file in /tmp/torah-jobs/\n4. Launch worker workflow (async)\n5. Return job_id immediately",
+        "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Fetch page segments from API\n3. Create job via POST /api/jobs\n4. Launch worker workflow (async)\n5. Return job_id immediately",
         "height": 420,
         "width": 320,
         "color": 6
@@ -128,13 +128,36 @@
     },
     {
       "parameters": {
-        "jsCode": "// Créer le fichier job dans /tmp/torah-jobs/\nconst input = $input.first().json;\n\nconst jobData = {\n  job_id: input.jobId,\n  status: 'started',\n  traite: input.traite,\n  page: input.page,\n  mode: input.mode,\n  target_language: input.targetLanguage,\n  reference: input.reference,\n  source_text_id: input.sourceTextId,\n  segments_count: input.segmentsCount,\n  current_segment: 0,\n  segments: input.segments,\n  translations: [],\n  started_at: new Date().toISOString(),\n  updated_at: new Date().toISOString(),\n  error: null\n};\n\n// Créer le répertoire s'il n'existe pas\nconst fs = require('fs');\nconst jobDir = '/tmp/torah-jobs';\nif (!fs.existsSync(jobDir)) {\n  fs.mkdirSync(jobDir, { recursive: true });\n}\n\n// Écrire le fichier job\nconst jobPath = `${jobDir}/${input.jobId}.json`;\nfs.writeFileSync(jobPath, JSON.stringify(jobData, null, 2));\n\n// Préparer les données pour le worker\nreturn [{\n  json: {\n    ...input,\n    jobPath: jobPath,\n    jobCreated: true\n  }\n}];"
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_type: 'page_translation', traite: $json.traite, page: $json.page, target_language: $json.targetLanguage, mode: $json.mode, segments_count: $json.segmentsCount, metadata: { requested_by: 'n8n_workflow', source_text_id: $json.sourceTextId, reference: $json.reference } }) }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
       },
-      "id": "create-job-file",
-      "name": "Create Job File",
+      "id": "create-job-api",
+      "name": "Create Job (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1720, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire le job_id de la réponse API\nconst input = $input.first().json;\nconst prevData = $('Extract Segments').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nif (statusCode >= 400 || data.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Erreur création job',\n        status: 'JOB_CREATION_ERROR'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    ...prevData,\n    jobId: data.job_id,\n    jobCreated: true\n  }\n}];"
+      },
+      "id": "extract-job-id",
+      "name": "Extract Job ID",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1720, 100]
+      "position": [1940, 100]
     },
     {
       "parameters": {
@@ -151,12 +174,12 @@
       "name": "Launch Worker (async)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1940, 100],
+      "position": [2160, 100],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// Préparer la réponse immédiate\nconst input = $('Create Job File').first().json;\n\nreturn [{\n  json: {\n    success: true,\n    job_id: input.jobId,\n    status: 'started',\n    traite: input.traite,\n    page: input.page,\n    segments_count: input.segmentsCount,\n    estimated_seconds: input.estimatedSeconds\n  }\n}];"
+        "jsCode": "// Préparer la réponse immédiate\nconst input = $('Extract Job ID').first().json;\n\nreturn [{\n  json: {\n    success: true,\n    job_id: input.jobId,\n    status: 'started',\n    traite: input.traite,\n    page: input.page,\n    segments_count: input.segmentsCount,\n    estimated_seconds: input.estimatedSeconds\n  }\n}];"
       },
       "id": "format-response",
       "name": "Format Response",
@@ -308,7 +331,7 @@
       "main": [
         [
           {
-            "node": "Create Job File",
+            "node": "Create Job (API)",
             "type": "main",
             "index": 0
           }
@@ -322,7 +345,18 @@
         ]
       ]
     },
-    "Create Job File": {
+    "Create Job (API)": {
+      "main": [
+        [
+          {
+            "node": "Extract Job ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Job ID": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary
- Add 3 workflows for asynchronous Talmud page translation
- Implements polling-based architecture as specified in issue #158
- Claude + GPT-4o dual LLM translation per segment

## Workflows Created

| Workflow | Endpoint | Description |
|----------|----------|-------------|
| `torah-translate-page` | POST `/webhook/torah-translate-page` | Start translation job |
| `torah-job-status` | GET `/webhook/torah-job-status?job_id=xxx` | Check job progress |
| `torah-translate-page-worker` | POST `/webhook/torah-translate-page-worker` | Background worker |

## Usage

**Start translation:**
```bash
POST /webhook/torah-translate-page
{
  "traite": "Berakhot",
  "page": "2a",
  "mode": "premium",
  "target_language": "fr",
  "api_key": "...",
  "openai_api_key": "..."
}
```

**Check status (poll every 5s):**
```bash
GET /webhook/torah-job-status?job_id=job_abc123
```

## Test plan
- [ ] Test start job endpoint with valid traite/page
- [ ] Test job status endpoint with valid job_id
- [ ] Test full translation flow with 1-2 segments
- [ ] Verify job file creation in /tmp/torah-jobs/

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)