### PR TITLE
feat(torah): add smart nekudot cache check in vocalization workflow

### DIFF
--- a/workflows/Torah/torah-vocalization.json
+++ b/workflows/Torah/torah-vocalization.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Vocalization (Nekudot) v1\n\n**Endpoint:** POST /webhook/torah-vocalization\n\n**Required:**\n- `text`: Texte hébreu sans voyelles\n- `openai_api_key`: Clé API OpenAI\n\n**Optional:**\n- `source_text_id`: UUID du texte source (cache optimisé)\n- `commentary_id`: UUID du commentaire\n- `context`: { traite, page, commentator }\n\n**Pipeline:**\n1. Check Cache (API Torah)\n2. Si cache miss → GPT-4o\n3. Sauvegarde en BDD",
+        "content": "## Torah Vocalization (Nekudot) v2\n\n**Endpoint:** POST /webhook/torah-vocalization\n\n**Required:**\n- `text`: Texte hébreu sans voyelles\n- `openai_api_key`: Clé API OpenAI\n\n**Optional:**\n- `source_text_id`: UUID du texte source\n- `commentary_id`: UUID du commentaire\n- `context`: { traite, page, commentator }\n\n**Pipeline v2:**\n1. Si commentary_id → Check has_nekudot via API\n   → Si existe → retourne vocalisation\n2. Sinon → Check Cache (ancien)\n3. Si cache miss → GPT-4o\n4. Sauvegarde en BDD",
         "height": 380,
         "width": 320,
         "color": 5
@@ -30,7 +30,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Validation et préparation des données\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst startTime = Date.now();\n\n// Extraction des paramètres\nconst text = body.text || '';\nconst openaiApiKey = body.openai_api_key || '';\nconst sourceTextId = body.source_text_id || null;\nconst commentaryId = body.commentary_id || null;\nconst context = body.context || {};\n\n// Validation\nconst errors = [];\nif (!text || text.trim().length === 0) {\n  errors.push('Le champ \"text\" est requis');\n}\nif (!openaiApiKey || openaiApiKey.trim().length === 0) {\n  errors.push('Le champ \"openai_api_key\" est requis');\n}\n\n// Construire les paramètres de recherche cache\nlet cacheSearchParams = '';\nif (sourceTextId) {\n  cacheSearchParams = `source_text_id=${sourceTextId}`;\n} else if (commentaryId) {\n  cacheSearchParams = `commentary_id=${commentaryId}`;\n} else if (context.traite && context.page) {\n  cacheSearchParams = `traite=${encodeURIComponent(context.traite)}&page=${encodeURIComponent(context.page)}`;\n  if (context.commentator) {\n    cacheSearchParams += `&commentator=${encodeURIComponent(context.commentator)}`;\n  }\n}\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    text: text,\n    openaiApiKey: openaiApiKey,\n    sourceTextId: sourceTextId,\n    commentaryId: commentaryId,\n    context: context,\n    startTime: startTime,\n    cacheSearchParams: cacheSearchParams,\n    canSearchCache: !!(sourceTextId || commentaryId || (context.traite && context.page))\n  }\n}];"
+        "jsCode": "// Validation et préparation des données\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst startTime = Date.now();\n\n// Extraction des paramètres\nconst text = body.text || '';\nconst openaiApiKey = body.openai_api_key || '';\nconst sourceTextId = body.source_text_id || null;\nconst commentaryId = body.commentary_id || null;\nconst context = body.context || {};\n\n// Validation\nconst errors = [];\nif (!text || text.trim().length === 0) {\n  errors.push('Le champ \"text\" est requis');\n}\nif (!openaiApiKey || openaiApiKey.trim().length === 0) {\n  errors.push('Le champ \"openai_api_key\" est requis');\n}\n\n// Construire les paramètres de recherche cache\nlet cacheSearchParams = '';\nif (sourceTextId) {\n  cacheSearchParams = `source_text_id=${sourceTextId}`;\n} else if (commentaryId) {\n  cacheSearchParams = `commentary_id=${commentaryId}`;\n} else if (context.traite && context.page) {\n  cacheSearchParams = `traite=${encodeURIComponent(context.traite)}&page=${encodeURIComponent(context.page)}`;\n  if (context.commentator) {\n    cacheSearchParams += `&commentator=${encodeURIComponent(context.commentator)}`;\n  }\n}\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    text: text,\n    openaiApiKey: openaiApiKey,\n    sourceTextId: sourceTextId,\n    commentaryId: commentaryId,\n    context: context,\n    startTime: startTime,\n    cacheSearchParams: cacheSearchParams,\n    canSearchCache: !!(sourceTextId || commentaryId || (context.traite && context.page)),\n    isCommentary: !!commentaryId\n  }\n}];"
       },
       "id": "validate-input",
       "name": "Validate Input",
@@ -330,6 +330,107 @@
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
       "position": [1280, 420]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "is-commentary",
+              "leftValue": "={{ $json.isCommentary }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-is-commentary",
+      "name": "Is Commentary?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1060, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/commentaries/nekudot",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ ids: [$json.commentaryId] }) }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "check-nekudot-api",
+      "name": "Check Nekudot API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1280, 0],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Vérifier si le commentaire a des nekudot\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Si erreur API, passer à la vocalisation\nif (statusCode >= 400) {\n  return [{\n    json: {\n      hasNekudot: false,\n      ...prevData\n    }\n  }];\n}\n\n// Vérifier si les nekudot existent\nconst nekudot = data.nekudot || {};\nconst nekudotData = nekudot[prevData.commentaryId];\n\nif (nekudotData && nekudotData.text) {\n  return [{\n    json: {\n      hasNekudot: true,\n      cachedNekudot: nekudotData.text,\n      cachedAt: nekudotData.vocalized_at,\n      originalText: prevData.text,\n      context: prevData.context,\n      startTime: prevData.startTime,\n      commentaryId: prevData.commentaryId\n    }\n  }];\n}\n\n// Pas de nekudot, passer à GPT-4o\nreturn [{\n  json: {\n    hasNekudot: false,\n    ...prevData\n  }\n}];"
+      },
+      "id": "check-nekudot-result",
+      "name": "Commentary Has Nekudot?",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1500, 0]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-nekudot",
+              "leftValue": "={{ $json.hasNekudot }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-has-nekudot",
+      "name": "Has Nekudot?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1720, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la réponse pour les nekudot depuis la BDD\nconst input = $input.first().json;\n\nconst endTime = Date.now();\nconst processingTime = endTime - input.startTime;\n\nreturn [{\n  json: {\n    success: true,\n    cached: true,\n    vocalization: {\n      original: input.originalText,\n      vocalized: input.cachedNekudot\n    },\n    metadata: {\n      traite: input.context.traite || null,\n      page: input.context.page || null,\n      commentator: input.context.commentator || null,\n      commentary_id: input.commentaryId,\n      vocalized_by: 'database',\n      source: 'database',\n      cached_at: input.cachedAt,\n      processing_time_ms: processingTime\n    }\n  }\n}];"
+      },
+      "id": "format-nekudot-response",
+      "name": "Format Nekudot Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1940, -100]
     }
   ],
   "connections": {
@@ -359,7 +460,7 @@
       "main": [
         [
           {
-            "node": "Can Search Cache?",
+            "node": "Is Commentary?",
             "type": "main",
             "index": 0
           }
@@ -367,6 +468,75 @@
         [
           {
             "node": "Build Error Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Commentary?": {
+      "main": [
+        [
+          {
+            "node": "Check Nekudot API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Can Search Cache?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Nekudot API": {
+      "main": [
+        [
+          {
+            "node": "Commentary Has Nekudot?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Commentary Has Nekudot?": {
+      "main": [
+        [
+          {
+            "node": "Has Nekudot?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Nekudot?": {
+      "main": [
+        [
+          {
+            "node": "Format Nekudot Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "GPT-4o Vocalize",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Nekudot Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary

- Added smart cache check for nekudot using new API endpoint
- If `commentary_id` is provided, checks `POST /api/commentaries/nekudot` first
- Returns cached nekudot directly if exists (0 LLM tokens)
- Falls back to GPT-4o vocalization if no cached version

## New Flow

```
Is Commentary? → Check Nekudot API → Has Nekudot?
                                          ↓
                          (true) → Format Response → Respond
                          (false) → GPT-4o → Save
```

## New Nodes

| Node | Purpose |
|------|---------|
| `Is Commentary?` | Check if commentary_id provided |
| `Check Nekudot API` | POST /api/commentaries/nekudot |
| `Commentary Has Nekudot?` | Parse API response |
| `Has Nekudot?` | Branch: DB or LLM |
| `Format Nekudot Response` | Format cached response |

## Benefits

- Avoids unnecessary GPT-4o calls for already vocalized commentaries
- Uses new API endpoint for reliable nekudot check
- Faster response for cached vocalizations

## Test plan

- [ ] Test with commentary_id that has nekudot → should return cached
- [ ] Test with commentary_id without nekudot → should vocalize via GPT-4o
- [ ] Test without commentary_id → should use existing cache search flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)