### PR TITLE
feat(torah): unified translation worker architecture

### DIFF
--- a/workflows/Torah/torah-discord-translate-v2.json
+++ b/workflows/Torah/torah-discord-translate-v2.json
@@ -1,0 +1,564 @@
+{
+  "name": "Torah Discord Translation v2 (Unified)",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Discord Translation v2 (Unified)\n\n**Endpoint:** POST /webhook/torah-discord-translate\n\n**Unified Architecture:**\n1. Check cache\n   → If hit: return immediately (cached: true)\n2. Create job via API\n3. Call worker asynchronously\n4. Return job_id immediately\n\n**Bot polls torah-job-status for result**\n\n**Response (cache hit):**\n```json\n{ \"cached\": true, \"translation\": {...} }\n```\n\n**Response (new translation):**\n```json\n{ \"cached\": false, \"job_id\": \"xxx\" }\n```",
+        "height": 340,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-discord-translate",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-discord-translate"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validation et préparation des données\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Extraction des paramètres\nconst text = body.text || '';\nconst apiKey = body.api_key || '';\nconst openaiApiKey = body.openai_api_key || '';\nconst targetLanguage = body.target_language || 'fr';\nconst sourceLanguage = body.source_language || 'he';\nconst context = body.context || {};\nconst mode = body.mode || 'standard';\n\n// Validation\nconst errors = [];\nif (!text || text.trim().length === 0) {\n  errors.push('Le champ \"text\" est requis');\n}\nif (!apiKey) {\n  errors.push('Le champ \"api_key\" est requis');\n}\nif (!openaiApiKey) {\n  errors.push('Le champ \"openai_api_key\" est requis');\n}\n\n// Cache search params\nlet cacheSearchParams = `target_language=${targetLanguage}`;\nif (context.traite && context.page) {\n  cacheSearchParams += `&traite=${encodeURIComponent(context.traite)}&page=${encodeURIComponent(context.page)}`;\n  if (context.commentator) {\n    cacheSearchParams += `&commentator=${encodeURIComponent(context.commentator)}`;\n  }\n  cacheSearchParams += `&text=${encodeURIComponent(text)}&exact=true`;\n}\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    text: text,\n    apiKey: apiKey,\n    openaiApiKey: openaiApiKey,\n    sourceLanguage: sourceLanguage,\n    targetLanguage: targetLanguage,\n    context: context,\n    mode: mode,\n    metadata: body.metadata || {},\n    requestId: body.request_id || 'req_' + Date.now(),\n    cacheSearchParams: cacheSearchParams,\n    canSearchCache: !!(context.traite && context.page)\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "can-cache",
+              "leftValue": "={{ $json.canSearchCache }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-can-cache",
+      "name": "Can Search Cache?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1060, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/translations/search?{{ $json.cacheSearchParams }}",
+        "options": {
+          "timeout": 5000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "search-cache",
+      "name": "Search Cache",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1280, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check cache result\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nconst cacheHit = statusCode === 200 && data.found === true && data.translations?.length > 0;\n\nif (cacheHit) {\n  const cached = data.translations[0];\n  return [{\n    json: {\n      cacheHit: true,\n      cachedTranslation: cached.translated_text,\n      cachedQuality: cached.quality_score || 0.9,\n      originalText: prevData.text,\n      targetLanguage: prevData.targetLanguage,\n      context: prevData.context\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    cacheHit: false,\n    ...prevData\n  }\n}];"
+      },
+      "id": "check-cache-result",
+      "name": "Check Cache Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1500, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cache-hit",
+              "leftValue": "={{ $json.cacheHit }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "is-cache-hit",
+      "name": "Cache Hit?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1720, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format cache hit response\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    success: true,\n    cached: true,\n    translation: {\n      original: input.originalText,\n      final: input.cachedTranslation,\n      source_language: 'he',\n      target_language: input.targetLanguage\n    },\n    verification: {\n      approved: true,\n      confidence: input.cachedQuality\n    },\n    tokens: null\n  }\n}];"
+      },
+      "id": "format-cache-response",
+      "name": "Format Cache Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1940, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_type: 'unit_translation', traite: $json.context.traite || 'Unknown', page: $json.context.page || '1a', target_language: $json.targetLanguage, segments_count: 1, metadata: { commentator: $json.context.commentator, text_type: $json.metadata.text_type || 'commentary' } }) }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "create-job",
+      "name": "Create Job",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1940, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract job_id and prepare worker call\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nif (statusCode >= 400 || !data.job_id) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || 'Erreur création job',\n        status: 'JOB_CREATE_ERROR'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    jobId: data.job_id,\n    workerPayload: {\n      job_id: data.job_id,\n      text: prevData.text,\n      segments: [prevData.text],\n      traite: prevData.context.traite,\n      page: prevData.context.page,\n      source_language: prevData.sourceLanguage,\n      target_language: prevData.targetLanguage,\n      mode: prevData.mode,\n      api_key: prevData.apiKey,\n      openai_api_key: prevData.openaiApiKey,\n      context: prevData.context,\n      metadata: prevData.metadata,\n      request_id: prevData.requestId\n    }\n  }\n}];"
+      },
+      "id": "extract-job-id",
+      "name": "Extract Job ID",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2160, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-job-id",
+              "leftValue": "={{ $json.jobId }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "job-created",
+      "name": "Job Created?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2380, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare response and worker call\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    jobId: input.jobId,\n    workerPayload: input.workerPayload,\n    response: {\n      success: true,\n      cached: false,\n      job_id: input.jobId\n    }\n  }\n}];"
+      },
+      "id": "prepare-response",
+      "name": "Prepare Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2600, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json.response) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-job-id",
+      "name": "Respond Job ID",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2820, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-translate-worker",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.workerPayload) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "call-worker",
+      "name": "Call Worker (Async)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3040, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-cache",
+      "name": "Respond Cache",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2160, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build error response\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1060, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1280, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 500 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-job-error",
+      "name": "Respond Job Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2600, 300]
+    },
+    {
+      "parameters": {},
+      "id": "done",
+      "name": "Done",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [3260, 100]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Can Search Cache?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Can Search Cache?": {
+      "main": [
+        [
+          {
+            "node": "Search Cache",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Create Job",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search Cache": {
+      "main": [
+        [
+          {
+            "node": "Check Cache Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Cache Result": {
+      "main": [
+        [
+          {
+            "node": "Cache Hit?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cache Hit?": {
+      "main": [
+        [
+          {
+            "node": "Format Cache Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Create Job",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Cache Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Cache",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Job": {
+      "main": [
+        [
+          {
+            "node": "Extract Job ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Job ID": {
+      "main": [
+        [
+          {
+            "node": "Job Created?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Job Created?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Job Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Job ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond Job ID": {
+      "main": [
+        [
+          {
+            "node": "Call Worker (Async)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Worker (Async)": {
+      "main": [
+        [
+          {
+            "node": "Done",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": true
+}

--- a/workflows/Torah/torah-job-status.json
+++ b/workflows/Torah/torah-job-status.json
@@ -3,8 +3,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Job Status - Check Progress\n\n**Endpoint:** GET /webhook/torah-job-status\n\n**Query Parameters:**\n- `job_id`: ID du job (ex: job_abc123)\n\n**Response (in_progress):**\n```json\n{\n  \"job_id\": \"job_abc123\",\n  \"status\": \"in_progress\",\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"progress\": {\n    \"current\": 5,\n    \"total\": 14,\n    \"percentage\": 36\n  },\n  \"started_at\": \"...\"\n}\n```\n\n**Response (completed):**\n```json\n{\n  \"job_id\": \"job_abc123\",\n  \"status\": \"completed\",\n  \"progress\": { \"current\": 14, \"total\": 14, \"percentage\": 100 },\n  \"completed_at\": \"...\",\n  \"duration_seconds\": 150,\n  \"translations_saved\": 14\n}\n```",
-        "height": 400,
+        "content": "## Torah Job Status - Check Progress & Get Result\n\n**Endpoint:** GET /webhook/torah-job-status\n\n**Query Parameters:**\n- `job_id`: ID du job (ex: job_abc123)\n\n**Response (in_progress):**\n```json\n{\n  \"job_id\": \"job_abc123\",\n  \"status\": \"in_progress\",\n  \"progress\": { \"current\": 5, \"total\": 14 }\n}\n```\n\n**Response (completed):**\n```json\n{\n  \"status\": \"completed\",\n  \"translation\": { \"final\": \"...\", ... },\n  \"tokens\": { \"claude\": {...}, \"gpt\": {...} },\n  \"verification\": { \"confidence\": 0.95, ... }\n}\n```\n\n**Note:** When completed, includes the full\ntranslation result for the bot to display.",
+        "height": 380,
         "width": 320,
         "color": 5
       },
@@ -30,7 +30,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Extraire le job_id des query params\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst jobId = query.job_id || null;\n\nif (!jobId) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 400,\n        message: 'Le paramètre \"job_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId\n  }\n}];"
+        "jsCode": "// Extract job_id from query params\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst jobId = query.job_id || null;\n\nif (!jobId) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 400,\n        message: 'Le paramètre \"job_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId\n  }\n}];"
       },
       "id": "parse-params",
       "name": "Parse Parameters",
@@ -89,13 +89,82 @@
     },
     {
       "parameters": {
-        "jsCode": "// Formater la réponse du job\nconst input = $input.first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Erreur API\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Job non trouvé',\n        status: 'JOB_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Retourner la réponse telle quelle de l'API\nreturn [{ json: data }];"
+        "jsCode": "// Format job response\nconst input = $input.first().json;\nconst jobId = $('Parse Parameters').first().json.jobId;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// API error\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Job non trouvé',\n        status: 'JOB_NOT_FOUND'\n      },\n      _needsResultFetch: false\n    }\n  }];\n}\n\n// If job is completed, we need to fetch the stored result\nif (data.status === 'completed') {\n  return [{\n    json: {\n      ...data,\n      jobId: jobId,\n      _needsResultFetch: true\n    }\n  }];\n}\n\n// Return API response as-is for in_progress\nreturn [{ json: { ...data, _needsResultFetch: false } }];"
       },
       "id": "format-job-response",
-      "name": "Format Response",
+      "name": "Check Job Status",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "needs-fetch",
+              "leftValue": "={{ $json._needsResultFetch }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "needs-result-fetch",
+      "name": "Needs Result?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1500, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-result-get?job_id={{ $json.jobId }}",
+        "options": {
+          "timeout": 5000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "fetch-result",
+      "name": "Fetch Result",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1720, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Combine job data with stored result\nconst input = $input.first().json;\nconst jobData = $('Check Job Status').first().json;\n\nconst resultData = input.body || input;\nconst storedResult = resultData.result;\n\n// If no stored result, return job data as-is\nif (!storedResult || !resultData.found) {\n  const response = { ...jobData };\n  delete response._needsResultFetch;\n  delete response.jobId;\n  return [{ json: response }];\n}\n\n// Build full response with translation\nconst segments = storedResult.segments || [];\nconst firstSegment = segments[0] || {};\n\nconst response = {\n  job_id: jobData.job_id || jobData.jobId,\n  status: 'completed',\n  traite: jobData.traite || storedResult.traite,\n  page: jobData.page || storedResult.page,\n  progress: jobData.progress || {\n    current: segments.length,\n    total: segments.length,\n    percentage: 100\n  },\n  duration_seconds: jobData.duration_seconds,\n  // Translation data (for single segment)\n  translation: segments.length === 1 ? {\n    original: firstSegment.original,\n    final: firstSegment.translation,\n    intermediate_en: firstSegment.intermediate_en,\n    source_language: storedResult.sourceLanguage,\n    target_language: storedResult.targetLanguage,\n    pivot_used: storedResult.pivotUsed,\n    claude_translation: firstSegment.claude_translation,\n    gpt_suggestion: firstSegment.gpt_translation\n  } : null,\n  // For multi-segment, provide all translations\n  translations: segments.length > 1 ? segments.map(s => ({\n    segment_index: s.segment_index,\n    original: s.original,\n    translation: s.translation,\n    confidence: s.confidence\n  })) : null,\n  verification: {\n    approved: firstSegment.approved,\n    confidence: firstSegment.confidence,\n    requires_vote: firstSegment.requires_vote\n  },\n  tokens: {\n    claude: storedResult.totalClaudeTokens,\n    gpt: storedResult.totalGptTokens,\n    total: {\n      input_tokens: (storedResult.totalClaudeTokens?.input_tokens || 0) + (storedResult.totalGptTokens?.input_tokens || 0),\n      output_tokens: (storedResult.totalClaudeTokens?.output_tokens || 0) + (storedResult.totalGptTokens?.output_tokens || 0),\n      total_tokens: (storedResult.totalClaudeTokens?.total_tokens || 0) + (storedResult.totalGptTokens?.total_tokens || 0)\n    }\n  },\n  requires_vote: firstSegment.requires_vote || false\n};\n\nreturn [{ json: response }];"
+      },
+      "id": "combine-result",
+      "name": "Combine Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1940, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Clean up and pass through\nconst input = $input.first().json;\nconst response = { ...input };\ndelete response._needsResultFetch;\ndelete response.jobId;\nreturn [{ json: response }];"
+      },
+      "id": "pass-through",
+      "name": "Pass Through",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1720, 300]
     },
     {
       "parameters": {
@@ -117,7 +186,7 @@
       "name": "Respond Status",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1280, 200]
+      "position": [1500, 200]
     },
     {
       "parameters": {
@@ -187,14 +256,65 @@
       "main": [
         [
           {
-            "node": "Format Response",
+            "node": "Check Job Status",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Format Response": {
+    "Check Job Status": {
+      "main": [
+        [
+          {
+            "node": "Needs Result?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Needs Result?": {
+      "main": [
+        [
+          {
+            "node": "Fetch Result",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Pass Through",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Result": {
+      "main": [
+        [
+          {
+            "node": "Combine Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Combine Result": {
+      "main": [
+        [
+          {
+            "node": "Respond Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pass Through": {
       "main": [
         [
           {
@@ -209,6 +329,5 @@
   "settings": {
     "executionOrder": "v1"
   },
-  "active": true,
-  "versionId": "1"
+  "active": true
 }

--- a/workflows/Torah/torah-result-store.json
+++ b/workflows/Torah/torah-result-store.json
@@ -1,0 +1,160 @@
+{
+  "name": "Torah Result Store",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Result Store\n\n**Internal workflow for storing/retrieving\ntranslation results between worker and job-status**\n\n**POST /webhook/torah-result-store**\nStore a result: { job_id, result }\n\n**GET /webhook/torah-result-store**\nGet a result: ?job_id=xxx",
+        "height": 200,
+        "width": 300,
+        "color": 4
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "=POST",
+        "path": "torah-result-store",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-post",
+      "name": "POST Store",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 200],
+      "webhookId": "torah-result-store-post"
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "torah-result-get",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-get",
+      "name": "GET Retrieve",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 400],
+      "webhookId": "torah-result-store-get"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Store result in static data\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst jobId = body.job_id;\nconst result = body.result;\n\nif (!jobId || !result) {\n  return [{\n    json: {\n      success: false,\n      error: 'job_id and result are required'\n    }\n  }];\n}\n\n// Store in global static data\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.results) {\n  staticData.results = {};\n}\n\nstaticData.results[jobId] = {\n  ...result,\n  storedAt: Date.now()\n};\n\n// Cleanup old results (>1 hour)\nconst oneHourAgo = Date.now() - (60 * 60 * 1000);\nObject.keys(staticData.results).forEach(key => {\n  if (staticData.results[key].storedAt < oneHourAgo) {\n    delete staticData.results[key];\n  }\n});\n\nreturn [{\n  json: {\n    success: true,\n    job_id: jobId,\n    stored: true\n  }\n}];"
+      },
+      "id": "store-result",
+      "name": "Store Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Retrieve result from static data\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst jobId = query.job_id;\n\nif (!jobId) {\n  return [{\n    json: {\n      success: false,\n      error: 'job_id query parameter is required'\n    }\n  }];\n}\n\n// Get from static data\nconst staticData = $getWorkflowStaticData('global');\nconst result = staticData.results?.[jobId];\n\nif (!result) {\n  return [{\n    json: {\n      success: false,\n      found: false,\n      job_id: jobId\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    success: true,\n    found: true,\n    job_id: jobId,\n    result: result\n  }\n}];"
+      },
+      "id": "retrieve-result",
+      "name": "Retrieve Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-post",
+      "name": "Respond POST",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [840, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-get",
+      "name": "Respond GET",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [840, 400]
+    }
+  ],
+  "connections": {
+    "POST Store": {
+      "main": [
+        [
+          {
+            "node": "Store Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GET Retrieve": {
+      "main": [
+        [
+          {
+            "node": "Retrieve Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Store Result": {
+      "main": [
+        [
+          {
+            "node": "Respond POST",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Retrieve Result": {
+      "main": [
+        [
+          {
+            "node": "Respond GET",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "active": true
+}

--- a/workflows/Torah/torah-translate-worker.json
+++ b/workflows/Torah/torah-translate-worker.json
@@ -1,0 +1,717 @@
+{
+  "name": "Torah Translate Worker",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Translate Worker (Unified)\n\n**Endpoint:** POST /webhook/torah-translate-worker\n\n**Called by:** torah-discord-translate\n\n**Features:**\n- Single or multi-segment translation\n- Auto-pivot if source ≠ en AND target ≠ en\n- Claude translation + GPT verification\n- Detailed tokens (claude/gpt/total)\n- Stores result for job-status retrieval\n\n**Process:**\n1. Respond immediately (async)\n2. PATCH /api/jobs → in_progress\n3. For each segment:\n   - Check if pivot needed\n   - Claude: translate (1 or 2 steps)\n   - GPT: verify\n   - POST /api/translations/save\n   - PATCH /api/jobs (progress + tokens)\n4. Store final result\n5. PATCH /api/jobs → completed",
+        "height": 420,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-translate-worker",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [420, 300],
+      "webhookId": "torah-translate-worker"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse input data\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Language names mapping\nconst languageNames = {\n  'fr': 'français',\n  'en': 'English',\n  'es': 'español',\n  'he': 'hébreu',\n  'ar': 'araméen',\n  'de': 'allemand',\n  'it': 'italien'\n};\n\nconst sourceLanguage = body.source_language || 'he';\nconst targetLanguage = body.target_language || 'fr';\n\n// Determine if pivot is needed\nconst needsPivot = sourceLanguage !== 'en' && targetLanguage !== 'en';\n\n// Handle segments - can be array or single text\nlet segments = [];\nif (Array.isArray(body.segments)) {\n  segments = body.segments;\n} else if (body.text) {\n  segments = [body.text];\n}\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    traite: body.traite,\n    page: body.page,\n    jobType: body.job_type || 'unit_translation',\n    mode: body.mode || 'standard',\n    sourceLanguage: sourceLanguage,\n    sourceLangName: languageNames[sourceLanguage] || sourceLanguage,\n    targetLanguage: targetLanguage,\n    targetLangName: languageNames[targetLanguage] || targetLanguage,\n    needsPivot: needsPivot,\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    segments: segments,\n    segmentsCount: segments.length,\n    context: body.context || {},\n    metadata: body.metadata || {},\n    requestId: body.request_id,\n    startTime: Date.now()\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [640, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ received: true, job_id: $json.jobId, segments_count: $json.segmentsCount, pivot: $json.needsPivot }) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-immediately",
+      "name": "Respond Immediately",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [860, 300]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'in_progress' }) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "set-in-progress",
+      "name": "Set In Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1080, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Get original data and prepare for loop\nconst prevData = $('Parse Input').first().json;\nreturn [{ json: prevData }];"
+      },
+      "id": "pass-data",
+      "name": "Pass Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1300, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Split segments into individual items\nconst input = $input.first().json;\n\nconst items = input.segments.map((segment, index) => ({\n  json: {\n    segmentIndex: index,\n    segmentText: segment,\n    totalSegments: input.segments.length,\n    jobId: input.jobId,\n    traite: input.traite,\n    page: input.page,\n    jobType: input.jobType,\n    mode: input.mode,\n    sourceLanguage: input.sourceLanguage,\n    sourceLangName: input.sourceLangName,\n    targetLanguage: input.targetLanguage,\n    targetLangName: input.targetLangName,\n    needsPivot: input.needsPivot,\n    apiKey: input.apiKey,\n    openaiApiKey: input.openaiApiKey,\n    context: input.context,\n    metadata: input.metadata,\n    requestId: input.requestId,\n    startTime: input.startTime,\n    // Accumulators for final result\n    allTranslations: [],\n    totalClaudeTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },\n    totalGptTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }\n  }\n}));\n\nreturn items;"
+      },
+      "id": "split-segments",
+      "name": "Split Segments",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1520, 300]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "loop-segments",
+      "name": "Loop Segments",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [1740, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "needs-pivot",
+              "leftValue": "={{ $json.needsPivot }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-pivot",
+      "name": "Needs Pivot?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1960, 400]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.apiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tu es un expert en textes talmudiques. Le texte source est en {{ $json.sourceLangName }}. Traduis en English (anglais).\\n\\nContexte: {{ $json.traite }} {{ $json.page }}{{ $json.metadata.commentator ? ' - ' + $json.metadata.commentator : '' }}\\n\\nTexte à traduire:\\n{{ $json.segmentText }}\\n\\nRéponds UNIQUEMENT avec la traduction anglaise.\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "claude-pivot-step1",
+      "name": "Claude Pivot Step 1",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2180, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract English translation and prepare for step 2\nconst input = $input.first().json;\nconst prevData = $('Needs Pivot?').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet englishTranslation = '';\nlet step1Usage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\nlet error = null;\n\nif (statusCode >= 400 || data.error) {\n  error = data.error?.message || `HTTP ${statusCode}`;\n} else if (data.content?.[0]?.text) {\n  englishTranslation = data.content[0].text.trim();\n  step1Usage = {\n    input_tokens: data.usage?.input_tokens || 0,\n    output_tokens: data.usage?.output_tokens || 0,\n    total_tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0)\n  };\n}\n\nreturn [{\n  json: {\n    ...prevData,\n    intermediateTranslation: englishTranslation,\n    step1Usage: step1Usage,\n    pivotError: error\n  }\n}];"
+      },
+      "id": "extract-step1",
+      "name": "Extract Step 1",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2400, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.apiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tu es un expert traducteur. Le texte est en English. Traduis en {{ $json.targetLangName }}.\\n\\nContexte: {{ $json.traite }} {{ $json.page }}{{ $json.metadata.commentator ? ' - ' + $json.metadata.commentator : '' }}\\n\\nTexte à traduire:\\n{{ $json.intermediateTranslation }}\\n\\nRéponds UNIQUEMENT avec la traduction.\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "claude-pivot-step2",
+      "name": "Claude Pivot Step 2",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2620, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract final translation from pivot\nconst input = $input.first().json;\nconst prevData = $('Extract Step 1').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet claudeTranslation = '';\nlet step2Usage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode < 400 && data.content?.[0]?.text) {\n  claudeTranslation = data.content[0].text.trim();\n  step2Usage = {\n    input_tokens: data.usage?.input_tokens || 0,\n    output_tokens: data.usage?.output_tokens || 0,\n    total_tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0)\n  };\n}\n\n// Combine Claude usage from both steps\nconst step1Usage = prevData.step1Usage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\nconst claudeUsage = {\n  input_tokens: step1Usage.input_tokens + step2Usage.input_tokens,\n  output_tokens: step1Usage.output_tokens + step2Usage.output_tokens,\n  total_tokens: step1Usage.total_tokens + step2Usage.total_tokens\n};\n\nreturn [{\n  json: {\n    ...prevData,\n    claudeTranslation: claudeTranslation,\n    claudeUsage: claudeUsage,\n    pivotUsed: true\n  }\n}];"
+      },
+      "id": "extract-step2",
+      "name": "Extract Step 2",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2840, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.apiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tu es un expert en textes talmudiques. Le texte source est en {{ $json.sourceLangName }}. Traduis en {{ $json.targetLangName }}.\\n\\nContexte: {{ $json.traite }} {{ $json.page }}{{ $json.metadata.commentator ? ' - ' + $json.metadata.commentator : '' }}\\n\\nTexte à traduire:\\n{{ $json.segmentText }}\\n\\nRéponds UNIQUEMENT avec la traduction.\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "claude-direct",
+      "name": "Claude Direct",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2180, 520],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract direct translation\nconst input = $input.first().json;\nconst prevData = $('Needs Pivot?').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet claudeTranslation = '';\nlet claudeUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode < 400 && data.content?.[0]?.text) {\n  claudeTranslation = data.content[0].text.trim();\n  claudeUsage = {\n    input_tokens: data.usage?.input_tokens || 0,\n    output_tokens: data.usage?.output_tokens || 0,\n    total_tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0)\n  };\n}\n\nreturn [{\n  json: {\n    ...prevData,\n    claudeTranslation: claudeTranslation,\n    claudeUsage: claudeUsage,\n    intermediateTranslation: null,\n    pivotUsed: false\n  }\n}];"
+      },
+      "id": "extract-direct",
+      "name": "Extract Direct",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2400, 520]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "mergeByFields": {
+          "values": []
+        },
+        "options": {}
+      },
+      "id": "merge-translations",
+      "name": "Merge Translations",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.1,
+      "position": [3060, 400]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'gpt-4o', temperature: 0.1, response_format: { type: 'json_object' }, messages: [{ role: 'system', content: 'Expert en textes talmudiques. Réponds en JSON.' }, { role: 'user', content: 'Vérifie cette traduction (' + $json.traite + ' ' + $json.page + ').\\n\\nOriginal (' + $json.sourceLangName + '):\\n' + $json.segmentText + ($json.intermediateTranslation ? '\\n\\nIntermédiaire (EN):\\n' + $json.intermediateTranslation : '') + '\\n\\nTraduction (' + $json.targetLangName + '):\\n' + $json.claudeTranslation + '\\n\\nJSON: { \"my_translation\": \"...\", \"approved\": true/false, \"confidence\": 0.0-1.0, \"issues\": [], \"notes\": \"...\" }' }] }) }}",
+        "options": {
+          "timeout": 60000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "gpt-verify",
+      "name": "GPT Verify",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3280, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract GPT verification\nconst input = $input.first().json;\nconst prevData = $('Merge Translations').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet verification = {\n  my_translation: null,\n  approved: true,\n  confidence: 0.8,\n  issues: [],\n  notes: null\n};\nlet gptUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode < 400 && data.choices?.[0]?.message?.content) {\n  try {\n    verification = JSON.parse(data.choices[0].message.content);\n    gptUsage = {\n      input_tokens: data.usage?.prompt_tokens || 0,\n      output_tokens: data.usage?.completion_tokens || 0,\n      total_tokens: (data.usage?.prompt_tokens || 0) + (data.usage?.completion_tokens || 0)\n    };\n  } catch (e) {\n    // Keep defaults\n  }\n}\n\n// Determine final translation\nconst finalTranslation = verification.approved ? prevData.claudeTranslation : (verification.my_translation || prevData.claudeTranslation);\nconst requiresVote = verification.confidence < 0.9 && !verification.approved;\n\nreturn [{\n  json: {\n    ...prevData,\n    verification: verification,\n    gptUsage: gptUsage,\n    finalTranslation: finalTranslation,\n    confidence: verification.confidence || 0.8,\n    approved: verification.approved,\n    requiresVote: requiresVote,\n    gptTranslation: verification.my_translation\n  }\n}];"
+      },
+      "id": "extract-gpt",
+      "name": "Extract GPT",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3500, 400]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/translations/save",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ text: $json.segmentText, translated_text: $json.finalTranslation, source_text_id: $json.metadata.source_text_id, segment_index: $json.segmentIndex, traite: $json.traite, page: $json.page, source_language: $json.sourceLanguage, target_language: $json.targetLanguage, quality_score: $json.confidence, notes: $json.verification.notes, issues: $json.verification.issues, provider: 'claude+openai', model: 'claude-sonnet-4+gpt-4o', mode: $json.mode, pivot_used: $json.pivotUsed, request_id: $json.requestId }) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "save-translation",
+      "name": "Save Translation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3720, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare job update with detailed tokens\nconst input = $input.first().json;\nconst prevData = $('Extract GPT').first().json;\n\nconst segmentIndex = prevData.segmentIndex;\nconst totalSegments = prevData.totalSegments;\nconst isComplete = segmentIndex + 1 >= totalSegments;\n\nconst claudeUsage = prevData.claudeUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\nconst gptUsage = prevData.gptUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nconst tokens = {\n  claude: {\n    input_tokens: claudeUsage.input_tokens,\n    output_tokens: claudeUsage.output_tokens,\n    total_tokens: claudeUsage.total_tokens\n  },\n  gpt: {\n    input_tokens: gptUsage.input_tokens,\n    output_tokens: gptUsage.output_tokens,\n    total_tokens: gptUsage.total_tokens\n  },\n  total: {\n    input_tokens: claudeUsage.input_tokens + gptUsage.input_tokens,\n    output_tokens: claudeUsage.output_tokens + gptUsage.output_tokens,\n    total_tokens: claudeUsage.total_tokens + gptUsage.total_tokens\n  }\n};\n\n// Build translation result for this segment\nconst segmentResult = {\n  segment_index: segmentIndex,\n  original: prevData.segmentText,\n  translation: prevData.finalTranslation,\n  intermediate_en: prevData.intermediateTranslation,\n  pivot_used: prevData.pivotUsed,\n  confidence: prevData.confidence,\n  approved: prevData.approved,\n  requires_vote: prevData.requiresVote,\n  claude_translation: prevData.claudeTranslation,\n  gpt_translation: prevData.gptTranslation\n};\n\nreturn [{\n  json: {\n    ...prevData,\n    isComplete: isComplete,\n    segmentResult: segmentResult,\n    tokens: tokens,\n    updatePayload: isComplete ? {\n      status: 'completed',\n      translations_saved: segmentIndex + 1,\n      tokens: tokens\n    } : {\n      status: 'in_progress',\n      current_segment: segmentIndex + 1,\n      translations_saved: segmentIndex + 1,\n      tokens: tokens\n    }\n  }\n}];"
+      },
+      "id": "prepare-update",
+      "name": "Prepare Update",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3940, 400]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.updatePayload) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-progress",
+      "name": "Update Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [4160, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare result for external storage\nconst input = $input.first().json;\nconst prevData = $('Prepare Update').first().json;\n\n// Use workflow static data to accumulate results across segments\nconst staticData = $getWorkflowStaticData('global');\nconst jobId = prevData.jobId;\n\nif (!staticData.pendingResults) {\n  staticData.pendingResults = {};\n}\nif (!staticData.pendingResults[jobId]) {\n  staticData.pendingResults[jobId] = {\n    segments: [],\n    totalClaudeTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },\n    totalGptTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 }\n  };\n}\n\n// Add this segment's result\nstaticData.pendingResults[jobId].segments.push(prevData.segmentResult);\n\n// Accumulate tokens\nconst claudeUsage = prevData.claudeUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\nconst gptUsage = prevData.gptUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nstaticData.pendingResults[jobId].totalClaudeTokens.input_tokens += claudeUsage.input_tokens;\nstaticData.pendingResults[jobId].totalClaudeTokens.output_tokens += claudeUsage.output_tokens;\nstaticData.pendingResults[jobId].totalClaudeTokens.total_tokens += claudeUsage.total_tokens;\n\nstaticData.pendingResults[jobId].totalGptTokens.input_tokens += gptUsage.input_tokens;\nstaticData.pendingResults[jobId].totalGptTokens.output_tokens += gptUsage.output_tokens;\nstaticData.pendingResults[jobId].totalGptTokens.total_tokens += gptUsage.total_tokens;\n\n// Store metadata\nstaticData.pendingResults[jobId].jobId = jobId;\nstaticData.pendingResults[jobId].traite = prevData.traite;\nstaticData.pendingResults[jobId].page = prevData.page;\nstaticData.pendingResults[jobId].sourceLanguage = prevData.sourceLanguage;\nstaticData.pendingResults[jobId].targetLanguage = prevData.targetLanguage;\nstaticData.pendingResults[jobId].pivotUsed = prevData.pivotUsed;\nstaticData.pendingResults[jobId].startTime = prevData.startTime;\nstaticData.pendingResults[jobId].completedAt = prevData.isComplete ? Date.now() : null;\n\n// Pass data along with the accumulated result for final storage\nreturn [{ \n  json: {\n    ...prevData,\n    accumulatedResult: staticData.pendingResults[jobId]\n  }\n}];"
+      },
+      "id": "store-result",
+      "name": "Accumulate Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [4380, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Get the final accumulated result and prepare for storage\nconst staticData = $getWorkflowStaticData('global');\nconst input = $input.first().json;\n\n// Find the jobId from previous data\nlet jobId = null;\nlet result = null;\n\n// Get all pending results and find the completed one\nif (staticData.pendingResults) {\n  for (const [id, data] of Object.entries(staticData.pendingResults)) {\n    if (data.completedAt) {\n      jobId = id;\n      result = data;\n      // Clean up\n      delete staticData.pendingResults[id];\n      break;\n    }\n  }\n}\n\nif (!jobId || !result) {\n  return [{ json: { stored: false, reason: 'no_completed_result' } }];\n}\n\nreturn [{\n  json: {\n    job_id: jobId,\n    result: result\n  }\n}];"
+      },
+      "id": "prepare-final-result",
+      "name": "Prepare Final Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [4600, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-result-store",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.job_id, result: $json.result }) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "store-to-external",
+      "name": "Store to External",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [4820, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {},
+      "id": "done",
+      "name": "Done",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [5040, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Input": {
+      "main": [
+        [
+          {
+            "node": "Respond Immediately",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond Immediately": {
+      "main": [
+        [
+          {
+            "node": "Set In Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set In Progress": {
+      "main": [
+        [
+          {
+            "node": "Pass Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pass Data": {
+      "main": [
+        [
+          {
+            "node": "Split Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Segments": {
+      "main": [
+        [
+          {
+            "node": "Loop Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Loop Segments": {
+      "main": [
+        [
+          {
+            "node": "Prepare Final Result",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Needs Pivot?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Final Result": {
+      "main": [
+        [
+          {
+            "node": "Store to External",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Store to External": {
+      "main": [
+        [
+          {
+            "node": "Done",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Needs Pivot?": {
+      "main": [
+        [
+          {
+            "node": "Claude Pivot Step 1",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Claude Direct",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Pivot Step 1": {
+      "main": [
+        [
+          {
+            "node": "Extract Step 1",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Step 1": {
+      "main": [
+        [
+          {
+            "node": "Claude Pivot Step 2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Pivot Step 2": {
+      "main": [
+        [
+          {
+            "node": "Extract Step 2",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Step 2": {
+      "main": [
+        [
+          {
+            "node": "Merge Translations",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Direct": {
+      "main": [
+        [
+          {
+            "node": "Extract Direct",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Direct": {
+      "main": [
+        [
+          {
+            "node": "Merge Translations",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Translations": {
+      "main": [
+        [
+          {
+            "node": "GPT Verify",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GPT Verify": {
+      "main": [
+        [
+          {
+            "node": "Extract GPT",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract GPT": {
+      "main": [
+        [
+          {
+            "node": "Save Translation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Save Translation": {
+      "main": [
+        [
+          {
+            "node": "Prepare Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Update": {
+      "main": [
+        [
+          {
+            "node": "Update Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Progress": {
+      "main": [
+        [
+          {
+            "node": "Store Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Store Result": {
+      "main": [
+        [
+          {
+            "node": "Loop Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "active": true
+}


### PR DESCRIPTION
## Summary

Implements the unified translation architecture as documented in `docs/issues/unification-architecture-traduction.md`.

### New workflows created:
- **torah-translate-worker**: Unified worker with pivot logic, handles both single and multi-segment translations
- **torah-result-store**: Shared storage for passing results between worker and job-status
- **torah-discord-translate-v2**: New orchestrator (cache check → create job → call worker → return job_id)

### Modified workflows:
- **torah-job-status**: Now fetches and returns full translation data when job is completed

### Architecture flow:
```
Bot → torah-discord-translate
     │
     ├─► Cache hit? → Return immediately (cached: true)
     │
     └─► Cache miss:
         1. Create job via API
         2. Call worker async
         3. Return job_id
         
Bot polls → torah-job-status
     │
     ├─► in_progress → { status, progress }
     │
     └─► completed → { status, translation, tokens, verification }
```

## Test plan
- [ ] Import workflows to n8n
- [ ] Test cache hit scenario
- [ ] Test new translation flow (single segment)
- [ ] Verify tokens format in response
- [ ] Test polling flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)