### PR TITLE
fix(torah): change Merge node mode from 'combine' to 'append'

### DIFF
--- a/workflows/Torah/torah-translate-worker.json
+++ b/workflows/Torah/torah-translate-worker.json
@@ -289,11 +289,7 @@
     },
     {
       "parameters": {
-        "mode": "combine",
-        "mergeByFields": {
-          "values": []
-        },
-        "options": {}
+        "mode": "append"
       },
       "id": "merge-translations",
       "name": "Merge Translations",


### PR DESCRIPTION
## Summary
- Fix worker crash caused by Merge node misconfiguration
- The node was set to `mode: "combine"` with no fields to match
- Error was: `You need to define at least one pair of fields in "Fields to Match"`
- Changed to `mode: "append"` since only one branch (pivot OR direct) has data at a time

## Test plan
- [ ] Retry translation request
- [ ] Verify worker completes without error
- [ ] Check job status shows completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)