### PR TITLE
fix(torah): use JSON.stringify for GPT vocalization call

### DIFF
--- a/workflows/Torah/torah-vocalization.json
+++ b/workflows/Torah/torah-vocalization.json
@@ -211,7 +211,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"gpt-4o\",\n  \"temperature\": 0.1,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un expert en hébreu biblique et rabbinique. Ta tâche est d'ajouter les nekudot (voyelles hébraïques/signes de vocalisation) au texte hébreu fourni. Retourne UNIQUEMENT le texte vocalisé, sans explication ni commentaire.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Ajoute les nekudot (voyelles hébraïques) à ce texte:\\n\\n{{ $json.text }}\"\n    }\n  ]\n}",
+        "jsonBody": "={{ JSON.stringify({ model: 'gpt-4o', temperature: 0.1, messages: [{ role: 'system', content: 'Tu es un expert en hébreu biblique et rabbinique. Ta tâche est d\\'ajouter les nekudot (voyelles hébraïques/signes de vocalisation) au texte hébreu fourni. Retourne UNIQUEMENT le texte vocalisé, sans explication ni commentaire.' }, { role: 'user', content: 'Ajoute les nekudot (voyelles hébraïques) à ce texte:\\n\\n' + $json.text }] }) }}",
         "options": {
           "timeout": 60000,
           "response": {


### PR DESCRIPTION
## Summary
- Fix vocalization crash: Hebrew text with quotes (like י"ד) was breaking the JSON body
- Same issue as translation - applied JSON.stringify fix

## Error fixed
```
{"error": "JSON parameter needs to be valid JSON"}
```
Which caused:
```
{"success":false,"error":{"code":500,"message":"Aucune vocalisation retournée par GPT","status":"EMPTY_GPT_RESPONSE"}}
```

## Test plan
- [ ] Retry vocalization request
- [ ] Verify nekudot are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)