### PR TITLE
fix(torah): add source_text field to Save Translation API call

### DIFF
--- a/workflows/Torah/torah-translate-worker.json
+++ b/workflows/Torah/torah-translate-worker.json
@@ -349,7 +349,7 @@
         "url": "={{ $env.TORAH_API_URL }}/api/translations/save",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ text: $json.segmentText, translated_text: $json.finalTranslation, source_text_id: $json.metadata.source_text_id, segment_index: $json.segmentIndex, traite: $json.traite, page: $json.page, source_language: $json.sourceLanguage, target_language: $json.targetLanguage, quality_score: $json.confidence, notes: $json.verification.notes, issues: $json.verification.issues, provider: 'claude+openai', model: 'claude-sonnet-4+gpt-4o', mode: $json.mode, pivot_used: $json.pivotUsed, request_id: $json.requestId }) }}",
+        "jsonBody": "={{ JSON.stringify({ source_text: $json.segmentText, text: $json.segmentText, translated_text: $json.finalTranslation, source_text_id: $json.metadata.source_text_id || undefined, commentary_id: $json.metadata.commentary_id || undefined, segment_index: $json.segmentIndex, traite: $json.traite, page: $json.page, commentator: $json.metadata.commentator || undefined, source_language: $json.sourceLanguage, target_language: $json.targetLanguage, quality_score: $json.confidence, notes: $json.verification.notes, issues: $json.verification.issues, provider: 'claude+openai', model: 'claude-sonnet-4+gpt-4o', mode: $json.mode, pivot_used: $json.pivotUsed, request_id: $json.requestId }) }}",
         "options": {
           "timeout": 10000
         }


### PR DESCRIPTION
## Summary
- Fix 400 error on POST /api/translations/save
- API requires `source_text_id`, `commentary_id`, OR `source_text`
- When metadata is empty, we now send `source_text` as fallback
- Also added `commentary_id` and `commentator` from metadata

## Error fixed
```
{"detail":"Fournir source_text_id, commentary_id, ou source_text"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)