### PR TITLE
feat(torah): add include_translations parameter to get-page-translations

### DIFF
--- a/workflows/Torah/torah-get-page-translations.json
+++ b/workflows/Torah/torah-get-page-translations.json
@@ -1,0 +1,542 @@
+{
+  "name": "Torah Get Page Translations",
+  "description": null,
+  "active": true,
+  "isArchived": false,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Get Page Translations\n\n**Endpoint:** GET /webhook/torah-get-page-translations\n\n**Query Parameters:**\n- `traite`: Nom du traité (ex: Berakhot)\n- `page`: Numéro de page (ex: 2a)\n\n**Response:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"reference\": \"Berakhot 2a\",\n  \"segments_count\": 14,\n  \"translated_count\": 14,\n  \"segments\": [\n    {\n      \"index\": 0,\n      \"hebrew_text\": \"מֵאֵימָתַי קוֹרִין...\",\n      \"translation\": {\n        \"text\": \"À partir de quand lit-on...\",\n        \"provider\": \"claude+openai\",\n        \"model\": \"claude-sonnet-4+gpt-4o\"\n      },\n      \"has_translation\": true\n    }\n  ]\n}\n```",
+        "height": 450,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        60,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "torah-get-page-translations",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        400,
+        300
+      ],
+      "webhookId": "torah-get-page-translations"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire et valider les paramètres\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst traite = query.traite || null;\nconst page = query.page || null;\nconst includeTranslations = query.include_translations === \"true\" || query.include_translations === true;\nconst targetLanguage = query.target_language || \"fr\";\n\n// Validation\nconst errors = [];\nif (!traite) errors.push('Le paramètre \"traite\" est requis');\nif (!page) errors.push('Le paramètre \"page\" est requis');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: errors.join(', '),\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    traite: traite,\n    page: page,\n    includeTranslations: includeTranslations,\n    targetLanguage: targetLanguage\n  }\n}];"
+      },
+      "id": "parse-params",
+      "name": "Parse Parameters",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        620,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        840,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/talmud/page/{{ encodeURIComponent($json.traite) }}/{{ encodeURIComponent($json.page) }}/segments{{ $json.includeTranslations ? '?include_translations=true&target_language=' + $json.targetLanguage : '' }}",
+        "options": {
+          "timeout": 30000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "get-page-api",
+      "name": "Get Page (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1060,
+        200
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la réponse de l'API\nconst input = $input.first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Erreur API\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Page non trouvée',\n        status: 'PAGE_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Retourner la réponse avec success flag\nreturn [{\n  json: {\n    success: true,\n    ...data\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1280,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? ($json.error.code || 500) : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1500,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1060,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Parameters": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Page (API)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Page (API)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false
+  },
+  "staticData": null,
+  "meta": null,
+  "pinData": null,
+  "activeVersionId": "77bff7dd-7383-4d31-85b4-15ab87180593",
+  "versionCounter": 19,
+  "triggerCount": 1,
+  "shared": [
+    {
+      "updatedAt": "2025-12-31T17:25:55.207Z",
+      "createdAt": "2025-12-31T17:25:55.207Z",
+      "role": "workflow:owner",
+      "workflowId": "pzHabIPpD6oFhxi7",
+      "projectId": "rkp1YaKKlE3ExOIx",
+      "project": {
+        "updatedAt": "2025-12-03T16:40:05.384Z",
+        "createdAt": "2025-12-03T14:59:10.085Z",
+        "id": "rkp1YaKKlE3ExOIx",
+        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
+        "type": "personal",
+        "icon": null,
+        "description": null,
+        "projectRelations": [
+          {
+            "updatedAt": "2025-12-03T14:59:10.085Z",
+            "createdAt": "2025-12-03T14:59:10.085Z",
+            "userId": "629b1a6e-a241-4160-a115-50b9404b216c",
+            "projectId": "rkp1YaKKlE3ExOIx",
+            "user": {
+              "updatedAt": "2026-01-01T21:49:35.000Z",
+              "createdAt": "2025-12-03T14:59:09.498Z",
+              "id": "629b1a6e-a241-4160-a115-50b9404b216c",
+              "email": "franck.sebbah@gmail.com",
+              "firstName": "Franck",
+              "lastName": "Sebbah",
+              "personalizationAnswers": {
+                "version": "v4",
+                "personalization_survey_submitted_at": "2025-12-03T16:40:49.872Z",
+                "personalization_survey_n8n_version": "1.122.4",
+                "automationGoalDevops": [
+                  "other"
+                ],
+                "companySize": "<20",
+                "companyType": "saas",
+                "role": "it",
+                "reportedSource": "google"
+              },
+              "settings": {
+                "userActivated": true,
+                "firstSuccessfulWorkflowId": "vqS4CsSXDFb3Ao33",
+                "userActivatedAt": 1764783902633
+              },
+              "disabled": false,
+              "mfaEnabled": false,
+              "lastActiveAt": "2026-01-01",
+              "isPending": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "tags": [],
+  "activeVersion": {
+    "updatedAt": "2025-12-31T17:25:55.223Z",
+    "createdAt": "2025-12-31T17:25:55.223Z",
+    "versionId": "77bff7dd-7383-4d31-85b4-15ab87180593",
+    "workflowId": "pzHabIPpD6oFhxi7",
+    "nodes": [
+      {
+        "parameters": {
+          "content": "## Torah Get Page Translations\n\n**Endpoint:** GET /webhook/torah-get-page-translations\n\n**Query Parameters:**\n- `traite`: Nom du traité (ex: Berakhot)\n- `page`: Numéro de page (ex: 2a)\n\n**Response:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"reference\": \"Berakhot 2a\",\n  \"segments_count\": 14,\n  \"translated_count\": 14,\n  \"segments\": [\n    {\n      \"index\": 0,\n      \"hebrew_text\": \"מֵאֵימָתַי קוֹרִין...\",\n      \"translation\": {\n        \"text\": \"À partir de quand lit-on...\",\n        \"provider\": \"claude+openai\",\n        \"model\": \"claude-sonnet-4+gpt-4o\"\n      },\n      \"has_translation\": true\n    }\n  ]\n}\n```",
+          "height": 450,
+          "width": 320,
+          "color": 5
+        },
+        "id": "sticky-doc",
+        "name": "Documentation",
+        "type": "n8n-nodes-base.stickyNote",
+        "typeVersion": 1,
+        "position": [
+          60,
+          60
+        ]
+      },
+      {
+        "parameters": {
+          "httpMethod": "GET",
+          "path": "torah-get-page-translations",
+          "responseMode": "responseNode",
+          "options": {}
+        },
+        "id": "webhook-trigger",
+        "name": "Webhook Trigger",
+        "type": "n8n-nodes-base.webhook",
+        "typeVersion": 2,
+        "position": [
+          400,
+          300
+        ],
+        "webhookId": "torah-get-page-translations"
+      },
+      {
+        "parameters": {
+          "jsCode": "// Extraire et valider les paramètres\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst traite = query.traite || null;\nconst page = query.page || null;\n\n// Validation\nconst errors = [];\nif (!traite) errors.push('Le paramètre \"traite\" est requis');\nif (!page) errors.push('Le paramètre \"page\" est requis');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: errors.join(', '),\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    traite: traite,\n    page: page\n  }\n}];"
+        },
+        "id": "parse-params",
+        "name": "Parse Parameters",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          620,
+          300
+        ]
+      },
+      {
+        "parameters": {
+          "conditions": {
+            "options": {
+              "caseSensitive": true,
+              "leftValue": "",
+              "typeValidation": "strict"
+            },
+            "conditions": [
+              {
+                "id": "check-valid",
+                "leftValue": "={{ $json.valid }}",
+                "rightValue": true,
+                "operator": {
+                  "type": "boolean",
+                  "operation": "equals"
+                }
+              }
+            ],
+            "combinator": "and"
+          },
+          "options": {}
+        },
+        "id": "check-valid",
+        "name": "Valid?",
+        "type": "n8n-nodes-base.if",
+        "typeVersion": 2.2,
+        "position": [
+          840,
+          300
+        ]
+      },
+      {
+        "parameters": {
+          "method": "GET",
+          "url": "={{ $env.TORAH_API_URL }}/api/talmud/page/{{ encodeURIComponent($json.traite) }}/{{ encodeURIComponent($json.page) }}/segments",
+          "options": {
+            "timeout": 30000,
+            "response": {
+              "response": {
+                "fullResponse": true
+              }
+            }
+          }
+        },
+        "id": "get-page-api",
+        "name": "Get Page (API)",
+        "type": "n8n-nodes-base.httpRequest",
+        "typeVersion": 4.2,
+        "position": [
+          1060,
+          200
+        ],
+        "onError": "continueRegularOutput"
+      },
+      {
+        "parameters": {
+          "jsCode": "// Formater la réponse de l'API\nconst input = $input.first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Erreur API\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || 'Page non trouvée',\n        status: 'PAGE_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Retourner la réponse avec success flag\nreturn [{\n  json: {\n    success: true,\n    ...data\n  }\n}];"
+        },
+        "id": "format-response",
+        "name": "Format Response",
+        "type": "n8n-nodes-base.code",
+        "typeVersion": 2,
+        "position": [
+          1280,
+          200
+        ]
+      },
+      {
+        "parameters": {
+          "respondWith": "json",
+          "responseBody": "={{ JSON.stringify($json) }}",
+          "options": {
+            "responseCode": "={{ $json.error ? ($json.error.code || 500) : 200 }}",
+            "responseHeaders": {
+              "entries": [
+                {
+                  "name": "Content-Type",
+                  "value": "application/json"
+                }
+              ]
+            }
+          }
+        },
+        "id": "respond-success",
+        "name": "Respond",
+        "type": "n8n-nodes-base.respondToWebhook",
+        "typeVersion": 1.1,
+        "position": [
+          1500,
+          200
+        ]
+      },
+      {
+        "parameters": {
+          "respondWith": "json",
+          "responseBody": "={{ JSON.stringify($json) }}",
+          "options": {
+            "responseCode": "={{ $json.error?.code || 400 }}",
+            "responseHeaders": {
+              "entries": [
+                {
+                  "name": "Content-Type",
+                  "value": "application/json"
+                }
+              ]
+            }
+          }
+        },
+        "id": "respond-error",
+        "name": "Respond Error",
+        "type": "n8n-nodes-base.respondToWebhook",
+        "typeVersion": 1.1,
+        "position": [
+          1060,
+          400
+        ]
+      }
+    ],
+    "connections": {
+      "Webhook Trigger": {
+        "main": [
+          [
+            {
+              "node": "Parse Parameters",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Parse Parameters": {
+        "main": [
+          [
+            {
+              "node": "Valid?",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Valid?": {
+        "main": [
+          [
+            {
+              "node": "Get Page (API)",
+              "type": "main",
+              "index": 0
+            }
+          ],
+          [
+            {
+              "node": "Respond Error",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Get Page (API)": {
+        "main": [
+          [
+            {
+              "node": "Format Response",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      },
+      "Format Response": {
+        "main": [
+          [
+            {
+              "node": "Respond",
+              "type": "main",
+              "index": 0
+            }
+          ]
+        ]
+      }
+    },
+    "authors": "Franck Sebbah",
+    "name": null,
+    "description": null
+  }
+}


### PR DESCRIPTION
## Summary
- Add support for `include_translations` query parameter
- Add support for `target_language` query parameter (default: "fr")
- Pass parameters to API when requesting page segments with commentaries

## Usage
```
GET /webhook/torah-get-page-translations?traite=Sukkah&page=47a&include_translations=true&target_language=fr
```

## Expected Response Format
When `include_translations=true`, commentaries will include a `translation` field:
```json
{
  "commentaries": [{
    "id": "uuid-123",
    "commentator": "Rashi",
    "text": "texte hébreu",
    "translation": {"text": "traduction française"}
  }]
}
```

## Test plan
- [ ] Test without parameters (backward compatible)
- [ ] Test with `include_translations=true`
- [ ] Test with `include_translations=true&target_language=en`

🤖 Generated with [Claude Code](https://claude.com/claude-code)