### PR TITLE
feat(stripe): add CLI tools for Stripe projects management

### DIFF
--- a/docs/issues/stripe-implementation-roadmap.md
+++ b/docs/issues/stripe-implementation-roadmap.md
@@ -1,0 +1,354 @@
+# Stripe Implementation Roadmap
+
+**Date:** 2026-01-02
+**Status:** In Progress
+**Related:** [stripe-integration.md](./stripe-integration.md)
+
+---
+
+## Overview
+
+This document tracks the remaining implementation tasks for the Stripe integration with n8n as a proxy.
+
+## Completed
+
+- [x] Architecture design (Option D: Isolation totale)
+- [x] Documentation complète (`docs/issues/stripe-integration.md`)
+- [x] Scripts CLI de gestion des projets Stripe
+  - [x] `init-db.sh` - Initialisation SQLite
+  - [x] `manage-projects.sh` - Gestion des projets
+  - [x] `validate-config.sh` - Validation de configuration
+- [x] Documentation des scripts (`docs/stripe/`)
+
+---
+
+## Phase 1: Workflows n8n (Proxy Stripe)
+
+### Issue #1: `subscription-checkout-create`
+
+**Priority:** High
+**Estimation:** Medium complexity
+
+**Description:**
+Create the n8n workflow that receives checkout requests from services and creates Stripe Checkout sessions.
+
+**Tasks:**
+- [ ] Create webhook trigger node (`POST /webhook/subscription-checkout-create`)
+- [ ] Add SQLite node to fetch project config by `project_id`
+- [ ] Add HTTP Request node to create Stripe Checkout session
+- [ ] Handle conditional options (trial, coupon, promotion codes)
+- [ ] Return checkout URL to caller
+- [ ] Add error handling
+
+**Input Expected:**
+```json
+{
+  "project_id": "torah",
+  "price_id": "price_xxx",
+  "customer_email": "user@example.com",
+  "callbacks": {
+    "success": "http://n8n.local:5678/webhook/torah-sub-success",
+    "renewal": "http://n8n.local:5678/webhook/torah-sub-renewal"
+  },
+  "urls": {
+    "success": "https://...",
+    "cancel": "https://..."
+  },
+  "metadata": { ... },
+  "options": {
+    "trial_days": 7,
+    "coupon_code": null
+  }
+}
+```
+
+**Output Expected:**
+```json
+{
+  "success": true,
+  "checkout_url": "https://checkout.stripe.com/...",
+  "session_id": "cs_xxx"
+}
+```
+
+---
+
+### Issue #2: `subscription-webhook-handler`
+
+**Priority:** High
+**Estimation:** High complexity
+
+**Description:**
+Create the n8n workflow that receives Stripe webhooks and routes events to the appropriate service callbacks.
+
+**Tasks:**
+- [ ] Create webhook trigger node (`POST /webhook/stripe-events`)
+- [ ] Add Code node for Stripe signature verification
+- [ ] Parse event type and extract metadata
+- [ ] For invoice events, fetch subscription to get metadata
+- [ ] Route to appropriate callback URL based on event type
+- [ ] Return 200 OK to Stripe
+
+**Events to Handle:**
+| Event | Callback |
+|-------|----------|
+| `checkout.session.completed` | `callback_success` |
+| `invoice.payment_succeeded` | `callback_renewal` |
+| `invoice.payment_failed` | `callback_failure` |
+| `customer.subscription.deleted` | `callback_cancel` |
+| `customer.subscription.updated` | `callback_success` |
+
+**Security:**
+- Must verify Stripe signature using `STRIPE_WEBHOOK_SECRET`
+- Reject requests with invalid signatures (return 400)
+
+---
+
+### Issue #3: `subscription-cancel`
+
+**Priority:** Medium
+**Estimation:** Low complexity
+
+**Description:**
+Create workflow to cancel a subscription (immediately or at period end).
+
+**Tasks:**
+- [ ] Create webhook trigger node (`POST /webhook/subscription-cancel`)
+- [ ] Fetch project config from SQLite
+- [ ] Call Stripe API to cancel subscription
+- [ ] Return success/failure
+
+**Input:**
+```json
+{
+  "project_id": "torah",
+  "stripe_subscription_id": "sub_xxx",
+  "cancel_immediately": false
+}
+```
+
+---
+
+### Issue #4: `subscription-change-plan`
+
+**Priority:** Medium
+**Estimation:** Low complexity
+
+**Description:**
+Create workflow to upgrade/downgrade a subscription.
+
+**Tasks:**
+- [ ] Create webhook trigger node (`POST /webhook/subscription-change-plan`)
+- [ ] Fetch project config from SQLite
+- [ ] Update subscription via Stripe API
+- [ ] Handle proration
+- [ ] Return success/failure
+
+**Input:**
+```json
+{
+  "project_id": "torah",
+  "stripe_subscription_id": "sub_xxx",
+  "new_price_id": "price_unlimited_xxx",
+  "proration_behavior": "create_prorations"
+}
+```
+
+---
+
+## Phase 2: Torah Integration
+
+### Issue #5: Torah Database Migration
+
+**Priority:** High
+**Estimation:** Low complexity
+
+**Description:**
+Add Stripe-related columns to Torah's `subscribers` table.
+
+**Tasks:**
+- [ ] Create migration script
+- [ ] Add columns: `stripe_customer_id`, `stripe_subscription_id`, `subscription_status`, `current_period_end`
+- [ ] Create `payment_history` table
+- [ ] Test migration on dev environment
+- [ ] Deploy to production
+
+**SQL:**
+```sql
+ALTER TABLE subscribers ADD COLUMN stripe_customer_id VARCHAR(255);
+ALTER TABLE subscribers ADD COLUMN stripe_subscription_id VARCHAR(255);
+ALTER TABLE subscribers ADD COLUMN subscription_status VARCHAR(50);
+ALTER TABLE subscribers ADD COLUMN current_period_end TIMESTAMP;
+
+CREATE TABLE payment_history (
+    id SERIAL PRIMARY KEY,
+    discord_user_id VARCHAR(50) NOT NULL,
+    stripe_payment_id VARCHAR(255),
+    amount_cents INTEGER,
+    currency VARCHAR(3) DEFAULT 'eur',
+    status VARCHAR(50),
+    plan VARCHAR(50),
+    created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+---
+
+### Issue #6: Torah Callback Workflows
+
+**Priority:** High
+**Estimation:** Medium complexity
+
+**Description:**
+Create Torah-specific callback workflows.
+
+**Tasks:**
+- [ ] `torah-sub-success`: Update DB, add credits, notify Discord
+- [ ] `torah-sub-renewal`: Add monthly credits, update period end
+- [ ] `torah-sub-cancel`: Downgrade to free, archive private room
+- [ ] `torah-sub-failure`: Notify user, handle grace period
+
+---
+
+### Issue #7: Discord Bot `/subscribe` Command
+
+**Priority:** High
+**Estimation:** Medium complexity
+
+**Description:**
+Modify the Discord bot to integrate with the new Stripe system.
+
+**Tasks:**
+- [ ] Update `/subscribe` command to call n8n workflow
+- [ ] Create `PaymentLinkView` with Stripe Checkout button
+- [ ] Add `/cancel-subscription` command
+- [ ] Add `/subscription-status` command
+- [ ] Handle multi-platform user identification
+
+---
+
+## Phase 3: MCP Integration
+
+### Issue #8: MCP Database Setup
+
+**Priority:** Medium
+**Estimation:** Low complexity
+
+**Description:**
+Create or update MCP user tables for subscription support.
+
+---
+
+### Issue #9: MCP Callback Workflows
+
+**Priority:** Medium
+**Estimation:** Medium complexity
+
+**Description:**
+Create MCP-specific callback workflows.
+
+---
+
+## Phase 4: Production & Monitoring
+
+### Issue #10: Stripe Dashboard Configuration
+
+**Priority:** High
+**Estimation:** Low complexity
+
+**Tasks:**
+- [ ] Create products in Stripe Dashboard
+- [ ] Create prices (EUR, USD if needed)
+- [ ] Configure webhook endpoint
+- [ ] Note all `price_xxx` IDs
+- [ ] Test with test cards
+
+---
+
+### Issue #11: Environment Configuration
+
+**Priority:** High
+**Estimation:** Low complexity
+
+**Tasks:**
+- [ ] Add `STRIPE_SECRET_KEY` to n8n environment
+- [ ] Add `STRIPE_WEBHOOK_SECRET` to n8n environment
+- [ ] Configure projects in SQLite using `manage-projects.sh`
+- [ ] Validate with `validate-config.sh`
+
+---
+
+### Issue #12: Monitoring & Alerts
+
+**Priority:** Medium
+**Estimation:** Medium complexity
+
+**Tasks:**
+- [ ] Set up Stripe webhook monitoring
+- [ ] Create n8n workflow for failed payment alerts
+- [ ] Set up logging for payment events
+- [ ] Create dashboard for subscription metrics
+
+---
+
+## Phase 5: Multi-Platform Support (Future)
+
+### Issue #13: User Identity Mapping
+
+**Priority:** Low (Future)
+**Estimation:** High complexity
+
+**Description:**
+Implement multi-platform user identity system as described in section 9.13 of the integration document.
+
+**Tasks:**
+- [ ] Create `torah_users` table
+- [ ] Create `torah_user_identities` table
+- [ ] Create `link_codes` table
+- [ ] Implement `/link` command on Discord
+- [ ] Implement `/link` command on Telegram
+- [ ] Update subscription flow to use internal user ID
+
+---
+
+## Priority Order
+
+1. **Phase 1** - Core workflows (Issues #1-4)
+2. **Phase 2** - Torah integration (Issues #5-7)
+3. **Phase 4** - Production setup (Issues #10-11)
+4. **Phase 3** - MCP integration (Issues #8-9)
+5. **Phase 4** - Monitoring (Issue #12)
+6. **Phase 5** - Multi-platform (Issue #13)
+
+---
+
+## Dependencies
+
+```
+Issue #10 (Stripe Dashboard)
+    │
+    ├── Issue #11 (Environment Config)
+    │       │
+    │       └── Issue #1 (checkout-create)
+    │               │
+    │               └── Issue #2 (webhook-handler)
+    │                       │
+    │                       ├── Issue #5 (Torah DB Migration)
+    │                       │       │
+    │                       │       └── Issue #6 (Torah Callbacks)
+    │                       │               │
+    │                       │               └── Issue #7 (Discord Bot)
+    │                       │
+    │                       └── Issue #3, #4 (cancel, change-plan)
+    │
+    └── Issue #8, #9 (MCP Integration)
+```
+
+---
+
+## Notes
+
+- All workflows should be tested with Stripe test keys first
+- Use test cards: `4242 4242 4242 4242`
+- Document any deviations from the original spec
+- Update `stripe-integration.md` if architecture changes

--- a/docs/stripe/README.md
+++ b/docs/stripe/README.md
@@ -1,0 +1,127 @@
+# Stripe Configuration Management
+
+This directory contains documentation for the Stripe configuration management system used by n8n workflows.
+
+## Overview
+
+The system allows managing multiple Stripe projects (Torah, MCP, etc.) without restarting n8n. Configuration is stored in a local SQLite database that n8n workflows can query at runtime.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     SERVICE APPELANT                             │
+│                   (Torah Bot, MCP, etc.)                        │
+│                                                                  │
+│  Envoie: project_id, price_id, callbacks, metadata              │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    n8n Workflow                                  │
+│                                                                  │
+│  1. Reçoit project_id                                           │
+│  2. SELECT * FROM stripe_projects WHERE project_id = ?          │
+│  3. Utilise secret_key pour appeler Stripe API                  │
+│  4. Retourne checkout URL                                       │
+└─────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              data/stripe-config.db (SQLite)                      │
+│                                                                  │
+│  stripe_projects:                                               │
+│  - project_id, display_name                                     │
+│  - secret_key, webhook_secret                                   │
+│  - prices (JSON), active                                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Quick Start
+
+```bash
+# 1. Initialize the database (once)
+./scripts/stripe/init-db.sh
+
+# 2. Add your Stripe projects
+./scripts/stripe/manage-projects.sh add \
+  -i torah \
+  -n "Torah Bot" \
+  -k sk_live_xxx \
+  -w whsec_xxx \
+  -P '{"basic": "price_basic", "premium": "price_premium"}'
+
+# 3. Validate configuration
+./scripts/stripe/validate-config.sh
+
+# 4. List configured projects
+./scripts/stripe/manage-projects.sh list
+```
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [init-db.md](./init-db.md) | Database initialization script |
+| [manage-projects.md](./manage-projects.md) | Project management CLI |
+| [validate-config.md](./validate-config.md) | Configuration validation |
+
+## File Structure
+
+```
+n8n-workflows/
+├── data/
+│   └── stripe-config.db        # SQLite database (created by init-db.sh)
+├── scripts/stripe/
+│   ├── init-db.sh              # Initialize database
+│   ├── manage-projects.sh      # Manage projects CLI
+│   └── validate-config.sh      # Validate configuration
+└── docs/stripe/
+    ├── README.md               # This file
+    ├── init-db.md              # init-db.sh documentation
+    ├── manage-projects.md      # manage-projects.sh documentation
+    └── validate-config.md      # validate-config.sh documentation
+```
+
+## Database Schema
+
+```sql
+CREATE TABLE stripe_projects (
+    project_id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    secret_key TEXT NOT NULL,
+    webhook_secret TEXT NOT NULL,
+    prices TEXT NOT NULL DEFAULT '{}',
+    active INTEGER DEFAULT 1,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+```
+
+## Security Notes
+
+- Secret keys are stored in SQLite (local file)
+- Use file permissions to restrict access: `chmod 600 data/stripe-config.db`
+- Secrets are masked in CLI output by default
+- Use `--show-secrets` flag only when necessary
+- Never commit the database file to git (add to .gitignore)
+
+## Adding a New Project
+
+When a new service needs Stripe integration:
+
+1. Create the products/prices in Stripe Dashboard
+2. Note the `price_xxx` IDs
+3. Get the API keys from Stripe Dashboard
+4. Run:
+   ```bash
+   ./scripts/stripe/manage-projects.sh add \
+     -i new_service \
+     -n "New Service Name" \
+     -k sk_live_xxx \
+     -w whsec_xxx \
+     -P '{"plan1": "price_xxx", "plan2": "price_yyy"}'
+   ```
+5. Validate: `./scripts/stripe/validate-config.sh`
+
+**No n8n restart required!**

--- a/docs/stripe/init-db.md
+++ b/docs/stripe/init-db.md
@@ -1,0 +1,100 @@
+# init-db.sh
+
+Initialize the SQLite database for Stripe projects configuration.
+
+## Synopsis
+
+```bash
+./scripts/stripe/init-db.sh [OPTIONS]
+```
+
+## Description
+
+Creates the SQLite database and table structure required for storing Stripe project configurations. This script should be run once before using the other management scripts.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-p, --path PATH` | Path to SQLite database (default: `data/stripe-config.db`) |
+| `-f, --force` | Force recreation of database (WARNING: drops existing tables) |
+| `-h, --help` | Show help message |
+
+## Examples
+
+### Basic initialization
+
+```bash
+./scripts/stripe/init-db.sh
+```
+
+Output:
+```
+[INFO] Creating database at: /path/to/data/stripe-config.db
+[OK] Database created successfully!
+
+========================================
+Database initialized!
+========================================
+
+  Path: /path/to/data/stripe-config.db
+  Tables: stripe_projects
+```
+
+### Custom path
+
+```bash
+./scripts/stripe/init-db.sh -p /custom/path/stripe.db
+```
+
+### Force recreation (WARNING: deletes all data)
+
+```bash
+./scripts/stripe/init-db.sh --force
+```
+
+## Database Structure Created
+
+### Table: `stripe_projects`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `project_id` | TEXT | Primary key, unique identifier (e.g., "torah", "mcp") |
+| `display_name` | TEXT | Human-readable name |
+| `secret_key` | TEXT | Stripe secret key (sk_test_* or sk_live_*) |
+| `webhook_secret` | TEXT | Stripe webhook secret (whsec_*) |
+| `prices` | TEXT | JSON mapping of plan names to price IDs |
+| `active` | INTEGER | 1 = active, 0 = inactive |
+| `created_at` | TEXT | Creation timestamp |
+| `updated_at` | TEXT | Last update timestamp (auto-updated) |
+
+### Indexes
+
+- `idx_stripe_projects_active` on `active` column
+
+### Triggers
+
+- `update_stripe_projects_timestamp`: Auto-updates `updated_at` on row modification
+
+## Prerequisites
+
+- `sqlite3` must be installed
+  ```bash
+  # Ubuntu/Debian
+  sudo apt install sqlite3
+
+  # MacOS
+  brew install sqlite3
+  ```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | Success |
+| 1 | Error (sqlite3 not installed, cannot create directory, etc.) |
+
+## See Also
+
+- [manage-projects.md](./manage-projects.md) - Manage projects
+- [validate-config.md](./validate-config.md) - Validate configuration

--- a/docs/stripe/manage-projects.md
+++ b/docs/stripe/manage-projects.md
@@ -1,0 +1,332 @@
+# manage-projects.sh
+
+Manage Stripe project configurations via command line.
+
+## Synopsis
+
+```bash
+./scripts/stripe/manage-projects.sh <COMMAND> [OPTIONS]
+```
+
+## Description
+
+A full-featured CLI for managing Stripe project configurations stored in SQLite. Allows adding, listing, updating, and removing projects without restarting n8n.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `add` | Add a new Stripe project |
+| `list` | List all projects |
+| `get` | Get details of a specific project |
+| `update` | Update an existing project |
+| `remove` | Deactivate a project (soft delete) |
+| `delete` | Permanently delete a project |
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `-d, --db PATH` | Path to SQLite database |
+| `-h, --help` | Show help for a command |
+
+---
+
+## Command: `add`
+
+Add a new Stripe project to the configuration.
+
+### Usage
+
+```bash
+./manage-projects.sh add [OPTIONS]
+```
+
+### Required Options
+
+| Option | Description |
+|--------|-------------|
+| `-i, --id ID` | Project identifier (lowercase, no spaces) |
+| `-n, --name NAME` | Display name for the project |
+| `-k, --key KEY` | Stripe secret key (sk_test_* or sk_live_*) |
+| `-w, --webhook SECRET` | Stripe webhook secret (whsec_*) |
+
+### Optional
+
+| Option | Description |
+|--------|-------------|
+| `-P, --prices JSON` | Prices mapping as JSON (default: '{}') |
+
+### Examples
+
+```bash
+# Add Torah project with prices
+./manage-projects.sh add \
+  -i torah \
+  -n "Torah Bot" \
+  -k sk_live_xxxxxxxxxxxx \
+  -w whsec_xxxxxxxxxxxx \
+  -P '{"basic": "price_basic_xxx", "premium": "price_premium_xxx", "unlimited": "price_unlimited_xxx"}'
+
+# Add MCP project
+./manage-projects.sh add \
+  -i mcp \
+  -n "MCP Tools" \
+  -k sk_live_yyyyyyyyyyyy \
+  -w whsec_yyyyyyyyyyyy \
+  -P '{"pro": "price_pro_xxx"}'
+
+# Add project with test keys
+./manage-projects.sh add \
+  -i myproject \
+  -n "My Project" \
+  -k sk_test_abc123 \
+  -w whsec_test_xyz789 \
+  -P '{"starter": "price_starter"}'
+```
+
+### Output
+
+```
+[OK] Project 'torah' added successfully!
+
+  Project ID:     torah
+  Display Name:   Torah Bot
+  Secret Key:     sk_live...xxxx
+  Webhook Secret: whsec_x...xxxx
+  Prices:         {"basic": "price_basic_xxx", "premium": "price_premium_xxx"}
+```
+
+---
+
+## Command: `list`
+
+List all configured projects.
+
+### Usage
+
+```bash
+./manage-projects.sh list [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-a, --all` | Include inactive projects |
+| `-j, --json` | Output as JSON |
+
+### Examples
+
+```bash
+# List active projects
+./manage-projects.sh list
+
+# Include inactive projects
+./manage-projects.sh list --all
+
+# Output as JSON (for scripting)
+./manage-projects.sh list --json
+```
+
+### Output
+
+```
+Stripe Projects
+===============
+
+ID      Name        Active  Key (masked)   Created
+------  ----------  ------  -------------  -------------------
+torah   Torah Bot   Yes     sk_live_xx...  2026-01-02 15:42:39
+mcp     MCP Tools   Yes     sk_live_yy...  2026-01-02 15:43:12
+
+  Total: 2 project(s)
+```
+
+---
+
+## Command: `get`
+
+Get details of a specific project.
+
+### Usage
+
+```bash
+./manage-projects.sh get <PROJECT_ID> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-s, --show-secrets` | Show full secrets (default: masked) |
+| `-j, --json` | Output as JSON |
+
+### Examples
+
+```bash
+# Get project details (secrets masked)
+./manage-projects.sh get torah
+
+# Get with full secrets visible
+./manage-projects.sh get torah --show-secrets
+
+# Get as JSON
+./manage-projects.sh get torah --json
+```
+
+### Output
+
+```
+Project Details: torah
+==============================
+
+  Project ID:     torah
+  Display Name:   Torah Bot
+  Active:         Yes
+
+  Secret Key:     sk_live...xxxx
+  Webhook Secret: whsec_x...xxxx
+  (use --show-secrets to reveal)
+
+  Prices:
+    - basic: price_basic_xxx
+    - premium: price_premium_xxx
+    - unlimited: price_unlimited_xxx
+
+  Created:        2026-01-02 15:42:39
+  Updated:        2026-01-02 15:42:39
+```
+
+---
+
+## Command: `update`
+
+Update an existing project.
+
+### Usage
+
+```bash
+./manage-projects.sh update <PROJECT_ID> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name NAME` | Update display name |
+| `-k, --key KEY` | Update secret key |
+| `-w, --webhook SECRET` | Update webhook secret |
+| `-P, --prices JSON` | Update prices mapping |
+| `-a, --activate` | Reactivate a deactivated project |
+
+### Examples
+
+```bash
+# Update display name
+./manage-projects.sh update torah -n "Torah Bot Production"
+
+# Rotate secret key
+./manage-projects.sh update torah -k sk_live_new_xxx
+
+# Update prices
+./manage-projects.sh update torah -P '{"basic": "price_new_basic", "premium": "price_new_premium"}'
+
+# Reactivate a disabled project
+./manage-projects.sh update torah --activate
+
+# Multiple updates at once
+./manage-projects.sh update torah \
+  -n "Torah Bot v2" \
+  -k sk_live_new_xxx \
+  -P '{"basic": "price_v2_basic"}'
+```
+
+---
+
+## Command: `remove`
+
+Deactivate a project (soft delete). The project remains in the database but is marked as inactive.
+
+### Usage
+
+```bash
+./manage-projects.sh remove <PROJECT_ID>
+```
+
+### Examples
+
+```bash
+./manage-projects.sh remove torah
+```
+
+### Output
+
+```
+[OK] Project 'torah' deactivated
+  To reactivate: ./manage-projects.sh update torah --activate
+  To delete permanently: ./manage-projects.sh delete torah
+```
+
+---
+
+## Command: `delete`
+
+Permanently delete a project from the database.
+
+### Usage
+
+```bash
+./manage-projects.sh delete <PROJECT_ID> [OPTIONS]
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `-f, --force` | Skip confirmation prompt |
+
+### Examples
+
+```bash
+# Delete with confirmation
+./manage-projects.sh delete torah
+
+# Delete without confirmation (use with caution)
+./manage-projects.sh delete torah --force
+```
+
+### Output
+
+```
+WARNING: This will permanently delete project 'torah'
+Type the project ID to confirm: torah
+[OK] Project 'torah' permanently deleted
+```
+
+---
+
+## Validation
+
+The script validates inputs:
+
+- **Project ID**: Must be lowercase, alphanumeric with underscores/hyphens
+- **Secret Key**: Warns if not matching `sk_test_*` or `sk_live_*`
+- **Webhook Secret**: Warns if not matching `whsec_*`
+- **Prices**: Must be valid JSON
+
+---
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | Success |
+| 1 | Error (invalid input, project not found, etc.) |
+
+---
+
+## See Also
+
+- [init-db.md](./init-db.md) - Initialize database
+- [validate-config.md](./validate-config.md) - Validate configuration

--- a/docs/stripe/validate-config.md
+++ b/docs/stripe/validate-config.md
@@ -1,0 +1,205 @@
+# validate-config.sh
+
+Validate Stripe configuration and identify potential issues.
+
+## Synopsis
+
+```bash
+./scripts/stripe/validate-config.sh [OPTIONS]
+```
+
+## Description
+
+Performs comprehensive validation of the Stripe projects configuration. Checks for common issues, missing data, and configuration inconsistencies.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-d, --db PATH` | Path to SQLite database |
+| `-v, --verbose` | Show detailed output for all checks |
+| `-j, --json` | Output results as JSON |
+| `--check-stripe` | Test actual connection to Stripe API (requires curl) |
+| `-h, --help` | Show help message |
+
+## Checks Performed
+
+| Check | Description | Severity |
+|-------|-------------|----------|
+| Database exists | Verifies database file exists | Error |
+| Database readable | Verifies database can be opened | Error |
+| Table exists | Verifies stripe_projects table exists | Error |
+| Table structure | Verifies all required columns exist | Error |
+| Has projects | At least one project configured | Error |
+| Has active projects | At least one active project | Warning |
+| Required fields | All required fields populated | Error |
+| Secret key format | Keys match sk_test_* or sk_live_* | Warning |
+| Webhook secret format | Secrets match whsec_* | Warning |
+| Prices JSON valid | Prices field contains valid JSON | Error |
+| Prices not empty | Prices are defined | Warning |
+| Environment consistency | No mix of test/live keys | Warning |
+| Stripe API (optional) | Actual API connectivity test | Error |
+
+## Examples
+
+### Basic validation
+
+```bash
+./scripts/stripe/validate-config.sh
+```
+
+Output:
+```
+Stripe Configuration Validator
+===============================
+
+Database: /path/to/data/stripe-config.db
+
+[PASS] Database exists: /path/to/data/stripe-config.db
+[PASS] Database is readable
+[PASS] Table 'stripe_projects' exists
+[PASS] All required columns present
+[PASS] Found 2 project(s)
+[PASS] Found 2 active project(s)
+[PASS] All required fields are populated
+[PASS] All secret keys have valid format
+[PASS] All webhook secrets have valid format
+[PASS] All prices are valid JSON
+[PASS] All projects have prices defined
+[PASS] All active projects use LIVE keys
+
+========================================
+Validation Summary
+========================================
+
+  Passed:   12
+  Warnings: 0
+  Errors:   0
+
+Configuration is valid!
+```
+
+### Verbose output with project overview
+
+```bash
+./scripts/stripe/validate-config.sh --verbose
+```
+
+Additional output:
+```
+Projects Overview
+==================
+
+ID      Name        Mode  Active  Prices
+------  ----------  ----  ------  ------
+torah   Torah Bot   LIVE  Yes     3
+mcp     MCP Tools   LIVE  Yes     1
+```
+
+### Test Stripe API connectivity
+
+```bash
+./scripts/stripe/validate-config.sh --check-stripe
+```
+
+Additional check:
+```
+[CHECK] Stripe API connectivity
+  ✓ torah: API key valid
+  ✓ mcp: API key valid
+[PASS] All Stripe API keys are valid
+```
+
+### JSON output (for CI/CD)
+
+```bash
+./scripts/stripe/validate-config.sh --json
+```
+
+Output:
+```json
+{
+  "status": "ok",
+  "passed": 12,
+  "warnings": 0,
+  "errors": 0,
+  "database": "/path/to/data/stripe-config.db"
+}
+```
+
+## Warning Examples
+
+### Mixed test/live keys
+
+```
+[WARN] Mixed test and live keys detected
+       Test mode: test_project
+       Live mode: torah, mcp
+       Consider using consistent environments
+```
+
+### Empty prices
+
+```
+[WARN] Empty prices for: new_project
+       Use './manage-projects.sh update <id> -P '{...}'' to add prices
+```
+
+### Invalid key format
+
+```
+[WARN] Invalid secret key format for: bad_project
+       Expected format: sk_test_* or sk_live_*
+```
+
+## Error Examples
+
+### Database not found
+
+```
+[FAIL] Database not found at: /path/to/data/stripe-config.db
+       Run './init-db.sh' to create the database
+```
+
+### No projects configured
+
+```
+[FAIL] No projects configured
+       Run './manage-projects.sh add' to add a project
+```
+
+### Invalid JSON
+
+```
+[FAIL] Invalid JSON in prices for: broken_project
+```
+
+## Exit Codes
+
+| Code | Description |
+|------|-------------|
+| 0 | All checks passed |
+| 1 | Errors found (critical issues that must be fixed) |
+| 2 | Warnings only (non-critical issues, review recommended) |
+
+## CI/CD Integration
+
+```bash
+# In your CI pipeline
+./scripts/stripe/validate-config.sh --json
+
+# Check exit code
+if [ $? -eq 0 ]; then
+  echo "Configuration valid"
+elif [ $? -eq 2 ]; then
+  echo "Configuration has warnings"
+else
+  echo "Configuration has errors"
+  exit 1
+fi
+```
+
+## See Also
+
+- [init-db.md](./init-db.md) - Initialize database
+- [manage-projects.md](./manage-projects.md) - Manage projects

--- a/scripts/stripe/init-db.sh
+++ b/scripts/stripe/init-db.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+#
+# init-db.sh - Initialize SQLite database for Stripe projects configuration
+#
+# Usage:
+#   ./init-db.sh [OPTIONS]
+#
+# Options:
+#   -p, --path PATH    Path to SQLite database (default: ../../data/stripe-config.db)
+#   -f, --force        Force recreation of database (drops existing tables)
+#   -h, --help         Show this help message
+#
+# Examples:
+#   ./init-db.sh                              # Create DB with default path
+#   ./init-db.sh -p /custom/path/stripe.db   # Create DB at custom path
+#   ./init-db.sh --force                      # Recreate DB (WARNING: deletes data)
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_DB_PATH="${SCRIPT_DIR}/../../data/stripe-config.db"
+DB_PATH="$DEFAULT_DB_PATH"
+FORCE=false
+
+# Functions
+show_help() {
+    cat << EOF
+${BLUE}Stripe Config DB Initializer${NC}
+
+${YELLOW}Usage:${NC}
+  $0 [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -p, --path PATH    Path to SQLite database
+                     Default: $DEFAULT_DB_PATH
+  -f, --force        Force recreation of database (WARNING: drops existing tables)
+  -h, --help         Show this help message
+
+${YELLOW}Examples:${NC}
+  $0                              # Create DB with default path
+  $0 -p /custom/path/stripe.db   # Create DB at custom path
+  $0 --force                      # Recreate DB (deletes existing data!)
+
+${YELLOW}What this script creates:${NC}
+  - stripe_projects table: Stores Stripe API keys per project
+  - Indexes for optimized queries
+
+EOF
+}
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[OK]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p|--path)
+            DB_PATH="$2"
+            shift 2
+            ;;
+        -f|--force)
+            FORCE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            echo "Use -h or --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if sqlite3 is installed
+if ! command -v sqlite3 &> /dev/null; then
+    log_error "sqlite3 is not installed. Please install it first."
+    echo "  Ubuntu/Debian: sudo apt install sqlite3"
+    echo "  MacOS: brew install sqlite3"
+    exit 1
+fi
+
+# Create directory if it doesn't exist
+DB_DIR=$(dirname "$DB_PATH")
+if [ ! -d "$DB_DIR" ]; then
+    log_info "Creating directory: $DB_DIR"
+    mkdir -p "$DB_DIR"
+fi
+
+# Check if database already exists
+if [ -f "$DB_PATH" ]; then
+    if [ "$FORCE" = true ]; then
+        log_warning "Force mode: Dropping existing tables..."
+        sqlite3 "$DB_PATH" "DROP TABLE IF EXISTS stripe_projects;"
+        log_success "Existing tables dropped"
+    else
+        log_warning "Database already exists at: $DB_PATH"
+        echo -e "  Use ${YELLOW}--force${NC} to recreate (WARNING: deletes all data)"
+        echo -e "  Or use ${YELLOW}manage-projects.sh${NC} to manage existing projects"
+        exit 0
+    fi
+fi
+
+log_info "Creating database at: $DB_PATH"
+
+# Create tables
+sqlite3 "$DB_PATH" << 'EOF'
+-- Stripe Projects Configuration Table
+CREATE TABLE IF NOT EXISTS stripe_projects (
+    project_id TEXT PRIMARY KEY,
+    display_name TEXT NOT NULL,
+    secret_key TEXT NOT NULL,
+    webhook_secret TEXT NOT NULL,
+    prices TEXT NOT NULL DEFAULT '{}',
+    active INTEGER DEFAULT 1,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Index for active projects lookup
+CREATE INDEX IF NOT EXISTS idx_stripe_projects_active
+ON stripe_projects(active);
+
+-- Trigger to update updated_at on modification
+CREATE TRIGGER IF NOT EXISTS update_stripe_projects_timestamp
+AFTER UPDATE ON stripe_projects
+BEGIN
+    UPDATE stripe_projects SET updated_at = datetime('now')
+    WHERE project_id = NEW.project_id;
+END;
+EOF
+
+log_success "Database created successfully!"
+
+# Show summary
+echo ""
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}Database initialized!${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+echo -e "  ${YELLOW}Path:${NC} $DB_PATH"
+echo -e "  ${YELLOW}Tables:${NC} stripe_projects"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Add a project:"
+echo -e "     ${GREEN}./manage-projects.sh add -i torah -n \"Torah Bot\" -k sk_xxx -w whsec_xxx -P '{\"basic\":\"price_xxx\"}'${NC}"
+echo ""
+echo "  2. List projects:"
+echo -e "     ${GREEN}./manage-projects.sh list${NC}"
+echo ""
+echo "  3. Validate configuration:"
+echo -e "     ${GREEN}./validate-config.sh${NC}"
+echo ""

--- a/scripts/stripe/manage-projects.sh
+++ b/scripts/stripe/manage-projects.sh
@@ -1,0 +1,860 @@
+#!/bin/bash
+#
+# manage-projects.sh - Manage Stripe project configurations
+#
+# Usage:
+#   ./manage-projects.sh <COMMAND> [OPTIONS]
+#
+# Commands:
+#   add       Add a new Stripe project
+#   list      List all projects
+#   get       Get details of a specific project
+#   update    Update an existing project
+#   remove    Deactivate a project (soft delete)
+#   delete    Permanently delete a project
+#
+# Run './manage-projects.sh <COMMAND> --help' for command-specific options.
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Default values
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_DB_PATH="${SCRIPT_DIR}/../../data/stripe-config.db"
+DB_PATH="$DEFAULT_DB_PATH"
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[OK]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+check_db_exists() {
+    if [ ! -f "$DB_PATH" ]; then
+        log_error "Database not found at: $DB_PATH"
+        echo -e "  Run ${GREEN}./init-db.sh${NC} first to create the database."
+        exit 1
+    fi
+}
+
+validate_project_id() {
+    local id="$1"
+    if [[ ! "$id" =~ ^[a-z0-9_-]+$ ]]; then
+        log_error "Invalid project_id: '$id'"
+        echo "  Project ID must contain only lowercase letters, numbers, underscores, and hyphens."
+        exit 1
+    fi
+}
+
+validate_secret_key() {
+    local key="$1"
+    if [[ ! "$key" =~ ^sk_(test|live)_ ]]; then
+        log_warning "Secret key doesn't match expected format (sk_test_* or sk_live_*)"
+        read -p "Continue anyway? [y/N]: " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    fi
+}
+
+validate_webhook_secret() {
+    local secret="$1"
+    if [[ ! "$secret" =~ ^whsec_ ]]; then
+        log_warning "Webhook secret doesn't match expected format (whsec_*)"
+        read -p "Continue anyway? [y/N]: " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    fi
+}
+
+validate_json() {
+    local json="$1"
+    if ! echo "$json" | python3 -c "import sys, json; json.load(sys.stdin)" 2>/dev/null; then
+        log_error "Invalid JSON format for prices"
+        echo "  Example: '{\"basic\": \"price_xxx\", \"premium\": \"price_yyy\"}'"
+        exit 1
+    fi
+}
+
+mask_secret() {
+    local secret="$1"
+    local len=${#secret}
+    if [ $len -gt 12 ]; then
+        echo "${secret:0:7}...${secret: -4}"
+    else
+        echo "***"
+    fi
+}
+
+# ============================================================================
+# Command: add
+# ============================================================================
+
+show_add_help() {
+    cat << EOF
+${BLUE}Add a new Stripe project${NC}
+
+${YELLOW}Usage:${NC}
+  $0 add [OPTIONS]
+
+${YELLOW}Required Options:${NC}
+  -i, --id ID              Project identifier (lowercase, no spaces)
+  -n, --name NAME          Display name for the project
+  -k, --key KEY            Stripe secret key (sk_test_* or sk_live_*)
+  -w, --webhook SECRET     Stripe webhook secret (whsec_*)
+
+${YELLOW}Optional:${NC}
+  -P, --prices JSON        Prices mapping as JSON (default: '{}')
+  -d, --db PATH            Path to database (default: $DEFAULT_DB_PATH)
+  -h, --help               Show this help
+
+${YELLOW}Examples:${NC}
+  # Add Torah project
+  $0 add -i torah -n "Torah Bot" -k sk_live_xxx -w whsec_xxx \\
+    -P '{"basic": "price_basic_xxx", "premium": "price_premium_xxx"}'
+
+  # Add MCP project
+  $0 add -i mcp -n "MCP Tools" -k sk_live_yyy -w whsec_yyy \\
+    -P '{"pro": "price_pro_xxx"}'
+
+  # Add with test keys
+  $0 add -i myproject -n "My Project" \\
+    -k sk_test_abc123 -w whsec_test_xyz789 \\
+    -P '{"starter": "price_starter"}'
+
+EOF
+}
+
+cmd_add() {
+    local project_id=""
+    local display_name=""
+    local secret_key=""
+    local webhook_secret=""
+    local prices="{}"
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -i|--id)
+                project_id="$2"
+                shift 2
+                ;;
+            -n|--name)
+                display_name="$2"
+                shift 2
+                ;;
+            -k|--key)
+                secret_key="$2"
+                shift 2
+                ;;
+            -w|--webhook)
+                webhook_secret="$2"
+                shift 2
+                ;;
+            -P|--prices)
+                prices="$2"
+                shift 2
+                ;;
+            -d|--db)
+                DB_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_add_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                echo "Use '$0 add --help' for usage information"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Validate required fields
+    if [ -z "$project_id" ]; then
+        log_error "Missing required option: -i/--id"
+        show_add_help
+        exit 1
+    fi
+    if [ -z "$display_name" ]; then
+        log_error "Missing required option: -n/--name"
+        show_add_help
+        exit 1
+    fi
+    if [ -z "$secret_key" ]; then
+        log_error "Missing required option: -k/--key"
+        show_add_help
+        exit 1
+    fi
+    if [ -z "$webhook_secret" ]; then
+        log_error "Missing required option: -w/--webhook"
+        show_add_help
+        exit 1
+    fi
+
+    check_db_exists
+    validate_project_id "$project_id"
+    validate_secret_key "$secret_key"
+    validate_webhook_secret "$webhook_secret"
+    validate_json "$prices"
+
+    # Check if project already exists
+    local existing
+    existing=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE project_id = '$project_id';")
+    if [ -n "$existing" ]; then
+        log_error "Project '$project_id' already exists"
+        echo "  Use 'update' command to modify or 'delete' to remove first."
+        exit 1
+    fi
+
+    # Insert into database
+    sqlite3 "$DB_PATH" "INSERT INTO stripe_projects (project_id, display_name, secret_key, webhook_secret, prices) VALUES ('$project_id', '$display_name', '$secret_key', '$webhook_secret', '$prices');"
+
+    log_success "Project '$project_id' added successfully!"
+    echo ""
+    echo -e "  ${YELLOW}Project ID:${NC}     $project_id"
+    echo -e "  ${YELLOW}Display Name:${NC}   $display_name"
+    echo -e "  ${YELLOW}Secret Key:${NC}     $(mask_secret "$secret_key")"
+    echo -e "  ${YELLOW}Webhook Secret:${NC} $(mask_secret "$webhook_secret")"
+    echo -e "  ${YELLOW}Prices:${NC}         $prices"
+}
+
+# ============================================================================
+# Command: list
+# ============================================================================
+
+show_list_help() {
+    cat << EOF
+${BLUE}List all Stripe projects${NC}
+
+${YELLOW}Usage:${NC}
+  $0 list [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -a, --all        Include inactive projects
+  -j, --json       Output as JSON
+  -d, --db PATH    Path to database (default: $DEFAULT_DB_PATH)
+  -h, --help       Show this help
+
+${YELLOW}Examples:${NC}
+  $0 list              # List active projects
+  $0 list --all        # Include inactive projects
+  $0 list --json       # Output as JSON
+
+EOF
+}
+
+cmd_list() {
+    local show_all=false
+    local json_output=false
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -a|--all)
+                show_all=true
+                shift
+                ;;
+            -j|--json)
+                json_output=true
+                shift
+                ;;
+            -d|--db)
+                DB_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_list_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    check_db_exists
+
+    local where_clause="WHERE active = 1"
+    if [ "$show_all" = true ]; then
+        where_clause=""
+    fi
+
+    if [ "$json_output" = true ]; then
+        sqlite3 -json "$DB_PATH" "SELECT project_id, display_name, prices, active, created_at, updated_at FROM stripe_projects $where_clause ORDER BY created_at;"
+    else
+        echo ""
+        echo -e "${BLUE}Stripe Projects${NC}"
+        echo -e "${BLUE}===============${NC}"
+        echo ""
+
+        local count
+        count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM stripe_projects $where_clause;")
+
+        if [ "$count" -eq 0 ]; then
+            log_warning "No projects found"
+            echo "  Use '$0 add' to add a new project."
+            return
+        fi
+
+        sqlite3 -header -column "$DB_PATH" "SELECT
+            project_id AS 'ID',
+            display_name AS 'Name',
+            CASE WHEN active = 1 THEN 'Yes' ELSE 'No' END AS 'Active',
+            SUBSTR(secret_key, 1, 10) || '...' AS 'Key (masked)',
+            created_at AS 'Created'
+        FROM stripe_projects $where_clause ORDER BY created_at;"
+
+        echo ""
+        echo -e "  ${CYAN}Total: $count project(s)${NC}"
+    fi
+}
+
+# ============================================================================
+# Command: get
+# ============================================================================
+
+show_get_help() {
+    cat << EOF
+${BLUE}Get details of a specific project${NC}
+
+${YELLOW}Usage:${NC}
+  $0 get <PROJECT_ID> [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -s, --show-secrets   Show full secrets (default: masked)
+  -j, --json           Output as JSON
+  -d, --db PATH        Path to database (default: $DEFAULT_DB_PATH)
+  -h, --help           Show this help
+
+${YELLOW}Examples:${NC}
+  $0 get torah                # Get torah project (secrets masked)
+  $0 get torah --show-secrets # Get with full secrets visible
+  $0 get mcp --json           # Get as JSON
+
+EOF
+}
+
+cmd_get() {
+    local project_id=""
+    local show_secrets=false
+    local json_output=false
+
+    # First argument is project_id
+    if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+        project_id="$1"
+        shift
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -s|--show-secrets)
+                show_secrets=true
+                shift
+                ;;
+            -j|--json)
+                json_output=true
+                shift
+                ;;
+            -d|--db)
+                DB_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_get_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$project_id" ]; then
+        log_error "Missing project ID"
+        show_get_help
+        exit 1
+    fi
+
+    check_db_exists
+
+    local result
+    result=$(sqlite3 -json "$DB_PATH" "SELECT * FROM stripe_projects WHERE project_id = '$project_id';")
+
+    if [ "$result" = "[]" ]; then
+        log_error "Project '$project_id' not found"
+        exit 1
+    fi
+
+    if [ "$json_output" = true ]; then
+        if [ "$show_secrets" = true ]; then
+            echo "$result"
+        else
+            echo "$result" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for item in data:
+    item['secret_key'] = item['secret_key'][:10] + '...'
+    item['webhook_secret'] = item['webhook_secret'][:10] + '...'
+print(json.dumps(data, indent=2))
+"
+        fi
+    else
+        echo ""
+        echo -e "${BLUE}Project Details: $project_id${NC}"
+        echo -e "${BLUE}==============================${NC}"
+        echo ""
+
+        local row
+        row=$(sqlite3 -separator '|' "$DB_PATH" "SELECT project_id, display_name, secret_key, webhook_secret, prices, active, created_at, updated_at FROM stripe_projects WHERE project_id = '$project_id';")
+
+        IFS='|' read -r pid name skey wsec prices active created updated <<< "$row"
+
+        echo -e "  ${YELLOW}Project ID:${NC}     $pid"
+        echo -e "  ${YELLOW}Display Name:${NC}   $name"
+        echo -e "  ${YELLOW}Active:${NC}         $([ "$active" = "1" ] && echo "Yes" || echo "No")"
+        echo ""
+
+        if [ "$show_secrets" = true ]; then
+            echo -e "  ${YELLOW}Secret Key:${NC}     $skey"
+            echo -e "  ${YELLOW}Webhook Secret:${NC} $wsec"
+        else
+            echo -e "  ${YELLOW}Secret Key:${NC}     $(mask_secret "$skey")"
+            echo -e "  ${YELLOW}Webhook Secret:${NC} $(mask_secret "$wsec")"
+            echo -e "  ${CYAN}(use --show-secrets to reveal)${NC}"
+        fi
+
+        echo ""
+        echo -e "  ${YELLOW}Prices:${NC}"
+        echo "$prices" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for k, v in data.items():
+    print(f'    - {k}: {v}')
+" 2>/dev/null || echo "    $prices"
+
+        echo ""
+        echo -e "  ${YELLOW}Created:${NC}        $created"
+        echo -e "  ${YELLOW}Updated:${NC}        $updated"
+    fi
+}
+
+# ============================================================================
+# Command: update
+# ============================================================================
+
+show_update_help() {
+    cat << EOF
+${BLUE}Update an existing Stripe project${NC}
+
+${YELLOW}Usage:${NC}
+  $0 update <PROJECT_ID> [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -n, --name NAME          Update display name
+  -k, --key KEY            Update secret key
+  -w, --webhook SECRET     Update webhook secret
+  -P, --prices JSON        Update prices mapping
+  -a, --activate           Activate the project
+  -d, --db PATH            Path to database
+  -h, --help               Show this help
+
+${YELLOW}Examples:${NC}
+  # Update display name
+  $0 update torah -n "Torah Bot Production"
+
+  # Update secret key (rotate)
+  $0 update torah -k sk_live_new_xxx
+
+  # Update prices
+  $0 update torah -P '{"basic": "price_new_basic", "premium": "price_new_premium"}'
+
+  # Reactivate a disabled project
+  $0 update torah --activate
+
+EOF
+}
+
+cmd_update() {
+    local project_id=""
+    local display_name=""
+    local secret_key=""
+    local webhook_secret=""
+    local prices=""
+    local activate=false
+
+    # First argument is project_id
+    if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+        project_id="$1"
+        shift
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -n|--name)
+                display_name="$2"
+                shift 2
+                ;;
+            -k|--key)
+                secret_key="$2"
+                shift 2
+                ;;
+            -w|--webhook)
+                webhook_secret="$2"
+                shift 2
+                ;;
+            -P|--prices)
+                prices="$2"
+                shift 2
+                ;;
+            -a|--activate)
+                activate=true
+                shift
+                ;;
+            -d|--db)
+                DB_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_update_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$project_id" ]; then
+        log_error "Missing project ID"
+        show_update_help
+        exit 1
+    fi
+
+    check_db_exists
+
+    # Check if project exists
+    local existing
+    existing=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE project_id = '$project_id';")
+    if [ -z "$existing" ]; then
+        log_error "Project '$project_id' not found"
+        exit 1
+    fi
+
+    # Build update query
+    local updates=()
+
+    if [ -n "$display_name" ]; then
+        updates+=("display_name = '$display_name'")
+    fi
+    if [ -n "$secret_key" ]; then
+        validate_secret_key "$secret_key"
+        updates+=("secret_key = '$secret_key'")
+    fi
+    if [ -n "$webhook_secret" ]; then
+        validate_webhook_secret "$webhook_secret"
+        updates+=("webhook_secret = '$webhook_secret'")
+    fi
+    if [ -n "$prices" ]; then
+        validate_json "$prices"
+        updates+=("prices = '$prices'")
+    fi
+    if [ "$activate" = true ]; then
+        updates+=("active = 1")
+    fi
+
+    if [ ${#updates[@]} -eq 0 ]; then
+        log_warning "No updates specified"
+        show_update_help
+        exit 1
+    fi
+
+    local update_sql
+    update_sql=$(IFS=', '; echo "${updates[*]}")
+
+    sqlite3 "$DB_PATH" "UPDATE stripe_projects SET $update_sql WHERE project_id = '$project_id';"
+
+    log_success "Project '$project_id' updated successfully!"
+}
+
+# ============================================================================
+# Command: remove (soft delete)
+# ============================================================================
+
+show_remove_help() {
+    cat << EOF
+${BLUE}Deactivate a Stripe project (soft delete)${NC}
+
+${YELLOW}Usage:${NC}
+  $0 remove <PROJECT_ID> [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -d, --db PATH    Path to database
+  -h, --help       Show this help
+
+${YELLOW}Examples:${NC}
+  $0 remove torah    # Deactivate torah project
+
+${YELLOW}Note:${NC}
+  This performs a soft delete (sets active = 0).
+  Use '$0 update <PROJECT_ID> --activate' to reactivate.
+  Use '$0 delete <PROJECT_ID>' to permanently remove.
+
+EOF
+}
+
+cmd_remove() {
+    local project_id=""
+
+    if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+        project_id="$1"
+        shift
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -d|--db)
+                DB_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_remove_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$project_id" ]; then
+        log_error "Missing project ID"
+        show_remove_help
+        exit 1
+    fi
+
+    check_db_exists
+
+    local existing
+    existing=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE project_id = '$project_id';")
+    if [ -z "$existing" ]; then
+        log_error "Project '$project_id' not found"
+        exit 1
+    fi
+
+    sqlite3 "$DB_PATH" "UPDATE stripe_projects SET active = 0 WHERE project_id = '$project_id';"
+
+    log_success "Project '$project_id' deactivated"
+    echo "  To reactivate: $0 update $project_id --activate"
+    echo "  To delete permanently: $0 delete $project_id"
+}
+
+# ============================================================================
+# Command: delete (hard delete)
+# ============================================================================
+
+show_delete_help() {
+    cat << EOF
+${BLUE}Permanently delete a Stripe project${NC}
+
+${YELLOW}Usage:${NC}
+  $0 delete <PROJECT_ID> [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -f, --force      Skip confirmation prompt
+  -d, --db PATH    Path to database
+  -h, --help       Show this help
+
+${YELLOW}Examples:${NC}
+  $0 delete torah           # Delete with confirmation
+  $0 delete torah --force   # Delete without confirmation
+
+${RED}WARNING:${NC} This action cannot be undone!
+
+EOF
+}
+
+cmd_delete() {
+    local project_id=""
+    local force=false
+
+    if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+        project_id="$1"
+        shift
+    fi
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            -f|--force)
+                force=true
+                shift
+                ;;
+            -d|--db)
+                DB_PATH="$2"
+                shift 2
+                ;;
+            -h|--help)
+                show_delete_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "$project_id" ]; then
+        log_error "Missing project ID"
+        show_delete_help
+        exit 1
+    fi
+
+    check_db_exists
+
+    local existing
+    existing=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE project_id = '$project_id';")
+    if [ -z "$existing" ]; then
+        log_error "Project '$project_id' not found"
+        exit 1
+    fi
+
+    if [ "$force" != true ]; then
+        echo -e "${RED}WARNING: This will permanently delete project '$project_id'${NC}"
+        read -p "Type the project ID to confirm: " confirm
+        if [ "$confirm" != "$project_id" ]; then
+            log_error "Confirmation failed. Aborting."
+            exit 1
+        fi
+    fi
+
+    sqlite3 "$DB_PATH" "DELETE FROM stripe_projects WHERE project_id = '$project_id';"
+
+    log_success "Project '$project_id' permanently deleted"
+}
+
+# ============================================================================
+# Main Help
+# ============================================================================
+
+show_main_help() {
+    cat << EOF
+${BLUE}${BOLD}Stripe Projects Manager${NC}
+
+Manage Stripe API configurations for multiple projects without restarting n8n.
+
+${YELLOW}Usage:${NC}
+  $0 <COMMAND> [OPTIONS]
+
+${YELLOW}Commands:${NC}
+  add       Add a new Stripe project
+  list      List all projects
+  get       Get details of a specific project
+  update    Update an existing project
+  remove    Deactivate a project (soft delete)
+  delete    Permanently delete a project
+
+${YELLOW}Global Options:${NC}
+  -d, --db PATH    Path to SQLite database (default: $DEFAULT_DB_PATH)
+  -h, --help       Show help for a command
+
+${YELLOW}Examples:${NC}
+  # Initialize database (run once)
+  ./init-db.sh
+
+  # Add a new project
+  $0 add -i torah -n "Torah Bot" -k sk_live_xxx -w whsec_xxx \\
+    -P '{"basic": "price_xxx", "premium": "price_yyy"}'
+
+  # List all projects
+  $0 list
+
+  # Get project details
+  $0 get torah
+  $0 get torah --show-secrets
+
+  # Update a project
+  $0 update torah -k sk_live_new_xxx
+
+  # Deactivate a project
+  $0 remove torah
+
+  # Validate configuration
+  ./validate-config.sh
+
+${YELLOW}More Information:${NC}
+  Run '$0 <COMMAND> --help' for detailed help on each command.
+
+EOF
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+# No arguments - show help
+if [ $# -eq 0 ]; then
+    show_main_help
+    exit 0
+fi
+
+# Parse command
+COMMAND="$1"
+shift
+
+case "$COMMAND" in
+    add)
+        cmd_add "$@"
+        ;;
+    list)
+        cmd_list "$@"
+        ;;
+    get)
+        cmd_get "$@"
+        ;;
+    update)
+        cmd_update "$@"
+        ;;
+    remove)
+        cmd_remove "$@"
+        ;;
+    delete)
+        cmd_delete "$@"
+        ;;
+    -h|--help|help)
+        show_main_help
+        ;;
+    *)
+        log_error "Unknown command: $COMMAND"
+        echo "Use '$0 --help' for usage information"
+        exit 1
+        ;;
+esac

--- a/scripts/stripe/validate-config.sh
+++ b/scripts/stripe/validate-config.sh
@@ -1,0 +1,528 @@
+#!/bin/bash
+#
+# validate-config.sh - Validate Stripe configuration and check for issues
+#
+# Usage:
+#   ./validate-config.sh [OPTIONS]
+#
+# Options:
+#   -d, --db PATH      Path to SQLite database
+#   -v, --verbose      Show detailed output
+#   -j, --json         Output as JSON
+#   --check-stripe     Test connection to Stripe API (requires curl)
+#   -h, --help         Show this help
+#
+# Examples:
+#   ./validate-config.sh                  # Basic validation
+#   ./validate-config.sh --verbose        # Detailed validation
+#   ./validate-config.sh --check-stripe   # Also verify Stripe API keys
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# Default values
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_DB_PATH="${SCRIPT_DIR}/../../data/stripe-config.db"
+DB_PATH="$DEFAULT_DB_PATH"
+VERBOSE=false
+JSON_OUTPUT=false
+CHECK_STRIPE=false
+
+# Counters
+ERRORS=0
+WARNINGS=0
+PASSED=0
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+show_help() {
+    cat << EOF
+${BLUE}${BOLD}Stripe Configuration Validator${NC}
+
+Validates your Stripe projects configuration and identifies potential issues.
+
+${YELLOW}Usage:${NC}
+  $0 [OPTIONS]
+
+${YELLOW}Options:${NC}
+  -d, --db PATH      Path to SQLite database (default: $DEFAULT_DB_PATH)
+  -v, --verbose      Show detailed output for all checks
+  -j, --json         Output results as JSON
+  --check-stripe     Test actual connection to Stripe API (requires curl)
+  -h, --help         Show this help
+
+${YELLOW}Examples:${NC}
+  $0                      # Basic validation
+  $0 --verbose            # Detailed validation with all checks
+  $0 --check-stripe       # Also verify Stripe API keys work
+  $0 -d /path/to/db.db    # Validate specific database
+
+${YELLOW}Checks Performed:${NC}
+  - Database existence and accessibility
+  - Table structure integrity
+  - Required fields populated
+  - Secret key format (sk_test_* or sk_live_*)
+  - Webhook secret format (whsec_*)
+  - Prices JSON validity
+  - At least one active project exists
+  - No duplicate project IDs
+  - Consistency between test/live keys
+
+${YELLOW}Exit Codes:${NC}
+  0 - All checks passed
+  1 - Errors found (critical issues)
+  2 - Warnings only (non-critical issues)
+
+EOF
+}
+
+log_check() {
+    if [ "$VERBOSE" = true ]; then
+        echo -e "${BLUE}[CHECK]${NC} $1"
+    fi
+}
+
+log_pass() {
+    ((PASSED++))
+    echo -e "${GREEN}[PASS]${NC} $1"
+}
+
+log_warn() {
+    ((WARNINGS++))
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_fail() {
+    ((ERRORS++))
+    echo -e "${RED}[FAIL]${NC} $1"
+}
+
+log_info() {
+    echo -e "${CYAN}[INFO]${NC} $1"
+}
+
+# ============================================================================
+# Parse Arguments
+# ============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d|--db)
+            DB_PATH="$2"
+            shift 2
+            ;;
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -j|--json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --check-stripe)
+            CHECK_STRIPE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}[ERROR]${NC} Unknown option: $1"
+            echo "Use -h or --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# ============================================================================
+# Validation Functions
+# ============================================================================
+
+check_database_exists() {
+    log_check "Database file exists"
+
+    if [ ! -f "$DB_PATH" ]; then
+        log_fail "Database not found at: $DB_PATH"
+        echo "       Run './init-db.sh' to create the database"
+        return 1
+    fi
+
+    log_pass "Database exists: $DB_PATH"
+    return 0
+}
+
+check_database_readable() {
+    log_check "Database is readable"
+
+    if ! sqlite3 "$DB_PATH" "SELECT 1;" &>/dev/null; then
+        log_fail "Cannot read database: $DB_PATH"
+        return 1
+    fi
+
+    log_pass "Database is readable"
+    return 0
+}
+
+check_table_exists() {
+    log_check "Required tables exist"
+
+    local tables
+    tables=$(sqlite3 "$DB_PATH" "SELECT name FROM sqlite_master WHERE type='table' AND name='stripe_projects';")
+
+    if [ -z "$tables" ]; then
+        log_fail "Table 'stripe_projects' not found"
+        echo "       Run './init-db.sh' to create the tables"
+        return 1
+    fi
+
+    log_pass "Table 'stripe_projects' exists"
+    return 0
+}
+
+check_table_structure() {
+    log_check "Table structure is correct"
+
+    local required_columns=("project_id" "display_name" "secret_key" "webhook_secret" "prices" "active")
+    local actual_columns
+    actual_columns=$(sqlite3 "$DB_PATH" "PRAGMA table_info(stripe_projects);" | cut -d'|' -f2)
+
+    local missing=()
+    for col in "${required_columns[@]}"; do
+        if ! echo "$actual_columns" | grep -q "^${col}$"; then
+            missing+=("$col")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_fail "Missing columns: ${missing[*]}"
+        return 1
+    fi
+
+    log_pass "All required columns present"
+    return 0
+}
+
+check_has_projects() {
+    log_check "At least one project configured"
+
+    local count
+    count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM stripe_projects;")
+
+    if [ "$count" -eq 0 ]; then
+        log_fail "No projects configured"
+        echo "       Run './manage-projects.sh add' to add a project"
+        return 1
+    fi
+
+    log_pass "Found $count project(s)"
+    return 0
+}
+
+check_has_active_projects() {
+    log_check "At least one active project"
+
+    local count
+    count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM stripe_projects WHERE active = 1;")
+
+    if [ "$count" -eq 0 ]; then
+        log_warn "No active projects found"
+        echo "       Use './manage-projects.sh update <id> --activate' to activate"
+        return 1
+    fi
+
+    log_pass "Found $count active project(s)"
+    return 0
+}
+
+check_secret_key_format() {
+    log_check "Secret key format validation"
+
+    local invalid
+    invalid=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE secret_key NOT LIKE 'sk_test_%' AND secret_key NOT LIKE 'sk_live_%';")
+
+    if [ -n "$invalid" ]; then
+        log_warn "Invalid secret key format for: $invalid"
+        echo "       Expected format: sk_test_* or sk_live_*"
+        return 1
+    fi
+
+    log_pass "All secret keys have valid format"
+    return 0
+}
+
+check_webhook_secret_format() {
+    log_check "Webhook secret format validation"
+
+    local invalid
+    invalid=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE webhook_secret NOT LIKE 'whsec_%';")
+
+    if [ -n "$invalid" ]; then
+        log_warn "Invalid webhook secret format for: $invalid"
+        echo "       Expected format: whsec_*"
+        return 1
+    fi
+
+    log_pass "All webhook secrets have valid format"
+    return 0
+}
+
+check_prices_json() {
+    log_check "Prices JSON validity"
+
+    local projects
+    projects=$(sqlite3 -separator '|' "$DB_PATH" "SELECT project_id, prices FROM stripe_projects;")
+
+    local invalid_projects=()
+
+    while IFS='|' read -r project_id prices; do
+        if ! echo "$prices" | python3 -c "import sys, json; json.load(sys.stdin)" 2>/dev/null; then
+            invalid_projects+=("$project_id")
+        fi
+    done <<< "$projects"
+
+    if [ ${#invalid_projects[@]} -gt 0 ]; then
+        log_fail "Invalid JSON in prices for: ${invalid_projects[*]}"
+        return 1
+    fi
+
+    log_pass "All prices are valid JSON"
+    return 0
+}
+
+check_prices_not_empty() {
+    log_check "Prices are defined"
+
+    local empty
+    empty=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE prices = '{}' OR prices = '' OR prices IS NULL;")
+
+    if [ -n "$empty" ]; then
+        log_warn "Empty prices for: $empty"
+        echo "       Use './manage-projects.sh update <id> -P '{...}'' to add prices"
+        return 1
+    fi
+
+    log_pass "All projects have prices defined"
+    return 0
+}
+
+check_env_consistency() {
+    log_check "Environment consistency (test vs live)"
+
+    local test_keys
+    local live_keys
+
+    test_keys=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE active = 1 AND secret_key LIKE 'sk_test_%';")
+    live_keys=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE active = 1 AND secret_key LIKE 'sk_live_%';")
+
+    if [ -n "$test_keys" ] && [ -n "$live_keys" ]; then
+        log_warn "Mixed test and live keys detected"
+        echo "       Test mode: $test_keys"
+        echo "       Live mode: $live_keys"
+        echo "       Consider using consistent environments"
+        return 1
+    fi
+
+    if [ -n "$test_keys" ]; then
+        log_pass "All active projects use TEST keys"
+        log_info "Projects in test mode: $test_keys"
+    elif [ -n "$live_keys" ]; then
+        log_pass "All active projects use LIVE keys"
+    fi
+
+    return 0
+}
+
+check_stripe_api() {
+    if [ "$CHECK_STRIPE" != true ]; then
+        return 0
+    fi
+
+    log_check "Stripe API connectivity"
+
+    if ! command -v curl &> /dev/null; then
+        log_warn "curl not installed, skipping API check"
+        return 1
+    fi
+
+    local projects
+    projects=$(sqlite3 -separator '|' "$DB_PATH" "SELECT project_id, secret_key FROM stripe_projects WHERE active = 1;")
+
+    local failed=()
+
+    while IFS='|' read -r project_id secret_key; do
+        [ -z "$project_id" ] && continue
+
+        local response
+        response=$(curl -s -o /dev/null -w "%{http_code}" \
+            -u "$secret_key:" \
+            "https://api.stripe.com/v1/balance" 2>/dev/null)
+
+        if [ "$response" = "200" ]; then
+            if [ "$VERBOSE" = true ]; then
+                echo -e "  ${GREEN}✓${NC} $project_id: API key valid"
+            fi
+        else
+            failed+=("$project_id (HTTP $response)")
+        fi
+    done <<< "$projects"
+
+    if [ ${#failed[@]} -gt 0 ]; then
+        log_fail "Stripe API connection failed for: ${failed[*]}"
+        return 1
+    fi
+
+    log_pass "All Stripe API keys are valid"
+    return 0
+}
+
+check_required_fields() {
+    log_check "Required fields populated"
+
+    local missing
+    missing=$(sqlite3 "$DB_PATH" "SELECT project_id FROM stripe_projects WHERE
+        project_id IS NULL OR project_id = '' OR
+        display_name IS NULL OR display_name = '' OR
+        secret_key IS NULL OR secret_key = '' OR
+        webhook_secret IS NULL OR webhook_secret = '';")
+
+    if [ -n "$missing" ]; then
+        log_fail "Missing required fields for: $missing"
+        return 1
+    fi
+
+    log_pass "All required fields are populated"
+    return 0
+}
+
+# ============================================================================
+# Summary Functions
+# ============================================================================
+
+show_summary() {
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BOLD}Validation Summary${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo ""
+    echo -e "  ${GREEN}Passed:${NC}   $PASSED"
+    echo -e "  ${YELLOW}Warnings:${NC} $WARNINGS"
+    echo -e "  ${RED}Errors:${NC}   $ERRORS"
+    echo ""
+
+    if [ $ERRORS -gt 0 ]; then
+        echo -e "${RED}${BOLD}Configuration has ERRORS that must be fixed.${NC}"
+        return 1
+    elif [ $WARNINGS -gt 0 ]; then
+        echo -e "${YELLOW}${BOLD}Configuration has warnings (review recommended).${NC}"
+        return 2
+    else
+        echo -e "${GREEN}${BOLD}Configuration is valid!${NC}"
+        return 0
+    fi
+}
+
+show_json_summary() {
+    local status="ok"
+    if [ $ERRORS -gt 0 ]; then
+        status="error"
+    elif [ $WARNINGS -gt 0 ]; then
+        status="warning"
+    fi
+
+    cat << EOF
+{
+  "status": "$status",
+  "passed": $PASSED,
+  "warnings": $WARNINGS,
+  "errors": $ERRORS,
+  "database": "$DB_PATH"
+}
+EOF
+}
+
+show_project_summary() {
+    echo ""
+    echo -e "${BLUE}Projects Overview${NC}"
+    echo -e "${BLUE}==================${NC}"
+    echo ""
+
+    sqlite3 -header -column "$DB_PATH" "SELECT
+        project_id AS 'ID',
+        display_name AS 'Name',
+        CASE
+            WHEN secret_key LIKE 'sk_test_%' THEN 'TEST'
+            WHEN secret_key LIKE 'sk_live_%' THEN 'LIVE'
+            ELSE 'UNKNOWN'
+        END AS 'Mode',
+        CASE WHEN active = 1 THEN 'Yes' ELSE 'No' END AS 'Active',
+        (SELECT COUNT(*) FROM json_each(prices)) AS 'Prices'
+    FROM stripe_projects
+    ORDER BY active DESC, project_id;" 2>/dev/null || \
+    sqlite3 -header -column "$DB_PATH" "SELECT
+        project_id AS 'ID',
+        display_name AS 'Name',
+        CASE WHEN active = 1 THEN 'Yes' ELSE 'No' END AS 'Active'
+    FROM stripe_projects
+    ORDER BY active DESC, project_id;"
+
+    echo ""
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+if [ "$JSON_OUTPUT" != true ]; then
+    echo ""
+    echo -e "${BLUE}${BOLD}Stripe Configuration Validator${NC}"
+    echo -e "${BLUE}===============================${NC}"
+    echo ""
+    echo -e "Database: ${CYAN}$DB_PATH${NC}"
+    echo ""
+fi
+
+# Run all checks
+check_database_exists || true
+check_database_readable || exit 1
+check_table_exists || exit 1
+check_table_structure || true
+check_has_projects || true
+check_has_active_projects || true
+check_required_fields || true
+check_secret_key_format || true
+check_webhook_secret_format || true
+check_prices_json || true
+check_prices_not_empty || true
+check_env_consistency || true
+check_stripe_api || true
+
+# Show results
+if [ "$JSON_OUTPUT" = true ]; then
+    show_json_summary
+else
+    if [ "$VERBOSE" = true ] && [ $ERRORS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
+        show_project_summary
+    fi
+    show_summary
+fi
+
+# Exit with appropriate code
+if [ $ERRORS -gt 0 ]; then
+    exit 1
+elif [ $WARNINGS -gt 0 ]; then
+    exit 2
+else
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- Add CLI scripts to manage Stripe multi-project configuration via SQLite
- `init-db.sh`: Initialize the SQLite database with `stripe_projects` table
- `manage-projects.sh`: Full CRUD operations (add/list/get/update/remove/delete)
- `validate-config.sh`: Validate configuration with optional Stripe API check
- Add comprehensive documentation for all scripts
- Add implementation roadmap with 13 issues organized in 5 phases

## Files

**Scripts (`scripts/stripe/`)**
| File | Description |
|------|-------------|
| `init-db.sh` | Initialize SQLite database |
| `manage-projects.sh` | CLI for project management |
| `validate-config.sh` | Configuration validation |

**Documentation (`docs/stripe/`)**
| File | Description |
|------|-------------|
| `README.md` | Overview and quick start |
| `init-db.md` | init-db.sh documentation |
| `manage-projects.md` | manage-projects.sh documentation |
| `validate-config.md` | validate-config.sh documentation |

**Roadmap (`docs/issues/`)**
| File | Description |
|------|-------------|
| `stripe-implementation-roadmap.md` | 13 issues in 5 phases |

## Next Steps

After merge, Phase 1 workflows:
1. Issue #10: Configure Stripe Dashboard (products, prices)
2. Issue #11: Configure n8n environment
3. Issue #1: Create `subscription-checkout-create` workflow
4. Issue #2: Create `subscription-webhook-handler` workflow

## Test plan

- [ ] Run `./scripts/stripe/init-db.sh` to create database
- [ ] Run `./scripts/stripe/manage-projects.sh add -i test -n "Test" -k sk_test_xxx -w whsec_xxx -P '{}'`
- [ ] Run `./scripts/stripe/validate-config.sh --verbose`
- [ ] Verify documentation is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)