### PR TITLE
feat(stripe): add n8n proxy workflows for subscription management

### DIFF
--- a/workflows/Stripe/subscription-cancel.json
+++ b/workflows/Stripe/subscription-cancel.json
@@ -1,0 +1,399 @@
+{
+  "name": "Stripe - Subscription Cancel",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Stripe Subscription Cancel\n\n**Endpoint:** POST /webhook/subscription-cancel\n\n**Purpose:** Cancel a subscription (immediately or at period end).\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"stripe_subscription_id\": \"sub_xxx\",\n  \"cancel_immediately\": false\n}\n```\n\n**Output (success):**\n```json\n{\n  \"success\": true,\n  \"subscription_id\": \"sub_xxx\",\n  \"status\": \"canceled\",\n  \"cancel_at_period_end\": true,\n  \"current_period_end\": 1234567890\n}\n```\n\n**Setup:** Create SQLite credential named 'Stripe Config DB'",
+        "height": 420,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "subscription-cancel",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [420, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input\nconst input = $input.first().json;\nconst body = input.body || {};\n\nconst requiredFields = ['project_id', 'stripe_subscription_id'];\nconst missing = requiredFields.filter(f => !body[f]);\n\nif (missing.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required fields: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: body.project_id,\n    subscription_id: body.stripe_subscription_id,\n    cancel_immediately: body.cancel_immediately === true\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [640, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [860, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT project_id, secret_key FROM stripe_projects WHERE project_id = '{{ $json.project_id }}' AND active = 1",
+        "options": {}
+      },
+      "id": "get-project-config",
+      "name": "Get Project Config",
+      "type": "n8n-nodes-base.sqlite",
+      "typeVersion": 1,
+      "position": [1080, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check project and prepare API call\nconst dbResults = $('Get Project Config').all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.secret_key) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Project '${inputData.project_id}' not found or inactive`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst secretKey = dbResults[0].json.secret_key;\n\nreturn [{\n  json: {\n    found: true,\n    authHeader: `Bearer ${secretKey}`,\n    subscription_id: inputData.subscription_id,\n    cancel_immediately: inputData.cancel_immediately\n  }\n}];"
+      },
+      "id": "prepare-request",
+      "name": "Prepare Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1300, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-found",
+      "name": "Project Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1520, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-immediate",
+              "leftValue": "={{ $json.cancel_immediately }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-immediate",
+      "name": "Cancel Immediately?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1740, 100]
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "=https://api.stripe.com/v1/subscriptions/{{ $json.subscription_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.authHeader }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "cancel-immediately",
+      "name": "Cancel Immediately",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1960, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.stripe.com/v1/subscriptions/{{ $json.subscription_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.authHeader }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/x-www-form-urlencoded"
+            }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "raw",
+        "body": "cancel_at_period_end=true",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "cancel-at-period-end",
+      "name": "Cancel at Period End",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1960, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response\nconst response = $input.first().json;\n\nif (response.statusCode === 200 && response.body) {\n  const sub = response.body;\n  return [{\n    json: {\n      success: true,\n      subscription_id: sub.id,\n      status: sub.status,\n      cancel_at_period_end: sub.cancel_at_period_end,\n      canceled_at: sub.canceled_at,\n      cancel_at: sub.cancel_at,\n      current_period_end: sub.current_period_end\n    }\n  }];\n}\n\nconst error = response.body?.error || {};\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: response.statusCode || 500,\n      message: error.message || 'Failed to cancel subscription',\n      type: error.type || 'api_error'\n    }\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2180, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}"
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2400, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1080, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}"
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1740, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Project Config",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Config": {
+      "main": [
+        [
+          {
+            "node": "Prepare Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Request": {
+      "main": [
+        [
+          {
+            "node": "Project Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Project Found?": {
+      "main": [
+        [
+          {
+            "node": "Cancel Immediately?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cancel Immediately?": {
+      "main": [
+        [
+          {
+            "node": "Cancel Immediately",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Cancel at Period End",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cancel Immediately": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Cancel at Period End": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Stripe/subscription-change-plan.json
+++ b/workflows/Stripe/subscription-change-plan.json
@@ -1,0 +1,434 @@
+{
+  "name": "Stripe - Subscription Change Plan",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Stripe Subscription Change Plan\n\n**Endpoint:** POST /webhook/subscription-change-plan\n\n**Purpose:** Upgrade or downgrade a subscription to a new plan/price.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"stripe_subscription_id\": \"sub_xxx\",\n  \"new_price_id\": \"price_xxx\",\n  \"proration_behavior\": \"create_prorations\"\n}\n```\n\n**Proration behaviors:**\n- `create_prorations` (default): Charge/credit prorated amount\n- `none`: No proration, change takes effect at next billing\n- `always_invoice`: Create invoice immediately\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"subscription_id\": \"sub_xxx\",\n  \"status\": \"active\",\n  \"new_price_id\": \"price_xxx\",\n  \"current_period_end\": 1234567890\n}\n```\n\n**Setup:** Create SQLite credential named 'Stripe Config DB'",
+        "height": 500,
+        "width": 360,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "subscription-change-plan",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input\nconst input = $input.first().json;\nconst body = input.body || {};\n\nconst requiredFields = ['project_id', 'stripe_subscription_id', 'new_price_id'];\nconst missing = requiredFields.filter(f => !body[f]);\n\nif (missing.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required fields: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Validate proration_behavior if provided\nconst validProrations = ['create_prorations', 'none', 'always_invoice'];\nconst proration = body.proration_behavior || 'create_prorations';\n\nif (!validProrations.includes(proration)) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Invalid proration_behavior. Must be one of: ${validProrations.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: body.project_id,\n    subscription_id: body.stripe_subscription_id,\n    new_price_id: body.new_price_id,\n    proration_behavior: proration\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT project_id, secret_key FROM stripe_projects WHERE project_id = '{{ $json.project_id }}' AND active = 1",
+        "options": {}
+      },
+      "id": "get-project-config",
+      "name": "Get Project Config",
+      "type": "n8n-nodes-base.sqlite",
+      "typeVersion": 1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check project and prepare API call\nconst dbResults = $('Get Project Config').all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.secret_key) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Project '${inputData.project_id}' not found or inactive`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst secretKey = dbResults[0].json.secret_key;\n\nreturn [{\n  json: {\n    found: true,\n    authHeader: `Bearer ${secretKey}`,\n    subscription_id: inputData.subscription_id,\n    new_price_id: inputData.new_price_id,\n    proration_behavior: inputData.proration_behavior\n  }\n}];"
+      },
+      "id": "prepare-request",
+      "name": "Prepare Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-found",
+      "name": "Project Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://api.stripe.com/v1/subscriptions/{{ $json.subscription_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.authHeader }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "get-subscription",
+      "name": "Get Subscription",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1760, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract subscription item ID and prepare update\nconst response = $input.first().json;\nconst prevData = $('Prepare Request').first().json;\n\nif (response.statusCode !== 200 || !response.body) {\n  const error = response.body?.error || {};\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: response.statusCode || 404,\n        message: error.message || 'Subscription not found',\n        type: error.type || 'api_error'\n      }\n    }\n  }];\n}\n\nconst subscription = response.body;\nconst items = subscription.items?.data || [];\n\nif (items.length === 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Subscription has no items',\n        type: 'invalid_request'\n      }\n    }\n  }];\n}\n\n// Get the first item (most subscriptions have one item)\nconst itemId = items[0].id;\n\n// Build form body\nconst params = new URLSearchParams();\nparams.append('items[0][id]', itemId);\nparams.append('items[0][price]', prevData.new_price_id);\nparams.append('proration_behavior', prevData.proration_behavior);\n\nreturn [{\n  json: {\n    valid: true,\n    authHeader: prevData.authHeader,\n    subscription_id: prevData.subscription_id,\n    bodyString: params.toString()\n  }\n}];"
+      },
+      "id": "extract-item-id",
+      "name": "Prepare Update",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-sub-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-sub-valid",
+      "name": "Subscription Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2200, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.stripe.com/v1/subscriptions/{{ $json.subscription_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.authHeader }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/x-www-form-urlencoded"
+            }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "raw",
+        "body": "={{ $json.bodyString }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "update-subscription",
+      "name": "Update Subscription",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2420, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response\nconst response = $input.first().json;\n\nif (response.statusCode === 200 && response.body) {\n  const sub = response.body;\n  const newPriceId = sub.items?.data?.[0]?.price?.id;\n  \n  return [{\n    json: {\n      success: true,\n      subscription_id: sub.id,\n      status: sub.status,\n      new_price_id: newPriceId,\n      current_period_end: sub.current_period_end,\n      latest_invoice: sub.latest_invoice\n    }\n  }];\n}\n\nconst error = response.body?.error || {};\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: response.statusCode || 500,\n      message: error.message || 'Failed to update subscription',\n      type: error.type || 'api_error'\n    }\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2640, 0]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}"
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2860, 0]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}"
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-sub-error",
+      "name": "Respond Sub Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2420, 200]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Project Config",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Config": {
+      "main": [
+        [
+          {
+            "node": "Prepare Request",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Request": {
+      "main": [
+        [
+          {
+            "node": "Project Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Project Found?": {
+      "main": [
+        [
+          {
+            "node": "Get Subscription",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Subscription": {
+      "main": [
+        [
+          {
+            "node": "Prepare Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Update": {
+      "main": [
+        [
+          {
+            "node": "Subscription Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Subscription Valid?": {
+      "main": [
+        [
+          {
+            "node": "Update Subscription",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Sub Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Subscription": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Stripe/subscription-checkout-create.json
+++ b/workflows/Stripe/subscription-checkout-create.json
@@ -1,0 +1,335 @@
+{
+  "name": "Stripe - Subscription Checkout Create",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Stripe Subscription Checkout Create\n\n**Endpoint:** POST /webhook/subscription-checkout-create\n\n**Purpose:** Creates a Stripe Checkout session for subscription signup.\nActs as a proxy - each project has its own Stripe account.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"price_id\": \"price_xxx\",\n  \"customer_email\": \"user@example.com\",\n  \"callbacks\": {\n    \"success\": \"http://...\",\n    \"renewal\": \"http://...\"\n  },\n  \"urls\": {\n    \"success\": \"https://...\",\n    \"cancel\": \"https://...\"\n  },\n  \"metadata\": {},\n  \"options\": {\n    \"trial_days\": 7\n  }\n}\n```\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"checkout_url\": \"https://checkout.stripe.com/...\",\n  \"session_id\": \"cs_xxx\"\n}\n```\n\n**Setup:** Create SQLite credential named 'Stripe Config DB' pointing to data/stripe-config.db",
+        "height": 580,
+        "width": 380,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "subscription-checkout-create",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [480, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate and extract input parameters\nconst input = $input.first().json;\nconst body = input.body || {};\n\n// Required fields\nconst requiredFields = ['project_id', 'price_id', 'customer_email', 'urls'];\nconst missing = requiredFields.filter(f => !body[f]);\n\nif (missing.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required fields: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Validate URLs\nif (!body.urls.success || !body.urls.cancel) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'urls.success and urls.cancel are required',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Extract and normalize data\nreturn [{\n  json: {\n    valid: true,\n    project_id: body.project_id,\n    price_id: body.price_id,\n    customer_email: body.customer_email,\n    callbacks: body.callbacks || {},\n    urls: body.urls,\n    metadata: body.metadata || {},\n    options: body.options || {}\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [700, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [920, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT project_id, display_name, secret_key, webhook_secret, prices, active FROM stripe_projects WHERE project_id = '{{ $json.project_id }}' AND active = 1",
+        "options": {}
+      },
+      "id": "get-project-config",
+      "name": "Get Project Config",
+      "type": "n8n-nodes-base.sqlite",
+      "typeVersion": 1,
+      "position": [1140, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check if project was found\nconst dbResults = $('Get Project Config').all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.project_id) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Project '${inputData.project_id}' not found or inactive`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst project = dbResults[0].json;\n\n// Parse prices JSON\nlet prices = {};\ntry {\n  prices = typeof project.prices === 'string' ? JSON.parse(project.prices) : project.prices;\n} catch (e) {\n  prices = {};\n}\n\nreturn [{\n  json: {\n    found: true,\n    project: {\n      project_id: project.project_id,\n      display_name: project.display_name,\n      secret_key: project.secret_key,\n      webhook_secret: project.webhook_secret,\n      prices: prices\n    },\n    input: inputData\n  }\n}];"
+      },
+      "id": "merge-project-data",
+      "name": "Merge Project Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1360, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-project-found",
+      "name": "Project Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1580, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare Stripe API call with dynamic auth\nconst data = $input.first().json;\nconst secretKey = data.project.secret_key;\n\n// Build form-urlencoded body as string\nconst params = new URLSearchParams();\nparams.append('mode', 'subscription');\nparams.append('customer_email', data.input.customer_email);\nparams.append('line_items[0][price]', data.input.price_id);\nparams.append('line_items[0][quantity]', '1');\nparams.append('success_url', `${data.input.urls.success}?session_id={CHECKOUT_SESSION_ID}`);\nparams.append('cancel_url', data.input.urls.cancel);\nparams.append('metadata[project_id]', data.project.project_id);\n\n// Add callbacks to metadata\nif (data.input.callbacks.success) {\n  params.append('metadata[callback_success]', data.input.callbacks.success);\n}\nif (data.input.callbacks.renewal) {\n  params.append('metadata[callback_renewal]', data.input.callbacks.renewal);\n}\nif (data.input.callbacks.failure) {\n  params.append('metadata[callback_failure]', data.input.callbacks.failure);\n}\nif (data.input.callbacks.cancel) {\n  params.append('metadata[callback_cancel]', data.input.callbacks.cancel);\n}\n\n// Add custom metadata\nif (data.input.metadata) {\n  Object.entries(data.input.metadata).forEach(([key, value]) => {\n    params.append(`metadata[${key}]`, String(value));\n  });\n}\n\n// Add trial if specified\nif (data.input.options.trial_days) {\n  params.append('subscription_data[trial_period_days]', String(data.input.options.trial_days));\n}\n\n// Add coupon if specified\nif (data.input.options.coupon_code) {\n  params.append('discounts[0][coupon]', data.input.options.coupon_code);\n}\n\n// Add promotion codes if enabled\nif (data.input.options.allow_promotion_codes) {\n  params.append('allow_promotion_codes', 'true');\n}\n\nreturn [{\n  json: {\n    authHeader: `Bearer ${secretKey}`,\n    bodyString: params.toString()\n  }\n}];"
+      },
+      "id": "prepare-stripe-request",
+      "name": "Prepare Stripe Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1800, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.stripe.com/v1/checkout/sessions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "={{ $json.authHeader }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/x-www-form-urlencoded"
+            }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "raw",
+        "body": "={{ $json.bodyString }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "call-stripe-api",
+      "name": "Call Stripe API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2020, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format success response\nconst stripeResponse = $input.first().json;\n\nif (stripeResponse.statusCode === 200 && stripeResponse.body) {\n  const session = stripeResponse.body;\n  return [{\n    json: {\n      success: true,\n      checkout_url: session.url,\n      session_id: session.id,\n      expires_at: session.expires_at\n    }\n  }];\n}\n\n// Handle Stripe error\nconst error = stripeResponse.body?.error || {};\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: stripeResponse.statusCode || 500,\n      message: error.message || 'Failed to create checkout session',\n      type: error.type || 'api_error',\n      stripe_code: error.code || null\n    }\n  }\n}];"
+      },
+      "id": "format-success-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2240, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}"
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2460, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}"
+        }
+      },
+      "id": "respond-project-not-found",
+      "name": "Respond Project Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1800, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Project Config",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Config": {
+      "main": [
+        [
+          {
+            "node": "Merge Project Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Project Data": {
+      "main": [
+        [
+          {
+            "node": "Project Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Project Found?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Stripe Request",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Project Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Stripe Request": {
+      "main": [
+        [
+          {
+            "node": "Call Stripe API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Stripe API": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Stripe/subscription-webhook-handler.json
+++ b/workflows/Stripe/subscription-webhook-handler.json
@@ -1,0 +1,403 @@
+{
+  "name": "Stripe - Subscription Webhook Handler",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Stripe Webhook Handler\n\n**Endpoint:** POST /webhook/stripe-events\n\n**Purpose:** Receives Stripe webhooks, verifies signature, and routes events to project-specific callbacks.\n\n**Events Handled:**\n- `checkout.session.completed` -> callback_success\n- `invoice.payment_succeeded` -> callback_renewal\n- `invoice.payment_failed` -> callback_failure\n- `customer.subscription.deleted` -> callback_cancel\n- `customer.subscription.updated` -> callback_success\n\n**Security:**\n- Verifies Stripe signature using webhook secret\n- Rejects invalid signatures with 400\n\n**Flow:**\n1. Receive raw webhook payload\n2. Extract project_id from metadata\n3. Get webhook_secret from SQLite\n4. Verify Stripe signature\n5. Route to appropriate callback URL\n6. Return 200 OK to Stripe\n\n**Setup:** Create SQLite credential named 'Stripe Config DB'",
+        "height": 520,
+        "width": 380,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "stripe-events",
+        "responseMode": "responseNode",
+        "options": {
+          "rawBody": true
+        }
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [480, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract event data and prepare for processing\nconst input = $input.first().json;\n\n// Get raw body for signature verification\nconst rawBody = input.rawBody || '';\nconst headers = input.headers || {};\nconst stripeSignature = headers['stripe-signature'] || '';\n\nif (!stripeSignature) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing Stripe signature header',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Parse the event body\nlet event;\ntry {\n  event = typeof input.body === 'string' ? JSON.parse(input.body) : input.body;\n} catch (e) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Invalid JSON payload',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nif (!event || !event.type) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Invalid Stripe event format',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Extract project_id from various locations\nlet project_id = null;\nlet metadata = {};\n\nconst eventObject = event.data?.object || {};\n\n// Try different locations for metadata\nif (eventObject.metadata?.project_id) {\n  metadata = eventObject.metadata;\n  project_id = metadata.project_id;\n} else if (eventObject.subscription_details?.metadata?.project_id) {\n  metadata = eventObject.subscription_details.metadata;\n  project_id = metadata.project_id;\n} else if (eventObject.lines?.data?.[0]?.metadata?.project_id) {\n  metadata = eventObject.lines.data[0].metadata;\n  project_id = metadata.project_id;\n}\n\nif (!project_id) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'No project_id found in event metadata',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: project_id,\n    metadata: metadata,\n    event: event,\n    eventType: event.type,\n    eventId: event.id,\n    eventObject: eventObject,\n    rawBody: rawBody,\n    stripeSignature: stripeSignature\n  }\n}];"
+      },
+      "id": "parse-webhook",
+      "name": "Parse Webhook",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [700, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid Event?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [920, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT project_id, webhook_secret FROM stripe_projects WHERE project_id = '{{ $json.project_id }}' AND active = 1",
+        "options": {}
+      },
+      "id": "get-webhook-secret",
+      "name": "Get Webhook Secret",
+      "type": "n8n-nodes-base.sqlite",
+      "typeVersion": 1,
+      "position": [1140, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verify Stripe signature\nconst crypto = require('crypto');\n\nconst dbResults = $('Get Webhook Secret').all();\nconst inputData = $('Parse Webhook').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.webhook_secret) {\n  return [{\n    json: {\n      verified: false,\n      error: {\n        code: 400,\n        message: `Project '${inputData.project_id}' not found or no webhook secret configured`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nconst webhookSecret = dbResults[0].json.webhook_secret;\nconst payload = inputData.rawBody;\nconst sigHeader = inputData.stripeSignature;\n\n// Parse the signature header\nconst sigParts = {};\nsigHeader.split(',').forEach(part => {\n  const [key, value] = part.split('=');\n  if (key && value) {\n    sigParts[key] = value;\n  }\n});\n\nconst timestamp = sigParts.t;\nconst signature = sigParts.v1;\n\nif (!timestamp || !signature) {\n  return [{\n    json: {\n      verified: false,\n      error: {\n        code: 400,\n        message: 'Invalid Stripe signature format',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Check timestamp (allow 5 minutes tolerance)\nconst now = Math.floor(Date.now() / 1000);\nif (Math.abs(now - parseInt(timestamp)) > 300) {\n  return [{\n    json: {\n      verified: false,\n      error: {\n        code: 400,\n        message: 'Webhook timestamp too old',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Compute expected signature\nconst signedPayload = `${timestamp}.${payload}`;\nconst expectedSig = crypto\n  .createHmac('sha256', webhookSecret)\n  .update(signedPayload)\n  .digest('hex');\n\n// Compare signatures\nif (signature !== expectedSig) {\n  return [{\n    json: {\n      verified: false,\n      error: {\n        code: 400,\n        message: 'Invalid Stripe signature',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Signature verified!\nreturn [{\n  json: {\n    verified: true,\n    project_id: inputData.project_id,\n    metadata: inputData.metadata,\n    event: inputData.event,\n    eventType: inputData.eventType,\n    eventId: inputData.eventId,\n    eventObject: inputData.eventObject\n  }\n}];"
+      },
+      "id": "verify-signature",
+      "name": "Verify Signature",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1360, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-verified",
+              "leftValue": "={{ $json.verified }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-verified",
+      "name": "Signature Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1580, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Determine callback URL based on event type\nconst data = $input.first().json;\nconst eventType = data.eventType;\nconst metadata = data.metadata || {};\n\n// Map event types to callback keys\nconst eventCallbackMap = {\n  'checkout.session.completed': 'callback_success',\n  'invoice.payment_succeeded': 'callback_renewal',\n  'invoice.payment_failed': 'callback_failure',\n  'customer.subscription.deleted': 'callback_cancel',\n  'customer.subscription.updated': 'callback_success'\n};\n\nconst callbackKey = eventCallbackMap[eventType];\n\nif (!callbackKey) {\n  // Event type not handled - acknowledge but don't process\n  return [{\n    json: {\n      shouldRoute: false,\n      reason: `Event type '${eventType}' not handled`,\n      eventId: data.eventId\n    }\n  }];\n}\n\nconst callbackUrl = metadata[callbackKey];\n\nif (!callbackUrl) {\n  // No callback configured for this event\n  return [{\n    json: {\n      shouldRoute: false,\n      reason: `No ${callbackKey} URL configured for project`,\n      eventId: data.eventId\n    }\n  }];\n}\n\n// Prepare callback payload\nconst eventObject = data.eventObject;\nconst callbackPayload = {\n  event_type: eventType,\n  event_id: data.eventId,\n  project_id: data.project_id,\n  timestamp: new Date().toISOString(),\n  data: {}\n};\n\n// Extract relevant data based on event type\nswitch (eventType) {\n  case 'checkout.session.completed':\n    callbackPayload.data = {\n      customer_id: eventObject.customer,\n      customer_email: eventObject.customer_email || eventObject.customer_details?.email,\n      subscription_id: eventObject.subscription,\n      payment_status: eventObject.payment_status,\n      amount_total: eventObject.amount_total,\n      currency: eventObject.currency,\n      metadata: eventObject.metadata\n    };\n    break;\n    \n  case 'invoice.payment_succeeded':\n  case 'invoice.payment_failed':\n    callbackPayload.data = {\n      customer_id: eventObject.customer,\n      customer_email: eventObject.customer_email,\n      subscription_id: eventObject.subscription,\n      invoice_id: eventObject.id,\n      amount_paid: eventObject.amount_paid,\n      amount_due: eventObject.amount_due,\n      currency: eventObject.currency,\n      status: eventObject.status,\n      billing_reason: eventObject.billing_reason,\n      period_start: eventObject.period_start,\n      period_end: eventObject.period_end\n    };\n    break;\n    \n  case 'customer.subscription.deleted':\n  case 'customer.subscription.updated':\n    callbackPayload.data = {\n      customer_id: eventObject.customer,\n      subscription_id: eventObject.id,\n      status: eventObject.status,\n      cancel_at: eventObject.cancel_at,\n      canceled_at: eventObject.canceled_at,\n      current_period_end: eventObject.current_period_end,\n      plan_id: eventObject.items?.data?.[0]?.price?.id,\n      metadata: eventObject.metadata\n    };\n    break;\n}\n\nreturn [{\n  json: {\n    shouldRoute: true,\n    callbackUrl: callbackUrl,\n    callbackPayload: callbackPayload,\n    eventId: data.eventId,\n    eventType: eventType\n  }\n}];"
+      },
+      "id": "determine-callback",
+      "name": "Determine Callback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1800, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-route",
+              "leftValue": "={{ $json.shouldRoute }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "should-route",
+      "name": "Should Route?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2020, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.callbackUrl }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Stripe-Event-Id",
+              "value": "={{ $json.eventId }}"
+            },
+            {
+              "name": "X-Stripe-Event-Type",
+              "value": "={{ $json.eventType }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.callbackPayload) }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "call-callback",
+      "name": "Call Callback",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2240, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Log callback result\nconst response = $input.first().json;\nconst prevData = $('Determine Callback').first().json;\n\nconst success = response.statusCode >= 200 && response.statusCode < 300;\n\nreturn [{\n  json: {\n    received: true,\n    event_id: prevData.eventId,\n    event_type: prevData.eventType,\n    callback_status: success ? 'delivered' : 'failed',\n    callback_url: prevData.callbackUrl,\n    callback_response_code: response.statusCode\n  }\n}];"
+      },
+      "id": "log-callback-result",
+      "name": "Log Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2460, 0]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { received: true, event_id: $json.event_id } }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond 200 OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2680, 0]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { received: true, event_id: $json.eventId, skipped: true, reason: $json.reason } }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "respond-skipped",
+      "name": "Respond Skipped",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2240, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-invalid",
+      "name": "Respond Invalid",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $json.error } }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-sig-invalid",
+      "name": "Respond Sig Invalid",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1800, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Webhook": {
+      "main": [
+        [
+          {
+            "node": "Valid Event?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid Event?": {
+      "main": [
+        [
+          {
+            "node": "Get Webhook Secret",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Invalid",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Webhook Secret": {
+      "main": [
+        [
+          {
+            "node": "Verify Signature",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Verify Signature": {
+      "main": [
+        [
+          {
+            "node": "Signature Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Signature Valid?": {
+      "main": [
+        [
+          {
+            "node": "Determine Callback",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Sig Invalid",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Determine Callback": {
+      "main": [
+        [
+          {
+            "node": "Should Route?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Should Route?": {
+      "main": [
+        [
+          {
+            "node": "Call Callback",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Skipped",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Callback": {
+      "main": [
+        [
+          {
+            "node": "Log Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log Result": {
+      "main": [
+        [
+          {
+            "node": "Respond 200 OK",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

Add 4 n8n workflows that act as a Stripe proxy for multi-tenant subscription management. Each workflow fetches project-specific Stripe credentials from SQLite, enabling isolated Stripe accounts per project.

## Workflows Created

| Workflow | Endpoint | Description |
|----------|----------|-------------|
| `subscription-checkout-create` | `POST /webhook/subscription-checkout-create` | Creates Stripe Checkout sessions for subscription signup |
| `subscription-webhook-handler` | `POST /webhook/stripe-events` | Receives Stripe webhooks, verifies signature, routes to callbacks |
| `subscription-cancel` | `POST /webhook/subscription-cancel` | Cancels subscriptions (immediate or at period end) |
| `subscription-change-plan` | `POST /webhook/subscription-change-plan` | Upgrades/downgrades subscription plans with proration |

## Architecture

```
┌─────────────┐     ┌──────────────────┐     ┌────────────┐
│   Service   │────▶│   n8n Workflow   │────▶│   Stripe   │
│ (Torah/MCP) │     │   (Proxy)        │     │   API      │
└─────────────┘     └────────┬─────────┘     └────────────┘
                             │
                    ┌────────▼─────────┐
                    │     SQLite       │
                    │ (stripe_projects)│
                    └──────────────────┘
```

## Features

- **Multi-tenant**: Each project has its own Stripe account
- **Signature verification**: Webhook handler verifies Stripe signatures
- **Callback routing**: Events are routed to project-specific callback URLs
- **Error handling**: Comprehensive error responses with proper HTTP codes
- **Trial support**: Checkout supports trial periods
- **Proration**: Plan changes support configurable proration behavior

## Related Issues

Implements Phase 1 of the Stripe integration roadmap:
- Issue #1: subscription-checkout-create
- Issue #2: subscription-webhook-handler  
- Issue #3: subscription-cancel
- Issue #4: subscription-change-plan

## Prerequisites

Before activating these workflows:
1. Run `scripts/stripe/init-db.sh` to create the SQLite database
2. Add projects with `scripts/stripe/manage-projects.sh`
3. Create an n8n credential for the SQLite database named "Stripe Config DB"

## Test plan

- [ ] Import workflows into n8n
- [ ] Configure SQLite credential pointing to `data/stripe-config.db`
- [ ] Add a test project with `manage-projects.sh`
- [ ] Test checkout-create with Stripe test keys
- [ ] Test webhook-handler with Stripe CLI (`stripe listen --forward-to`)
- [ ] Test cancel and change-plan endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)