### PR TITLE
feat(books): Phase 1 - Translation workflows - Issue #179

### DIFF
--- a/workflows/Books/books-job-status.json
+++ b/workflows/Books/books-job-status.json
@@ -1,0 +1,212 @@
+{
+  "name": "Books Job Status",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Books Job Status\n\n**Endpoint:** GET /webhook/books-job-status\n\n**Request:**\n```\nGET /webhook/books-job-status?job_id=job_abc123\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"in_progress\",\n  \"text_name\": \"The Book of Maccabees II\",\n  \"chapter\": 1,\n  \"current_verse\": 15,\n  \"total_verses\": 41,\n  \"translations_saved\": 14,\n  \"progress_percent\": 34.1,\n  \"tokens\": {\n    \"total\": 25000\n  }\n}\n```",
+        "height": 380,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "books-job-status",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "books-job-status"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire le job_id des query params\nconst input = $input.first().json;\n\nconst jobId = input.query?.job_id || input.params?.job_id || '';\n\nif (!jobId) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Le paramètre \"job_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-validation",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "fetch-job",
+      "name": "Fetch Job Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la réponse\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nif (statusCode >= 400 || data.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || data.detail || 'Job non trouvé',\n        status: 'JOB_NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Calculer la progression\nconst totalVerses = data.verses_count || data.metadata?.verses_count || 0;\nconst translationsSaved = data.translations_saved || 0;\nconst progressPercent = totalVerses > 0 ? Math.round((translationsSaved / totalVerses) * 1000) / 10 : 0;\n\nreturn [{\n  json: {\n    success: true,\n    job_id: data.job_id || prevData.jobId,\n    status: data.status || 'unknown',\n    job_type: data.job_type,\n    text_name: data.text_name || data.metadata?.text_name,\n    chapter: data.chapter || data.metadata?.chapter,\n    current_verse: data.current_verse,\n    total_verses: totalVerses,\n    translations_saved: translationsSaved,\n    progress_percent: progressPercent,\n    tokens: data.tokens,\n    error: data.error,\n    created_at: data.created_at,\n    updated_at: data.updated_at\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-result",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1500, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Fetch Job Status",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Job Status": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Books/books-translation-manager.json
+++ b/workflows/Books/books-translation-manager.json
@@ -1,0 +1,459 @@
+{
+  "name": "Books Translation Manager",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Books Translation Manager\n\n**Endpoint:** POST /webhook/books-translate\n\n**Request:**\n```json\n{\n  \"project\": \"Second Temple\",\n  \"text_name\": \"The Book of Maccabees II\",\n  \"chapter\": 1,\n  \"api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"text_name\": \"The Book of Maccabees II\",\n  \"chapter\": 1,\n  \"verses_count\": 41,\n  \"verses_to_translate\": 35\n}\n```\n\n**Flow:**\n1. Validate input\n2. Fetch chapter from Books API\n3. Filter untranslated verses\n4. Create job via POST /api/jobs\n5. Launch worker workflow (async)\n6. Return job_id immediately",
+        "height": 480,
+        "width": 340,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "books-translate",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "books-translate"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validation des paramètres\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst project = body.project || '';\nconst textName = body.text_name || '';\nconst chapter = body.chapter || null;\nconst targetLanguage = body.target_language || 'fr';\nconst apiKey = body.api_key || '';\nconst openaiApiKey = body.openai_api_key || '';\n\n// Validation\nconst errors = [];\nif (!textName) errors.push('Le champ \"text_name\" est requis');\nif (chapter === null) errors.push('Le champ \"chapter\" est requis');\nif (!apiKey) errors.push('Le champ \"api_key\" (Anthropic) est requis');\n\n// Générer un job_id unique\nconst jobId = 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\n\n// Encoder le nom du livre pour l'URL\nconst encodedTextName = encodeURIComponent(textName);\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    jobId: jobId,\n    project: project,\n    textName: textName,\n    encodedTextName: encodedTextName,\n    chapter: chapter,\n    targetLanguage: targetLanguage,\n    apiKey: apiKey,\n    openaiApiKey: openaiApiKey\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-validation",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/books/{{ $json.encodedTextName }}/{{ $json.chapter }}?include_translation=true",
+        "options": {
+          "timeout": 30000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "fetch-chapter",
+      "name": "Fetch Chapter",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire les versets du chapitre\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Vérifier les erreurs\nif (statusCode >= 400 || data.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || data.message || data.detail || 'Chapitre non trouvé',\n        status: 'CHAPTER_NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst verses = data.verses || [];\nconst refFormat = data.ref_format || 'chapter_verse';\n\nif (verses.length === 0) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: 'Aucun verset trouvé pour ce chapitre',\n        status: 'NO_VERSES'\n      }\n    }\n  }];\n}\n\n// Filtrer les versets non traduits\nconst untranslatedVerses = verses.filter(v => !v.translated && !v.translation);\n\nif (untranslatedVerses.length === 0) {\n  return [{\n    json: {\n      success: true,\n      alreadyComplete: true,\n      message: 'Tous les versets sont déjà traduits',\n      textName: prevData.textName,\n      chapter: prevData.chapter,\n      versesCount: verses.length,\n      versesToTranslate: 0\n    }\n  }];\n}\n\n// Estimation du temps (~5 secondes par verset)\nconst estimatedSeconds = Math.ceil(untranslatedVerses.length * 5);\n\nreturn [{\n  json: {\n    success: true,\n    alreadyComplete: false,\n    jobId: prevData.jobId,\n    project: prevData.project,\n    textName: prevData.textName,\n    chapter: prevData.chapter,\n    refFormat: refFormat,\n    targetLanguage: prevData.targetLanguage,\n    apiKey: prevData.apiKey,\n    openaiApiKey: prevData.openaiApiKey,\n    verses: untranslatedVerses,\n    versesCount: verses.length,\n    versesToTranslate: untranslatedVerses.length,\n    estimatedSeconds: estimatedSeconds\n  }\n}];"
+      },
+      "id": "extract-verses",
+      "name": "Extract Verses",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            },
+            {
+              "id": "check-not-complete",
+              "leftValue": "={{ $json.alreadyComplete }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-verses",
+      "name": "Verses to Translate?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_type: 'books_translation', text_name: $json.textName, chapter: $json.chapter, target_language: $json.targetLanguage, verses_count: $json.versesToTranslate, metadata: { requested_by: 'n8n_workflow', project: $json.project, ref_format: $json.refFormat } }) }}",
+        "options": {
+          "timeout": 10000,
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "create-job-api",
+      "name": "Create Job (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1760, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire le job_id de la réponse API\nconst input = $input.first().json;\nconst prevData = $('Extract Verses').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// Si l'API jobs n'existe pas, utiliser le jobId généré localement\nlet jobId = prevData.jobId;\nif (statusCode < 400 && data.job_id) {\n  jobId = data.job_id;\n}\n\nreturn [{\n  json: {\n    ...prevData,\n    jobId: jobId,\n    jobCreated: statusCode < 400\n  }\n}];"
+      },
+      "id": "extract-job-id",
+      "name": "Extract Job ID",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Préparer le payload pour le worker\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    workerPayload: {\n      job_id: data.jobId,\n      project: data.project,\n      text_name: data.textName,\n      chapter: data.chapter,\n      ref_format: data.refFormat,\n      target_language: data.targetLanguage,\n      api_key: data.apiKey,\n      openai_api_key: data.openaiApiKey,\n      verses: data.verses\n    },\n    // Garder les autres données pour Format Response\n    jobId: data.jobId,\n    textName: data.textName,\n    chapter: data.chapter,\n    versesCount: data.versesCount,\n    versesToTranslate: data.versesToTranslate,\n    estimatedSeconds: data.estimatedSeconds\n  }\n}];"
+      },
+      "id": "prepare-worker-payload",
+      "name": "Prepare Worker Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2200, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/books-translation-worker",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.workerPayload }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "launch-worker",
+      "name": "Launch Worker (async)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2420, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Préparer la réponse immédiate\nconst input = $('Prepare Worker Payload').first().json;\n\nreturn [{\n  json: {\n    success: true,\n    job_id: input.jobId,\n    status: 'started',\n    text_name: input.textName,\n    chapter: input.chapter,\n    verses_count: input.versesCount,\n    verses_to_translate: input.versesToTranslate,\n    estimated_seconds: input.estimatedSeconds\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2640, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2860, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Construire la réponse d'erreur de validation\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
+      },
+      "id": "build-validation-error",
+      "name": "Build Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 500 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-chapter-error",
+      "name": "Respond Chapter Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-already-complete",
+      "name": "Respond Already Complete",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 200]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Fetch Chapter",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Chapter": {
+      "main": [
+        [
+          {
+            "node": "Extract Verses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Verses": {
+      "main": [
+        [
+          {
+            "node": "Verses to Translate?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Verses to Translate?": {
+      "main": [
+        [
+          {
+            "node": "Create Job (API)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Already Complete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Job (API)": {
+      "main": [
+        [
+          {
+            "node": "Extract Job ID",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Job ID": {
+      "main": [
+        [
+          {
+            "node": "Prepare Worker Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Worker Payload": {
+      "main": [
+        [
+          {
+            "node": "Launch Worker (async)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Launch Worker (async)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Books/books-translation-worker.json
+++ b/workflows/Books/books-translation-worker.json
@@ -1,0 +1,546 @@
+{
+  "name": "Books Translation Worker",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Books Translation Worker\n\n**Endpoint:** POST /webhook/books-translation-worker\n\n**Called by:** books-translation-manager workflow\n\n**Process:**\n1. Respond immediately (async)\n2. PATCH /api/jobs → in_progress\n3. Loop through each verse:\n   - Claude translation (draft)\n   - GPT-4o verification\n   - POST /api/translations/save (with llm_usage)\n   - PATCH /api/jobs (progress)\n4. PATCH /api/jobs → completed\n\n**llm_usage format:**\n```json\n{\n  \"llm_usage\": [\n    { \"model\": \"claude-sonnet-4\", \"provider\": \"anthropic\", \"input_tokens\": 1500, \"output_tokens\": 800 },\n    { \"model\": \"gpt-4o\", \"provider\": \"openai\", \"input_tokens\": 1200, \"output_tokens\": 600 }\n  ]\n}\n```\n\n**Time:** ~5s per verse",
+        "height": 420,
+        "width": 340,
+        "color": 3
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "books-translation-worker",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "books-translation-worker"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire les données du job\nconst input = $input.first().json;\n\nlet verses = [];\nlet body = input;\n\n// Structure webhook standard\nif (input.body && Array.isArray(input.body.verses)) {\n  verses = input.body.verses;\n  body = input.body;\n} else if (Array.isArray(input.verses)) {\n  verses = input.verses;\n} else if (input.body && typeof input.body === 'string') {\n  try {\n    const parsed = JSON.parse(input.body);\n    if (Array.isArray(parsed.verses)) {\n      verses = parsed.verses;\n      body = parsed;\n    }\n  } catch(e) {}\n}\n\nreturn [{\n  json: {\n    jobId: body.job_id || input.job_id,\n    project: body.project || input.project,\n    textName: body.text_name || input.text_name,\n    chapter: body.chapter || input.chapter,\n    refFormat: body.ref_format || input.ref_format || 'chapter_verse',\n    targetLanguage: body.target_language || input.target_language || 'fr',\n    apiKey: body.api_key || input.api_key,\n    openaiApiKey: body.openai_api_key || input.openai_api_key,\n    verses: verses,\n    versesCount: verses.length\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ received: true, job_id: $json.jobId, verses_count: $json.versesCount }) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-immediately",
+      "name": "Respond Immediately",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'in_progress' }) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-status-in-progress",
+      "name": "Set In Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Passer les données originales\nconst prevData = $('Parse Input').first().json;\nreturn [{ json: prevData }];"
+      },
+      "id": "pass-data",
+      "name": "Pass Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Convertir les versets en items pour la boucle\nconst input = $input.first().json;\n\nconst items = input.verses.map((verse, index) => {\n  // Construire la référence selon le format\n  let reference;\n  if (input.refFormat === 'chapter_only') {\n    reference = `${input.textName} ${input.chapter}`;\n  } else {\n    reference = `${input.textName} ${input.chapter}:${verse.verse || index + 1}`;\n  }\n\n  return {\n    json: {\n      verseIndex: index,\n      verseId: verse.id,\n      verseNumber: verse.verse || 0,\n      verseText: verse.hebrew_text || verse.text || '',\n      reference: reference,\n      totalVerses: input.verses.length,\n      jobId: input.jobId,\n      project: input.project,\n      textName: input.textName,\n      chapter: input.chapter,\n      refFormat: input.refFormat,\n      targetLanguage: input.targetLanguage,\n      apiKey: input.apiKey,\n      openaiApiKey: input.openaiApiKey\n    }\n  };\n});\n\nreturn items;"
+      },
+      "id": "split-verses",
+      "name": "Split Verses",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1500, 300]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "loop-verses",
+      "name": "Loop Verses",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [1720, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.apiKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"claude-sonnet-4-20250514\",\n  \"max_tokens\": 2048,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Tu es un expert en textes bibliques et rabbiniques. Traduis ce verset de {{ $json.textName }} ({{ $json.reference }}) en {{ $json.targetLanguage === 'fr' ? 'français' : $json.targetLanguage }}.\\n\\nTexte à traduire:\\n{{ $json.verseText }}\\n\\nRéponds UNIQUEMENT avec la traduction, sans commentaires ni explications.\"\n    }\n  ]\n}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 60000
+        }
+      },
+      "id": "call-claude",
+      "name": "Claude Translation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1940, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire la traduction Claude\nconst input = $input.first().json;\nconst prevData = $('Loop Verses').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet claudeTranslation = '';\nlet claudeError = null;\nlet claudeUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode >= 400 || data.type === 'error' || data.error) {\n  claudeError = data.error?.message || data.message || `Erreur Claude HTTP ${statusCode}`;\n} else if (data.content?.[0]?.text) {\n  claudeTranslation = data.content[0].text.trim();\n  claudeUsage = {\n    input_tokens: data.usage?.input_tokens || 0,\n    output_tokens: data.usage?.output_tokens || 0,\n    total_tokens: (data.usage?.input_tokens || 0) + (data.usage?.output_tokens || 0)\n  };\n}\n\nreturn [{\n  json: {\n    ...prevData,\n    claudeTranslation: claudeTranslation,\n    claudeError: claudeError,\n    claudeUsage: claudeUsage\n  }\n}];"
+      },
+      "id": "extract-claude",
+      "name": "Extract Claude",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2160, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-claude-ok",
+              "leftValue": "={{ $json.claudeTranslation }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "exists"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-claude-ok",
+      "name": "Claude OK?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2380, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'gpt-4o', temperature: 0.1, response_format: { type: 'json_object' }, messages: [{ role: 'system', content: 'Tu es un expert en textes bibliques et rabbiniques. Vérifie et améliore cette traduction. Réponds en JSON.' }, { role: 'user', content: 'Vérifie cette traduction de ' + $json.textName + ' (' + $json.reference + '):\\n\\nTexte original (hébreu):\\n' + $json.verseText + '\\n\\nTraduction proposée:\\n' + $json.claudeTranslation + '\\n\\nRéponds en JSON:\\n{\\n  \"my_translation\": \"ta traduction corrigée ou identique\",\\n  \"approved\": true/false,\\n  \"confidence\": 0.0-1.0,\\n  \"issues\": []\\n}' }] }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 60000
+        }
+      },
+      "id": "call-gpt4o",
+      "name": "GPT-4o Verify",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2600, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire et combiner les résultats\nconst input = $input.first().json;\nconst prevData = $('Claude OK?').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\nlet gptVerification = {\n  my_translation: prevData.claudeTranslation,\n  approved: true,\n  confidence: 0.8,\n  issues: []\n};\nlet gptUsage = { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nif (statusCode < 400 && data.choices?.[0]?.message?.content) {\n  try {\n    gptVerification = JSON.parse(data.choices[0].message.content);\n    gptUsage = {\n      input_tokens: data.usage?.prompt_tokens || 0,\n      output_tokens: data.usage?.completion_tokens || 0,\n      total_tokens: (data.usage?.prompt_tokens || 0) + (data.usage?.completion_tokens || 0)\n    };\n  } catch (e) {\n    // Garder les valeurs par défaut\n  }\n}\n\n// Déterminer la traduction finale\nconst finalTranslation = gptVerification.approved ? prevData.claudeTranslation : (gptVerification.my_translation || prevData.claudeTranslation);\n\nreturn [{\n  json: {\n    ...prevData,\n    gptVerification: gptVerification,\n    gptUsage: gptUsage,\n    finalTranslation: finalTranslation,\n    confidence: gptVerification.confidence || 0.8,\n    approved: gptVerification.approved\n  }\n}];"
+      },
+      "id": "extract-gpt",
+      "name": "Extract GPT",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2820, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/translations/save",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source_text_id: $json.verseId, translated_text: $json.finalTranslation, target_language: $json.targetLanguage, quality_score: $json.confidence, provider: 'anthropic+openai', model: 'claude-sonnet-4+gpt-4o', llm_usage: [{ model: 'claude-sonnet-4-20250514', provider: 'anthropic', input_tokens: $json.claudeUsage.input_tokens, output_tokens: $json.claudeUsage.output_tokens, total_tokens: $json.claudeUsage.total_tokens }, { model: 'gpt-4o', provider: 'openai', input_tokens: $json.gptUsage.input_tokens, output_tokens: $json.gptUsage.output_tokens, total_tokens: $json.gptUsage.total_tokens }] }) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "save-translation",
+      "name": "Save Translation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3040, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Préparer les données pour la mise à jour du job\nconst input = $input.first().json;\nconst prevData = $('Extract GPT').first().json;\n\nconst verseIndex = prevData.verseIndex;\nconst totalVerses = prevData.totalVerses;\nconst isComplete = verseIndex + 1 >= totalVerses;\n\n// Récupérer les tokens Claude et GPT\nconst claudeUsage = prevData.claudeUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\nconst gptUsage = prevData.gptUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };\n\nconst tokens = {\n  claude: claudeUsage,\n  gpt: gptUsage,\n  total: {\n    input_tokens: (claudeUsage.input_tokens || 0) + (gptUsage.input_tokens || 0),\n    output_tokens: (claudeUsage.output_tokens || 0) + (gptUsage.output_tokens || 0),\n    total_tokens: (claudeUsage.total_tokens || 0) + (gptUsage.total_tokens || 0)\n  }\n};\n\nreturn [{\n  json: {\n    ...prevData,\n    isComplete: isComplete,\n    updatePayload: isComplete ? {\n      status: 'completed',\n      translations_saved: verseIndex + 1,\n      tokens: tokens\n    } : {\n      status: 'in_progress',\n      current_verse: verseIndex + 1,\n      translations_saved: verseIndex + 1,\n      tokens: tokens\n    }\n  }\n}];"
+      },
+      "id": "prepare-update",
+      "name": "Prepare Update",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3260, 100]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.updatePayload) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-progress-api",
+      "name": "Update Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3480, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Retourner au loop si pas terminé\nconst prevData = $('Prepare Update').first().json;\n\nreturn [{\n  json: {\n    continue: !prevData.isComplete,\n    verseIndex: prevData.verseIndex,\n    totalVerses: prevData.totalVerses\n  }\n}];"
+      },
+      "id": "check-continue",
+      "name": "Check Continue",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3700, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Préparer la mise à jour pour erreur\nconst input = $input.first().json;\n\nconst verseIndex = input.verseIndex;\nconst totalVerses = input.totalVerses;\nconst isComplete = verseIndex + 1 >= totalVerses;\n\nreturn [{\n  json: {\n    ...input,\n    isComplete: isComplete,\n    updatePayload: isComplete ? {\n      status: 'completed',\n      translations_saved: verseIndex,\n      error: input.claudeError\n    } : {\n      status: 'in_progress',\n      current_verse: verseIndex + 1,\n      translations_saved: verseIndex,\n      last_error: input.claudeError\n    }\n  }\n}];"
+      },
+      "id": "prepare-error-update",
+      "name": "Prepare Error Update",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2600, 300]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.TORAH_API_URL }}/api/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.updatePayload) }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-error-api",
+      "name": "Update Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2820, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {},
+      "id": "noop-end",
+      "name": "Done",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [3920, 200]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Input": {
+      "main": [
+        [
+          {
+            "node": "Respond Immediately",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond Immediately": {
+      "main": [
+        [
+          {
+            "node": "Set In Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set In Progress": {
+      "main": [
+        [
+          {
+            "node": "Pass Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pass Data": {
+      "main": [
+        [
+          {
+            "node": "Split Verses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Verses": {
+      "main": [
+        [
+          {
+            "node": "Loop Verses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Loop Verses": {
+      "main": [
+        [
+          {
+            "node": "Done",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Claude Translation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Translation": {
+      "main": [
+        [
+          {
+            "node": "Extract Claude",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Claude": {
+      "main": [
+        [
+          {
+            "node": "Claude OK?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude OK?": {
+      "main": [
+        [
+          {
+            "node": "GPT-4o Verify",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare Error Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GPT-4o Verify": {
+      "main": [
+        [
+          {
+            "node": "Extract GPT",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract GPT": {
+      "main": [
+        [
+          {
+            "node": "Save Translation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Save Translation": {
+      "main": [
+        [
+          {
+            "node": "Prepare Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Update": {
+      "main": [
+        [
+          {
+            "node": "Update Progress",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Progress": {
+      "main": [
+        [
+          {
+            "node": "Check Continue",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Continue": {
+      "main": [
+        [
+          {
+            "node": "Loop Verses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Error Update": {
+      "main": [
+        [
+          {
+            "node": "Update Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Error": {
+      "main": [
+        [
+          {
+            "node": "Loop Verses",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 implementation of Books API translation workflows.

- Add `books-translation-manager.json` - Orchestrator workflow
- Add `books-translation-worker.json` - LLM translation worker
- Add `books-job-status.json` - Job progress tracking

Relates to #179

## Workflows

### 1. Translation Manager
```
POST /webhook/books-translate
{
  "project": "Second Temple",
  "text_name": "The Book of Maccabees II",
  "chapter": 1,
  "api_key": "...",
  "openai_api_key": "..."
}
```

### 2. Translation Worker
- Claude Sonnet 4 for initial translation
- GPT-4o for verification
- Saves with `llm_usage` array format per API spec

### 3. Job Status
```
GET /webhook/books-job-status?job_id=job_xxx
```

## Features

- URL encoding for book names with spaces
- Support for `chapter_verse` and `chapter_only` ref formats
- Async worker pattern (non-blocking response)
- Token tracking per LLM provider

## Test plan

- [ ] Import workflows to n8n
- [ ] Test with sample chapter translation
- [ ] Verify `llm_usage` format in `/api/translations/save`
- [ ] Check job status updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)