### PR TITLE
fix(torah): rename text_type to ref_format

### DIFF
--- a/workflows/Torah/torah-discord-translate-v2.json
+++ b/workflows/Torah/torah-discord-translate-v2.json
@@ -171,7 +171,7 @@
         "url": "={{ $env.TORAH_API_URL }}/api/jobs",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ job_type: $json.isBatch ? 'commentary_translation' : $json.jobType, traite: $json.traite || $json.context.traite || 'Unknown', page: $json.page || $json.context.page || '1a', target_language: $json.targetLanguage, segments_count: $json.isBatch ? $json.segments.length : 1, metadata: { commentator: $json.commentator || $json.context.commentator, text_type: $json.metadata.text_type || 'commentary' } }) }}",
+        "jsonBody": "={{ JSON.stringify({ job_type: $json.isBatch ? 'commentary_translation' : $json.jobType, traite: $json.traite || $json.context.traite || 'Unknown', page: $json.page || $json.context.page || '1a', target_language: $json.targetLanguage, segments_count: $json.isBatch ? $json.segments.length : 1, metadata: { commentator: $json.commentator || $json.context.commentator, ref_format: $json.metadata.ref_format || 'commentary' } }) }}",
         "options": {
           "timeout": 10000,
           "response": {


### PR DESCRIPTION
## Summary

- Update `torah-discord-translate-v2.json` to use `ref_format` instead of `text_type`
- Aligns n8n workflows with Books API harmonization (PR #181 côté API)

## Changes

| File | Change |
|------|--------|
| `workflows/Torah/torah-discord-translate-v2.json` | `text_type` → `ref_format` |

## Verification

```bash
grep -r "text_type" workflows/  # Should return nothing
grep -r "ref_format" workflows/ # Should show Books workflows
```

## Test Plan

- [ ] Verify torah-discord-translate-v2 workflow still works
- [ ] Confirm API accepts `ref_format` in job metadata

Relates to #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)