### PR TITLE
feat(discord): add Discord bot integration workflows

### DIFF
--- a/docs/RFC-stripe-key-management.md
+++ b/docs/RFC-stripe-key-management.md
@@ -1,211 +1,541 @@
 # RFC: Gestion des cles Stripe en architecture multi-tenant
 
 **Date:** 2025-01-05
+**Mise a jour:** 2025-01-05
 **Statut:** En discussion
-**Equipes concernees:** Bot Discord, Plugin Torah, Backend n8n
+**Equipes concernees:** Framework Bot Discord, Plugins, Backend n8n
 
 ---
 
-## Contexte
+## 1. Architecture clarifiee
 
-L'architecture actuelle implique trois composants :
+### 1.1 Modele de deploiement
+
+Le framework bot-discord est une **dependance pip** installee par chaque plugin.
+**1 plugin = 1 repo = 1 bot Discord = 1 cle Stripe = 1 deploiement independant**
 
 ```
-┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│   Plugin    │     │  Bot Discord│     │    n8n      │
-│   (Torah)   │     │  (generique)│     │  (workflows)│
-└─────────────┘     └─────────────┘     └─────────────┘
-      │                    │                   │
-      │ stripe_secret_key  │ project_id        │ Stripe API
-      │ (config locale)    │ (seul parametre)  │ (necessite la cle)
+┌─────────────────────────────┐   ┌─────────────────────────────┐
+│     Plugin Torah (repo)     │   │     Plugin MCP (repo)       │
+├─────────────────────────────┤   ├─────────────────────────────┤
+│ requirements.txt:           │   │ requirements.txt:           │
+│   discord-bot-framework     │   │   discord-bot-framework     │
+│                             │   │                             │
+│ .env:                       │   │ .env:                       │
+│   PROJECT_ID=torah          │   │   PROJECT_ID=mcp            │
+│   DISCORD_TOKEN=token_a     │   │   DISCORD_TOKEN=token_b     │
+│   STRIPE_SECRET_KEY=sk_a    │   │   STRIPE_SECRET_KEY=sk_b    │
+│   STRIPE_WEBHOOK_SECRET=... │   │   STRIPE_WEBHOOK_SECRET=... │
+└──────────────┬──────────────┘   └──────────────┬──────────────┘
+               │                                  │
+               │         Meme serveur             │
+               └──────────────┬───────────────────┘
+                              ▼
+                    ┌───────────────────┐
+                    │        n8n        │
+                    │   (workflows      │
+                    │    partages)      │
+                    └───────────────────┘
 ```
 
-**Probleme:** Le bot appelle n8n avec uniquement `project_id`, mais n8n doit appeler l'API Stripe qui necessite la `stripe_secret_key` specifique au projet.
+### 1.2 Principe fondamental: Source unique de verite
 
-**Question centrale:** Ou stocker la cle Stripe et comment la transmettre a n8n ?
+**Comme OAuth2:** La cle est stockee a UN SEUL endroit - la configuration du plugin.
+
+- Le plugin possede sa cle Stripe dans son `.env`
+- La cle est passee a n8n a chaque requete (comme un Bearer token)
+- n8n n'a **pas** de stockage de cles
+- Pas de duplication, pas de synchronisation
 
 ---
 
-## Options proposees
+## 2. Les deux flux a considerer
 
-### Option A : Le bot transmet la cle
+### 2.1 Flux Bot → n8n (commandes Discord)
 
 ```
-Bot → n8n : { project_id, stripe_secret_key }
+User ──► Bot ──► n8n ──► Stripe API
+              │
+              └─► Le bot PEUT passer la cle
 ```
+
+**Exemple:** `/plans`, `/subscribe`, `/account`
+
+Le bot connait la cle (depuis sa config) et peut la transmettre a n8n.
+
+**Implementation proposee:**
+```
+POST /webhook/discord-get-plans
+Headers:
+  X-Project-ID: torah
+  X-Stripe-Secret-Key: sk_live_xxx    ← Header (pas dans le body)
+```
+
+### 2.2 Flux Stripe → n8n (webhooks)
+
+```
+Stripe ──────────────────────► n8n /webhook/stripe-events
+                                    │
+                                    └─► Le bot N'EST PAS dans la boucle
+```
+
+**Probleme:** n8n recoit un webhook Stripe mais:
+- Ne sait pas quel projet est concerne
+- N'a pas le `webhook_secret` pour valider la signature
+- Le bot ne peut pas aider (pas dans la boucle)
+
+**C'est le probleme principal de ce RFC.**
+
+---
+
+## 3. Options pour le flux Stripe → n8n
+
+### Option A: Un endpoint webhook par projet
+
+```
+Stripe Torah ──► n8n /webhook/stripe-events-torah
+Stripe MCP   ──► n8n /webhook/stripe-events-mcp
+```
+
+n8n stocke le `webhook_secret` par endpoint (credential ou env var).
 
 | Avantages | Inconvenients |
 |-----------|---------------|
-| Simple a implementer | Cle en transit a chaque requete |
-| Pas de stockage cote n8n | Bot doit stocker les cles (securite) |
-| | Exposition via logs/debug |
+| Isolation totale | 1 workflow par projet |
+| Simple a debugger | Ne scale pas (5+ projets) |
+| webhook_secret par endpoint | Duplication de code |
 
-**Questions pour l'equipe Bot:**
-- Le bot a-t-il acces aux cles Stripe de chaque projet ?
-- Comment le bot obtiendrait-il ces cles ?
-- Etes-vous a l'aise avec la responsabilite de gerer ces secrets ?
+### Option B: project_id dans metadata Stripe
 
----
-
-### Option B : Stockage PostgreSQL (table projects)
-
-```sql
-CREATE TABLE projects (
-  project_id VARCHAR PRIMARY KEY,
-  display_name VARCHAR,
-  stripe_secret_key VARCHAR,  -- Chiffre ?
-  stripe_webhook_secret VARCHAR,
-  active BOOLEAN DEFAULT true,
-  created_at TIMESTAMP
-);
-```
-
-```
-Plugin → n8n : POST /register-project { project_id, stripe_secret_key }
-Bot → n8n : GET /get-plans?project_id=torah
-n8n : SELECT stripe_secret_key FROM projects WHERE project_id = 'torah'
-n8n → Stripe API
-```
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| Cle jamais en transit apres init | Necessite workflow d'enregistrement |
-| Bot n'a jamais acces aux cles | Sync a maintenir si cle change |
-| Centralise et auditable | Stockage sensible en DB |
-
-**Questions pour l'equipe Plugin:**
-- Le plugin peut-il appeler un endpoint d'init au demarrage ?
-- Qui gere le cycle de vie des cles (rotation, revocation) ?
-- Preferez-vous un enregistrement manuel (admin) ou automatique ?
-
----
-
-### Option C : Credentials n8n par projet
-
-Creer une credential n8n par projet : `stripe-torah`, `stripe-mcp`, etc.
-
-```
-n8n : Utilise la credential correspondant au project_id
-```
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| Natif n8n, securise | Pas dynamique (code dur) |
-| Chiffrement integre | Ajout manuel pour chaque projet |
-| | Ne scale pas bien |
-
-**Questions pour l'equipe Backend:**
-- Combien de projets sont prevus ?
-- La gestion manuelle des credentials est-elle acceptable ?
-
----
-
-### Option D : Le plugin appelle n8n directement
-
-```
-User → Bot : /plans
-Bot → Plugin : get_plans()
-Plugin → n8n : { project_id, stripe_secret_key }
-n8n → Stripe API
-Plugin → Bot : plans
-Bot → User : affiche plans
-```
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| Plugin garde le controle des cles | Architecture plus complexe |
-| Pas de stockage externe | Latence supplementaire |
-| | Bot devient passif (proxy) |
-
-**Questions pour les deux equipes:**
-- Cette complexite est-elle justifiee ?
-- Le bot doit-il rester l'orchestrateur principal ?
-
----
-
-### Option E : Variables d'environnement n8n
-
-```
-STRIPE_KEY_TORAH=sk_live_xxx
-STRIPE_KEY_MCP=sk_live_yyy
-```
+Configurer Stripe pour inclure `project_id` dans les metadata:
 
 ```javascript
-// Dans n8n Code node
-const key = process.env[`STRIPE_KEY_${projectId.toUpperCase()}`];
+// Lors de la creation du checkout (cote bot → n8n)
+metadata: {
+  project_id: "torah",
+  discord_user_id: "123456789"
+}
+```
+
+Stripe renvoie ces metadata dans les webhooks:
+
+```json
+{
+  "type": "checkout.session.completed",
+  "data": {
+    "object": {
+      "metadata": {
+        "project_id": "torah"
+      }
+    }
+  }
+}
+```
+
+n8n peut alors router vers le bon projet.
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| 1 seul endpoint webhook | webhook_secret toujours necessaire |
+| Metadata inclus par Stripe | Dependance config Stripe correcte |
+| Scale bien | Pas de validation signature multi-projet |
+
+### Option C: Stockage des webhook_secrets dans n8n
+
+Contradiction avec "source unique", mais pragmatique:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    n8n                               │
+│  ┌───────────────────────────────────────────────┐  │
+│  │ SQLite: stripe_webhook_secrets                │  │
+│  │ ┌────────────┬─────────────────────────────┐  │  │
+│  │ │ project_id │ webhook_secret              │  │  │
+│  │ ├────────────┼─────────────────────────────┤  │  │
+│  │ │ torah      │ whsec_xxx                   │  │  │
+│  │ │ mcp        │ whsec_yyy                   │  │  │
+│  │ └────────────┴─────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+Le plugin enregistre son `webhook_secret` au demarrage:
+```
+Plugin ──► n8n POST /admin/register-webhook-secret
+           { project_id, webhook_secret }
 ```
 
 | Avantages | Inconvenients |
 |-----------|---------------|
-| Simple, pas de DB | Redemarrage n8n si ajout projet |
-| Securise (env vars) | Ne scale pas |
-| | Gestion manuelle |
+| Validation signature OK | Stockage de secrets cote n8n |
+| Scale bien | Sync necessaire si rotation |
+| 1 seul endpoint | Deux sources de verite |
+
+### Option D: Credentials n8n par projet (manuel)
+
+Creer manuellement une credential n8n par projet:
+- `stripe-webhook-torah`
+- `stripe-webhook-mcp`
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| Natif n8n, chiffre | Gestion manuelle |
+| Pas de code custom | Ne scale pas |
+| Securise | Ajout projet = config n8n |
+
+### Option E: Stripe Connect (architecture alternative)
+
+Une seule cle Stripe "platform", chaque projet est un "connected account":
+
+```
+┌─────────────────────────────────┐
+│    Compte Platform (vous)       │  ← 1 seule cle API
+│    sk_platform_xxx              │
+└───────────────┬─────────────────┘
+                │
+    ┌───────────┼───────────┐
+    ▼           ▼           ▼
+┌───────┐  ┌───────┐  ┌───────┐
+│ Torah │  │  MCP  │  │ Proj X│   ← Connected Accounts
+│ acct_ │  │ acct_ │  │ acct_ │      (pas de cles separees)
+└───────┘  └───────┘  └───────┘
+```
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| 1 seule cle a gerer | Setup Stripe Connect |
+| Isolation native | Frais Stripe supplementaires |
+| Webhooks simplifies | Complexite onboarding |
+| Scale infiniment | Overkill pour 5 projets? |
 
 ---
 
-## Matrice de decision
+## 4. Matrice de decision
 
 | Critere | Option A | Option B | Option C | Option D | Option E |
 |---------|----------|----------|----------|----------|----------|
-| Securite | Faible | Bonne | Excellente | Bonne | Bonne |
-| Scalabilite | Bonne | Excellente | Faible | Moyenne | Faible |
-| Simplicite | Excellente | Moyenne | Moyenne | Faible | Bonne |
-| Maintenance | Faible | Moyenne | Elevee | Elevee | Moyenne |
-| Autonomie Bot | Oui | Oui | Oui | Non | Oui |
+| **Securite** | Bonne | Moyenne | Bonne | Excellente | Excellente |
+| **Scalabilite** | Faible | Bonne | Bonne | Faible | Excellente |
+| **Source unique** | Oui | Oui | Non | Non | Oui |
+| **Validation webhook** | Oui | Non | Oui | Oui | Oui |
+| **Effort n8n** | Eleve | Faible | Moyen | Faible | Moyen |
+| **Effort plugin** | Faible | Moyen | Moyen | Faible | Eleve |
 
 ---
 
-## Recommandation initiale
+## 5. Responsabilites par composant
 
-**Option B (PostgreSQL)** semble offrir le meilleur equilibre :
-- Securite correcte (cle stockee cote serveur)
-- Scalabilite (ajout de projets sans code)
-- Le bot reste simple (envoie juste `project_id`)
+### 5.1 Framework Bot Discord (dependance pip)
 
-Avec un workflow `discord-register-project` appele :
-- Soit par le plugin au demarrage
-- Soit manuellement par un admin via UI/script
+| Responsabilite | Description |
+|----------------|-------------|
+| Fournir `N8nClient` | Client HTTP pour appeler n8n |
+| Passer `project_id` | Identifiant du projet |
+| Passer `stripe_secret_key` | Via header HTTP securise |
+| Gerer les erreurs n8n | Retry, timeout, fallback |
+| **NE PAS** stocker de cles | Juste transmettre depuis config |
 
----
+### 5.2 Plugin (utilisateur du framework)
 
-## Questions ouvertes
+| Responsabilite | Description |
+|----------------|-------------|
+| Configurer `.env` | `PROJECT_ID`, `STRIPE_SECRET_KEY`, etc. |
+| Instancier le bot | Avec la config appropriee |
+| Posseder les cles Stripe | Source unique de verite |
+| Enregistrer webhook_secret? | Si Option C choisie |
 
-1. **Chiffrement des cles en DB ?**
-   - Faut-il chiffrer `stripe_secret_key` dans PostgreSQL ?
-   - Qui gere la cle de chiffrement ?
+### 5.3 n8n (workflows)
 
-2. **Rotation des cles ?**
-   - Quelle procedure si une cle Stripe est compromise ?
-   - Notification automatique aux equipes ?
-
-3. **Environnement de test ?**
-   - Cles `sk_test_` vs `sk_live_` par projet ?
-   - Comment gerer les deux environnements ?
-
-4. **Audit et logs ?**
-   - Faut-il logger les acces aux cles ?
-   - Retention des logs ?
-
----
-
-## Prochaines etapes
-
-- [ ] Review par equipe Bot
-- [ ] Review par equipe Plugin
-- [ ] Decision architecturale
-- [ ] Implementation de la solution choisie
-
-**Deadline pour feedback:** [A definir]
+| Responsabilite | Description |
+|----------------|-------------|
+| Definir les endpoints | `/discord-get-plans`, etc. |
+| Recevoir les webhooks Stripe | `/stripe-events` |
+| Appeler l'API Stripe | Avec la cle recue |
+| Valider les signatures webhook | Avec le secret approprie |
+| Mettre a jour PostgreSQL | Subscribers, transactions |
+| **Definir le contrat API** | Ce RFC devrait etre cote n8n |
 
 ---
 
-## Commentaires
+## 6. Recommandation
 
-### Equipe Bot
-_[A completer]_
+### Court terme (5 projets)
 
-### Equipe Plugin
-_[A completer]_
+**Option D (Credentials n8n manuelles)** pour les `webhook_secret`:
+- Simple, natif n8n
+- Securise (chiffrement integre)
+- Acceptable pour 5 projets
 
-### Equipe Backend
-_[A completer]_
+**Option "Transmission directe"** pour les `stripe_secret_key`:
+- Le bot passe la cle via header a chaque requete
+- n8n ne stocke pas les cles API
+- Source unique dans le plugin
+
+### Long terme (10+ projets)
+
+**Option E (Stripe Connect)** a evaluer:
+- Elimine la gestion multi-cles
+- Scale naturellement
+- Webhooks centralises
+
+---
+
+## 7. Questions pour l'equipe n8n
+
+1. **Validation webhook:** Comment validez-vous actuellement les signatures Stripe?
+
+2. **Stockage:** Acceptez-vous de stocker les `webhook_secret` dans n8n (Option C)?
+
+3. **Credentials manuelles:** Est-ce acceptable de creer 5 credentials Stripe manuellement?
+
+4. **Header vs Body:** Preferez-vous recevoir `stripe_secret_key` en header ou dans le body JSON?
+
+5. **Stripe Connect:** Avez-vous de l'experience avec Stripe Connect?
+
+6. **Ce RFC:** Souhaitez-vous reprendre ce document cote n8n puisque vous definissez l'API?
+
+---
+
+## 8. Questions ouvertes
+
+1. **Rotation des cles:**
+   - Procedure si une cle est compromise?
+   - Comment synchroniser si Option C?
+
+2. **Environnement test/prod:**
+   - `sk_test_` vs `sk_live_` par projet?
+   - Endpoints n8n separes ou meme endpoint?
+
+3. **Audit:**
+   - Logger les appels avec `stripe_secret_key`?
+   - Masquer les cles dans les logs n8n?
+
+4. **TLS:**
+   - Communication bot ↔ n8n en HTTPS obligatoire?
+   - Certificats auto-signes acceptes (meme serveur)?
+
+---
+
+## 9. Prochaines etapes
+
+- [x] Review par equipe Bot (ce document)
+- [ ] Review par equipe n8n
+- [ ] Decision sur Option webhook (A/B/C/D)
+- [ ] Decision sur transmission stripe_key (Header vs Body)
+- [ ] Implementation
+
+**Deadline pour feedback n8n:** [A definir]
+
+---
+
+## 10. Historique
+
+| Date | Modification |
+|------|--------------|
+| 2025-01-05 | Version initiale |
+| 2025-01-05 | Rewrite complet apres analyse equipe Bot |
+
+---
+
+## 11. Reponse equipe n8n (2025-01-05)
+
+### 11.1 Analyse du document
+
+**Points d'accord:**
+- Architecture 1 plugin = 1 bot = 1 cle : claire et maintenable
+- Principe de source unique pour `stripe_secret_key` : correct
+- Transmission via header plutot que body : bonne pratique
+- Le flux Stripe → n8n est bien le probleme principal
+
+**Points de challenge:**
+
+| Affirmation | Challenge |
+|-------------|-----------|
+| "Le bot passe la cle a chaque requete" | Acceptable si HTTPS, mais augmente la surface d'attaque |
+| "n8n ne stocke pas de cles" | Contradiction avec Option C qui stocke webhook_secret |
+| "Option D pour court terme" | Gestion manuelle = source d'erreurs et oublis |
+
+### 11.2 Reponses aux questions (Section 7)
+
+**Q1. Validation webhook - Comment validez-vous actuellement?**
+
+Actuellement, nous n'avons PAS de validation de signature Stripe.
+Les workflows Stripe existants font confiance a l'appelant.
+C'est un **risque de securite** a corriger.
+
+**Q2. Stockage webhook_secret dans n8n (Option C)?**
+
+**OUI, acceptable.** Justification:
+- Le `webhook_secret` n'est PAS la cle API (ne permet pas d'actions)
+- Il sert uniquement a valider l'origine des webhooks
+- Stocker ce secret cote n8n est coherent : c'est n8n qui recoit les webhooks
+- Ce n'est pas une "duplication" mais une delegation de responsabilite
+
+**Q3. 5 credentials manuelles?**
+
+**NON recommande.** Problemes:
+- Erreur humaine lors de l'ajout d'un projet
+- Pas de visibilite sur la liste des projets configures
+- Difficile a auditer
+- Necessite acces admin n8n pour chaque nouveau projet
+
+**Q4. Header vs Body pour stripe_secret_key?**
+
+**HEADER obligatoire.** Raisons:
+- `X-Stripe-Secret-Key` en header
+- Plus facile a exclure des logs applicatifs
+- Separation claire donnees/authentification
+- Convention standard (comme `Authorization: Bearer`)
+
+**Q5. Experience Stripe Connect?**
+
+Non, mais pret a explorer pour le long terme si >10 projets.
+
+**Q6. Reprendre ce RFC cote n8n?**
+
+**OUI.** Ce document definit le contrat API n8n.
+Il devrait vivre dans le repo n8n-workflows (deja le cas).
+
+### 11.3 Recommandation n8n
+
+**Proposition : Option B + C combinee**
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         ARCHITECTURE                             │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  FLUX 1: Bot → n8n                                              │
+│  ─────────────────                                              │
+│  Bot passe: X-Project-ID + X-Stripe-Secret-Key (headers)        │
+│  n8n: utilise la cle recue, ne stocke rien                      │
+│                                                                  │
+│  FLUX 2: Stripe → n8n                                           │
+│  ─────────────────────                                          │
+│  Stripe envoie: webhook avec metadata.project_id (Option B)     │
+│  n8n: lookup webhook_secret dans PostgreSQL (Option C)          │
+│  n8n: valide signature, route vers le bon projet                │
+│                                                                  │
+│  INITIALISATION (une fois par projet):                          │
+│  ─────────────────────────────────────                          │
+│  Plugin → n8n: POST /admin/register-project                     │
+│  { project_id, webhook_secret, callback_url? }                  │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Avantages de cette approche:**
+1. `stripe_secret_key` jamais stockee cote n8n (source unique = plugin)
+2. `webhook_secret` stocke cote n8n (logique: c'est n8n qui valide)
+3. Un seul endpoint webhook Stripe (`/webhook/stripe-events`)
+4. Routing dynamique via `metadata.project_id`
+5. Scale bien (ajout projet = 1 appel API)
+
+### 11.4 Reponses aux questions ouvertes (Section 8)
+
+**Q1. Rotation des cles**
+
+| Scenario | Procedure |
+|----------|-----------|
+| Rotation planifiee `stripe_secret_key` | Plugin met a jour son .env, rien a faire cote n8n |
+| Rotation planifiee `webhook_secret` | Plugin appelle `/admin/register-project` avec nouveau secret |
+| Cle compromise | 1. Revoquer dans Stripe 2. Generer nouvelle cle 3. Mettre a jour config 4. Alerter les equipes |
+
+**Q2. Environnement test/prod**
+
+Proposition:
+```
+project_id = "torah"       → Production (sk_live_)
+project_id = "torah-test"  → Test (sk_test_)
+```
+
+Meme endpoint n8n, le plugin decide de son `project_id`.
+Permet de tester sans impacter la prod.
+
+**Q3. Audit et logs**
+
+| Element | Action |
+|---------|--------|
+| `stripe_secret_key` dans header | JAMAIS loggue (exclure X-Stripe-* des logs) |
+| `webhook_secret` | JAMAIS loggue |
+| `project_id` | Loggue (pour audit) |
+| Appels Stripe API | Loggue (sans la cle) |
+| Erreurs validation webhook | Loggue avec alerte |
+
+Implementation n8n: configurer les workflows pour masquer les headers sensibles.
+
+**Q4. TLS (HTTPS)**
+
+| Communication | Exigence |
+|---------------|----------|
+| Bot → n8n (meme serveur) | HTTP acceptable si localhost/reseau prive |
+| Bot → n8n (serveurs differents) | **HTTPS obligatoire** |
+| Plugin → n8n (init) | HTTPS recommande |
+| Stripe → n8n | HTTPS obligatoire (impose par Stripe) |
+
+Pour notre setup actuel (pi6.local, meme reseau):
+- HTTP acceptable en interne
+- Mais HTTPS recommande si le reseau n'est pas de confiance
+
+### 11.5 Schema de donnees PostgreSQL propose
+
+```sql
+-- Table pour les secrets webhook (pas les cles API!)
+CREATE TABLE IF NOT EXISTS project_webhooks (
+    project_id VARCHAR(50) PRIMARY KEY,
+    webhook_secret VARCHAR(255) NOT NULL,  -- whsec_xxx
+    display_name VARCHAR(100),
+    callback_url VARCHAR(500),             -- URL pour notifier le bot
+    active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Index pour lookup rapide
+CREATE INDEX idx_project_webhooks_active ON project_webhooks(active);
+
+-- Note: stripe_secret_key n'est PAS stocke ici
+-- Elle est passee par le bot a chaque requete
+```
+
+### 11.6 Endpoints n8n a implementer
+
+| Endpoint | Methode | Usage |
+|----------|---------|-------|
+| `/admin/register-project` | POST | Plugin enregistre son webhook_secret |
+| `/admin/unregister-project` | DELETE | Retirer un projet |
+| `/webhook/stripe-events` | POST | Reception webhooks Stripe (unique) |
+| `/webhook/discord-*` | GET/POST | Endpoints existants (deja OK) |
+
+### 11.7 Decision demandee
+
+**Pour avancer, nous avons besoin de validation sur:**
+
+- [ ] Accord sur Option B+C (metadata + stockage webhook_secret)
+- [ ] Accord sur headers pour `stripe_secret_key`
+- [ ] Accord sur schema PostgreSQL `project_webhooks`
+- [ ] Accord sur HTTP interne / HTTPS externe
+
+**Deadline decision:** [A definir par le projet]
+
+---
+
+## Annexe: Format des headers proposes
+
+```http
+POST /webhook/discord-get-plans HTTP/1.1
+Host: pi6.local:5678
+Content-Type: application/json
+X-Project-ID: torah
+X-Stripe-Secret-Key: sk_live_xxxxxxxxxxxx
+
+{
+  "discord_user_id": "123456789"
+}
+```
+
+**Pourquoi des headers?**
+- Separation donnees/authentification
+- Plus facile a filtrer des logs
+- Convention standard (comme `Authorization`)
+- Pas de risque d'inclure dans les logs de body JSON

--- a/docs/RFC-stripe-key-management.md
+++ b/docs/RFC-stripe-key-management.md
@@ -1,0 +1,211 @@
+# RFC: Gestion des cles Stripe en architecture multi-tenant
+
+**Date:** 2025-01-05
+**Statut:** En discussion
+**Equipes concernees:** Bot Discord, Plugin Torah, Backend n8n
+
+---
+
+## Contexte
+
+L'architecture actuelle implique trois composants :
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Plugin    │     │  Bot Discord│     │    n8n      │
+│   (Torah)   │     │  (generique)│     │  (workflows)│
+└─────────────┘     └─────────────┘     └─────────────┘
+      │                    │                   │
+      │ stripe_secret_key  │ project_id        │ Stripe API
+      │ (config locale)    │ (seul parametre)  │ (necessite la cle)
+```
+
+**Probleme:** Le bot appelle n8n avec uniquement `project_id`, mais n8n doit appeler l'API Stripe qui necessite la `stripe_secret_key` specifique au projet.
+
+**Question centrale:** Ou stocker la cle Stripe et comment la transmettre a n8n ?
+
+---
+
+## Options proposees
+
+### Option A : Le bot transmet la cle
+
+```
+Bot → n8n : { project_id, stripe_secret_key }
+```
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| Simple a implementer | Cle en transit a chaque requete |
+| Pas de stockage cote n8n | Bot doit stocker les cles (securite) |
+| | Exposition via logs/debug |
+
+**Questions pour l'equipe Bot:**
+- Le bot a-t-il acces aux cles Stripe de chaque projet ?
+- Comment le bot obtiendrait-il ces cles ?
+- Etes-vous a l'aise avec la responsabilite de gerer ces secrets ?
+
+---
+
+### Option B : Stockage PostgreSQL (table projects)
+
+```sql
+CREATE TABLE projects (
+  project_id VARCHAR PRIMARY KEY,
+  display_name VARCHAR,
+  stripe_secret_key VARCHAR,  -- Chiffre ?
+  stripe_webhook_secret VARCHAR,
+  active BOOLEAN DEFAULT true,
+  created_at TIMESTAMP
+);
+```
+
+```
+Plugin → n8n : POST /register-project { project_id, stripe_secret_key }
+Bot → n8n : GET /get-plans?project_id=torah
+n8n : SELECT stripe_secret_key FROM projects WHERE project_id = 'torah'
+n8n → Stripe API
+```
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| Cle jamais en transit apres init | Necessite workflow d'enregistrement |
+| Bot n'a jamais acces aux cles | Sync a maintenir si cle change |
+| Centralise et auditable | Stockage sensible en DB |
+
+**Questions pour l'equipe Plugin:**
+- Le plugin peut-il appeler un endpoint d'init au demarrage ?
+- Qui gere le cycle de vie des cles (rotation, revocation) ?
+- Preferez-vous un enregistrement manuel (admin) ou automatique ?
+
+---
+
+### Option C : Credentials n8n par projet
+
+Creer une credential n8n par projet : `stripe-torah`, `stripe-mcp`, etc.
+
+```
+n8n : Utilise la credential correspondant au project_id
+```
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| Natif n8n, securise | Pas dynamique (code dur) |
+| Chiffrement integre | Ajout manuel pour chaque projet |
+| | Ne scale pas bien |
+
+**Questions pour l'equipe Backend:**
+- Combien de projets sont prevus ?
+- La gestion manuelle des credentials est-elle acceptable ?
+
+---
+
+### Option D : Le plugin appelle n8n directement
+
+```
+User → Bot : /plans
+Bot → Plugin : get_plans()
+Plugin → n8n : { project_id, stripe_secret_key }
+n8n → Stripe API
+Plugin → Bot : plans
+Bot → User : affiche plans
+```
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| Plugin garde le controle des cles | Architecture plus complexe |
+| Pas de stockage externe | Latence supplementaire |
+| | Bot devient passif (proxy) |
+
+**Questions pour les deux equipes:**
+- Cette complexite est-elle justifiee ?
+- Le bot doit-il rester l'orchestrateur principal ?
+
+---
+
+### Option E : Variables d'environnement n8n
+
+```
+STRIPE_KEY_TORAH=sk_live_xxx
+STRIPE_KEY_MCP=sk_live_yyy
+```
+
+```javascript
+// Dans n8n Code node
+const key = process.env[`STRIPE_KEY_${projectId.toUpperCase()}`];
+```
+
+| Avantages | Inconvenients |
+|-----------|---------------|
+| Simple, pas de DB | Redemarrage n8n si ajout projet |
+| Securise (env vars) | Ne scale pas |
+| | Gestion manuelle |
+
+---
+
+## Matrice de decision
+
+| Critere | Option A | Option B | Option C | Option D | Option E |
+|---------|----------|----------|----------|----------|----------|
+| Securite | Faible | Bonne | Excellente | Bonne | Bonne |
+| Scalabilite | Bonne | Excellente | Faible | Moyenne | Faible |
+| Simplicite | Excellente | Moyenne | Moyenne | Faible | Bonne |
+| Maintenance | Faible | Moyenne | Elevee | Elevee | Moyenne |
+| Autonomie Bot | Oui | Oui | Oui | Non | Oui |
+
+---
+
+## Recommandation initiale
+
+**Option B (PostgreSQL)** semble offrir le meilleur equilibre :
+- Securite correcte (cle stockee cote serveur)
+- Scalabilite (ajout de projets sans code)
+- Le bot reste simple (envoie juste `project_id`)
+
+Avec un workflow `discord-register-project` appele :
+- Soit par le plugin au demarrage
+- Soit manuellement par un admin via UI/script
+
+---
+
+## Questions ouvertes
+
+1. **Chiffrement des cles en DB ?**
+   - Faut-il chiffrer `stripe_secret_key` dans PostgreSQL ?
+   - Qui gere la cle de chiffrement ?
+
+2. **Rotation des cles ?**
+   - Quelle procedure si une cle Stripe est compromise ?
+   - Notification automatique aux equipes ?
+
+3. **Environnement de test ?**
+   - Cles `sk_test_` vs `sk_live_` par projet ?
+   - Comment gerer les deux environnements ?
+
+4. **Audit et logs ?**
+   - Faut-il logger les acces aux cles ?
+   - Retention des logs ?
+
+---
+
+## Prochaines etapes
+
+- [ ] Review par equipe Bot
+- [ ] Review par equipe Plugin
+- [ ] Decision architecturale
+- [ ] Implementation de la solution choisie
+
+**Deadline pour feedback:** [A definir]
+
+---
+
+## Commentaires
+
+### Equipe Bot
+_[A completer]_
+
+### Equipe Plugin
+_[A completer]_
+
+### Equipe Backend
+_[A completer]_

--- a/docs/RFC-stripe-key-management.md
+++ b/docs/RFC-stripe-key-management.md
@@ -2,7 +2,7 @@
 
 **Date:** 2025-01-05
 **Mise a jour:** 2025-01-05
-**Statut:** En discussion
+**Statut:** DECISION PRISE - Option F (Redis)
 **Equipes concernees:** Framework Bot Discord, Plugins, Backend n8n
 
 ---
@@ -32,20 +32,25 @@ Le framework bot-discord est une **dependance pip** installee par chaque plugin.
                └──────────────┬───────────────────┘
                               ▼
                     ┌───────────────────┐
+                    │   Redis (vault)   │◄──── Secrets centralises
+                    │  host3.local:6381 │
+                    └─────────┬─────────┘
+                              │
+                              ▼
+                    ┌───────────────────┐
                     │        n8n        │
-                    │   (workflows      │
-                    │    partages)      │
+                    │   (workflows)     │
                     └───────────────────┘
 ```
 
 ### 1.2 Principe fondamental: Source unique de verite
 
-**Comme OAuth2:** La cle est stockee a UN SEUL endroit - la configuration du plugin.
+**Redis comme vault de secrets:**
 
-- Le plugin possede sa cle Stripe dans son `.env`
-- La cle est passee a n8n a chaque requete (comme un Bearer token)
-- n8n n'a **pas** de stockage de cles
-- Pas de duplication, pas de synchronisation
+- Le plugin possede ses cles Stripe dans son `.env`
+- Au demarrage, le plugin **pousse** ses secrets dans Redis
+- n8n **lit** les secrets depuis Redis (jamais en transit HTTP)
+- Redis = source unique partagee entre plugin et n8n
 
 ---
 
@@ -54,172 +59,94 @@ Le framework bot-discord est une **dependance pip** installee par chaque plugin.
 ### 2.1 Flux Bot → n8n (commandes Discord)
 
 ```
-User ──► Bot ──► n8n ──► Stripe API
+User ──► Bot ──► n8n ──► Redis (lookup) ──► Stripe API
               │
-              └─► Le bot PEUT passer la cle
+              └─► Bot passe UNIQUEMENT project_id
 ```
 
 **Exemple:** `/plans`, `/subscribe`, `/account`
 
-Le bot connait la cle (depuis sa config) et peut la transmettre a n8n.
-
-**Implementation proposee:**
-```
-POST /webhook/discord-get-plans
-Headers:
-  X-Project-ID: torah
-  X-Stripe-Secret-Key: sk_live_xxx    ← Header (pas dans le body)
-```
+Le bot passe seulement `X-Project-ID`. n8n recupere la cle depuis Redis.
 
 ### 2.2 Flux Stripe → n8n (webhooks)
 
 ```
-Stripe ──────────────────────► n8n /webhook/stripe-events
-                                    │
-                                    └─► Le bot N'EST PAS dans la boucle
+Stripe ──► n8n /webhook/stripe-events
+               │
+               └─► n8n extrait project_id des metadata
+               └─► n8n recupere webhook_secret depuis Redis
+               └─► n8n valide la signature
 ```
 
-**Probleme:** n8n recoit un webhook Stripe mais:
-- Ne sait pas quel projet est concerne
-- N'a pas le `webhook_secret` pour valider la signature
-- Le bot ne peut pas aider (pas dans la boucle)
-
-**C'est le probleme principal de ce RFC.**
+**Avec Redis, les deux flux sont resolus de la meme maniere.**
 
 ---
 
-## 3. Options pour le flux Stripe → n8n
+## 3. Options evaluees
 
 ### Option A: Un endpoint webhook par projet
-
-```
-Stripe Torah ──► n8n /webhook/stripe-events-torah
-Stripe MCP   ──► n8n /webhook/stripe-events-mcp
-```
-
-n8n stocke le `webhook_secret` par endpoint (credential ou env var).
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| Isolation totale | 1 workflow par projet |
-| Simple a debugger | Ne scale pas (5+ projets) |
-| webhook_secret par endpoint | Duplication de code |
+_(Ne scale pas - rejetee)_
 
 ### Option B: project_id dans metadata Stripe
+_(Bonne idee, integree dans Option F)_
 
-Configurer Stripe pour inclure `project_id` dans les metadata:
+### Option C: Stockage PostgreSQL
+_(Remplacee par Redis - plus performant)_
 
-```javascript
-// Lors de la creation du checkout (cote bot → n8n)
-metadata: {
-  project_id: "torah",
-  discord_user_id: "123456789"
-}
-```
+### Option D: Credentials n8n manuelles
+_(Rejetee par equipe n8n - erreurs humaines)_
 
-Stripe renvoie ces metadata dans les webhooks:
+### Option E: Stripe Connect
+_(Overkill pour 5 projets - a reevaluer si >10)_
 
-```json
-{
-  "type": "checkout.session.completed",
-  "data": {
-    "object": {
-      "metadata": {
-        "project_id": "torah"
-      }
-    }
-  }
-}
-```
-
-n8n peut alors router vers le bon projet.
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| 1 seul endpoint webhook | webhook_secret toujours necessaire |
-| Metadata inclus par Stripe | Dependance config Stripe correcte |
-| Scale bien | Pas de validation signature multi-projet |
-
-### Option C: Stockage des webhook_secrets dans n8n
-
-Contradiction avec "source unique", mais pragmatique:
+### Option F: Redis comme vault de secrets (RETENUE)
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                    n8n                               │
-│  ┌───────────────────────────────────────────────┐  │
-│  │ SQLite: stripe_webhook_secrets                │  │
-│  │ ┌────────────┬─────────────────────────────┐  │  │
-│  │ │ project_id │ webhook_secret              │  │  │
-│  │ ├────────────┼─────────────────────────────┤  │  │
-│  │ │ torah      │ whsec_xxx                   │  │  │
-│  │ │ mcp        │ whsec_yyy                   │  │  │
-│  │ └────────────┴─────────────────────────────┘  │  │
-│  └───────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────────────┐
+│                    OPTION F - ARCHITECTURE REDIS                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  INITIALISATION (demarrage plugin):                             │
+│  ──────────────────────────────────                             │
+│  Plugin → Redis (host3.local:6381/2):                           │
+│    HSET project:torah stripe_key "sk_live_xxx"                  │
+│    HSET project:torah webhook_secret "whsec_xxx"                │
+│    HSET project:torah display_name "Torah App"                  │
+│    HSET project:torah active "true"                             │
+│                                                                  │
+│  FLUX 1: Bot → n8n                                              │
+│  ─────────────────                                              │
+│  Bot: POST /webhook/discord-get-plans                           │
+│       Header: X-Project-ID: torah                               │
+│       (PAS de cle dans le header!)                              │
+│  n8n: HGET project:torah stripe_key                             │
+│  n8n: appelle Stripe API avec la cle                            │
+│                                                                  │
+│  FLUX 2: Stripe → n8n                                           │
+│  ─────────────────────                                          │
+│  Stripe: POST /webhook/stripe-events                            │
+│          Body contient metadata.project_id                      │
+│  n8n: HGET project:torah webhook_secret                         │
+│  n8n: valide la signature Stripe                                │
+│  n8n: traite le webhook                                         │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
 ```
-
-Le plugin enregistre son `webhook_secret` au demarrage:
-```
-Plugin ──► n8n POST /admin/register-webhook-secret
-           { project_id, webhook_secret }
-```
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| Validation signature OK | Stockage de secrets cote n8n |
-| Scale bien | Sync necessaire si rotation |
-| 1 seul endpoint | Deux sources de verite |
-
-### Option D: Credentials n8n par projet (manuel)
-
-Creer manuellement une credential n8n par projet:
-- `stripe-webhook-torah`
-- `stripe-webhook-mcp`
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| Natif n8n, chiffre | Gestion manuelle |
-| Pas de code custom | Ne scale pas |
-| Securise | Ajout projet = config n8n |
-
-### Option E: Stripe Connect (architecture alternative)
-
-Une seule cle Stripe "platform", chaque projet est un "connected account":
-
-```
-┌─────────────────────────────────┐
-│    Compte Platform (vous)       │  ← 1 seule cle API
-│    sk_platform_xxx              │
-└───────────────┬─────────────────┘
-                │
-    ┌───────────┼───────────┐
-    ▼           ▼           ▼
-┌───────┐  ┌───────┐  ┌───────┐
-│ Torah │  │  MCP  │  │ Proj X│   ← Connected Accounts
-│ acct_ │  │ acct_ │  │ acct_ │      (pas de cles separees)
-└───────┘  └───────┘  └───────┘
-```
-
-| Avantages | Inconvenients |
-|-----------|---------------|
-| 1 seule cle a gerer | Setup Stripe Connect |
-| Isolation native | Frais Stripe supplementaires |
-| Webhooks simplifies | Complexite onboarding |
-| Scale infiniment | Overkill pour 5 projets? |
 
 ---
 
 ## 4. Matrice de decision
 
-| Critere | Option A | Option B | Option C | Option D | Option E |
-|---------|----------|----------|----------|----------|----------|
-| **Securite** | Bonne | Moyenne | Bonne | Excellente | Excellente |
-| **Scalabilite** | Faible | Bonne | Bonne | Faible | Excellente |
-| **Source unique** | Oui | Oui | Non | Non | Oui |
-| **Validation webhook** | Oui | Non | Oui | Oui | Oui |
-| **Effort n8n** | Eleve | Faible | Moyen | Faible | Moyen |
-| **Effort plugin** | Faible | Moyen | Moyen | Faible | Eleve |
+| Critere | Option B+C | Option D | Option E | **Option F (Redis)** |
+|---------|------------|----------|----------|----------------------|
+| **Securite** | Bonne | Excellente | Excellente | **Excellente** |
+| **Cle en transit** | Oui (header) | Non | Non | **Non** |
+| **Scalabilite** | Bonne | Faible | Excellente | **Excellente** |
+| **Source unique** | Non (2 endroits) | Non | Oui | **Oui (Redis)** |
+| **Performance lookup** | ~5-10ms | ~1ms | N/A | **~1ms** |
+| **Effort n8n** | Moyen | Faible | Moyen | **Faible** |
+| **Effort plugin** | Moyen | Faible | Eleve | **Faible** |
+| **Infra existante** | Oui (PG) | Oui | Non | **Oui (Redis)** |
 
 ---
 
@@ -230,312 +157,451 @@ Une seule cle Stripe "platform", chaque projet est un "connected account":
 | Responsabilite | Description |
 |----------------|-------------|
 | Fournir `N8nClient` | Client HTTP pour appeler n8n |
-| Passer `project_id` | Identifiant du projet |
-| Passer `stripe_secret_key` | Via header HTTP securise |
-| Gerer les erreurs n8n | Retry, timeout, fallback |
-| **NE PAS** stocker de cles | Juste transmettre depuis config |
+| Fournir `RedisSecretsClient` | Client pour pousser secrets dans Redis |
+| Passer `X-Project-ID` | Seul header necessaire (plus de cle!) |
+| Enregistrer secrets au demarrage | `HSET project:{id} ...` |
+| Gerer les erreurs | Retry, timeout, fallback |
 
 ### 5.2 Plugin (utilisateur du framework)
 
 | Responsabilite | Description |
 |----------------|-------------|
 | Configurer `.env` | `PROJECT_ID`, `STRIPE_SECRET_KEY`, etc. |
-| Instancier le bot | Avec la config appropriee |
-| Posseder les cles Stripe | Source unique de verite |
-| Enregistrer webhook_secret? | Si Option C choisie |
+| Configurer Redis | `REDIS_HOST`, `REDIS_PORT`, `REDIS_DB` |
+| Appeler `register_secrets()` | Au demarrage du bot |
+| Posseder les cles Stripe | Dans son `.env` local |
 
 ### 5.3 n8n (workflows)
 
 | Responsabilite | Description |
 |----------------|-------------|
-| Definir les endpoints | `/discord-get-plans`, etc. |
-| Recevoir les webhooks Stripe | `/stripe-events` |
-| Appeler l'API Stripe | Avec la cle recue |
-| Valider les signatures webhook | Avec le secret approprie |
-| Mettre a jour PostgreSQL | Subscribers, transactions |
-| **Definir le contrat API** | Ce RFC devrait etre cote n8n |
+| Lire secrets depuis Redis | `HGET project:{id} stripe_key` |
+| Valider webhooks Stripe | Avec `webhook_secret` de Redis |
+| Appeler l'API Stripe | Avec la cle lue depuis Redis |
+| **Ne plus attendre de cle en header** | Juste `X-Project-ID` |
+
+### 5.4 Redis (vault)
+
+| Responsabilite | Description |
+|----------------|-------------|
+| Stocker les secrets | Hash par projet |
+| Haute disponibilite | Deja en place sur host3.local |
+| Acces rapide | ~1ms lookup |
 
 ---
 
-## 6. Recommandation
+## 6. Recommandation finale
 
-### Court terme (5 projets)
+### DECISION: Option F (Redis)
 
-**Option D (Credentials n8n manuelles)** pour les `webhook_secret`:
-- Simple, natif n8n
-- Securise (chiffrement integre)
-- Acceptable pour 5 projets
+**Pourquoi Redis plutot que B+C (PostgreSQL)?**
 
-**Option "Transmission directe"** pour les `stripe_secret_key`:
-- Le bot passe la cle via header a chaque requete
-- n8n ne stocke pas les cles API
-- Source unique dans le plugin
+| Critere | PostgreSQL (B+C) | Redis (F) |
+|---------|------------------|-----------|
+| Cle en transit | Oui (chaque requete) | **Non** |
+| Latence | ~5-10ms | **~1ms** |
+| Infrastructure | Deja la | **Deja la** |
+| Complexite | 2 systemes (header + PG) | **1 systeme (Redis)** |
 
-### Long terme (10+ projets)
+**Avantages decisifs de Redis:**
 
-**Option E (Stripe Connect)** a evaluer:
-- Elimine la gestion multi-cles
-- Scale naturellement
-- Webhooks centralises
-
----
-
-## 7. Questions pour l'equipe n8n
-
-1. **Validation webhook:** Comment validez-vous actuellement les signatures Stripe?
-
-2. **Stockage:** Acceptez-vous de stocker les `webhook_secret` dans n8n (Option C)?
-
-3. **Credentials manuelles:** Est-ce acceptable de creer 5 credentials Stripe manuellement?
-
-4. **Header vs Body:** Preferez-vous recevoir `stripe_secret_key` en header ou dans le body JSON?
-
-5. **Stripe Connect:** Avez-vous de l'experience avec Stripe Connect?
-
-6. **Ce RFC:** Souhaitez-vous reprendre ce document cote n8n puisque vous definissez l'API?
+1. **Cle JAMAIS en transit** - Meme pas en header HTTPS
+2. **Performance** - Redis est concu pour ca
+3. **Simplicite** - Un seul systeme pour tous les secrets
+4. **Infrastructure existante** - `host3.local:6381` deja disponible
+5. **Source unique** - Redis devient le vault partage
 
 ---
 
-## 8. Questions ouvertes
+## 7. Configuration Redis
 
-1. **Rotation des cles:**
-   - Procedure si une cle est compromise?
-   - Comment synchroniser si Option C?
+### 7.1 Acces Redis existant
 
-2. **Environnement test/prod:**
-   - `sk_test_` vs `sk_live_` par projet?
-   - Endpoints n8n separes ou meme endpoint?
+```env
+REDIS_HOST=host3.local
+REDIS_PORT=6381
+REDIS_DB=2
+REDIS_PASSWORD=
+```
 
-3. **Audit:**
-   - Logger les appels avec `stripe_secret_key`?
-   - Masquer les cles dans les logs n8n?
+### 7.2 Schema Redis
 
-4. **TLS:**
-   - Communication bot ↔ n8n en HTTPS obligatoire?
-   - Certificats auto-signes acceptes (meme serveur)?
+```redis
+# Hash par projet - toutes les infos regroupees
+HSET project:torah stripe_key "sk_live_xxxxxxxxxxxx"
+HSET project:torah webhook_secret "whsec_xxxxxxxxxxxx"
+HSET project:torah display_name "Torah App"
+HSET project:torah active "true"
+HSET project:torah registered_at "2025-01-05T10:00:00Z"
+
+# Commandes de lecture
+HGET project:torah stripe_key          # → "sk_live_xxx"
+HGET project:torah webhook_secret      # → "whsec_xxx"
+HGETALL project:torah                  # → toutes les infos
+
+# Liste des projets actifs
+KEYS project:*                         # → ["project:torah", "project:mcp", ...]
+```
+
+### 7.3 TTL optionnel (rotation forcee)
+
+```redis
+# Forcer re-enregistrement toutes les 24h
+EXPIRE project:torah 86400
+```
 
 ---
 
-## 9. Prochaines etapes
+## 8. Implementation cote Bot
 
-- [x] Review par equipe Bot (ce document)
-- [ ] Review par equipe n8n
-- [ ] Decision sur Option webhook (A/B/C/D)
-- [ ] Decision sur transmission stripe_key (Header vs Body)
-- [ ] Implementation
+### 8.1 Nouveau client Redis
 
-**Deadline pour feedback n8n:** [A definir]
+```python
+# framework/services/redis_secrets.py
+
+import redis.asyncio as redis
+from dataclasses import dataclass
+
+@dataclass
+class RedisConfig:
+    host: str = "host3.local"
+    port: int = 6381
+    db: int = 2
+    password: str | None = None
+
+class RedisSecretsClient:
+    """Client pour gerer les secrets Stripe dans Redis."""
+
+    def __init__(self, config: RedisConfig):
+        self.config = config
+        self._client: redis.Redis | None = None
+
+    async def connect(self):
+        self._client = redis.Redis(
+            host=self.config.host,
+            port=self.config.port,
+            db=self.config.db,
+            password=self.config.password,
+            decode_responses=True
+        )
+
+    async def register_project(
+        self,
+        project_id: str,
+        stripe_key: str,
+        webhook_secret: str,
+        display_name: str | None = None
+    ):
+        """Enregistre les secrets d'un projet dans Redis."""
+        key = f"project:{project_id}"
+        await self._client.hset(key, mapping={
+            "stripe_key": stripe_key,
+            "webhook_secret": webhook_secret,
+            "display_name": display_name or project_id,
+            "active": "true",
+            "registered_at": datetime.utcnow().isoformat()
+        })
+
+    async def unregister_project(self, project_id: str):
+        """Supprime un projet de Redis."""
+        await self._client.delete(f"project:{project_id}")
+```
+
+### 8.2 Utilisation au demarrage du plugin
+
+```python
+# Plugin main.py
+
+from framework import N8nClient, RedisSecretsClient, RedisConfig
+
+async def main():
+    # Configuration
+    config = load_config()
+
+    # Enregistrer secrets dans Redis
+    redis_client = RedisSecretsClient(RedisConfig(
+        host=config.redis_host,
+        port=config.redis_port,
+        db=config.redis_db
+    ))
+    await redis_client.connect()
+    await redis_client.register_project(
+        project_id=config.project_id,
+        stripe_key=config.stripe_secret_key,
+        webhook_secret=config.stripe_webhook_secret,
+        display_name="Torah App"
+    )
+
+    # Initialiser le bot (plus besoin de passer stripe_key!)
+    n8n_client = N8nClient(
+        base_url=config.n8n_base_url,
+        project_id=config.project_id  # Plus de stripe_key ici
+    )
+
+    # Demarrer le bot...
+```
+
+### 8.3 N8nClient simplifie
+
+```python
+# Plus besoin de X-Stripe-Secret-Key!
+headers = {
+    "X-Project-ID": self.project_id,
+    "Content-Type": "application/json"
+}
+# n8n lira la cle depuis Redis
+```
 
 ---
 
-## 10. Historique
+## 9. Implementation cote n8n
+
+### 9.1 Lecture Redis dans workflow
+
+```javascript
+// Node "Code" dans n8n
+const Redis = require('ioredis');
+
+const redis = new Redis({
+  host: 'host3.local',
+  port: 6381,
+  db: 2
+});
+
+const projectId = $input.first().headers['x-project-id'];
+const stripeKey = await redis.hget(`project:${projectId}`, 'stripe_key');
+
+if (!stripeKey) {
+  throw new Error(`Project ${projectId} not found in Redis`);
+}
+
+// Utiliser stripeKey pour appeler Stripe API
+return { stripeKey, projectId };
+```
+
+### 9.2 Validation webhook Stripe
+
+```javascript
+const projectId = $input.first().json.data.object.metadata.project_id;
+const webhookSecret = await redis.hget(`project:${projectId}`, 'webhook_secret');
+
+// Valider la signature
+const signature = $input.first().headers['stripe-signature'];
+const isValid = stripe.webhooks.constructEvent(
+  rawBody,
+  signature,
+  webhookSecret
+);
+```
+
+---
+
+## 10. Securite
+
+### 10.1 Acces Redis
+
+| Risque | Mitigation |
+|--------|------------|
+| Redis expose | Bind sur reseau prive uniquement |
+| Pas d'auth | `REDIS_PASSWORD` si necessaire |
+| Donnees en clair | Acceptable sur reseau interne |
+
+### 10.2 Audit
+
+| Element | Action |
+|---------|--------|
+| `stripe_key` | JAMAIS loggue |
+| `webhook_secret` | JAMAIS loggue |
+| `project_id` | Loggue pour audit |
+| Acces Redis | Logger les connexions |
+
+### 10.3 Rotation des cles
+
+| Scenario | Procedure |
+|----------|-----------|
+| Rotation planifiee | 1. Mettre a jour `.env` du plugin 2. Redemarrer le plugin (re-enregistre dans Redis) |
+| Cle compromise | 1. Revoquer dans Stripe 2. Generer nouvelle cle 3. Mettre a jour `.env` 4. Redemarrer plugin |
+
+---
+
+## 11. Historique des discussions
+
+### 11.1 Reponse equipe n8n (initiale)
+
+L'equipe n8n avait propose Option B+C (metadata + PostgreSQL).
+
+**Points d'accord conserves:**
+- Architecture 1 plugin = 1 bot = 1 cle
+- Metadata `project_id` dans webhooks Stripe
+- Header plutot que body pour identifiants
+
+**Point ameliore avec Redis:**
+- Plus besoin de passer `stripe_secret_key` en header
+- Un seul systeme (Redis) au lieu de deux (header + PostgreSQL)
+
+### 11.2 Decision finale
+
+Apres analyse, **Option F (Redis)** retenue car:
+1. Infrastructure Redis deja disponible
+2. Cle jamais en transit (meilleure securite)
+3. Plus simple (un seul systeme)
+4. Plus performant (~1ms vs ~5-10ms)
+
+---
+
+## 12. Prochaines etapes
+
+- [x] Review par equipe Bot
+- [x] Review par equipe n8n
+- [x] Decision: Option F (Redis)
+- [ ] Implementation `RedisSecretsClient` dans framework
+- [ ] Implementation lecture Redis dans n8n
+- [ ] Tests integration
+- [ ] Documentation plugin
+
+---
+
+## 13. Historique
 
 | Date | Modification |
 |------|--------------|
 | 2025-01-05 | Version initiale |
-| 2025-01-05 | Rewrite complet apres analyse equipe Bot |
+| 2025-01-05 | Rewrite apres analyse equipe Bot |
+| 2025-01-05 | Ajout reponse equipe n8n (Option B+C) |
+| 2025-01-05 | **Decision finale: Option F (Redis)** |
 
 ---
 
-## 11. Reponse equipe n8n (2025-01-05)
+## 14. Analyse n8n de l'Option F (Redis)
 
-### 11.1 Analyse du document
+### 14.1 Points d'accord
 
-**Points d'accord:**
-- Architecture 1 plugin = 1 bot = 1 cle : claire et maintenable
-- Principe de source unique pour `stripe_secret_key` : correct
-- Transmission via header plutot que body : bonne pratique
-- Le flux Stripe → n8n est bien le probleme principal
+| Point | Verdict |
+|-------|---------|
+| Cle jamais en transit HTTP | **Excellent** - meilleure securite |
+| Performance ~1ms | **Bon** - Redis est fait pour ca |
+| Infrastructure existante | **Bon** - pas de nouveau systeme a deployer |
+| Simplification headers | **Bon** - juste X-Project-ID |
 
-**Points de challenge:**
+### 14.2 Points de challenge
 
-| Affirmation | Challenge |
-|-------------|-----------|
-| "Le bot passe la cle a chaque requete" | Acceptable si HTTPS, mais augmente la surface d'attaque |
-| "n8n ne stocke pas de cles" | Contradiction avec Option C qui stocke webhook_secret |
-| "Option D pour court terme" | Gestion manuelle = source d'erreurs et oublis |
+| Concern | Question/Risque |
+|---------|-----------------|
+| **Integration n8n/Redis** | ioredis est-il disponible dans n8n? Faut-il installer un package npm? |
+| **Single Point of Failure** | Si Redis down → TOUS les projets KO. Pas de fallback. |
+| **Persistence Redis** | AOF/RDB active? Risque de perte au restart? |
+| **Authentification Redis** | `REDIS_PASSWORD` vide dans l'exemple. Redis est-il protege? |
+| **Audit/Logging** | PostgreSQL a meilleur outillage audit que Redis |
+| **Code node limitations** | Le Code node n8n peut-il faire `require('ioredis')`? |
 
-### 11.2 Reponses aux questions (Section 7)
+### 14.3 Questions techniques pour validation
 
-**Q1. Validation webhook - Comment validez-vous actuellement?**
+**Q1. ioredis dans n8n?**
 
-Actuellement, nous n'avons PAS de validation de signature Stripe.
-Les workflows Stripe existants font confiance a l'appelant.
-C'est un **risque de securite** a corriger.
+Le Code node n8n ne permet PAS `require()` de packages externes par defaut.
+Options:
+- a) Utiliser le node "Redis" natif de n8n (si disponible)
+- b) HTTP Request vers une API Redis (comme Redis REST)
+- c) Custom node n8n avec ioredis
+- d) Executer un script externe via Bash node
 
-**Q2. Stockage webhook_secret dans n8n (Option C)?**
+**Quelle approche est prevue?**
 
-**OUI, acceptable.** Justification:
-- Le `webhook_secret` n'est PAS la cle API (ne permet pas d'actions)
-- Il sert uniquement a valider l'origine des webhooks
-- Stocker ce secret cote n8n est coherent : c'est n8n qui recoit les webhooks
-- Ce n'est pas une "duplication" mais une delegation de responsabilite
+**Q2. Fallback si Redis indisponible?**
 
-**Q3. 5 credentials manuelles?**
+Scenario: Redis down pendant 5 minutes.
+- Webhooks Stripe arrives → echec validation → perte d'evenements?
+- Commandes Discord → echec → mauvaise UX?
 
-**NON recommande.** Problemes:
-- Erreur humaine lors de l'ajout d'un projet
-- Pas de visibilite sur la liste des projets configures
-- Difficile a auditer
-- Necessite acces admin n8n pour chaque nouveau projet
+**Proposition:** Implementer un circuit breaker ou cache local temporaire.
 
-**Q4. Header vs Body pour stripe_secret_key?**
+**Q3. Persistence Redis?**
 
-**HEADER obligatoire.** Raisons:
-- `X-Stripe-Secret-Key` en header
-- Plus facile a exclure des logs applicatifs
-- Separation claire donnees/authentification
-- Convention standard (comme `Authorization: Bearer`)
-
-**Q5. Experience Stripe Connect?**
-
-Non, mais pret a explorer pour le long terme si >10 projets.
-
-**Q6. Reprendre ce RFC cote n8n?**
-
-**OUI.** Ce document definit le contrat API n8n.
-Il devrait vivre dans le repo n8n-workflows (deja le cas).
-
-### 11.3 Recommandation n8n
-
-**Proposition : Option B + C combinee**
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         ARCHITECTURE                             │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  FLUX 1: Bot → n8n                                              │
-│  ─────────────────                                              │
-│  Bot passe: X-Project-ID + X-Stripe-Secret-Key (headers)        │
-│  n8n: utilise la cle recue, ne stocke rien                      │
-│                                                                  │
-│  FLUX 2: Stripe → n8n                                           │
-│  ─────────────────────                                          │
-│  Stripe envoie: webhook avec metadata.project_id (Option B)     │
-│  n8n: lookup webhook_secret dans PostgreSQL (Option C)          │
-│  n8n: valide signature, route vers le bon projet                │
-│                                                                  │
-│  INITIALISATION (une fois par projet):                          │
-│  ─────────────────────────────────────                          │
-│  Plugin → n8n: POST /admin/register-project                     │
-│  { project_id, webhook_secret, callback_url? }                  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+```bash
+# Verifier la config Redis
+redis-cli -h host3.local -p 6381 CONFIG GET appendonly
+redis-cli -h host3.local -p 6381 CONFIG GET save
 ```
 
-**Avantages de cette approche:**
-1. `stripe_secret_key` jamais stockee cote n8n (source unique = plugin)
-2. `webhook_secret` stocke cote n8n (logique: c'est n8n qui valide)
-3. Un seul endpoint webhook Stripe (`/webhook/stripe-events`)
-4. Routing dynamique via `metadata.project_id`
-5. Scale bien (ajout projet = 1 appel API)
+Si `appendonly=no` et `save=""` → donnees perdues au restart!
 
-### 11.4 Reponses aux questions ouvertes (Section 8)
+**Q4. Securite Redis?**
 
-**Q1. Rotation des cles**
-
-| Scenario | Procedure |
-|----------|-----------|
-| Rotation planifiee `stripe_secret_key` | Plugin met a jour son .env, rien a faire cote n8n |
-| Rotation planifiee `webhook_secret` | Plugin appelle `/admin/register-project` avec nouveau secret |
-| Cle compromise | 1. Revoquer dans Stripe 2. Generer nouvelle cle 3. Mettre a jour config 4. Alerter les equipes |
-
-**Q2. Environnement test/prod**
-
-Proposition:
-```
-project_id = "torah"       → Production (sk_live_)
-project_id = "torah-test"  → Test (sk_test_)
+```env
+REDIS_PASSWORD=       # Vide = pas d'auth!
 ```
 
-Meme endpoint n8n, le plugin decide de son `project_id`.
-Permet de tester sans impacter la prod.
+Redis sur reseau prive uniquement? Firewall?
 
-**Q3. Audit et logs**
+### 14.4 Proposition d'implementation n8n
 
-| Element | Action |
-|---------|--------|
-| `stripe_secret_key` dans header | JAMAIS loggue (exclure X-Stripe-* des logs) |
-| `webhook_secret` | JAMAIS loggue |
-| `project_id` | Loggue (pour audit) |
-| Appels Stripe API | Loggue (sans la cle) |
-| Erreurs validation webhook | Loggue avec alerte |
+**Option A: HTTP Request vers Redis (si Redis REST disponible)**
 
-Implementation n8n: configurer les workflows pour masquer les headers sensibles.
-
-**Q4. TLS (HTTPS)**
-
-| Communication | Exigence |
-|---------------|----------|
-| Bot → n8n (meme serveur) | HTTP acceptable si localhost/reseau prive |
-| Bot → n8n (serveurs differents) | **HTTPS obligatoire** |
-| Plugin → n8n (init) | HTTPS recommande |
-| Stripe → n8n | HTTPS obligatoire (impose par Stripe) |
-
-Pour notre setup actuel (pi6.local, meme reseau):
-- HTTP acceptable en interne
-- Mais HTTPS recommande si le reseau n'est pas de confiance
-
-### 11.5 Schema de donnees PostgreSQL propose
-
-```sql
--- Table pour les secrets webhook (pas les cles API!)
-CREATE TABLE IF NOT EXISTS project_webhooks (
-    project_id VARCHAR(50) PRIMARY KEY,
-    webhook_secret VARCHAR(255) NOT NULL,  -- whsec_xxx
-    display_name VARCHAR(100),
-    callback_url VARCHAR(500),             -- URL pour notifier le bot
-    active BOOLEAN DEFAULT true,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
-
--- Index pour lookup rapide
-CREATE INDEX idx_project_webhooks_active ON project_webhooks(active);
-
--- Note: stripe_secret_key n'est PAS stocke ici
--- Elle est passee par le bot a chaque requete
+```javascript
+// Pas besoin de ioredis
+const response = await $http.request({
+  method: 'GET',
+  url: 'http://host3.local:6380/HGET/project:torah/stripe_key'
+});
 ```
 
-### 11.6 Endpoints n8n a implementer
+**Option B: Node Redis natif n8n**
 
-| Endpoint | Methode | Usage |
-|----------|---------|-------|
-| `/admin/register-project` | POST | Plugin enregistre son webhook_secret |
-| `/admin/unregister-project` | DELETE | Retirer un projet |
-| `/webhook/stripe-events` | POST | Reception webhooks Stripe (unique) |
-| `/webhook/discord-*` | GET/POST | Endpoints existants (deja OK) |
+Verifier si `n8n-nodes-base.redis` existe et supporte HGET.
 
-### 11.7 Decision demandee
+**Option C: Script externe**
 
-**Pour avancer, nous avons besoin de validation sur:**
+```javascript
+// Dans Code node - appeler redis-cli via exec
+const { execSync } = require('child_process');
+const key = execSync('redis-cli -h host3.local -p 6381 HGET project:torah stripe_key').toString().trim();
+```
 
-- [ ] Accord sur Option B+C (metadata + stockage webhook_secret)
-- [ ] Accord sur headers pour `stripe_secret_key`
-- [ ] Accord sur schema PostgreSQL `project_webhooks`
-- [ ] Accord sur HTTP interne / HTTPS externe
+### 14.5 Conditions d'acceptation
 
-**Deadline decision:** [A definir par le projet]
+**J'accepte Option F (Redis) SI:**
+
+- [ ] Confirmation que ioredis ou alternative fonctionne dans n8n
+- [ ] Redis a persistence activee (AOF ou RDB)
+- [ ] Redis est sur reseau prive OU a authentification
+- [ ] Plan de fallback documente si Redis down
+- [ ] Test d'integration valide le flux complet
+
+### 14.6 Alternative de repli
+
+Si l'integration Redis/n8n s'avere trop complexe:
+
+**Revenir a Option B+C avec header chiffre:**
+
+```http
+X-Stripe-Key-Encrypted: base64(encrypt(sk_live_xxx, shared_secret))
+```
+
+n8n dechiffre avec une cle partagee. Cle en transit mais chiffree.
 
 ---
 
-## Annexe: Format des headers proposes
+## Annexe: Format des requetes
+
+### Avant (Option B+C)
 
 ```http
 POST /webhook/discord-get-plans HTTP/1.1
 Host: pi6.local:5678
-Content-Type: application/json
 X-Project-ID: torah
-X-Stripe-Secret-Key: sk_live_xxxxxxxxxxxx
+X-Stripe-Secret-Key: sk_live_xxxxxxxxxxxx  ← Cle en transit
 
-{
-  "discord_user_id": "123456789"
-}
+{"discord_user_id": "123456789"}
 ```
 
-**Pourquoi des headers?**
-- Separation donnees/authentification
-- Plus facile a filtrer des logs
-- Convention standard (comme `Authorization`)
-- Pas de risque d'inclure dans les logs de body JSON
+### Apres (Option F - Redis)
+
+```http
+POST /webhook/discord-get-plans HTTP/1.1
+Host: pi6.local:5678
+X-Project-ID: torah
+                                            ← Plus de cle!
+{"discord_user_id": "123456789"}
+```
+
+n8n recupere la cle depuis Redis: `HGET project:torah stripe_key`

--- a/docs/RFC-stripe-key-management.md
+++ b/docs/RFC-stripe-key-management.md
@@ -2,8 +2,239 @@
 
 **Date:** 2025-01-05
 **Mise a jour:** 2025-01-05
-**Statut:** DECISION PRISE - Option F (Redis)
+**Statut:** DECISION FINALE - Architecture hybride Redis + PostgreSQL + Stripe
 **Equipes concernees:** Framework Bot Discord, Plugins, Backend n8n
+
+---
+
+## 0. Resume executif (TL;DR)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   ARCHITECTURE FINALE                        │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  REDIS (secrets projet)                                     │
+│  └── project:{id} → stripe_key, webhook_secret              │
+│                                                              │
+│  POSTGRESQL (credits utilisateurs uniquement)               │
+│  └── user_credits → project_id, discord_user_id, credits    │
+│                                                              │
+│  STRIPE API (source de verite pour tout le reste)           │
+│  └── Customers, Subscriptions, Prices, Invoices             │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Principe :** Minimiser la duplication. Stripe est la source de verite.
+
+### APIs a creer
+
+| Endpoint | Methode | Description | Appelant |
+|----------|---------|-------------|----------|
+| `/webhook/stripe-register-project` | POST | Enregistre stripe_key et webhook_secret dans Redis | Plugin (demarrage) |
+| `/webhook/stripe-events` | POST | Recoit les webhooks Stripe, valide signature | Stripe |
+| `/webhook/credits-get` | GET | Recupere credits d'un utilisateur | Bot |
+| `/webhook/credits-debit` | POST | Debite des credits | Bot/Workflow interne |
+| `/webhook/credits-credit` | POST | Credite des credits (renouvellement) | Webhook Stripe |
+| `/webhook/credits-set` | POST | Definit les credits (admin) | Admin/Webhook |
+
+### Schema PostgreSQL
+
+```sql
+CREATE TABLE IF NOT EXISTS user_credits (
+    project_id VARCHAR(50) NOT NULL,
+    discord_user_id VARCHAR(50) NOT NULL,
+    credits_remaining INTEGER DEFAULT 0,
+    credits_total INTEGER DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (project_id, discord_user_id)
+);
+
+CREATE INDEX idx_user_credits_project ON user_credits(project_id);
+```
+
+### Schema Redis
+
+```redis
+HSET project:torah stripe_key "sk_live_xxx" webhook_secret "whsec_xxx"
+HSET project:mcp stripe_key "sk_live_yyy" webhook_secret "whsec_yyy"
+```
+
+### Qui fait quoi ?
+
+#### Plugin (au demarrage)
+
+```python
+# 1. Plugin demarre et enregistre ses secrets dans Redis via n8n
+await n8n_client.post("/webhook/stripe-register-project", {
+    "project_id": "torah",
+    "stripe_key": os.getenv("STRIPE_SECRET_KEY"),
+    "webhook_secret": os.getenv("STRIPE_WEBHOOK_SECRET"),
+    "display_name": "Torah App"
+})
+```
+
+#### Bot (commandes Discord)
+
+```python
+# /plans - Recuperer les plans disponibles
+response = await n8n_client.get("/webhook/discord-get-plans",
+    headers={"X-Project-ID": "torah"})
+# n8n lit stripe_key depuis Redis, appelle Stripe API
+
+# /credits - Voir ses credits
+response = await n8n_client.get("/webhook/credits-get",
+    params={"project_id": "torah", "discord_user_id": "123456789"})
+# n8n lit depuis PostgreSQL user_credits
+
+# /translate (ou autre action qui consomme des credits)
+# 1. Bot verifie credits disponibles
+credits = await n8n_client.get("/webhook/credits-get", ...)
+if credits["credits_remaining"] > 0:
+    # 2. Bot effectue l'action
+    result = await do_translation(...)
+    # 3. Bot debite les credits
+    await n8n_client.post("/webhook/credits-debit", {
+        "project_id": "torah",
+        "discord_user_id": "123456789",
+        "amount": 1,
+        "reason": "translation"
+    })
+```
+
+#### Stripe (webhooks automatiques)
+
+```
+Stripe envoie webhook → n8n /webhook/stripe-events
+
+Events geres:
+- checkout.session.completed → Creer/crediter user dans user_credits
+- invoice.paid → Renouveler credits mensuels
+- customer.subscription.deleted → Mettre credits a 0
+```
+
+### Flux detailles
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ FLUX 1: Enregistrement projet (plugin demarrage)                    │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  Plugin                    n8n                         Redis         │
+│    │                        │                            │           │
+│    │ POST /stripe-register  │                            │           │
+│    │ {project_id,           │                            │           │
+│    │  stripe_key,           │                            │           │
+│    │  webhook_secret}       │                            │           │
+│    │───────────────────────►│                            │           │
+│    │                        │ HSET project:torah ...     │           │
+│    │                        │───────────────────────────►│           │
+│    │                        │                            │           │
+│    │◄───────────────────────│ {success: true}            │           │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ FLUX 2: Commande Discord (ex: /plans)                               │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  User    Bot              n8n                Redis       Stripe      │
+│   │       │                │                   │           │         │
+│   │/plans │                │                   │           │         │
+│   │──────►│                │                   │           │         │
+│   │       │ GET /discord-  │                   │           │         │
+│   │       │ get-plans      │                   │           │         │
+│   │       │ X-Project-ID:  │                   │           │         │
+│   │       │ torah          │                   │           │         │
+│   │       │───────────────►│                   │           │         │
+│   │       │                │ HGET project:     │           │         │
+│   │       │                │ torah stripe_key  │           │         │
+│   │       │                │──────────────────►│           │         │
+│   │       │                │◄──────────────────│           │         │
+│   │       │                │ sk_live_xxx       │           │         │
+│   │       │                │                   │           │         │
+│   │       │                │ GET /v1/prices    │           │         │
+│   │       │                │───────────────────────────────►         │
+│   │       │                │◄───────────────────────────────         │
+│   │       │                │ {plans: [...]}    │           │         │
+│   │       │◄───────────────│                   │           │         │
+│   │◄──────│ Affiche plans  │                   │           │         │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ FLUX 3: Webhook Stripe (nouvel abonnement)                          │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  Stripe              n8n                   Redis       PostgreSQL    │
+│    │                  │                      │              │        │
+│    │ POST /stripe-    │                      │              │        │
+│    │ events           │                      │              │        │
+│    │ {type: checkout. │                      │              │        │
+│    │  session.complete│                      │              │        │
+│    │  metadata: {     │                      │              │        │
+│    │   project_id,    │                      │              │        │
+│    │   discord_user}} │                      │              │        │
+│    │─────────────────►│                      │              │        │
+│    │                  │ HGET project:torah   │              │        │
+│    │                  │ webhook_secret       │              │        │
+│    │                  │─────────────────────►│              │        │
+│    │                  │◄─────────────────────│              │        │
+│    │                  │ Valide signature     │              │        │
+│    │                  │                      │              │        │
+│    │                  │ INSERT user_credits  │              │        │
+│    │                  │ (project, user,      │              │        │
+│    │                  │  credits=1000)       │              │        │
+│    │                  │─────────────────────────────────────►        │
+│    │◄─────────────────│ 200 OK               │              │        │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ FLUX 4: Consommation credits                                        │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  User    Bot              n8n                         PostgreSQL     │
+│   │       │                │                               │         │
+│   │/use   │                │                               │         │
+│   │──────►│                │                               │         │
+│   │       │ GET /credits-  │                               │         │
+│   │       │ get?user=123   │                               │         │
+│   │       │───────────────►│                               │         │
+│   │       │                │ SELECT credits_remaining      │         │
+│   │       │                │ FROM user_credits             │         │
+│   │       │                │ WHERE discord_user_id='123'   │         │
+│   │       │                │──────────────────────────────►│         │
+│   │       │                │◄──────────────────────────────│         │
+│   │       │◄───────────────│ {credits: 850}                │         │
+│   │       │                │                               │         │
+│   │       │ [Bot fait action]                              │         │
+│   │       │                │                               │         │
+│   │       │ POST /credits- │                               │         │
+│   │       │ debit          │                               │         │
+│   │       │ {user, amt: 1} │                               │         │
+│   │       │───────────────►│                               │         │
+│   │       │                │ UPDATE user_credits           │         │
+│   │       │                │ SET credits = credits - 1     │         │
+│   │       │                │──────────────────────────────►│         │
+│   │       │◄───────────────│ {credits: 849}                │         │
+│   │◄──────│ Action OK      │                               │         │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Donnees echangees par endpoint
+
+| Endpoint | Input | Output |
+|----------|-------|--------|
+| `POST /stripe-register-project` | `{project_id, stripe_key, webhook_secret, display_name}` | `{success: true}` |
+| `GET /discord-get-plans` | Header: `X-Project-ID` | `{plans: [{id, name, price, credits}]}` |
+| `GET /credits-get` | `?project_id=torah&discord_user_id=123` | `{credits_remaining: 850, credits_total: 1000}` |
+| `POST /credits-debit` | `{project_id, discord_user_id, amount, reason}` | `{credits_remaining: 849}` |
+| `POST /credits-credit` | `{project_id, discord_user_id, amount, reason}` | `{credits_remaining: 1850}` |
+| `POST /credits-set` | `{project_id, discord_user_id, credits_remaining, credits_total}` | `{success: true}` |
+| `POST /stripe-events` | Stripe webhook payload | `200 OK` |
 
 ---
 
@@ -453,11 +684,15 @@ Apres analyse, **Option F (Redis)** retenue car:
 
 - [x] Review par equipe Bot
 - [x] Review par equipe n8n
-- [x] Decision: Option F (Redis)
-- [ ] Implementation `RedisSecretsClient` dans framework
-- [ ] Implementation lecture Redis dans n8n
-- [ ] Tests integration
-- [ ] Documentation plugin
+- [x] Decision architecture finale (Redis + PostgreSQL + Stripe)
+- [ ] **Framework Bot:** Implementer `RedisSecretsClient`
+- [ ] **n8n:** Creer workflow `stripe-register-project`
+- [ ] **n8n:** Creer workflow `stripe-events` (webhooks)
+- [ ] **n8n:** Creer workflows credits (`credits-get`, `credits-debit`, `credits-credit`, `credits-set`)
+- [ ] **n8n:** Mettre a jour workflows Discord existants pour lire Redis
+- [ ] **PostgreSQL:** Creer table `user_credits`
+- [ ] **Tests:** Integration complete
+- [ ] **Documentation:** Mise a jour guides plugin
 
 ---
 

--- a/docs/SPEC-api-team.md
+++ b/docs/SPEC-api-team.md
@@ -1,0 +1,311 @@
+# Specifications pour l'equipe API
+
+**Date:** 2025-01-05
+**Statut:** FINAL
+**Destinataire:** Equipe API / Backend
+
+---
+
+## 1. Contexte
+
+L'architecture Discord Bot utilise:
+- **Redis** pour les secrets Stripe (gere par n8n)
+- **Stripe API** comme source de verite pour les abonnements
+- **PostgreSQL** pour les credits utilisateurs (VOTRE RESPONSABILITE)
+
+---
+
+## 2. Ce que l'equipe API doit implementer
+
+### 2.1 Schema PostgreSQL
+
+```sql
+CREATE TABLE IF NOT EXISTS user_credits (
+    project_id VARCHAR(50) NOT NULL,
+    discord_user_id VARCHAR(50) NOT NULL,
+    credits_remaining INTEGER DEFAULT 0,
+    credits_total INTEGER DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (project_id, discord_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_credits_project ON user_credits(project_id);
+```
+
+### 2.2 Endpoints a exposer
+
+| Endpoint | Methode | Description |
+|----------|---------|-------------|
+| `/webhook/credits-get` | GET | Recupere les credits d'un utilisateur |
+| `/webhook/credits-debit` | POST | Debite des credits |
+| `/webhook/credits-credit` | POST | Credite des credits |
+| `/webhook/credits-set` | POST | Definit les credits (admin/webhook) |
+
+---
+
+## 3. Specifications des endpoints
+
+### 3.1 GET /webhook/credits-get
+
+**Description:** Recupere les credits d'un utilisateur
+
+**Input:**
+```http
+GET /webhook/credits-get?project_id=torah&discord_user_id=123456789 HTTP/1.1
+Host: pi6.local:5678
+X-Project-ID: torah
+```
+
+**Output (succes):**
+```json
+{
+    "success": true,
+    "credits": {
+        "project_id": "torah",
+        "discord_user_id": "123456789",
+        "credits_remaining": 850,
+        "credits_total": 1000,
+        "updated_at": "2025-01-05T10:00:00Z"
+    }
+}
+```
+
+**Output (utilisateur non trouve):**
+```json
+{
+    "success": false,
+    "error": {
+        "code": 404,
+        "message": "User not found",
+        "status": "NOT_FOUND"
+    }
+}
+```
+
+---
+
+### 3.2 POST /webhook/credits-debit
+
+**Description:** Debite des credits (utilisation)
+
+**Input:**
+```http
+POST /webhook/credits-debit HTTP/1.1
+Host: pi6.local:5678
+Content-Type: application/json
+X-Project-ID: torah
+
+{
+    "discord_user_id": "123456789",
+    "amount": 1,
+    "reason": "translation"
+}
+```
+
+**Output (succes):**
+```json
+{
+    "success": true,
+    "credits": {
+        "credits_remaining": 849,
+        "credits_total": 1000,
+        "debited": 1
+    }
+}
+```
+
+**Output (credits insuffisants):**
+```json
+{
+    "success": false,
+    "error": {
+        "code": 402,
+        "message": "Insufficient credits",
+        "status": "PAYMENT_REQUIRED",
+        "credits_remaining": 0
+    }
+}
+```
+
+**Logique SQL:**
+```sql
+UPDATE user_credits
+SET credits_remaining = credits_remaining - :amount,
+    updated_at = CURRENT_TIMESTAMP
+WHERE project_id = :project_id
+  AND discord_user_id = :discord_user_id
+  AND credits_remaining >= :amount
+RETURNING credits_remaining, credits_total;
+```
+
+---
+
+### 3.3 POST /webhook/credits-credit
+
+**Description:** Credite des credits (renouvellement, achat)
+
+**Input:**
+```http
+POST /webhook/credits-credit HTTP/1.1
+Host: pi6.local:5678
+Content-Type: application/json
+X-Project-ID: torah
+
+{
+    "discord_user_id": "123456789",
+    "amount": 1000,
+    "reason": "subscription_renewal"
+}
+```
+
+**Output:**
+```json
+{
+    "success": true,
+    "credits": {
+        "credits_remaining": 1849,
+        "credits_total": 2000,
+        "credited": 1000
+    }
+}
+```
+
+**Logique SQL:**
+```sql
+INSERT INTO user_credits (project_id, discord_user_id, credits_remaining, credits_total)
+VALUES (:project_id, :discord_user_id, :amount, :amount)
+ON CONFLICT (project_id, discord_user_id)
+DO UPDATE SET
+    credits_remaining = user_credits.credits_remaining + :amount,
+    credits_total = user_credits.credits_total + :amount,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING credits_remaining, credits_total;
+```
+
+---
+
+### 3.4 POST /webhook/credits-set
+
+**Description:** Definit les credits (admin, initialisation)
+
+**Input:**
+```http
+POST /webhook/credits-set HTTP/1.1
+Host: pi6.local:5678
+Content-Type: application/json
+X-Project-ID: torah
+
+{
+    "discord_user_id": "123456789",
+    "credits_remaining": 1000,
+    "credits_total": 1000
+}
+```
+
+**Output:**
+```json
+{
+    "success": true,
+    "credits": {
+        "credits_remaining": 1000,
+        "credits_total": 1000
+    }
+}
+```
+
+**Logique SQL:**
+```sql
+INSERT INTO user_credits (project_id, discord_user_id, credits_remaining, credits_total)
+VALUES (:project_id, :discord_user_id, :credits_remaining, :credits_total)
+ON CONFLICT (project_id, discord_user_id)
+DO UPDATE SET
+    credits_remaining = :credits_remaining,
+    credits_total = :credits_total,
+    updated_at = CURRENT_TIMESTAMP
+RETURNING credits_remaining, credits_total;
+```
+
+---
+
+## 4. Appels depuis les webhooks Stripe
+
+Les webhooks Stripe (geres par n8n) appelleront vos endpoints:
+
+| Event Stripe | Action | Endpoint appele |
+|--------------|--------|-----------------|
+| `checkout.session.completed` | Nouvel abonnement | `POST /credits-set` |
+| `invoice.paid` | Renouvellement mensuel | `POST /credits-credit` |
+| `customer.subscription.deleted` | Annulation | `POST /credits-set` (credits=0) |
+
+**Exemple d'appel depuis n8n:**
+```javascript
+// Apres validation webhook Stripe
+const credits = plan.metadata.credits_per_month || 1000;
+
+await $http.request({
+    method: 'POST',
+    url: 'http://localhost:5678/webhook/credits-set',
+    headers: { 'X-Project-ID': projectId },
+    body: {
+        discord_user_id: metadata.discord_user_id,
+        credits_remaining: credits,
+        credits_total: credits
+    }
+});
+```
+
+---
+
+## 5. Codes d'erreur standards
+
+| Code | Status | Description |
+|------|--------|-------------|
+| 200 | OK | Succes |
+| 400 | BAD_REQUEST | Parametres manquants/invalides |
+| 402 | PAYMENT_REQUIRED | Credits insuffisants |
+| 404 | NOT_FOUND | Utilisateur non trouve |
+| 500 | INTERNAL_ERROR | Erreur serveur |
+
+---
+
+## 6. Securite
+
+| Aspect | Implementation |
+|--------|----------------|
+| Authentification | Header `X-Project-ID` requis |
+| Validation | Verifier que `amount > 0` |
+| Atomicite | Utiliser transactions SQL |
+| Logs | Logger toutes les operations de credits |
+
+---
+
+## 7. Tests recommandes
+
+```bash
+# Creer un utilisateur
+curl -X POST http://pi6.local:5678/webhook/credits-set \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: torah" \
+  -d '{"discord_user_id": "test123", "credits_remaining": 100, "credits_total": 100}'
+
+# Recuperer credits
+curl "http://pi6.local:5678/webhook/credits-get?project_id=torah&discord_user_id=test123"
+
+# Debiter
+curl -X POST http://pi6.local:5678/webhook/credits-debit \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: torah" \
+  -d '{"discord_user_id": "test123", "amount": 10, "reason": "test"}'
+
+# Crediter
+curl -X POST http://pi6.local:5678/webhook/credits-credit \
+  -H "Content-Type: application/json" \
+  -H "X-Project-ID: torah" \
+  -d '{"discord_user_id": "test123", "amount": 50, "reason": "bonus"}'
+```
+
+---
+
+## 8. Questions?
+
+Contacter l'equipe n8n pour toute question sur l'integration.

--- a/docs/SPEC-bot-team.md
+++ b/docs/SPEC-bot-team.md
@@ -1,0 +1,190 @@
+# Specifications pour l'equipe Bot
+
+**Date:** 2025-01-05
+**Statut:** FINAL
+**Destinataire:** Equipe Bot / Framework Discord
+
+---
+
+## 1. Architecture finale
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   ARCHITECTURE FINALE                        │
+├─────────────────────────────────────────────────────────────┤
+│                                                              │
+│  REDIS (host3.local:6381)                                   │
+│  └── Secrets projet: stripe_key, webhook_secret             │
+│                                                              │
+│  STRIPE API                                                  │
+│  └── Source de verite: customers, subscriptions, prices     │
+│                                                              │
+│  POSTGRESQL (gere par equipe API)                           │
+│  └── Credits utilisateurs                                   │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Decisions techniques
+
+| Sujet | Decision | Justification |
+|-------|----------|---------------|
+| **Stockage secrets** | Redis | Cle jamais en transit HTTP |
+| **Format Redis** | JSON via GET/SET | Node natif n8n ne supporte pas HGET/HSET |
+| **Credits** | PostgreSQL via API | Gere par equipe API |
+| **Source de verite** | Stripe API | Pas de duplication |
+
+---
+
+## 3. Ce que le Bot/Plugin doit faire
+
+### 3.1 Au demarrage du plugin
+
+```python
+# Enregistrer les secrets dans Redis via n8n
+await n8n_client.post("/webhook/stripe-register-project", json={
+    "project_id": "torah",
+    "stripe_key": os.getenv("STRIPE_SECRET_KEY"),
+    "webhook_secret": os.getenv("STRIPE_WEBHOOK_SECRET"),
+    "display_name": "Torah App"
+})
+```
+
+### 3.2 Commandes Discord
+
+| Commande | Endpoint n8n | Header | Body/Params |
+|----------|--------------|--------|-------------|
+| `/plans` | `GET /webhook/discord-get-plans` | `X-Project-ID: torah` | - |
+| `/credits` | `GET /webhook/credits-get` | `X-Project-ID: torah` | `?discord_user_id=123` |
+| `/subscribe` | `POST /webhook/discord-subscribe` | `X-Project-ID: torah` | `{discord_user_id, plan_id}` |
+
+### 3.3 Consommation de credits
+
+```python
+# 1. Verifier credits disponibles
+response = await n8n_client.get(
+    "/webhook/credits-get",
+    headers={"X-Project-ID": project_id},
+    params={"discord_user_id": user_id}
+)
+credits = response.json()["credits_remaining"]
+
+# 2. Si credits > 0, effectuer l'action
+if credits > 0:
+    result = await do_action(...)
+
+    # 3. Debiter les credits
+    await n8n_client.post(
+        "/webhook/credits-debit",
+        headers={"X-Project-ID": project_id},
+        json={
+            "discord_user_id": user_id,
+            "amount": 1,
+            "reason": "action_name"
+        }
+    )
+```
+
+---
+
+## 4. Format des requetes
+
+### 4.1 Enregistrement projet (demarrage)
+
+```http
+POST /webhook/stripe-register-project HTTP/1.1
+Host: pi6.local:5678
+Content-Type: application/json
+
+{
+    "project_id": "torah",
+    "stripe_key": "sk_live_xxxxxxxxxxxx",
+    "webhook_secret": "whsec_xxxxxxxxxxxx",
+    "display_name": "Torah App"
+}
+```
+
+**Reponse:**
+```json
+{"success": true, "message": "Project registered"}
+```
+
+### 4.2 Requetes avec X-Project-ID
+
+```http
+GET /webhook/discord-get-plans HTTP/1.1
+Host: pi6.local:5678
+X-Project-ID: torah
+```
+
+**Note:** Plus besoin de passer `stripe_key` - n8n le lit depuis Redis.
+
+---
+
+## 5. Configuration .env du plugin
+
+```env
+# Identifiant projet (unique)
+PROJECT_ID=torah
+
+# Discord
+DISCORD_TOKEN=xxx
+DISCORD_GUILD_ID=xxx
+
+# Stripe (source de verite)
+STRIPE_SECRET_KEY=sk_live_xxx
+STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+# n8n
+N8N_BASE_URL=http://pi6.local:5678
+
+# Redis (optionnel - si acces direct necessaire)
+REDIS_HOST=host3.local
+REDIS_PORT=6381
+REDIS_DB=2
+```
+
+---
+
+## 6. Responsabilites
+
+| Composant | Responsabilite |
+|-----------|----------------|
+| **Plugin** | Possede les cles Stripe dans `.env` |
+| **Plugin** | Appelle `/stripe-register-project` au demarrage |
+| **Bot** | Envoie `X-Project-ID` dans chaque requete |
+| **Bot** | Ne stocke PAS les cles Stripe en memoire |
+| **n8n** | Lit les cles depuis Redis |
+| **n8n** | Appelle Stripe API |
+| **API** | Gere les credits (PostgreSQL) |
+
+---
+
+## 7. Gestion des erreurs
+
+| Erreur | Code | Action Bot |
+|--------|------|------------|
+| Projet non enregistre | 404 | Re-appeler `/stripe-register-project` |
+| Credits insuffisants | 402 | Afficher message "credits epuises" |
+| Stripe erreur | 500 | Afficher message "erreur paiement" |
+| Redis indisponible | 503 | Retry avec backoff |
+
+---
+
+## 8. Questions resolues
+
+| Question | Reponse |
+|----------|---------|
+| Ou stocker stripe_key? | Redis (via n8n) |
+| Cle en transit? | NON - juste X-Project-ID |
+| Qui gere les credits? | Equipe API (PostgreSQL) |
+| Format Redis? | JSON (GET/SET) car HGET/HSET pas supporte nativement |
+
+---
+
+## 9. Contact
+
+- **n8n/workflows:** @claude (ce repo)
+- **API/PostgreSQL:** Equipe API (voir SPEC-api-team.md)

--- a/docs/discord-bot-integration.md
+++ b/docs/discord-bot-integration.md
@@ -4,54 +4,90 @@
 
 Ce document décrit l'intégration entre les commandes du bot Discord et les workflows n8n pour la gestion des abonnements, crédits, etc.
 
-**Objectif :** Remplacer les accès directs PostgreSQL du bot par des appels aux webhooks n8n.
+**Objectif :** Le bot Discord n'accède **jamais** directement aux bases de données. Toutes les opérations passent par les webhooks n8n.
 
 ---
 
-## 1. Vue d'ensemble
+## 1. Architecture Multi-Bot Centralisee
 
-### Statut des workflows
+### Schema
+
+```
+┌─────────────────┐
+│ Bot Torah       │──┐
+│ (serveur 1)     │  │
+└─────────────────┘  │
+                     │     ┌─────────────────────┐     ┌─────────────────┐
+┌─────────────────┐  │     │   n8n Workflows     │     │   PostgreSQL    │
+│ Bot MCP         │──┼────▶│   (centralise)      │────▶│   (centralise)  │
+│ (serveur 2)     │  │     │   pi6.local:5678    │     │   subscribers   │
+└─────────────────┘  │     └─────────────────────┘     └─────────────────┘
+                     │              │
+┌─────────────────┐  │              ▼
+│ Bot X           │──┘     ┌─────────────────┐
+│ (serveur 3)     │        │   Stripe API    │
+└─────────────────┘        │   (par projet)  │
+                           └─────────────────┘
+```
+
+### Principes cles
+
+| Principe | Description |
+|----------|-------------|
+| **Multi-tenant** | Plusieurs bots peuvent appeler les memes workflows via `project_id` |
+| **Pas d'acces direct DB** | Le bot ne connait pas PostgreSQL, il passe par n8n |
+| **Plans depuis Stripe** | Les plans sont recuperes en temps reel depuis l'API Stripe |
+| **Centralisation** | n8n est le point d'entree unique pour toutes les operations |
+
+### Sources de donnees
+
+| Donnee | Source | Raison |
+|--------|--------|--------|
+| Plans/Prix | **Stripe API** | Source de verite, temps reel |
+| Config Stripe (cles) | SQLite `stripe_projects` | Config multi-tenant |
+| Subscribers | PostgreSQL | Donnees utilisateurs |
+| Transactions | PostgreSQL | Historique |
+
+---
+
+## 2. Vue d'ensemble des workflows
+
+### Statut
 
 | Statut | Description |
 |--------|-------------|
-| ✅ EXISTE | Workflow déjà créé dans `workflows/Stripe/` |
-| ❌ A CRÉER | Workflow à développer (spec dans ce document) |
+| ✅ EXISTE | Workflow deja cree |
+| ❌ A CREER | Workflow a developper |
 
-### Correspondance commandes ↔ workflows
+### Correspondance commandes - workflows
 
-| Commande Bot | Action Actuelle | Workflow n8n | Statut |
-|--------------|-----------------|--------------|--------|
-| `/plans` | Dictionnaire PLANS en dur | `DISCORD - Get Plans` | ❌ A CRÉER |
-| `/plan` | SELECT/UPDATE PostgreSQL | `DISCORD - Get Subscriber` | ❌ A CRÉER |
-| `/credits` | SELECT PostgreSQL | `DISCORD - Get Subscriber` | ❌ A CRÉER |
-| `/solde` | SELECT PostgreSQL | `DISCORD - Get Balance` | ❌ A CRÉER |
-| `/account` | SELECT PostgreSQL | `DISCORD - Get Transactions` | ❌ A CRÉER |
-| `/subscribe` | INSERT PostgreSQL | `Stripe - Subscription Checkout Create` | ✅ EXISTE |
-
----
-
-## 2. Workflows EXISTANTS (Stripe)
-
-Ces workflows **existent déjà** dans `workflows/Stripe/` et gèrent l'interaction avec l'API Stripe.
-
-| Workflow | Fichier | Webhook |
-|----------|---------|---------|
-| `Stripe - Subscription Checkout Create` | `subscription-checkout-create.json` | `POST /webhook/subscription-checkout-create` |
-| `Stripe - Subscription Change Plan` | `subscription-change-plan.json` | `POST /webhook/subscription-change-plan` |
-| `Stripe - Subscription Cancel` | `subscription-cancel.json` | `POST /webhook/subscription-cancel` |
-| `Stripe - Subscription Webhook Handler` | `subscription-webhook-handler.json` | `POST /webhook/stripe-events` |
-
-**Note :** Ces workflows sont fonctionnels et ne nécessitent pas de modification.
+| Commande Bot | Workflow n8n | Source | Statut |
+|--------------|--------------|--------|--------|
+| `/plans` | `DISCORD - Get Plans` | **Stripe API** | ❌ A CREER |
+| `/plan` | `DISCORD - Get Subscriber` | PostgreSQL (via n8n) | ❌ A CREER |
+| `/credits` | `DISCORD - Get Subscriber` | PostgreSQL (via n8n) | ❌ A CREER |
+| `/solde` | `DISCORD - Get Balance` | PostgreSQL (via n8n) | ❌ A CREER |
+| `/account` | `DISCORD - Get Transactions` | PostgreSQL (via n8n) | ❌ A CREER |
+| `/subscribe` | `Stripe - Subscription Checkout Create` | Stripe API | ✅ EXISTE |
 
 ---
 
-## 3. Workflows À CRÉER (Discord)
+## 3. Workflows EXISTANTS (Stripe)
 
-Les workflows suivants **n'existent pas encore**. Cette section décrit les spécifications pour leur développement.
+Ces workflows **existent deja** dans `workflows/Stripe/` :
 
-Ils seront créés dans `workflows/Discord/`
+| Workflow | Webhook | Usage |
+|----------|---------|-------|
+| `Stripe - Subscription Checkout Create` | `POST /webhook/subscription-checkout-create` | Creer session Stripe |
+| `Stripe - Subscription Change Plan` | `POST /webhook/subscription-change-plan` | Changer de plan |
+| `Stripe - Subscription Cancel` | `POST /webhook/subscription-cancel` | Annuler abonnement |
+| `Stripe - Subscription Webhook Handler` | `POST /webhook/stripe-events` | Recevoir evenements Stripe |
 
-### 3.1 DISCORD - Registry
+---
+
+## 4. Workflows A CREER (Discord)
+
+### 4.1 DISCORD - Registry
 
 **Fichier:** `workflows/Discord/discord-registry.json`
 
@@ -59,7 +95,7 @@ Ils seront créés dans `workflows/Discord/`
 
 **Description:** Liste tous les workflows Discord disponibles.
 
-**Réponse:**
+**Reponse:**
 ```json
 {
   "version": "1.0",
@@ -69,18 +105,17 @@ Ils seront créés dans `workflows/Discord/`
     "port": 5678,
     "webhook_base": "http://pi6.local:5678/webhook"
   },
-  "total_tools": 6,
+  "total_tools": 5,
   "tools": {
-    "discord-get-plans": { ... },
-    "discord-get-subscriber": { ... },
-    ...
+    "discord-get-plans": { "method": "GET", "command": "/plans" },
+    "discord-get-subscriber": { "method": "GET", "command": "/plan, /credits" }
   }
 }
 ```
 
 ---
 
-### 3.2 DISCORD - Get Plans
+### 4.2 DISCORD - Get Plans
 
 **Fichier:** `workflows/Discord/discord-get-plans.json`
 
@@ -88,44 +123,61 @@ Ils seront créés dans `workflows/Discord/`
 
 **Commande bot:** `/plans`
 
+**Source:** **Stripe API** (temps reel)
+
 **Query Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
-| `project_id` | string | Oui | ID du projet (ex: `torah`) |
+| `project_id` | string | Oui | ID du projet (ex: `torah`, `mcp`) |
 
-**Réponse:**
+**Flux interne:**
+1. Valider `project_id`
+2. Recuperer `secret_key` Stripe depuis SQLite (`stripe_projects`)
+3. Appeler Stripe API `GET /v1/prices?active=true&expand[]=data.product`
+4. Formater et retourner les plans
+
+**Reponse:**
 ```json
 {
   "success": true,
   "project_id": "torah",
+  "project_name": "Torah App",
+  "plans_count": 2,
   "plans": [
     {
-      "id": "free",
+      "id": "price_xxx",
+      "product_id": "prod_xxx",
       "name": "Free",
-      "price_id": null,
+      "description": "Acces de base",
       "price": 0,
-      "currency": "EUR",
+      "currency": "eur",
+      "interval": "month",
       "credits_per_month": 100,
-      "features": ["Basic access"]
+      "features": ["Acces basique", "100 credits/mois"]
     },
     {
-      "id": "premium",
+      "id": "price_yyy",
+      "product_id": "prod_yyy",
       "name": "Premium",
-      "price_id": "price_xxx",
+      "description": "Acces complet",
       "price": 9.99,
-      "currency": "EUR",
+      "currency": "eur",
+      "interval": "month",
       "credits_per_month": 1000,
-      "features": ["Priority support", "Advanced features"]
+      "features": ["Support prioritaire", "1000 credits/mois"]
     }
   ]
 }
 ```
 
-**Source de données:** SQLite `stripe_projects.prices` (JSON)
+**Configuration Stripe requise:**
+Les produits Stripe doivent avoir ces metadata :
+- `credits_per_month`: Nombre de credits par mois
+- `features`: Liste JSON des fonctionnalites (ex: `["Feature 1", "Feature 2"]`)
 
 ---
 
-### 3.3 DISCORD - Get Subscriber
+### 4.3 DISCORD - Get Subscriber
 
 **Fichier:** `workflows/Discord/discord-get-subscriber.json`
 
@@ -133,13 +185,15 @@ Ils seront créés dans `workflows/Discord/`
 
 **Commandes bot:** `/plan`, `/credits`
 
+**Source:** PostgreSQL `subscribers` (via n8n)
+
 **Query Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `project_id` | string | Oui | ID du projet |
 | `discord_user_id` | string | Oui | ID Discord de l'utilisateur |
 
-**Réponse:**
+**Reponse:**
 ```json
 {
   "success": true,
@@ -147,7 +201,7 @@ Ils seront créés dans `workflows/Discord/`
     "id": 123,
     "discord_user_id": "123456789",
     "email": "user@example.com",
-    "plan_id": "premium",
+    "plan_id": "price_yyy",
     "stripe_customer_id": "cus_xxx",
     "stripe_subscription_id": "sub_xxx",
     "credits_remaining": 850,
@@ -158,11 +212,9 @@ Ils seront créés dans `workflows/Discord/`
 }
 ```
 
-**Source de données:** PostgreSQL `subscribers`
-
 ---
 
-### 3.4 DISCORD - Get Balance
+### 4.4 DISCORD - Get Balance
 
 **Fichier:** `workflows/Discord/discord-get-balance.json`
 
@@ -170,13 +222,15 @@ Ils seront créés dans `workflows/Discord/`
 
 **Commande bot:** `/solde`
 
+**Source:** PostgreSQL `subscribers` + `transactions` (via n8n)
+
 **Query Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `project_id` | string | Oui | ID du projet |
 | `discord_user_id` | string | Oui | ID Discord de l'utilisateur |
 
-**Réponse:**
+**Reponse:**
 ```json
 {
   "success": true,
@@ -198,11 +252,9 @@ Ils seront créés dans `workflows/Discord/`
 }
 ```
 
-**Source de données:** PostgreSQL `subscribers` + `transactions`
-
 ---
 
-### 3.5 DISCORD - Get Transactions
+### 4.5 DISCORD - Get Transactions
 
 **Fichier:** `workflows/Discord/discord-get-transactions.json`
 
@@ -210,15 +262,17 @@ Ils seront créés dans `workflows/Discord/`
 
 **Commande bot:** `/account`
 
+**Source:** PostgreSQL `transactions` (via n8n)
+
 **Query Parameters:**
 | Param | Type | Required | Description |
 |-------|------|----------|-------------|
 | `project_id` | string | Oui | ID du projet |
 | `discord_user_id` | string | Oui | ID Discord |
-| `limit` | number | Non | Max résultats (défaut: 20) |
-| `offset` | number | Non | Pagination (défaut: 0) |
+| `limit` | number | Non | Max resultats (defaut: 20) |
+| `offset` | number | Non | Pagination (defaut: 0) |
 
-**Réponse:**
+**Reponse:**
 ```json
 {
   "success": true,
@@ -229,13 +283,6 @@ Ils seront créés dans `workflows/Discord/`
       "amount": 1000,
       "description": "Monthly renewal - Premium",
       "created_at": "2025-01-01T00:00:00Z"
-    },
-    {
-      "id": 455,
-      "type": "usage",
-      "amount": -10,
-      "description": "Translation: Berakhot 2a",
-      "created_at": "2024-12-30T15:00:00Z"
     }
   ],
   "pagination": {
@@ -247,56 +294,72 @@ Ils seront créés dans `workflows/Discord/`
 }
 ```
 
-**Source de données:** PostgreSQL `transactions`
+---
+
+## 5. Gestion des callbacks Stripe
+
+### Comment ca fonctionne
+
+```
+┌─────────────┐     ┌─────────────────────────┐     ┌─────────────────────┐
+│   Stripe    │────▶│ Stripe - Webhook Handler│────▶│ Callback workflows  │
+│   Events    │     │ /webhook/stripe-events  │     │ discord-sub-*       │
+└─────────────┘     └─────────────────────────┘     └─────────────────────┘
+                                                              │
+                                                              ▼
+                                                    ┌─────────────────────┐
+                                                    │ PostgreSQL          │
+                                                    │ (mise a jour)       │
+                                                    └─────────────────────┘
+```
+
+### Workflows de callback (a creer)
+
+| Callback | Evenement Stripe | Action |
+|----------|------------------|--------|
+| `discord-sub-success` | `checkout.session.completed` | Creer subscriber en DB |
+| `discord-sub-renewal` | `invoice.payment_succeeded` | Renouveler credits |
+| `discord-sub-failure` | `invoice.payment_failed` | Marquer echec paiement |
+| `discord-sub-cancel` | `customer.subscription.deleted` | Desactiver subscriber |
+
+### Comment le bot est notifie ?
+
+Le bot **n'est pas notifie en temps reel**. Il query les workflows n8n :
+1. Stripe envoie evenement → `stripe-events`
+2. Handler route vers callback → `discord-sub-success`
+3. Callback met a jour PostgreSQL
+4. Bot appelle `/webhook/discord-get-subscriber` → donnees a jour
+
+**Avantages:**
+- Pas besoin d'API cote bot
+- Le bot peut etre hors ligne pendant l'evenement
+- Source de verite unique (PostgreSQL via n8n)
 
 ---
 
-## 4. Gestion des credentials
+## 6. Implementation cote Bot
 
 ### Principe fondamental
 
-**JAMAIS de credentials en dur dans les workflows.**
+**Le bot ne connait que l'URL n8n et le `project_id`.**
 
-### Comment passer les credentials
-
-#### Pour le bot Discord
-
-Le bot passe uniquement des identifiants (pas de secrets) :
-```json
-{
-  "project_id": "torah",
-  "discord_user_id": "123456789"
-}
-```
-
-#### Pour les workflows n8n
-
-Les workflows récupèrent les secrets via :
-
-1. **SQLite** (`stripe-config.db`) pour les clés Stripe par projet
-2. **Credentials n8n** pour PostgreSQL
-3. **Variables d'environnement** pour les configurations globales
-
-### Credentials requis dans n8n
-
-| Credential Name | Type | Usage |
-|-----------------|------|-------|
-| `Stripe Config DB` | SQLite | Lecture `stripe_projects` |
-| `PostgreSQL Subscribers` | PostgreSQL | Lecture `subscribers`, `transactions` |
-| `Header Auth n8n` | HTTP Header | Appels API n8n internes |
-
----
-
-## 5. Implementation côté Bot
+Il n'a pas :
+- Acces direct a PostgreSQL
+- Cles Stripe
+- Credentials quelconques
 
 ### Client Python
 
 ```python
 import aiohttp
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 
 class DiscordN8nClient:
-    """Client pour les workflows n8n Discord."""
+    """Client pour les workflows n8n Discord.
+
+    Le bot passe uniquement des identifiants (project_id, discord_user_id).
+    Toutes les operations DB et Stripe sont gerees par n8n.
+    """
 
     def __init__(self, base_url: str = "http://pi6.local:5678"):
         self.base_url = base_url
@@ -318,10 +381,22 @@ class DiscordN8nClient:
             ) as response:
                 return await response.json()
 
-    # ==================== Nouveaux workflows Discord ====================
+    # ==================== Workflows Discord ====================
+
+    async def get_registry(self) -> Dict[str, Any]:
+        """GET /webhook/discord-registry
+        Decouvre tous les workflows disponibles.
+        """
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{self.webhook_base}/discord-registry"
+            ) as response:
+                return await response.json()
 
     async def get_plans(self, project_id: str) -> Dict[str, Any]:
-        """GET /webhook/discord-get-plans"""
+        """GET /webhook/discord-get-plans
+        Recupere les plans depuis Stripe API.
+        """
         return await self._get("discord-get-plans", {
             "project_id": project_id
         })
@@ -329,7 +404,9 @@ class DiscordN8nClient:
     async def get_subscriber(
         self, project_id: str, discord_user_id: str
     ) -> Dict[str, Any]:
-        """GET /webhook/discord-get-subscriber"""
+        """GET /webhook/discord-get-subscriber
+        Recupere les infos d'un abonne.
+        """
         return await self._get("discord-get-subscriber", {
             "project_id": project_id,
             "discord_user_id": discord_user_id
@@ -338,7 +415,9 @@ class DiscordN8nClient:
     async def get_balance(
         self, project_id: str, discord_user_id: str
     ) -> Dict[str, Any]:
-        """GET /webhook/discord-get-balance"""
+        """GET /webhook/discord-get-balance
+        Recupere le solde et transactions recentes.
+        """
         return await self._get("discord-get-balance", {
             "project_id": project_id,
             "discord_user_id": discord_user_id
@@ -351,7 +430,9 @@ class DiscordN8nClient:
         limit: int = 20,
         offset: int = 0
     ) -> Dict[str, Any]:
-        """GET /webhook/discord-get-transactions"""
+        """GET /webhook/discord-get-transactions
+        Recupere l'historique des transactions.
+        """
         return await self._get("discord-get-transactions", {
             "project_id": project_id,
             "discord_user_id": discord_user_id,
@@ -359,7 +440,7 @@ class DiscordN8nClient:
             "offset": offset
         })
 
-    # ==================== Workflows Stripe existants ====================
+    # ==================== Workflows Stripe ====================
 
     async def create_checkout(
         self,
@@ -370,7 +451,9 @@ class DiscordN8nClient:
         success_url: str,
         cancel_url: str
     ) -> Dict[str, Any]:
-        """POST /webhook/subscription-checkout-create"""
+        """POST /webhook/subscription-checkout-create
+        Cree une session Stripe Checkout.
+        """
         return await self._post("subscription-checkout-create", {
             "project_id": project_id,
             "price_id": price_id,
@@ -396,7 +479,9 @@ class DiscordN8nClient:
         stripe_subscription_id: str,
         new_price_id: str
     ) -> Dict[str, Any]:
-        """POST /webhook/subscription-change-plan"""
+        """POST /webhook/subscription-change-plan
+        Change le plan d'un abonne.
+        """
         return await self._post("subscription-change-plan", {
             "project_id": project_id,
             "stripe_subscription_id": stripe_subscription_id,
@@ -409,7 +494,9 @@ class DiscordN8nClient:
         stripe_subscription_id: str,
         cancel_immediately: bool = False
     ) -> Dict[str, Any]:
-        """POST /webhook/subscription-cancel"""
+        """POST /webhook/subscription-cancel
+        Annule un abonnement.
+        """
         return await self._post("subscription-cancel", {
             "project_id": project_id,
             "stripe_subscription_id": stripe_subscription_id,
@@ -420,52 +507,129 @@ class DiscordN8nClient:
 ### Exemple d'utilisation
 
 ```python
+# Configuration
+PROJECT_ID = "torah"  # ou "mcp", ou autre
+client = DiscordN8nClient(base_url="http://pi6.local:5678")
+
 @bot.slash_command(name="plans")
 async def plans_command(ctx):
-    client = DiscordN8nClient()
-    result = await client.get_plans("torah")
+    """Affiche les plans disponibles (depuis Stripe)."""
+    result = await client.get_plans(PROJECT_ID)
 
-    if result.get("success"):
-        # Afficher les plans...
-        pass
+    if not result.get("success"):
+        await ctx.respond(f"Erreur: {result.get('error', {}).get('message')}")
+        return
+
+    embed = discord.Embed(title="Plans disponibles")
+    for plan in result["plans"]:
+        embed.add_field(
+            name=f"{plan['name']} - {plan['price']} {plan['currency'].upper()}/mois",
+            value=f"Credits: {plan['credits_per_month']}/mois\n" +
+                  "\n".join(f"- {f}" for f in plan.get('features', [])),
+            inline=False
+        )
+
+    await ctx.respond(embed=embed)
 
 @bot.slash_command(name="credits")
 async def credits_command(ctx):
-    client = DiscordN8nClient()
-    result = await client.get_subscriber("torah", str(ctx.author.id))
+    """Affiche les credits restants."""
+    result = await client.get_subscriber(PROJECT_ID, str(ctx.author.id))
+
+    if not result.get("success"):
+        await ctx.respond("Vous n'avez pas d'abonnement. Utilisez /subscribe")
+        return
+
+    sub = result["subscriber"]
+    await ctx.respond(
+        f"Credits: {sub['credits_remaining']}/{sub['credits_total']}\n"
+        f"Plan: {sub['plan_id']}\n"
+        f"Renouvellement: {sub['current_period_end']}"
+    )
+
+@bot.slash_command(name="subscribe")
+async def subscribe_command(ctx, plan: str, email: str):
+    """Cree un abonnement."""
+    # D'abord recuperer les plans pour avoir le price_id
+    plans_result = await client.get_plans(PROJECT_ID)
+    if not plans_result.get("success"):
+        await ctx.respond("Erreur lors de la recuperation des plans")
+        return
+
+    # Trouver le plan demande
+    price_id = None
+    for p in plans_result["plans"]:
+        if p["name"].lower() == plan.lower():
+            price_id = p["id"]
+            break
+
+    if not price_id:
+        await ctx.respond(f"Plan '{plan}' non trouve")
+        return
+
+    # Creer la session checkout
+    result = await client.create_checkout(
+        project_id=PROJECT_ID,
+        price_id=price_id,
+        customer_email=email,
+        discord_user_id=str(ctx.author.id),
+        success_url="https://votresite.com/success",
+        cancel_url="https://votresite.com/cancel"
+    )
 
     if result.get("success"):
-        sub = result["subscriber"]
-        await ctx.respond(f"Crédits: {sub['credits_remaining']}/{sub['credits_total']}")
+        await ctx.respond(f"Cliquez ici pour payer: {result['checkout_url']}")
+    else:
+        await ctx.respond(f"Erreur: {result.get('error', {}).get('message')}")
 ```
 
 ---
 
-## 6. Résumé des webhooks
+## 7. Resume des webhooks
 
-### ❌ À CRÉER (Discord)
+### ❌ A CREER (Discord)
 
-| Webhook | Méthode | Commande | Fichier |
-|---------|---------|----------|---------|
-| `/webhook/discord-registry` | GET | Discovery | `workflows/Discord/discord-registry.json` |
-| `/webhook/discord-get-plans` | GET | `/plans` | `workflows/Discord/discord-get-plans.json` |
-| `/webhook/discord-get-subscriber` | GET | `/plan`, `/credits` | `workflows/Discord/discord-get-subscriber.json` |
-| `/webhook/discord-get-balance` | GET | `/solde` | `workflows/Discord/discord-get-balance.json` |
-| `/webhook/discord-get-transactions` | GET | `/account` | `workflows/Discord/discord-get-transactions.json` |
+| Webhook | Methode | Commande | Source |
+|---------|---------|----------|--------|
+| `/webhook/discord-registry` | GET | Discovery | n8n API |
+| `/webhook/discord-get-plans` | GET | `/plans` | **Stripe API** |
+| `/webhook/discord-get-subscriber` | GET | `/plan`, `/credits` | PostgreSQL |
+| `/webhook/discord-get-balance` | GET | `/solde` | PostgreSQL |
+| `/webhook/discord-get-transactions` | GET | `/account` | PostgreSQL |
+| `/webhook/discord-sub-success` | POST | Callback | PostgreSQL |
+| `/webhook/discord-sub-renewal` | POST | Callback | PostgreSQL |
+| `/webhook/discord-sub-failure` | POST | Callback | PostgreSQL |
+| `/webhook/discord-sub-cancel` | POST | Callback | PostgreSQL |
 
 ### ✅ EXISTANTS (Stripe)
 
-| Webhook | Méthode | Usage | Fichier |
-|---------|---------|-------|---------|
-| `/webhook/subscription-checkout-create` | POST | `/subscribe` | `workflows/Stripe/subscription-checkout-create.json` |
-| `/webhook/subscription-change-plan` | POST | Upgrade/downgrade | `workflows/Stripe/subscription-change-plan.json` |
-| `/webhook/subscription-cancel` | POST | Annulation | `workflows/Stripe/subscription-cancel.json` |
-| `/webhook/stripe-events` | POST | Webhooks Stripe | `workflows/Stripe/subscription-webhook-handler.json` |
+| Webhook | Methode | Usage |
+|---------|---------|-------|
+| `/webhook/subscription-checkout-create` | POST | `/subscribe` |
+| `/webhook/subscription-change-plan` | POST | Upgrade/downgrade |
+| `/webhook/subscription-cancel` | POST | Annulation |
+| `/webhook/stripe-events` | POST | Webhooks Stripe |
 
 ---
 
-## 7. Questions pour l'équipe
+## 8. Configuration requise
 
-1. **Schéma PostgreSQL** : Tables `subscribers` et `transactions` - quel est le schéma exact ?
-2. **Multi-projet** : Le bot gère-t-il plusieurs projets ou un seul ?
-3. **Callbacks Stripe** : Les workflows `discord-sub-success`, `discord-sub-renewal`, etc. doivent-ils être créés ?
+### Cote Stripe (par projet)
+
+Chaque produit Stripe doit avoir ces **metadata** :
+- `credits_per_month`: Nombre de credits mensuels
+- `features`: JSON array des fonctionnalites
+
+Exemple:
+```
+metadata.credits_per_month = "1000"
+metadata.features = "[\"Support prioritaire\", \"API access\"]"
+```
+
+### Cote n8n
+
+| Credential | Type | Usage |
+|------------|------|-------|
+| `Stripe Config DB` | SQLite | Config multi-tenant (`stripe_projects`) |
+| `PostgreSQL Subscribers` | PostgreSQL | Donnees utilisateurs |
+| `Header Auth n8n` | HTTP Header | Appels API n8n internes |

--- a/workflows/Discord/discord-get-balance.json
+++ b/workflows/Discord/discord-get-balance.json
@@ -1,0 +1,329 @@
+{
+  "name": "DISCORD - Get Balance",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DISCORD - Get Balance\n\n**Endpoint:** GET /webhook/discord-get-balance\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord de l'utilisateur\n\n**Source:** PostgreSQL `subscribers` + `transactions`\n\n**Commande bot:** `/solde`\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"balance\": {\n    \"credits_remaining\": 850,\n    \"credits_total\": 1000,\n    \"credits_used\": 150,\n    \"usage_percent\": 15,\n    \"renewal_date\": \"2025-02-01\",\n    \"recent_transactions\": [...]\n  }\n}\n```",
+        "height": 400,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "discord-get-balance",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "discord-get-balance"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider les parametres\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst projectId = query.project_id || null;\nconst discordUserId = query.discord_user_id || null;\n\nconst errors = [];\nif (!projectId) errors.push('project_id');\nif (!discordUserId) errors.push('discord_user_id');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Parametres requis manquants: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: projectId,\n    discord_user_id: discordUserId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id, credits_remaining, credits_total, subscription_status, current_period_end FROM subscribers WHERE project_id = '{{ $json.project_id }}' AND discord_user_id = '{{ $json.discord_user_id }}' LIMIT 1",
+        "options": {}
+      },
+      "id": "get-subscriber",
+      "name": "Get Subscriber",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1100, 200],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verifier si le subscriber existe\nconst dbResults = $input.all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.id) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Aucun abonnement trouve pour discord_user_id '${inputData.discord_user_id}' dans le projet '${inputData.project_id}'`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst subscriber = dbResults[0].json;\n\nreturn [{\n  json: {\n    found: true,\n    subscriber_id: subscriber.id,\n    project_id: inputData.project_id,\n    discord_user_id: inputData.discord_user_id,\n    credits_remaining: subscriber.credits_remaining || 0,\n    credits_total: subscriber.credits_total || 0,\n    subscription_status: subscriber.subscription_status,\n    current_period_end: subscriber.current_period_end\n  }\n}];"
+      },
+      "id": "check-subscriber",
+      "name": "Check Subscriber",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "subscriber-found",
+      "name": "Subscriber Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id, type, amount, description, created_at FROM transactions WHERE subscriber_id = {{ $json.subscriber_id }} ORDER BY created_at DESC LIMIT 5",
+        "options": {}
+      },
+      "id": "get-transactions",
+      "name": "Get Recent Transactions",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1760, 100],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la reponse balance\nconst subscriberData = $('Check Subscriber').first().json;\nconst transactionsResults = $input.all();\n\n// Calculer les stats\nconst creditsRemaining = subscriberData.credits_remaining || 0;\nconst creditsTotal = subscriberData.credits_total || 0;\nconst creditsUsed = creditsTotal - creditsRemaining;\nconst usagePercent = creditsTotal > 0 \n  ? Math.round((creditsUsed / creditsTotal) * 100) \n  : 0;\n\n// Formater les transactions recentes\nconst recentTransactions = transactionsResults\n  .filter(t => t.json && t.json.id)\n  .map(t => ({\n    id: t.json.id,\n    type: t.json.type,\n    amount: t.json.amount,\n    description: t.json.description,\n    created_at: t.json.created_at\n  }));\n\nreturn [{\n  json: {\n    success: true,\n    balance: {\n      credits_remaining: creditsRemaining,\n      credits_total: creditsTotal,\n      credits_used: creditsUsed,\n      usage_percent: usagePercent,\n      subscription_status: subscriberData.subscription_status,\n      renewal_date: subscriberData.current_period_end,\n      recent_transactions: recentTransactions\n    }\n  }\n}];"
+      },
+      "id": "format-balance",
+      "name": "Format Balance",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2200, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Check Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Subscriber Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Subscriber Found?": {
+      "main": [
+        [
+          {
+            "node": "Get Recent Transactions",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Recent Transactions": {
+      "main": [
+        [
+          {
+            "node": "Format Balance",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Balance": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Discord/discord-get-plans.json
+++ b/workflows/Discord/discord-get-plans.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## DISCORD - Get Plans\n\n**Endpoint:** GET /webhook/discord-get-plans\n\n**Query Parameters:**\n- `project_id` (required): ID du projet (ex: torah, mcp)\n\n**Source:** Stripe API (temps reel)\n\n**Flow:**\n1. Valider project_id\n2. Recuperer secret_key depuis SQLite\n3. Appeler Stripe API /v1/prices\n4. Appeler Stripe API /v1/products\n5. Formater et retourner les plans\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"project_id\": \"torah\",\n  \"plans\": [\n    {\n      \"id\": \"price_xxx\",\n      \"product_id\": \"prod_xxx\",\n      \"name\": \"Premium\",\n      \"price\": 9.99,\n      \"currency\": \"eur\",\n      \"interval\": \"month\",\n      \"features\": [...]\n    }\n  ]\n}\n```",
+        "content": "## DISCORD - Get Plans\n\n**Endpoint:** GET /webhook/discord-get-plans\n\n**Query Parameters:**\n- `project_id` (required): ID du projet (ex: torah, mcp)\n\n**Source:** Stripe API (temps reel)\n\n**Flow:**\n1. Valider project_id\n2. Recuperer stripe_secret_key depuis PostgreSQL (table projects)\n3. Appeler Stripe API /v1/prices\n4. Formater et retourner les plans\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"project_id\": \"torah\",\n  \"plans\": [\n    {\n      \"id\": \"price_xxx\",\n      \"product_id\": \"prod_xxx\",\n      \"name\": \"Premium\",\n      \"price\": 9.99,\n      \"currency\": \"eur\",\n      \"interval\": \"month\",\n      \"features\": [...]\n    }\n  ]\n}\n```",
         "height": 480,
         "width": 340,
         "color": 5
@@ -70,18 +70,18 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "SELECT project_id, secret_key, display_name FROM stripe_projects WHERE project_id = '{{ $json.project_id }}' AND active = 1",
+        "query": "SELECT project_id, stripe_secret_key as secret_key, display_name FROM projects WHERE project_id = '{{ $json.project_id }}' AND active = true",
         "options": {}
       },
       "id": "get-stripe-config",
       "name": "Get Stripe Config",
-      "type": "n8n-nodes-base.sqlite",
-      "typeVersion": 1,
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
       "position": [1100, 200],
       "credentials": {
-        "sqlite": {
-          "id": "stripe-config-db",
-          "name": "Stripe Config DB"
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
         }
       }
     },

--- a/workflows/Discord/discord-get-plans.json
+++ b/workflows/Discord/discord-get-plans.json
@@ -1,0 +1,339 @@
+{
+  "name": "DISCORD - Get Plans",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DISCORD - Get Plans\n\n**Endpoint:** GET /webhook/discord-get-plans\n\n**Query Parameters:**\n- `project_id` (required): ID du projet (ex: torah, mcp)\n\n**Source:** Stripe API (temps reel)\n\n**Flow:**\n1. Valider project_id\n2. Recuperer secret_key depuis SQLite\n3. Appeler Stripe API /v1/prices\n4. Appeler Stripe API /v1/products\n5. Formater et retourner les plans\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"project_id\": \"torah\",\n  \"plans\": [\n    {\n      \"id\": \"price_xxx\",\n      \"product_id\": \"prod_xxx\",\n      \"name\": \"Premium\",\n      \"price\": 9.99,\n      \"currency\": \"eur\",\n      \"interval\": \"month\",\n      \"features\": [...]\n    }\n  ]\n}\n```",
+        "height": 480,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "discord-get-plans",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "discord-get-plans"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider les parametres\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst projectId = query.project_id || null;\n\nif (!projectId) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Le parametre \"project_id\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: projectId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT project_id, secret_key, display_name FROM stripe_projects WHERE project_id = '{{ $json.project_id }}' AND active = 1",
+        "options": {}
+      },
+      "id": "get-stripe-config",
+      "name": "Get Stripe Config",
+      "type": "n8n-nodes-base.sqlite",
+      "typeVersion": 1,
+      "position": [1100, 200],
+      "credentials": {
+        "sqlite": {
+          "id": "stripe-config-db",
+          "name": "Stripe Config DB"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verifier que le projet existe\nconst dbResults = $('Get Stripe Config').all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.secret_key) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Projet '${inputData.project_id}' non trouve ou inactif`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst project = dbResults[0].json;\n\nreturn [{\n  json: {\n    found: true,\n    project_id: project.project_id,\n    display_name: project.display_name,\n    secret_key: project.secret_key\n  }\n}];"
+      },
+      "id": "check-project",
+      "name": "Check Project",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "project-found",
+      "name": "Project Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "https://api.stripe.com/v1/prices?active=true&expand[]=data.product",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.secret_key }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "get-stripe-prices",
+      "name": "Get Stripe Prices",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1760, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater les plans depuis la reponse Stripe\nconst input = $input.first().json;\nconst projectData = $('Check Project').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst data = input.body || input;\n\n// Verifier les erreurs Stripe\nif (statusCode >= 400 || data.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || 'Erreur Stripe API',\n        status: 'STRIPE_ERROR'\n      }\n    }\n  }];\n}\n\nconst prices = data.data || [];\n\n// Formater les plans\nconst plans = prices.map(price => {\n  const product = price.product || {};\n  \n  // Extraire les features depuis les metadata du produit\n  let features = [];\n  if (product.metadata?.features) {\n    try {\n      features = JSON.parse(product.metadata.features);\n    } catch (e) {\n      features = product.metadata.features.split(',').map(f => f.trim());\n    }\n  }\n  \n  // Extraire credits_per_month depuis metadata\n  const creditsPerMonth = parseInt(product.metadata?.credits_per_month || price.metadata?.credits_per_month || '0');\n  \n  return {\n    id: price.id,\n    product_id: product.id || price.product,\n    name: product.name || 'Plan',\n    description: product.description || null,\n    price: (price.unit_amount || 0) / 100,\n    currency: price.currency || 'eur',\n    interval: price.recurring?.interval || 'month',\n    interval_count: price.recurring?.interval_count || 1,\n    credits_per_month: creditsPerMonth,\n    features: features,\n    metadata: {\n      ...product.metadata,\n      ...price.metadata\n    }\n  };\n});\n\n// Trier par prix\nplans.sort((a, b) => a.price - b.price);\n\nreturn [{\n  json: {\n    success: true,\n    project_id: projectData.project_id,\n    project_name: projectData.display_name,\n    plans_count: plans.length,\n    plans: plans\n  }\n}];"
+      },
+      "id": "format-plans",
+      "name": "Format Plans",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2200, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Stripe Config",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Stripe Config": {
+      "main": [
+        [
+          {
+            "node": "Check Project",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Project": {
+      "main": [
+        [
+          {
+            "node": "Project Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Project Found?": {
+      "main": [
+        [
+          {
+            "node": "Get Stripe Prices",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Stripe Prices": {
+      "main": [
+        [
+          {
+            "node": "Format Plans",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Plans": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Discord/discord-get-subscriber.json
+++ b/workflows/Discord/discord-get-subscriber.json
@@ -1,0 +1,279 @@
+{
+  "name": "DISCORD - Get Subscriber",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DISCORD - Get Subscriber\n\n**Endpoint:** GET /webhook/discord-get-subscriber\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord de l'utilisateur\n\n**Source:** PostgreSQL `subscribers`\n\n**Commandes bot:** `/plan`, `/credits`\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"subscriber\": {\n    \"id\": 123,\n    \"discord_user_id\": \"123456789\",\n    \"email\": \"user@example.com\",\n    \"plan_id\": \"price_xxx\",\n    \"credits_remaining\": 850,\n    \"credits_total\": 1000,\n    \"subscription_status\": \"active\"\n  }\n}\n```",
+        "height": 400,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "discord-get-subscriber",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "discord-get-subscriber"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider les parametres\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst projectId = query.project_id || null;\nconst discordUserId = query.discord_user_id || null;\n\nconst errors = [];\nif (!projectId) errors.push('project_id');\nif (!discordUserId) errors.push('discord_user_id');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Parametres requis manquants: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: projectId,\n    discord_user_id: discordUserId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id, project_id, discord_user_id, email, plan_id, stripe_customer_id, stripe_subscription_id, credits_remaining, credits_total, subscription_status, current_period_start, current_period_end, created_at, updated_at FROM subscribers WHERE project_id = '{{ $json.project_id }}' AND discord_user_id = '{{ $json.discord_user_id }}' LIMIT 1",
+        "options": {}
+      },
+      "id": "get-subscriber",
+      "name": "Get Subscriber",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1100, 200],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verifier si le subscriber existe et formater la reponse\nconst dbResults = $input.all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.id) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Aucun abonnement trouve pour discord_user_id '${inputData.discord_user_id}' dans le projet '${inputData.project_id}'`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst subscriber = dbResults[0].json;\n\n// Calculer le pourcentage d'utilisation\nconst creditsUsed = (subscriber.credits_total || 0) - (subscriber.credits_remaining || 0);\nconst usagePercent = subscriber.credits_total > 0 \n  ? Math.round((creditsUsed / subscriber.credits_total) * 100) \n  : 0;\n\nreturn [{\n  json: {\n    found: true,\n    subscriber: {\n      id: subscriber.id,\n      project_id: subscriber.project_id,\n      discord_user_id: subscriber.discord_user_id,\n      email: subscriber.email,\n      plan_id: subscriber.plan_id,\n      stripe_customer_id: subscriber.stripe_customer_id,\n      stripe_subscription_id: subscriber.stripe_subscription_id,\n      credits_remaining: subscriber.credits_remaining || 0,\n      credits_total: subscriber.credits_total || 0,\n      credits_used: creditsUsed,\n      usage_percent: usagePercent,\n      subscription_status: subscriber.subscription_status || 'unknown',\n      current_period_start: subscriber.current_period_start,\n      current_period_end: subscriber.current_period_end,\n      created_at: subscriber.created_at,\n      updated_at: subscriber.updated_at\n    }\n  }\n}];"
+      },
+      "id": "format-subscriber",
+      "name": "Format Subscriber",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "subscriber-found",
+      "name": "Subscriber Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: true, subscriber: $json.subscriber }) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Format Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Subscriber Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Subscriber Found?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Discord/discord-get-transactions.json
+++ b/workflows/Discord/discord-get-transactions.json
@@ -1,0 +1,379 @@
+{
+  "name": "DISCORD - Get Transactions",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DISCORD - Get Transactions\n\n**Endpoint:** GET /webhook/discord-get-transactions\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord\n- `limit` (optional): Max resultats (defaut: 20)\n- `offset` (optional): Pagination (defaut: 0)\n\n**Source:** PostgreSQL `transactions`\n\n**Commande bot:** `/account`\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"transactions\": [...],\n  \"pagination\": {\n    \"total\": 45,\n    \"limit\": 20,\n    \"offset\": 0,\n    \"has_more\": true\n  }\n}\n```",
+        "height": 400,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "discord-get-transactions",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "discord-get-transactions"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider les parametres\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst projectId = query.project_id || null;\nconst discordUserId = query.discord_user_id || null;\nconst limit = Math.min(Math.max(parseInt(query.limit) || 20, 1), 100); // Entre 1 et 100\nconst offset = Math.max(parseInt(query.offset) || 0, 0);\n\nconst errors = [];\nif (!projectId) errors.push('project_id');\nif (!discordUserId) errors.push('discord_user_id');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Parametres requis manquants: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: projectId,\n    discord_user_id: discordUserId,\n    limit: limit,\n    offset: offset\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id FROM subscribers WHERE project_id = '{{ $json.project_id }}' AND discord_user_id = '{{ $json.discord_user_id }}' LIMIT 1",
+        "options": {}
+      },
+      "id": "get-subscriber",
+      "name": "Get Subscriber",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1100, 200],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verifier si le subscriber existe\nconst dbResults = $input.all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.id) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Aucun abonnement trouve pour discord_user_id '${inputData.discord_user_id}' dans le projet '${inputData.project_id}'`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    found: true,\n    subscriber_id: dbResults[0].json.id,\n    limit: inputData.limit,\n    offset: inputData.offset\n  }\n}];"
+      },
+      "id": "check-subscriber",
+      "name": "Check Subscriber",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "subscriber-found",
+      "name": "Subscriber Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT COUNT(*) as total FROM transactions WHERE subscriber_id = {{ $json.subscriber_id }}",
+        "options": {}
+      },
+      "id": "count-transactions",
+      "name": "Count Transactions",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [1760, 100],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Stocker le total et preparer la requete des transactions\nconst countResult = $input.first().json;\nconst subscriberData = $('Check Subscriber').first().json;\n\nreturn [{\n  json: {\n    subscriber_id: subscriberData.subscriber_id,\n    limit: subscriberData.limit,\n    offset: subscriberData.offset,\n    total: parseInt(countResult.total) || 0\n  }\n}];"
+      },
+      "id": "prepare-query",
+      "name": "Prepare Query",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id, type, amount, description, reference, created_at FROM transactions WHERE subscriber_id = {{ $json.subscriber_id }} ORDER BY created_at DESC LIMIT {{ $json.limit }} OFFSET {{ $json.offset }}",
+        "options": {}
+      },
+      "id": "get-transactions",
+      "name": "Get Transactions",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [2200, 100],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-subscribers",
+          "name": "PostgreSQL Subscribers"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la reponse avec pagination\nconst paginationData = $('Prepare Query').first().json;\nconst transactionsResults = $input.all();\n\n// Formater les transactions\nconst transactions = transactionsResults\n  .filter(t => t.json && t.json.id)\n  .map(t => ({\n    id: t.json.id,\n    type: t.json.type,\n    amount: t.json.amount,\n    description: t.json.description,\n    reference: t.json.reference || null,\n    created_at: t.json.created_at\n  }));\n\nconst total = paginationData.total;\nconst limit = paginationData.limit;\nconst offset = paginationData.offset;\nconst hasMore = (offset + transactions.length) < total;\n\nreturn [{\n  json: {\n    success: true,\n    transactions: transactions,\n    pagination: {\n      total: total,\n      limit: limit,\n      offset: offset,\n      count: transactions.length,\n      has_more: hasMore\n    }\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2420, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2640, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Check Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Subscriber Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Subscriber Found?": {
+      "main": [
+        [
+          {
+            "node": "Count Transactions",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Count Transactions": {
+      "main": [
+        [
+          {
+            "node": "Prepare Query",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Query": {
+      "main": [
+        [
+          {
+            "node": "Get Transactions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Transactions": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Discord/discord-registry.json
+++ b/workflows/Discord/discord-registry.json
@@ -1,0 +1,121 @@
+{
+  "name": "DISCORD - Registry",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DISCORD Registry\n\n**Endpoint:** GET /webhook/discord-registry\n\n**Description:** Liste tous les workflows Discord disponibles avec leurs metadonnees.\n\n**Response:**\n```json\n{\n  \"version\": \"1.0\",\n  \"updated_at\": \"2025-01-05T...\",\n  \"n8n\": {\n    \"host\": \"pi6.local\",\n    \"port\": 5678,\n    \"webhook_base\": \"http://pi6.local:5678/webhook\"\n  },\n  \"total_tools\": 5,\n  \"tools\": { ... }\n}\n```",
+        "height": 340,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "discord-registry",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-registry",
+      "name": "Webhook Registry",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [300, 300],
+      "webhookId": "discord-registry"
+    },
+    {
+      "parameters": {
+        "url": "http://pi6.local:5678/api/v1/workflows?active=true&limit=250",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "http-get-workflows",
+      "name": "Get Active Workflows",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [520, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "aHxvULwe4es6Gnmh",
+          "name": "Header Auth account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================================================\n// DISCORD REGISTRY - Build Registry with Metadata\n// ============================================================================\n\n// Discord Workflow Metadata\nconst discordMetadata = {\n  \"discord-registry\": {\n    \"label\": \"Registry\",\n    \"icon\": \"📋\",\n    \"description\": \"Liste tous les workflows Discord disponibles\",\n    \"tags\": [\"discord\", \"registry\", \"discovery\"],\n    \"scope\": \"system\"\n  },\n  \"discord-get-plans\": {\n    \"label\": \"Get Plans\",\n    \"icon\": \"📊\",\n    \"description\": \"Recupere la liste des plans disponibles pour un projet\",\n    \"tags\": [\"discord\", \"plans\", \"subscription\"],\n    \"scope\": \"user\",\n    \"command\": \"/plans\"\n  },\n  \"discord-get-subscriber\": {\n    \"label\": \"Get Subscriber\",\n    \"icon\": \"👤\",\n    \"description\": \"Recupere les informations d'un abonne (plan, credits)\",\n    \"tags\": [\"discord\", \"subscriber\", \"credits\"],\n    \"scope\": \"user\",\n    \"command\": \"/plan, /credits\"\n  },\n  \"discord-get-balance\": {\n    \"label\": \"Get Balance\",\n    \"icon\": \"💰\",\n    \"description\": \"Recupere le solde et les transactions recentes\",\n    \"tags\": [\"discord\", \"balance\", \"transactions\"],\n    \"scope\": \"user\",\n    \"command\": \"/solde\"\n  },\n  \"discord-get-transactions\": {\n    \"label\": \"Get Transactions\",\n    \"icon\": \"📜\",\n    \"description\": \"Recupere l'historique des transactions\",\n    \"tags\": [\"discord\", \"transactions\", \"history\"],\n    \"scope\": \"user\",\n    \"command\": \"/account\"\n  }\n};\n\n// ============================================================================\n// BUILD REGISTRY\n// ============================================================================\n\nconst workflows = $input.first().json.data || [];\n\n// Filter active Discord workflows\nconst discordWorkflows = workflows.filter(w => \n  w.active && \n  w.name.startsWith('DISCORD')\n);\n\n// Build tools object\nconst tools = {};\n\nfor (const workflow of discordWorkflows) {\n  // Find all webhook nodes in the workflow\n  const webhookNodes = workflow.nodes?.filter(n => n.type === 'n8n-nodes-base.webhook') || [];\n  \n  for (const webhookNode of webhookNodes) {\n    const webhookPath = webhookNode.parameters?.path || webhookNode.webhookId;\n    const toolName = webhookPath;\n    \n    // Get metadata\n    const meta = discordMetadata[toolName] || {};\n    \n    tools[toolName] = {\n      name: workflow.name,\n      label: meta.label || workflow.name.replace('DISCORD - ', ''),\n      icon: meta.icon || '🤖',\n      description: meta.description || `Discord Tool: ${workflow.name}`,\n      tags: meta.tags || ['discord'],\n      scope: meta.scope || 'user',\n      command: meta.command || null,\n      workflow_id: workflow.id,\n      endpoint: `/webhook/${webhookPath}`,\n      webhook_url: `http://pi6.local:5678/webhook/${webhookPath}`,\n      method: webhookNode.parameters?.httpMethod || 'GET',\n      active: workflow.active\n    };\n  }\n}\n\n// Build final registry response\nconst registry = {\n  version: \"1.0\",\n  updated_at: new Date().toISOString(),\n  n8n: {\n    host: \"pi6.local\",\n    port: 5678,\n    protocol: \"http\",\n    webhook_base: \"http://pi6.local:5678/webhook\"\n  },\n  scopes: {\n    user: \"Endpoint accessible par le bot Discord\",\n    system: \"Endpoint interne pour orchestration\"\n  },\n  total_tools: Object.keys(tools).length,\n  tools: tools\n};\n\nreturn { json: registry };"
+      },
+      "id": "code-registry",
+      "name": "Build Registry",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [740, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-registry",
+      "name": "Respond Registry",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [960, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Registry": {
+      "main": [
+        [
+          {
+            "node": "Get Active Workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Active Workflows": {
+      "main": [
+        [
+          {
+            "node": "Build Registry",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Registry": {
+      "main": [
+        [
+          {
+            "node": "Respond Registry",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

Implémentation des workflows Discord pour l'intégration avec le bot Discord.

Closes #186

## Workflows créés

| Workflow | Webhook | Commande Bot |
|----------|---------|--------------|
| `DISCORD - Registry` | `GET /webhook/discord-registry` | Discovery |
| `DISCORD - Get Plans` | `GET /webhook/discord-get-plans` | `/plans` |
| `DISCORD - Get Subscriber` | `GET /webhook/discord-get-subscriber` | `/plan`, `/credits` |
| `DISCORD - Get Balance` | `GET /webhook/discord-get-balance` | `/solde` |
| `DISCORD - Get Transactions` | `GET /webhook/discord-get-transactions` | `/account` |

## Architecture

```
Bot Torah ──┐
Bot MCP   ──┼──▶ n8n Workflows ──▶ PostgreSQL
Bot X     ──┘         │
                      ▼
                 Stripe API
```

### Principes clés

- **Multi-tenant** : Plusieurs bots via `project_id`
- **Pas d'accès direct DB** : Le bot passe toujours par n8n
- **Plans depuis Stripe** : API Stripe en temps réel (pas hardcodé)
- **Callbacks** : Mettent à jour PostgreSQL, bot query pour données à jour

## Documentation mise à jour

- `docs/discord-bot-integration.md` : Architecture, specs, client Python

## Credentials requis

| Credential | Type | Usage |
|------------|------|-------|
| `Stripe Config DB` | SQLite | Config multi-tenant |
| `PostgreSQL Subscribers` | PostgreSQL | Données utilisateurs |
| `Header Auth n8n` | HTTP Header | Appels API n8n |

## Test plan

- [ ] Importer les workflows dans n8n
- [ ] Configurer les credentials
- [ ] Tester chaque endpoint avec curl/Postman
- [ ] Intégrer avec le bot Discord

🤖 Generated with [Claude Code](https://claude.com/claude-code)