### PR TITLE
feat: Redis integration for Discord/Stripe workflows

### DIFF
--- a/workflows/Discord/discord-get-plans.json
+++ b/workflows/Discord/discord-get-plans.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## DISCORD - Get Plans\n\n**Endpoint:** GET /webhook/discord-get-plans\n\n**Query Parameters:**\n- `project_id` (required): ID du projet (ex: torah, mcp)\n\n**Source:** Stripe API (temps reel)\n\n**Flow:**\n1. Valider project_id\n2. Recuperer stripe_secret_key depuis PostgreSQL (table projects)\n3. Appeler Stripe API /v1/prices\n4. Formater et retourner les plans\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"project_id\": \"torah\",\n  \"plans\": [\n    {\n      \"id\": \"price_xxx\",\n      \"product_id\": \"prod_xxx\",\n      \"name\": \"Premium\",\n      \"price\": 9.99,\n      \"currency\": \"eur\",\n      \"interval\": \"month\",\n      \"features\": [...]\n    }\n  ]\n}\n```",
+        "content": "## DISCORD - Get Plans\n\n**Endpoint:** GET /webhook/discord-get-plans\n\n**Query Parameters:**\n- `project_id` (required): ID du projet (ex: torah, mcp)\n\n**Source:** Stripe API (temps reel)\n\n**Flow:**\n1. Valider project_id\n2. Recuperer stripe_key depuis Redis (cle: project:{project_id})\n3. Appeler Stripe API /v1/prices\n4. Formater et retourner les plans\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"project_id\": \"torah\",\n  \"plans\": [\n    {\n      \"id\": \"price_xxx\",\n      \"product_id\": \"prod_xxx\",\n      \"name\": \"Premium\",\n      \"price\": 9.99,\n      \"currency\": \"eur\",\n      \"interval\": \"month\",\n      \"features\": [...]\n    }\n  ]\n}\n```",
         "height": 480,
         "width": 340,
         "color": 5
@@ -69,25 +69,24 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "SELECT project_id, stripe_secret_key as secret_key, display_name FROM projects WHERE project_id = '{{ $json.project_id }}' AND active = true",
-        "options": {}
+        "operation": "get",
+        "key": "=project:{{ $json.project_id }}"
       },
       "id": "get-stripe-config",
-      "name": "Get Stripe Config",
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.5,
+      "name": "Get Stripe Config (Redis)",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
       "position": [1100, 200],
       "credentials": {
-        "postgres": {
-          "id": "postgres-subscribers",
-          "name": "PostgreSQL Subscribers"
+        "redis": {
+          "id": "redis-secrets",
+          "name": "Redis Secrets"
         }
       }
     },
     {
       "parameters": {
-        "jsCode": "// Verifier que le projet existe\nconst dbResults = $('Get Stripe Config').all();\nconst inputData = $('Validate Input').first().json;\n\nif (!dbResults || dbResults.length === 0 || !dbResults[0].json.secret_key) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Projet '${inputData.project_id}' non trouve ou inactif`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nconst project = dbResults[0].json;\n\nreturn [{\n  json: {\n    found: true,\n    project_id: project.project_id,\n    display_name: project.display_name,\n    secret_key: project.secret_key\n  }\n}];"
+        "jsCode": "// Verifier que le projet existe dans Redis\nconst redisResult = $('Get Stripe Config (Redis)').first();\nconst inputData = $('Validate Input').first().json;\n\n// Redis retourne la valeur dans json.value ou directement\nconst rawValue = redisResult?.json?.value || redisResult?.json;\n\nif (!rawValue || rawValue === null) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Projet '${inputData.project_id}' non enregistre. Appelez /stripe-register-project d'abord.`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Parser le JSON stocke dans Redis\nlet project;\ntry {\n  project = typeof rawValue === 'string' ? JSON.parse(rawValue) : rawValue;\n} catch (e) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 500,\n        message: `Erreur parsing Redis: ${e.message}`,\n        status: 'INTERNAL_ERROR'\n      }\n    }\n  }];\n}\n\nif (!project.stripe_key) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Projet '${inputData.project_id}' n'a pas de cle Stripe configuree`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    found: true,\n    project_id: inputData.project_id,\n    display_name: project.display_name || inputData.project_id,\n    secret_key: project.stripe_key\n  }\n}];"
       },
       "id": "check-project",
       "name": "Check Project",
@@ -256,7 +255,7 @@
       "main": [
         [
           {
-            "node": "Get Stripe Config",
+            "node": "Get Stripe Config (Redis)",
             "type": "main",
             "index": 0
           }
@@ -270,7 +269,7 @@
         ]
       ]
     },
-    "Get Stripe Config": {
+    "Get Stripe Config (Redis)": {
       "main": [
         [
           {

--- a/workflows/Stripe/stripe-register-project.json
+++ b/workflows/Stripe/stripe-register-project.json
@@ -1,0 +1,211 @@
+{
+  "name": "STRIPE - Register Project",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## STRIPE - Register Project\n\n**Endpoint:** POST /webhook/stripe-register-project\n\n**Description:** Enregistre les secrets Stripe d'un projet dans Redis.\nAppele par le plugin au demarrage.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"stripe_key\": \"sk_live_xxx\",\n  \"webhook_secret\": \"whsec_xxx\",\n  \"display_name\": \"Torah App\"\n}\n```\n\n**Redis:**\n```\nHSET project:torah stripe_key \"sk_xxx\"\nHSET project:torah webhook_secret \"whsec_xxx\"\n```\n\n**Response:**\n```json\n{\"success\": true, \"message\": \"Project registered\"}\n```",
+        "height": 420,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "stripe-register-project",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "stripe-register-project"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider les parametres requis\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst projectId = body.project_id || null;\nconst stripeKey = body.stripe_key || null;\nconst webhookSecret = body.webhook_secret || null;\nconst displayName = body.display_name || projectId;\n\nconst errors = [];\nif (!projectId) errors.push('project_id');\nif (!stripeKey) errors.push('stripe_key');\nif (!webhookSecret) errors.push('webhook_secret');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Parametres requis manquants: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\n// Valider le format des cles\nif (!stripeKey.startsWith('sk_')) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'stripe_key doit commencer par sk_',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nif (!webhookSecret.startsWith('whsec_')) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'webhook_secret doit commencer par whsec_',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: projectId,\n    stripe_key: stripeKey,\n    webhook_secret: webhookSecret,\n    display_name: displayName,\n    redis_key: `project:${projectId}`\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "operation": "set",
+        "key": "={{ $json.redis_key }}",
+        "value": "={{ JSON.stringify({ stripe_key: $json.stripe_key, webhook_secret: $json.webhook_secret, display_name: $json.display_name, registered_at: new Date().toISOString() }) }}",
+        "expire": false
+      },
+      "id": "redis-set",
+      "name": "Redis SET",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [1100, 200],
+      "credentials": {
+        "redis": {
+          "id": "redis-secrets",
+          "name": "Redis Secrets"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Preparer la reponse de succes\nconst inputData = $('Validate Input').first().json;\n\nreturn [{\n  json: {\n    success: true,\n    message: 'Project registered successfully',\n    project: {\n      project_id: inputData.project_id,\n      display_name: inputData.display_name,\n      redis_key: inputData.redis_key\n    }\n  }\n}];"
+      },
+      "id": "format-success",
+      "name": "Format Success",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 420]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Redis SET",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Redis SET": {
+      "main": [
+        [
+          {
+            "node": "Format Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

- Add `stripe-register-project` workflow to store Stripe secrets in Redis
- Refactor `discord-get-plans` to read Stripe key from Redis instead of PostgreSQL
- Add `discord-subscribe` workflow for Stripe Checkout sessions
- Update specs for Bot and API teams with new endpoint names

## Workflows

| Workflow | Endpoint | Description |
|----------|----------|-------------|
| STRIPE - Register Project | `POST /webhook/stripe-register-project` | Store Stripe secrets in Redis |
| DISCORD - Get Plans | `GET /webhook/discord-get-plans` | List Stripe plans (reads from Redis) |
| DISCORD - Subscribe | `POST /webhook/discord-subscribe` | Create Stripe Checkout session |

## Architecture

- **Redis** (`host3.local:6381`): Stripe secrets storage
- **n8n** (`pi6.local:5678`): Workflow endpoints
- **API** (`pi6.local:3031`): Credits management (API team)

## Test plan

- [ ] Test stripe-register-project with valid/invalid data
- [ ] Test discord-get-plans after project registration
- [ ] Test discord-subscribe checkout flow
- [ ] Verify Redis credentials are configured in n8n

🤖 Generated with [Claude Code](https://claude.com/claude-code)