### PR TITLE
feat(stripe): add webhook handler workflow for Discord credits

### DIFF
--- a/config/nginx/stripe.azy.solutions.conf
+++ b/config/nginx/stripe.azy.solutions.conf
@@ -1,0 +1,12 @@
+# /etc/nginx/sites-available/stripe.azy.solutions
+server {
+    listen 80;
+    server_name stripe.azy.solutions;
+
+    location /webhook/ {
+        proxy_pass http://pi6.local:5678/webhook/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/workflows/Stripe/stripe-register-project.json
+++ b/workflows/Stripe/stripe-register-project.json
@@ -81,8 +81,8 @@
       "position": [1100, 200],
       "credentials": {
         "redis": {
-          "id": "redis-secrets",
-          "name": "Redis Secrets"
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
         }
       }
     },

--- a/workflows/Stripe/stripe-webhook-handler.json
+++ b/workflows/Stripe/stripe-webhook-handler.json
@@ -1,0 +1,185 @@
+{
+  "name": "STRIPE - Webhook Handler",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## STRIPE - Webhook Handler\n\n**Endpoint:** POST /webhook/stripe-webhook/{project_id}\n\n**Events geres (Phase 1):**\n- checkout.session.completed\n- invoice.paid\n- customer.subscription.deleted",
+        "height": 300,
+        "width": 300,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": ":project_id",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [300, 300],
+      "webhookId": "stripe-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\n\n// Extraire project_id\nconst projectId = input.params?.project_id;\nif (!projectId) {\n  return [{ json: { success: false, error: { code: 400, message: 'project_id manquant' } } }];\n}\n\n// Extraire signature\nconst signature = input.headers?.['stripe-signature'];\nif (!signature) {\n  return [{ json: { success: false, error: { code: 400, message: 'stripe-signature manquant' } } }];\n}\n\n// Parser event\nlet event;\ntry {\n  event = typeof input.body === 'string' ? JSON.parse(input.body) : input.body;\n} catch (e) {\n  return [{ json: { success: false, error: { code: 400, message: 'JSON invalide' } } }];\n}\n\nreturn [{\n  json: {\n    success: true,\n    project_id: projectId,\n    redis_key: `project:${projectId}`,\n    signature: signature,\n    raw_body: typeof input.body === 'string' ? input.body : JSON.stringify(input.body),\n    event_id: event.id,\n    event_type: event.type,\n    event_data: event.data?.object || {}\n  }\n}];"
+      },
+      "id": "extract-data",
+      "name": "Extract & Validate",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [520, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [{ "id": "valid", "leftValue": "={{ $json.success }}", "rightValue": true, "operator": { "type": "boolean", "operation": "equals" } }],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [740, 300]
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "key": "={{ $json.redis_key }}"
+      },
+      "id": "get-secret",
+      "name": "Get Secret (Redis)",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [960, 200],
+      "credentials": {
+        "redis": { "id": "2idv3VKZ91q5gOnz", "name": "Redis account" }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const prev = $('Extract & Validate').first().json;\nconst redisData = $input.first().json;\n\n// Parser secrets Redis\nlet secrets;\ntry {\n  const raw = redisData.propertyName || redisData.value || redisData;\n  secrets = typeof raw === 'string' ? JSON.parse(raw) : raw;\n} catch (e) {\n  return [{ json: { verified: false, error: { code: 500, message: 'Redis parse error' } } }];\n}\n\nif (!secrets?.webhook_secret) {\n  return [{ json: { verified: false, error: { code: 404, message: 'webhook_secret non trouve' } } }];\n}\n\n// Parser signature Stripe\nconst sig = prev.signature;\nconst parts = {};\nsig.split(',').forEach(p => { const [k,v] = p.split('='); parts[k] = v; });\n\nconst timestamp = parts['t'];\nconst expected = parts['v1'];\n\nif (!timestamp || !expected) {\n  return [{ json: { verified: false, error: { code: 400, message: 'Signature format invalide' } } }];\n}\n\n// TODO: Signature verification disabled - Web Crypto API not available in n8n\n// For production, use external verification service or custom node\n// For now, just check that we have the webhook_secret configured\n\nreturn [{\n  json: {\n    verified: true,\n    project_id: prev.project_id,\n    event_id: prev.event_id,\n    event_type: prev.event_type,\n    event_data: prev.event_data,\n    _warning: 'Signature verification temporarily disabled'\n  }\n}];"
+      },
+      "id": "verify-sig",
+      "name": "Verify Signature",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1180, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [{ "id": "verified", "leftValue": "={{ $json.verified }}", "rightValue": true, "operator": { "type": "boolean", "operation": "equals" } }],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-sig",
+      "name": "Sig Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1400, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst eventType = input.event_type;\nconst data = input.event_data;\nconst metadata = data.metadata || {};\n\nlet action = null;\nlet payload = { project_id: input.project_id };\n\nif (eventType === 'checkout.session.completed') {\n  const credits = parseInt(metadata.credits_per_month || '1000');\n  action = 'set';\n  payload.discord_user_id = metadata.discord_user_id;\n  payload.credits_remaining = credits;\n  payload.credits_total = credits;\n  payload.reason = 'checkout_completed';\n}\nelse if (eventType === 'invoice.paid') {\n  if (data.billing_reason === 'subscription_create') {\n    return [{ json: { action: 'skip', reason: 'First invoice' } }];\n  }\n  const subMeta = data.subscription_details?.metadata || metadata;\n  action = 'credit';\n  payload.discord_user_id = subMeta.discord_user_id;\n  payload.amount = parseInt(subMeta.credits_per_month || '1000');\n  payload.reason = 'renewal';\n}\nelse if (eventType === 'customer.subscription.deleted') {\n  action = 'set';\n  payload.discord_user_id = metadata.discord_user_id;\n  payload.credits_remaining = 0;\n  payload.credits_total = 0;\n  payload.reason = 'subscription_deleted';\n}\nelse {\n  return [{ json: { action: 'skip', reason: `Event ${eventType} not handled` } }];\n}\n\nif (!payload.discord_user_id) {\n  return [{ json: { action: 'error', reason: 'discord_user_id missing' } }];\n}\n\nreturn [{ json: { action, ...payload } }];"
+      },
+      "id": "process-event",
+      "name": "Process Event",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1620, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            { "id": "not-skip", "leftValue": "={{ $json.action }}", "rightValue": "skip", "operator": { "type": "string", "operation": "notEquals" } },
+            { "id": "not-error", "leftValue": "={{ $json.action }}", "rightValue": "error", "operator": { "type": "string", "operation": "notEquals" } }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "should-call",
+      "name": "Call API?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1840, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=http://pi6.local:3031/api/webhook/account/{{ $json.action }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-Project-ID", "value": "={{ $json.project_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ discord_user_id: $json.discord_user_id, ...(($json.action === 'set') ? { credits_remaining: $json.credits_remaining, credits_total: $json.credits_total } : {}), ...(($json.action === 'credit') ? { amount: $json.amount, reason: $json.reason } : {}) }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } }
+        }
+      },
+      "id": "call-api",
+      "name": "Call Credits API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2060, 0],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ received: true }) }}",
+        "options": { "responseCode": 200 }
+      },
+      "id": "respond-ok",
+      "name": "200 OK",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2280, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: $json.error }) }}",
+        "options": { "responseCode": "={{ $json.error?.code || 400 }}" }
+      },
+      "id": "respond-error",
+      "name": "Error Response",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1400, 420]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": { "main": [[{ "node": "Extract & Validate", "type": "main", "index": 0 }]] },
+    "Extract & Validate": { "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]] },
+    "Valid?": { "main": [[{ "node": "Get Secret (Redis)", "type": "main", "index": 0 }], [{ "node": "Error Response", "type": "main", "index": 0 }]] },
+    "Get Secret (Redis)": { "main": [[{ "node": "Verify Signature", "type": "main", "index": 0 }]] },
+    "Verify Signature": { "main": [[{ "node": "Sig Valid?", "type": "main", "index": 0 }]] },
+    "Sig Valid?": { "main": [[{ "node": "Process Event", "type": "main", "index": 0 }], [{ "node": "Error Response", "type": "main", "index": 0 }]] },
+    "Process Event": { "main": [[{ "node": "Call API?", "type": "main", "index": 0 }]] },
+    "Call API?": { "main": [[{ "node": "Call Credits API", "type": "main", "index": 0 }], [{ "node": "200 OK", "type": "main", "index": 0 }]] },
+    "Call Credits API": { "main": [[{ "node": "200 OK", "type": "main", "index": 0 }]] }
+  },
+  "settings": { "executionOrder": "v1" }
+}


### PR DESCRIPTION
## Summary
- Add `stripe-webhook-handler.json` workflow to handle Stripe webhook events (Phase 1)
- Add nginx proxy config for `stripe.azy.solutions`
- Fix Redis credential ID in `stripe-register-project.json`

## Events handled (Phase 1)
| Event | Action |
|-------|--------|
| `checkout.session.completed` | Set initial credits for new subscriber |
| `invoice.paid` | Credit account on renewal |
| `customer.subscription.deleted` | Reset credits to 0 |

## Workflow flow
1. Receive webhook at `/webhook/stripe-webhook/{project_id}`
2. Validate request parameters
3. Get webhook_secret from Redis (`project:{project_id}`)
4. Verify Stripe signature (⚠️ temporarily disabled - Web Crypto API not available)
5. Process event and call Credits API
6. Return 200 OK to Stripe

## Test plan
- [x] Test webhook endpoint with curl
- [x] Verify Redis integration (host3.local:6381 db=2)
- [x] Verify Credits API call works (HTTP Request node)
- [ ] Test with Stripe CLI (`stripe trigger checkout.session.completed`)

## Known limitations
- Signature verification is temporarily disabled because Web Crypto API is not available in n8n Code nodes
- For production, need to implement signature verification via external service or custom node

🤖 Generated with [Claude Code](https://claude.com/claude-code)