### PR TITLE
fix(recipes): correct Switch node structure for n8n compatibility

### DIFF
--- a/workflows/Recipes/recipes-generate.json
+++ b/workflows/Recipes/recipes-generate.json
@@ -66,30 +66,56 @@
       "position": [900, 200],
       "parameters": {
         "rules": {
-          "rules": [
+          "values": [
             {
               "outputKey": "anthropic",
               "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
                 "conditions": [
                   {
+                    "id": "cond-anthropic",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
                     "leftValue": "={{ $json.provider }}",
-                    "rightValue": "anthropic",
-                    "operator": { "type": "string", "operation": "equals" }
+                    "rightValue": "anthropic"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
               "outputKey": "openai",
               "conditions": {
+                "options": {
+                  "version": 2,
+                  "leftValue": "",
+                  "caseSensitive": true,
+                  "typeValidation": "strict"
+                },
+                "combinator": "and",
                 "conditions": [
                   {
+                    "id": "cond-openai",
+                    "operator": {
+                      "name": "filter.operator.equals",
+                      "type": "string",
+                      "operation": "equals"
+                    },
                     "leftValue": "={{ $json.provider }}",
-                    "rightValue": "openai",
-                    "operator": { "type": "string", "operation": "equals" }
+                    "rightValue": "openai"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             }
           ]
         },

--- a/workflows/Recipes/recipes-web-search.json
+++ b/workflows/Recipes/recipes-web-search.json
@@ -66,54 +66,70 @@
       "position": [900, 300],
       "parameters": {
         "rules": {
-          "rules": [
+          "values": [
             {
               "outputKey": "openai",
               "conditions": {
+                "options": { "version": 2, "leftValue": "", "caseSensitive": true, "typeValidation": "strict" },
+                "combinator": "and",
                 "conditions": [
                   {
+                    "id": "cond-openai",
+                    "operator": { "name": "filter.operator.equals", "type": "string", "operation": "equals" },
                     "leftValue": "={{ $json.provider_type }}",
-                    "rightValue": "openai",
-                    "operator": { "type": "string", "operation": "equals" }
+                    "rightValue": "openai"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
               "outputKey": "claude",
               "conditions": {
+                "options": { "version": 2, "leftValue": "", "caseSensitive": true, "typeValidation": "strict" },
+                "combinator": "and",
                 "conditions": [
                   {
+                    "id": "cond-claude",
+                    "operator": { "name": "filter.operator.equals", "type": "string", "operation": "equals" },
                     "leftValue": "={{ $json.provider_type }}",
-                    "rightValue": "claude",
-                    "operator": { "type": "string", "operation": "equals" }
+                    "rightValue": "claude"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
               "outputKey": "gemini",
               "conditions": {
+                "options": { "version": 2, "leftValue": "", "caseSensitive": true, "typeValidation": "strict" },
+                "combinator": "and",
                 "conditions": [
                   {
+                    "id": "cond-gemini",
+                    "operator": { "name": "filter.operator.equals", "type": "string", "operation": "equals" },
                     "leftValue": "={{ $json.provider_type }}",
-                    "rightValue": "gemini",
-                    "operator": { "type": "string", "operation": "equals" }
+                    "rightValue": "gemini"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             },
             {
               "outputKey": "mistral",
               "conditions": {
+                "options": { "version": 2, "leftValue": "", "caseSensitive": true, "typeValidation": "strict" },
+                "combinator": "and",
                 "conditions": [
                   {
+                    "id": "cond-mistral",
+                    "operator": { "name": "filter.operator.equals", "type": "string", "operation": "equals" },
                     "leftValue": "={{ $json.provider_type }}",
-                    "rightValue": "mistral",
-                    "operator": { "type": "string", "operation": "equals" }
+                    "rightValue": "mistral"
                   }
                 ]
-              }
+              },
+              "renameOutput": true
             }
           ]
         },


### PR DESCRIPTION
## Summary

Fix the Switch node structure in 2 recipe workflows that failed to activate with "Could not find property option" error.

### Changes:
- **recipes-generate.json**: Fixed Switch node for provider selection (anthropic/openai)
- **recipes-web-search.json**: Fixed Switch node for multi-provider routing (openai/claude/gemini/mistral)

### Technical fix:
- Changed `rules.rules` to `rules.values` (correct structure for Switch v3.2)
- Added required properties: `combinator`, `options`, `renameOutput`, `operator.name`

### Status after fix:
All 7 Recipes workflows now active:
- ✅ Recipes - Generate (bWoIVf6iAKdBcklI)
- ✅ Recipes - Search (5vuaukXUYQG8o0ap)
- ✅ Recipes - Similar (CsBYvSlTBJPxhHge)
- ✅ Recipes - Save (h6oeliX57qsiXrXM)
- ✅ Recipes - YouTube (qp0Rbo9xf0P2otz9)
- ✅ Recipes - Web Search (y5CIB2FbkF5JbtJ3)
- ✅ Recipes - Timer Notify (P4IPXi2JVP8PZhm3)

## Test plan
- [x] Import workflows to n8n
- [x] Activate all workflows successfully
- [ ] Test each webhook endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)