### PR TITLE
feat(recipes): complete comments/ratings workflows

### DIFF
--- a/docs/issues/RECIPES_COMMENTS_RATINGS.md
+++ b/docs/issues/RECIPES_COMMENTS_RATINGS.md
@@ -27,16 +27,16 @@
 | **COMMENTS** | | |
 | `POST /api/recipes/{id}/comments` | :white_check_mark: Existe | OK |
 | `GET /api/recipes/{id}/comments` | :white_check_mark: Existe | Pagination `offset/limit` |
-| `DELETE /api/recipes/{id}/comments/{id}` | :x: Manquant | A implementer |
+| `DELETE /api/recipes/{id}/comments/{id}` | :white_check_mark: Existe | Ownership check |
 | **RATINGS** | | |
 | `POST /api/recipes/{id}/rating` | :white_check_mark: Existe | Upsert OK |
-| `GET /api/recipes/{id}/ratings` | :x: Manquant | Stats + distribution |
+| `GET /api/recipes/{id}/ratings` | :white_check_mark: Existe | Stats + distribution |
 
-### Reste a faire (Equipe API)
+### Reste a faire (Equipe API) :white_check_mark: COMPLETE
 
-1. :x: Ajouter `DELETE /api/recipes/{id}/comments/{comment_id}`
-2. :x: Ajouter `GET /api/recipes/{id}/ratings` avec distribution
-3. :grey_question: Confirmer que `recipes.discord_user_id` existe et est retourne par GET
+1. :white_check_mark: `DELETE /api/recipes/{id}/comments/{comment_id}`
+2. :white_check_mark: `GET /api/recipes/{id}/ratings` avec distribution
+3. :white_check_mark: Confirmer que `recipes.discord_user_id` existe et est retourne par GET
 4. :grey_question: Optionnel: ajouter `discord_username` au schema comments
 
 ---
@@ -303,9 +303,9 @@ recipes.discord_user_id VARCHAR(50) NOT NULL
 |----------|---------|-------------|--------|
 | `recipes-add-comment.json` | `POST /webhook/recipes-add-comment` | :white_check_mark: | :white_check_mark: Actif |
 | `recipes-get-comments.json` | `GET /webhook/recipes-get-comments` | :white_check_mark: | :white_check_mark: Actif |
-| `recipes-delete-comment.json` | `DELETE /webhook/recipes-delete-comment` | :x: Attente | Bloque |
+| `recipes-delete-comment.json` | `DELETE /webhook/recipes-delete-comment` | :white_check_mark: | :white_check_mark: Actif |
 | `recipes-add-rating.json` | `POST /webhook/recipes-add-rating` | :white_check_mark: | :white_check_mark: Actif |
-| `recipes-get-ratings.json` | `GET /webhook/recipes-get-ratings` | :x: Attente | Bloque |
+| `recipes-get-ratings.json` | `GET /webhook/recipes-get-ratings` | :white_check_mark: | :white_check_mark: Actif |
 
 ### Workflow `recipes-add-comment` - Detail
 
@@ -319,22 +319,22 @@ Le workflow doit:
 
 ## 5. Plan d'Implementation
 
-### Phase 1 - Backend (Equipe API)
+### Phase 1 - Backend (Equipe API) :white_check_mark: COMPLETE
 - [x] Tables `recipe_comments` et `recipe_ratings`
 - [x] `POST /api/recipes/{id}/comments`
 - [x] `GET /api/recipes/{id}/comments`
 - [x] `POST /api/recipes/{id}/rating` (upsert)
-- [ ] **`DELETE /api/recipes/{id}/comments/{id}`**
-- [ ] **`GET /api/recipes/{id}/ratings`**
+- [x] `DELETE /api/recipes/{id}/comments/{id}`
+- [x] `GET /api/recipes/{id}/ratings`
 - [x] Confirmer `recipes.discord_user_id` accessible via GET
 
-### Phase 2 - Workflows (Equipe n8n)
+### Phase 2 - Workflows (Equipe n8n) :white_check_mark: COMPLETE
 - [x] `recipes-add-comment.json` avec notify
 - [x] `recipes-get-comments.json`
 - [x] `recipes-add-rating.json` avec notify
-- [ ] `recipes-delete-comment.json` (attente API)
-- [ ] `recipes-get-ratings.json` (attente API)
-- [x] Import et activation n8n (3/5 workflows)
+- [x] `recipes-delete-comment.json`
+- [x] `recipes-get-ratings.json`
+- [x] Import et activation n8n (5/5 workflows)
 
 ### Phase 3 - Plugin (Equipe Plugin)
 - [ ] UI Modal commentaires

--- a/workflows/Recipes/recipes-delete-comment.json
+++ b/workflows/Recipes/recipes-delete-comment.json
@@ -1,0 +1,127 @@
+{
+  "name": "RECIPES - Delete Comment",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RECIPES - Delete Comment\n\n**Endpoint:** DELETE /webhook/recipes-delete-comment\n\n**Parameters:**\n- `recipe_id` (required): ID de la recette\n- `comment_id` (required): ID du commentaire\n- `discord_user_id` (required): ID Discord (verification ownership)\n\n**Regles:**\n- Seul l'auteur du commentaire peut le supprimer",
+        "height": 260,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "DELETE",
+        "path": "recipes-delete-comment",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [300, 300],
+      "webhookId": "recipes-delete-comment"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst body = input.body || input;\nconst query = input.query || {};\n\n// Accept from body or query\nconst recipeId = body.recipe_id || query.recipe_id;\nconst commentId = body.comment_id || query.comment_id;\nconst discordUserId = body.discord_user_id || query.discord_user_id;\n\nconst errors = [];\nif (!recipeId) errors.push('recipe_id');\nif (!commentId) errors.push('comment_id');\nif (!discordUserId) errors.push('discord_user_id');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Parametres requis manquants: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    recipe_id: recipeId,\n    comment_id: commentId,\n    discord_user_id: discordUserId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [520, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [{ "id": "valid", "leftValue": "={{ $json.valid }}", "rightValue": true, "operator": { "type": "boolean", "operation": "equals" } }],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [740, 300]
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "={{ $env.TORAH_API_URL }}/api/recipes/{{ $json.recipe_id }}/comments/{{ $json.comment_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-Discord-User-ID", "value": "={{ $json.discord_user_id }}" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "fullResponse": true } }
+        }
+      },
+      "id": "delete-comment",
+      "name": "Delete Comment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [960, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const apiResponse = $input.first().json;\nconst inputData = $('Validate Input').first().json;\n\nconst statusCode = apiResponse.statusCode || 200;\nconst body = apiResponse.body || apiResponse;\n\nif (statusCode === 403) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 403,\n        message: 'Non autorise: vous ne pouvez supprimer que vos propres commentaires',\n        status: 'FORBIDDEN'\n      }\n    }\n  }];\n}\n\nif (statusCode === 404) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: `Commentaire '${inputData.comment_id}' non trouve`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.detail || 'Erreur lors de la suppression du commentaire',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    success: true,\n    message: 'Commentaire supprime',\n    deleted: {\n      recipe_id: inputData.recipe_id,\n      comment_id: inputData.comment_id\n    }\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1180, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 400) }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1400, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [960, 420]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": { "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]] },
+    "Validate Input": { "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]] },
+    "Valid?": { "main": [[{ "node": "Delete Comment", "type": "main", "index": 0 }], [{ "node": "Respond Error", "type": "main", "index": 0 }]] },
+    "Delete Comment": { "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]] },
+    "Format Response": { "main": [[{ "node": "Respond", "type": "main", "index": 0 }]] }
+  },
+  "settings": { "executionOrder": "v1" }
+}

--- a/workflows/Recipes/recipes-get-ratings.json
+++ b/workflows/Recipes/recipes-get-ratings.json
@@ -1,0 +1,124 @@
+{
+  "name": "RECIPES - Get Ratings",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RECIPES - Get Ratings\n\n**Endpoint:** GET /webhook/recipes-get-ratings\n\n**Query Parameters:**\n- `recipe_id` (required): ID de la recette\n- `discord_user_id` (optional): Pour inclure la note de l'utilisateur\n\n**Response:**\n- avg_rating, rating_count\n- distribution (1-5)\n- user_rating (si discord_user_id fourni)",
+        "height": 280,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "recipes-get-ratings",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [300, 300],
+      "webhookId": "recipes-get-ratings"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst query = input.query || {};\n\nconst recipeId = query.recipe_id || null;\nconst discordUserId = query.discord_user_id || null;\n\nif (!recipeId) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Parametre requis manquant: recipe_id',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    recipe_id: recipeId,\n    discord_user_id: discordUserId\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [520, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [{ "id": "valid", "leftValue": "={{ $json.valid }}", "rightValue": true, "operator": { "type": "boolean", "operation": "equals" } }],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [740, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/recipes/{{ $json.recipe_id }}/ratings{{ $json.discord_user_id ? '?discord_user_id=' + $json.discord_user_id : '' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [{ "name": "Content-Type", "value": "application/json" }]
+        },
+        "options": {
+          "response": { "response": { "fullResponse": true } }
+        }
+      },
+      "id": "get-ratings",
+      "name": "Get Ratings",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [960, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const apiResponse = $input.first().json;\nconst inputData = $('Validate Input').first().json;\n\nconst statusCode = apiResponse.statusCode || 200;\nconst body = apiResponse.body || apiResponse;\n\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.detail || 'Erreur lors de la recuperation des notes',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Format response\nconst response = {\n  success: true,\n  recipe_id: body.recipe_id || inputData.recipe_id,\n  avg_rating: body.avg_rating || 0,\n  rating_count: body.rating_count || 0,\n  distribution: body.distribution || { '1': 0, '2': 0, '3': 0, '4': 0, '5': 0 }\n};\n\n// Include user_rating if requested and available\nif (inputData.discord_user_id) {\n  response.user_rating = body.user_rating !== undefined ? body.user_rating : null;\n}\n\nreturn [{ json: response }];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1180, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 400) }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1400, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [960, 420]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": { "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]] },
+    "Validate Input": { "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]] },
+    "Valid?": { "main": [[{ "node": "Get Ratings", "type": "main", "index": 0 }], [{ "node": "Respond Error", "type": "main", "index": 0 }]] },
+    "Get Ratings": { "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]] },
+    "Format Response": { "main": [[{ "node": "Respond", "type": "main", "index": 0 }]] }
+  },
+  "settings": { "executionOrder": "v1" }
+}


### PR DESCRIPTION
## Summary

- Add `recipes-delete-comment.json` workflow (DELETE comment with ownership check)
- Add `recipes-get-ratings.json` workflow (GET rating stats with distribution)
- All 5 comments/ratings workflows now complete and active

## Workflows

| Workflow | Webhook | Status |
|----------|---------|--------|
| `recipes-add-comment.json` | `POST /webhook/recipes-add-comment` | :white_check_mark: Actif |
| `recipes-get-comments.json` | `GET /webhook/recipes-get-comments` | :white_check_mark: Actif |
| `recipes-delete-comment.json` | `DELETE /webhook/recipes-delete-comment` | :white_check_mark: Actif |
| `recipes-add-rating.json` | `POST /webhook/recipes-add-rating` | :white_check_mark: Actif |
| `recipes-get-ratings.json` | `GET /webhook/recipes-get-ratings` | :white_check_mark: Actif |

## Features

- All workflows use `$env.TORAH_API_URL` (no hardcoded URLs)
- `add-comment` and `add-rating` include `notify` object for DM notifications
- `delete-comment` validates ownership via `X-Discord-User-ID` header
- `get-ratings` returns avg, count, distribution, and user_rating

## Test plan

- [x] Import and activate all workflows in n8n
- [x] Verify no webhook conflicts
- [ ] Plugin team integration testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)