### PR TITLE
feat(discord): add billing-portal workflow for subscription management

### DIFF
--- a/workflows/Discord/discord-billing-portal.json
+++ b/workflows/Discord/discord-billing-portal.json
@@ -1,0 +1,490 @@
+{
+  "name": "DISCORD - Billing Portal",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## DISCORD - Billing Portal\n\n**Endpoint:** POST /webhook/discord-billing-portal\n\n**Description:** Cree une session Stripe Billing Portal pour gerer l'abonnement.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah-fun\",\n  \"discord_user_id\": \"123456789\"\n}\n```\n\n**Flow:**\n1. Valider les parametres\n2. Recuperer stripe_customer_id depuis Torah API\n3. Recuperer stripe_key depuis Redis\n4. Creer session Stripe Billing Portal\n5. Retourner l'URL du portal\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"portal_url\": \"https://billing.stripe.com/session/xxx\",\n  \"return_url\": \"https://torah-fun.solutions/subscription\"\n}\n```\n\n**Use Cases:**\n- Changer de plan (upgrade/downgrade)\n- Mettre a jour le moyen de paiement\n- Annuler l'abonnement\n- Voir les factures",
+        "height": 520,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord-billing-portal",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "discord-billing-portal"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Valider les parametres requis\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst projectId = body.project_id || null;\nconst discordUserId = body.discord_user_id || null;\n\nconst errors = [];\nif (!projectId) errors.push('project_id');\nif (!discordUserId) errors.push('discord_user_id');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Parametres requis manquants: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    project_id: projectId,\n    discord_user_id: discordUserId,\n    redis_key: `project:${projectId}`\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/subscription/status/{{ $json.discord_user_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "get-subscriber",
+      "name": "Get Subscriber (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extraire le stripe_customer_id de la reponse API\nconst apiResponse = $input.first().json;\nconst inputData = $('Validate Input').first().json;\n\nconst statusCode = apiResponse.statusCode || 200;\nconst body = apiResponse.body || apiResponse;\n\n// Verifier si l'utilisateur existe\nif (statusCode === 404 || !body || body.error) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: 'Utilisateur non trouve. Vous devez d\\'abord souscrire a un plan.',\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Verifier si l'utilisateur a un stripe_customer_id\nconst stripeCustomerId = body.stripe_customer_id;\n\nif (!stripeCustomerId) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 400,\n        message: 'Aucun abonnement Stripe trouve. Utilisez /subscribe pour souscrire.',\n        status: 'NO_SUBSCRIPTION'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    found: true,\n    project_id: inputData.project_id,\n    discord_user_id: inputData.discord_user_id,\n    stripe_customer_id: stripeCustomerId,\n    redis_key: inputData.redis_key\n  }\n}];"
+      },
+      "id": "check-subscriber",
+      "name": "Check Subscriber",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "subscriber-found",
+      "name": "Subscriber Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "key": "={{ $json.redis_key }}"
+      },
+      "id": "get-stripe-config",
+      "name": "Get Stripe Config (Redis)",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [1760, 100],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verifier que le projet existe dans Redis et extraire stripe_key\nconst redisResult = $('Get Stripe Config (Redis)').first();\nconst inputData = $('Check Subscriber').first().json;\n\n// Verifier si Redis a retourne une erreur\nconst redisJson = redisResult?.json || {};\nif (redisJson.error || redisJson.message?.includes('ECONNREFUSED')) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 503,\n        message: 'Service Redis indisponible',\n        status: 'SERVICE_UNAVAILABLE'\n      }\n    }\n  }];\n}\n\n// Redis retourne la valeur dans propertyName, value, ou directement\nconst rawValue = redisJson.propertyName || redisJson.value || redisJson;\n\nif (!rawValue || rawValue === null || rawValue === 'null') {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Projet '${inputData.project_id}' non enregistre.`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Parser le JSON stocke dans Redis\nlet project;\ntry {\n  project = typeof rawValue === 'string' ? JSON.parse(rawValue) : rawValue;\n} catch (e) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 500,\n        message: `Erreur parsing Redis: ${e.message}`,\n        status: 'INTERNAL_ERROR'\n      }\n    }\n  }];\n}\n\nif (!project.stripe_key) {\n  return [{\n    json: {\n      found: false,\n      error: {\n        code: 404,\n        message: `Projet '${inputData.project_id}' n'a pas de cle Stripe configuree`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    found: true,\n    project_id: inputData.project_id,\n    discord_user_id: inputData.discord_user_id,\n    stripe_customer_id: inputData.stripe_customer_id,\n    stripe_key: project.stripe_key,\n    return_url: `https://${inputData.project_id}.solutions/subscription`\n  }\n}];"
+      },
+      "id": "check-project",
+      "name": "Check Project",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-project-found",
+              "leftValue": "={{ $json.found }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "project-found",
+      "name": "Project Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2200, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.stripe.com/v1/billing_portal/sessions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.stripe_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/x-www-form-urlencoded"
+            }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "name": "customer",
+              "value": "={{ $json.stripe_customer_id }}"
+            },
+            {
+              "name": "return_url",
+              "value": "={{ $json.return_url }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          }
+        }
+      },
+      "id": "create-portal-session",
+      "name": "Create Portal Session",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2420, 0],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Formater la reponse Stripe Billing Portal\nconst input = $input.first().json;\nconst projectData = $('Check Project').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst data = input.body || input;\n\n// Verifier les erreurs Stripe\nif (statusCode >= 400 || data.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.error?.message || 'Erreur Stripe Billing Portal',\n        status: 'STRIPE_ERROR',\n        type: data.error?.type || 'api_error'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    success: true,\n    portal_url: data.url,\n    return_url: projectData.return_url,\n    project_id: projectData.project_id,\n    discord_user_id: projectData.discord_user_id,\n    expires_at: new Date(data.created * 1000 + 300000).toISOString() // 5 min expiry\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2640, 0]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2860, 0]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 420]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 404 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 500 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-project-error",
+      "name": "Respond Project Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2420, 200]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Subscriber (API)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Subscriber (API)": {
+      "main": [
+        [
+          {
+            "node": "Check Subscriber",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Subscriber": {
+      "main": [
+        [
+          {
+            "node": "Subscriber Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Subscriber Found?": {
+      "main": [
+        [
+          {
+            "node": "Get Stripe Config (Redis)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Stripe Config (Redis)": {
+      "main": [
+        [
+          {
+            "node": "Check Project",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Project": {
+      "main": [
+        [
+          {
+            "node": "Project Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Project Found?": {
+      "main": [
+        [
+          {
+            "node": "Create Portal Session",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Project Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Portal Session": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- New workflow `DISCORD - Billing Portal` for managing Stripe subscriptions
- Endpoint: `POST /webhook/discord-billing-portal`

## Features
- Validates input parameters (project_id, discord_user_id)
- Retrieves stripe_customer_id from Torah API
- Gets stripe_key from Redis project config
- Creates Stripe Billing Portal session
- Returns portal URL for subscription management

## Use Cases
- Upgrade/downgrade subscription plan
- Update payment method
- Cancel subscription
- View invoices

## API Specification

**Input:**
```json
{
  "project_id": "torah-fun",
  "discord_user_id": "123456789"
}
```

**Output:**
```json
{
  "success": true,
  "portal_url": "https://billing.stripe.com/session/xxx",
  "return_url": "https://torah-fun.solutions/subscription"
}
```

## Related
- Chatbot Core PR #72 (implements /plan command with Billing Portal button)

## Test plan
- [ ] Test with user without Stripe subscription (should return error)
- [ ] Test with user with Stripe subscription (should return portal_url)

🤖 Generated with [Claude Code](https://claude.com/claude-code)