### PR TITLE
docs: Discord DM notification specs for API and n8n teams

### DIFF
--- a/docs/issues/dm-notification-api.md
+++ b/docs/issues/dm-notification-api.md
@@ -1,0 +1,410 @@
+# Documentation API - Notification Discord après Stripe
+
+**Date:** 2026-01-08
+**Version:** 1.0
+**Statut:** Spécification
+
+---
+
+## Contexte
+
+Après un paiement Stripe réussi, n8n appelle l'API Torah pour notifier le bot Discord. L'API doit :
+1. Valider la requête
+2. Publier un message dans Redis Streams
+3. Le bot Discord consomme ces messages pour envoyer DM, messages canal, et créer des salles privées
+
+---
+
+## Architecture
+
+```
+n8n                        API Torah                    Redis                    Bot Discord
+────                       ─────────                    ─────                    ───────────
+  │                            │                          │                          │
+  │  POST /api/discord/notify  │                          │                          │
+  │───────────────────────────▶│                          │                          │
+  │                            │                          │                          │
+  │                            │  XADD discord:dm:{pid}   │                          │
+  │                            │─────────────────────────▶│                          │
+  │                            │                          │                          │
+  │         200 OK             │                          │                          │
+  │◀───────────────────────────│                          │                          │
+  │                            │                          │                          │
+  │                            │                          │  XREADGROUP              │
+  │                            │                          │◀─────────────────────────│
+  │                            │                          │                          │
+  │                            │                          │  Message data            │
+  │                            │                          │─────────────────────────▶│
+  │                            │                          │                          │
+  │                            │                          │                     Send DM
+  │                            │                          │                     Send Channel
+  │                            │                          │                     Create Room
+```
+
+---
+
+## Endpoint à créer
+
+### `POST /api/discord/notify`
+
+#### Headers requis
+
+| Header | Valeur | Description |
+|--------|--------|-------------|
+| `Authorization` | `Bearer {API_KEY}` | Clé API n8n |
+| `Content-Type` | `application/json` | Type de contenu |
+
+#### Body de la requête
+
+```json
+{
+  "project_id": "torah-fun",
+  "user_id": "636639897767378954",
+  "username": "fsebbah",
+  "guild_id": "815368074995040286",
+  "channel_id": "123456789012345678",
+  "event": "checkout_completed",
+  "plan_id": "premium",
+  "credits": 1000,
+  "embed": {
+    "title": "Bienvenue Premium !",
+    "description": "1000 crédits ajoutés.",
+    "color": 5763719
+  },
+  "actions": {
+    "send_dm": true,
+    "send_channel_message": true,
+    "create_private_channel": true
+  }
+}
+```
+
+#### Champs
+
+| Champ | Type | Obligatoire | Description |
+|-------|------|-------------|-------------|
+| `project_id` | string | ✅ | ID du projet (torah-fun, bot-appetit) |
+| `user_id` | string | ✅ | Discord user ID |
+| `username` | string | ❌ | Discord username (pour logs) |
+| `guild_id` | string | ✅ | Discord server ID |
+| `channel_id` | string | ✅ | Canal où /subscribe a été utilisé |
+| `event` | string | ✅ | Type d'événement Stripe |
+| `plan_id` | string | ❌ | ID du plan souscrit |
+| `credits` | number | ❌ | Crédits ajoutés |
+| `embed` | object | ❌ | Embed Discord par défaut |
+| `actions` | object | ❌ | Actions à effectuer (défaut: tout à true) |
+
+#### Events supportés
+
+| Event | Description |
+|-------|-------------|
+| `checkout_completed` | Premier paiement réussi |
+| `renewal` | Renouvellement mensuel |
+| `subscription_deleted` | Annulation |
+| `payment_failed` | Échec de paiement |
+
+#### Réponses
+
+**Succès (200)**
+```json
+{
+  "success": true,
+  "message_id": "1704672000000-0",
+  "stream": "discord:dm:torah-fun"
+}
+```
+
+**Erreur validation (400)**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 400,
+    "message": "Missing required field: user_id"
+  }
+}
+```
+
+**Erreur auth (401)**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 401,
+    "message": "Invalid API key"
+  }
+}
+```
+
+**Erreur serveur (500)**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 500,
+    "message": "Redis connection failed"
+  }
+}
+```
+
+---
+
+## Implémentation Redis
+
+### Configuration Redis
+
+| Paramètre | Valeur |
+|-----------|--------|
+| Host | `host3.local` |
+| Port | `6381` |
+| Database | `0` (queue DM) |
+| Version | `8.4.0` |
+
+### Pattern de stream
+
+Un stream par projet pour permettre la scalabilité :
+
+```
+discord:dm:{project_id}
+```
+
+Exemples :
+- `discord:dm:torah-fun`
+- `discord:dm:bot-appetit`
+- `discord:dm:recipes`
+
+### Commande XADD
+
+```python
+import redis
+import json
+import time
+
+def notify_discord(data: dict) -> str:
+    r = redis.Redis(host='host3.local', port=6381, db=0)
+
+    stream_key = f"discord:dm:{data['project_id']}"
+
+    message = {
+        'user_id': data['user_id'],
+        'username': data.get('username', ''),
+        'guild_id': data['guild_id'],
+        'channel_id': data['channel_id'],
+        'event': data['event'],
+        'plan_id': data.get('plan_id', ''),
+        'credits': str(data.get('credits', 0)),
+        'embed': json.dumps(data.get('embed', {})),
+        'actions': json.dumps(data.get('actions', {
+            'send_dm': True,
+            'send_channel_message': True,
+            'create_private_channel': True
+        })),
+        'timestamp': str(int(time.time()))
+    }
+
+    message_id = r.xadd(stream_key, message)
+    return message_id
+```
+
+### Structure du message dans le stream
+
+```
+XADD discord:dm:torah-fun * \
+  user_id "636639897767378954" \
+  username "fsebbah" \
+  guild_id "815368074995040286" \
+  channel_id "123456789012345678" \
+  event "checkout_completed" \
+  plan_id "premium" \
+  credits "1000" \
+  embed '{"title":"Bienvenue Premium !","description":"1000 crédits ajoutés.","color":5763719}' \
+  actions '{"send_dm":true,"send_channel_message":true,"create_private_channel":true}' \
+  timestamp "1704672000"
+```
+
+### Création du consumer group (à faire une seule fois)
+
+```bash
+redis-cli -h host3.local -p 6381 XGROUP CREATE discord:dm:torah-fun dm-listeners $ MKSTREAM
+redis-cli -h host3.local -p 6381 XGROUP CREATE discord:dm:bot-appetit dm-listeners $ MKSTREAM
+```
+
+---
+
+## Exemple d'implémentation (FastAPI)
+
+```python
+from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+import redis
+import json
+import time
+import os
+
+app = FastAPI()
+
+REDIS_HOST = os.getenv('REDIS_HOST', 'host3.local')
+REDIS_PORT = int(os.getenv('REDIS_PORT', 6381))
+REDIS_DB = int(os.getenv('REDIS_DM_DB', 0))
+API_KEY = os.getenv('N8N_API_KEY')
+
+r = redis.Redis(host=REDIS_HOST, port=REDIS_PORT, db=REDIS_DB, decode_responses=True)
+
+
+class Actions(BaseModel):
+    send_dm: bool = True
+    send_channel_message: bool = True
+    create_private_channel: bool = True
+
+
+class Embed(BaseModel):
+    title: str
+    description: str
+    color: int = 5763719
+
+
+class NotifyRequest(BaseModel):
+    project_id: str
+    user_id: str
+    username: Optional[str] = None
+    guild_id: str
+    channel_id: str
+    event: str
+    plan_id: Optional[str] = None
+    credits: Optional[int] = 0
+    embed: Optional[Embed] = None
+    actions: Optional[Actions] = Actions()
+
+
+@app.post("/api/discord/notify")
+async def notify_discord(
+    request: NotifyRequest,
+    authorization: str = Header(...)
+):
+    # Vérifier l'API key
+    if not authorization.startswith('Bearer ') or authorization[7:] != API_KEY:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    # Construire le stream key
+    stream_key = f"discord:dm:{request.project_id}"
+
+    # Préparer le message
+    message = {
+        'user_id': request.user_id,
+        'username': request.username or '',
+        'guild_id': request.guild_id,
+        'channel_id': request.channel_id,
+        'event': request.event,
+        'plan_id': request.plan_id or '',
+        'credits': str(request.credits),
+        'embed': json.dumps(request.embed.dict() if request.embed else {}),
+        'actions': json.dumps(request.actions.dict()),
+        'timestamp': str(int(time.time()))
+    }
+
+    try:
+        # XADD vers Redis
+        message_id = r.xadd(stream_key, message)
+
+        return {
+            "success": True,
+            "message_id": message_id,
+            "stream": stream_key
+        }
+    except redis.RedisError as e:
+        raise HTTPException(status_code=500, detail=f"Redis error: {str(e)}")
+```
+
+---
+
+## Migration depuis /api/discord/send-dm
+
+Si l'endpoint `/api/discord/send-dm` existe déjà :
+
+| Aspect | Ancien (`send-dm`) | Nouveau (`notify`) |
+|--------|--------------------|--------------------|
+| Champs | 5 | 11 |
+| Actions | Non | Oui |
+| Stream | `discord:dm` | `discord:dm:{project_id}` |
+| Multi-projet | Non | Oui |
+
+### Option 1 : Remplacer
+
+Supprimer `/api/discord/send-dm` et utiliser uniquement `/api/discord/notify`.
+
+### Option 2 : Adapter
+
+Garder `/api/discord/send-dm` comme alias qui redirige vers `/api/discord/notify` avec des valeurs par défaut.
+
+---
+
+## Tests
+
+### Test avec curl
+
+```bash
+curl -X POST http://pi6.local:3031/api/discord/notify \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "project_id": "torah-fun",
+    "user_id": "636639897767378954",
+    "username": "fsebbah",
+    "guild_id": "815368074995040286",
+    "channel_id": "123456789012345678",
+    "event": "checkout_completed",
+    "plan_id": "premium",
+    "credits": 1000,
+    "embed": {
+      "title": "Test Notification",
+      "description": "Ceci est un test",
+      "color": 5763719
+    },
+    "actions": {
+      "send_dm": true,
+      "send_channel_message": false,
+      "create_private_channel": false
+    }
+  }'
+```
+
+### Vérifier le stream Redis
+
+```bash
+redis-cli -h host3.local -p 6381 XRANGE discord:dm:torah-fun - + COUNT 5
+```
+
+---
+
+## Checklist API
+
+- [ ] Créer endpoint `POST /api/discord/notify`
+- [ ] Valider les champs obligatoires
+- [ ] Vérifier l'API key
+- [ ] Implémenter XADD vers Redis Streams
+- [ ] Pattern de stream par projet : `discord:dm:{project_id}`
+- [ ] Créer les consumer groups pour chaque projet
+- [ ] Retourner le message_id dans la réponse
+- [ ] Logger les erreurs
+- [ ] Tester avec curl
+- [ ] Documenter l'API key dans les variables d'environnement
+
+---
+
+## Variables d'environnement requises
+
+```env
+# Redis
+REDIS_HOST=host3.local
+REDIS_PORT=6381
+REDIS_DM_DB=0
+
+# API Key pour n8n
+N8N_API_KEY=your_api_key_here
+```
+
+---
+
+*Document créé le 2026-01-08 - Équipe n8n*
+*À destination de l'équipe API Torah*

--- a/docs/issues/dm-notification-n8n.md
+++ b/docs/issues/dm-notification-n8n.md
@@ -1,0 +1,302 @@
+# Documentation n8n - Notification Discord après Stripe
+
+## Contexte
+
+Après un paiement Stripe réussi, n8n doit transmettre les informations nécessaires pour que le bot Discord puisse :
+1. Envoyer un DM à l'utilisateur
+2. Envoyer un message dans le canal d'origine
+3. Créer une salle privée pour l'utilisateur
+
+## Modifications requises
+
+### 1. Workflow /subscribe (plugin)
+
+Le plugin doit stocker des métadonnées supplémentaires lors de la création de la session Stripe :
+
+```javascript
+// Métadonnées à envoyer à Stripe lors du checkout
+{
+  "discord_user_id": "636639897767378954",
+  "discord_username": "fsebbah",
+  "discord_channel_id": "123456789012345678",  // NOUVEAU
+  "discord_guild_id": "815368074995040286",    // NOUVEAU
+  "project_id": "torah-fun",
+  "plan_id": "premium"
+}
+```
+
+### 2. Workflow STRIPE - Webhook Handler
+
+Après "Call Credits API", ajouter un node HTTP pour notifier le bot :
+
+```
+HTTP Request
+├── Method: POST
+├── URL: {{ $env.TORAH_API_URL }}/api/discord/notify
+├── Headers:
+│   └── Authorization: Bearer {{ $env.N8N_API_KEY }}
+└── Body: voir ci-dessous
+```
+
+### 3. Format du body à envoyer
+
+```json
+{
+  "project_id": "torah-fun",
+  "user_id": "636639897767378954",
+  "username": "fsebbah",
+  "guild_id": "815368074995040286",
+  "channel_id": "123456789012345678",
+  "event": "checkout_completed",
+  "plan_id": "premium",
+  "credits": 1000,
+  "embed": {
+    "title": "Bienvenue Premium !",
+    "description": "1000 crédits ajoutés.",
+    "color": 5763719
+  },
+  "actions": {
+    "send_dm": true,
+    "send_channel_message": true,
+    "create_private_channel": true
+  }
+}
+```
+
+## Champs requis
+
+| Champ | Type | Description | Obligatoire |
+|-------|------|-------------|-------------|
+| `project_id` | string | ID du projet (torah-fun, bot-appetit) | ✅ |
+| `user_id` | string | Discord user ID | ✅ |
+| `username` | string | Discord username | ✅ |
+| `guild_id` | string | Discord server ID | ✅ |
+| `channel_id` | string | Canal où /subscribe a été utilisé | ✅ |
+| `event` | string | Type d'événement | ✅ |
+| `plan_id` | string | ID du plan souscrit | ✅ |
+| `credits` | number | Crédits ajoutés | ❌ |
+| `embed` | object | Embed par défaut | ❌ |
+| `actions` | object | Actions à effectuer | ❌ |
+
+## Events supportés
+
+| Event | Description |
+|-------|-------------|
+| `checkout_completed` | Premier paiement réussi |
+| `subscription_renewed` | Renouvellement mensuel |
+| `subscription_cancelled` | Annulation |
+| `payment_failed` | Échec de paiement |
+
+## Actions disponibles
+
+| Action | Description | Défaut |
+|--------|-------------|--------|
+| `send_dm` | Envoyer un DM à l'utilisateur | `true` |
+| `send_channel_message` | Message dans le canal d'origine | `true` |
+| `create_private_channel` | Créer une salle privée | `true` |
+
+## Flux complet
+
+```
+Stripe Webhook
+      │
+      ▼
+n8n reçoit l'événement
+      │
+      ├── Verify signature (Torah API)
+      │
+      ├── Set Credits (Torah API)
+      │
+      └── POST /api/discord/notify  ← NOUVEAU
+              │
+              ▼
+        Torah API
+              │
+              └── XADD Redis discord:dm:{project_id}
+                        │
+                        ▼
+                  Bot Discord (DMListener)
+                        │
+                        ├── DM
+                        ├── Message canal
+                        └── Salle privée
+```
+
+## Exemple Switch par event
+
+Pour personnaliser les messages selon l'événement :
+
+```
+Switch Node (event_type)
+├── checkout_completed → Embed "Bienvenue !"
+├── subscription_renewed → Embed "Merci pour votre fidélité"
+├── subscription_cancelled → Embed "À bientôt"
+└── payment_failed → Embed "Problème de paiement"
+```
+
+## Variables disponibles dans n8n
+
+| Variable | Source |
+|----------|--------|
+| `{{ $json.discord_user_id }}` | Metadata Stripe |
+| `{{ $json.discord_username }}` | Metadata Stripe |
+| `{{ $json.discord_channel_id }}` | Metadata Stripe |
+| `{{ $json.discord_guild_id }}` | Metadata Stripe |
+| `{{ $json.project_id }}` | Metadata Stripe |
+| `{{ $json.plan_id }}` | Stripe price/product |
+| `{{ $json.credits_per_month }}` | Config n8n |
+
+## Checklist n8n
+
+- [ ] Vérifier que le plugin envoie `channel_id` et `guild_id` dans metadata Stripe
+- [ ] Ajouter node HTTP après "Call Credits API"
+- [ ] Configurer le body avec tous les champs requis
+- [ ] Tester avec un paiement Stripe de test
+
+---
+
+## État actuel du code n8n (PR #212)
+
+### Ce qui a été implémenté
+
+Le workflow `STRIPE - Webhook Handler` a été mis à jour (PR #212 mergée) avec :
+
+1. **Node "HTTP Request"** ajouté après "Call Credits API"
+2. **Endpoint actuel** : `POST {{ $env.TORAH_API_URL }}/api/discord/send-dm`
+3. **Payload actuel** :
+```json
+{
+  "user_id": "{{ $json.discord_user_id }}",
+  "event": "{{ $json.reason }}",
+  "project_id": "{{ $json.project_id }}",
+  "credits": {{ $json.credits_remaining }},
+  "embed": {
+    "title": "Bienvenue Premium !",
+    "description": "{{ $json.credits_remaining }} crédits ajoutés.",
+    "color": 5763719
+  }
+}
+```
+
+### Champs actuellement extraits des metadata Stripe
+
+| Champ | Extrait | Transmis |
+|-------|---------|----------|
+| `discord_user_id` | ✅ | ✅ |
+| `project_id` | ✅ | ✅ |
+| `credits_per_month` | ✅ | ✅ |
+| `discord_channel_id` | ❌ | ❌ |
+| `discord_guild_id` | ❌ | ❌ |
+| `discord_username` | ❌ | ❌ |
+| `plan_id` | ❌ | ❌ |
+
+---
+
+## Modifications requises (Phase 2)
+
+### Dépendance : Équipe Plugin
+
+**n8n ne peut pas extraire des champs qui n'existent pas dans les metadata Stripe.**
+
+Avant toute modification n8n, les plugins doivent envoyer ces champs lors de la création du checkout :
+- `discord_channel_id`
+- `discord_guild_id`
+- `discord_username`
+- `plan_id`
+
+### Modifications n8n une fois les plugins mis à jour
+
+#### 1. Node "Extract & Validate"
+
+Ajouter l'extraction des nouveaux champs :
+```javascript
+// Champs actuels
+const projectId = metadata.project_id;
+const discordUserId = metadata.discord_user_id;
+const creditsPerMonth = metadata.credits_per_month || "1000";
+
+// Nouveaux champs à extraire
+const discordChannelId = metadata.discord_channel_id;
+const discordGuildId = metadata.discord_guild_id;
+const discordUsername = metadata.discord_username;
+const planId = metadata.plan_id;
+```
+
+#### 2. Node "Process Event"
+
+Propager les nouveaux champs dans le payload :
+```javascript
+payload.discord_channel_id = metadata.discord_channel_id;
+payload.discord_guild_id = metadata.discord_guild_id;
+payload.discord_username = metadata.discord_username;
+payload.plan_id = metadata.plan_id;
+```
+
+#### 3. Node "HTTP Request"
+
+| Aspect | Actuel | Cible |
+|--------|--------|-------|
+| Endpoint | `/api/discord/send-dm` | `/api/discord/notify` |
+| Champs | 5 | 11 |
+| Actions | Non | Oui |
+
+Nouveau body complet :
+```json
+{
+  "project_id": "{{ $json.project_id }}",
+  "user_id": "{{ $json.discord_user_id }}",
+  "username": "{{ $json.discord_username }}",
+  "guild_id": "{{ $json.discord_guild_id }}",
+  "channel_id": "{{ $json.discord_channel_id }}",
+  "event": "{{ $json.reason }}",
+  "plan_id": "{{ $json.plan_id }}",
+  "credits": {{ $json.credits_remaining }},
+  "embed": {
+    "title": "Bienvenue Premium !",
+    "description": "{{ $json.credits_remaining }} crédits ajoutés.",
+    "color": 5763719
+  },
+  "actions": {
+    "send_dm": true,
+    "send_channel_message": true,
+    "create_private_channel": true
+  }
+}
+```
+
+---
+
+## Ordre des modifications
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  1. PLUGIN  │  Ajouter metadata Stripe                      │
+│             │  (channel_id, guild_id, username, plan_id)    │
+├─────────────┼───────────────────────────────────────────────┤
+│  2. API     │  Créer endpoint /api/discord/notify           │
+│             │  Implémenter XADD vers Redis                  │
+├─────────────┼───────────────────────────────────────────────┤
+│  3. N8N     │  Extraire nouveaux champs                     │
+│             │  Modifier HTTP Request                        │
+├─────────────┼───────────────────────────────────────────────┤
+│  4. BOT     │  Implémenter DMListener avec XREADGROUP       │
+└─────────────┴───────────────────────────────────────────────┘
+```
+
+---
+
+## Checklist n8n
+
+- [x] Ajouter node HTTP après "Call Credits API" (PR #212)
+- [x] Configurer le body minimal (user_id, event, credits, embed)
+- [ ] **ATTENDRE** : Plugin doit ajouter metadata supplémentaires
+- [ ] **ATTENDRE** : API doit exposer `/api/discord/notify`
+- [ ] Extraire `channel_id`, `guild_id`, `username`, `plan_id` des metadata
+- [ ] Modifier endpoint vers `/api/discord/notify`
+- [ ] Ajouter objet `actions` dans le body
+- [ ] Tester avec un paiement Stripe de test
+
+---
+
+*Document créé le 2026-01-08 - Équipe chatbot-core*
+*Mis à jour le 2026-01-08 - Équipe n8n (PR #212 mergée)*


### PR DESCRIPTION
## Summary
- Update `dm-notification-n8n.md` with current implementation state (PR #212 merged) and Phase 2 requirements
- Add `dm-notification-api.md` with complete API specification for the `/api/discord/notify` endpoint

## Documents

### dm-notification-n8n.md (updated)
- Current state: what's implemented in PR #212
- Fields currently extracted vs fields needed
- Modifications required once plugins add metadata
- Order of modifications across teams
- Updated checklist

### dm-notification-api.md (new)
- Endpoint specification: `POST /api/discord/notify`
- Request/response formats
- Redis Streams implementation (XADD)
- Stream pattern: `discord:dm:{project_id}`
- FastAPI example implementation
- Testing procedures
- Environment variables

## Order of implementation
```
1. PLUGIN  → Add metadata to Stripe checkout
2. API     → Create /api/discord/notify endpoint (this doc)
3. N8N     → Extract new fields, update HTTP Request
4. BOT     → Implement DMListener with XREADGROUP
```

Related to #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)