### PR TITLE
fix(recipes): update Claude web search to new API format

### DIFF
--- a/workflows/Recipes/recipes-web-search.json
+++ b/workflows/Recipes/recipes-web-search.json
@@ -175,13 +175,12 @@
           "parameters": [
             { "name": "x-api-key", "value": "={{ $json.anthropic_api_key }}" },
             { "name": "anthropic-version", "value": "2023-06-01" },
-            { "name": "anthropic-beta", "value": "web-search-2024-10-22" },
             { "name": "Content-Type", "value": "application/json" }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"{{ $json.provider === 'claude-haiku' ? 'claude-3-5-haiku-latest' : 'claude-sonnet-4-20250514' }}\",\n  \"max_tokens\": 4096,\n  \"tools\": [{\n    \"type\": \"web_search\",\n    \"name\": \"web_search\"\n    {{ $json.options.allowed_domains.length > 0 ? ', \"allowed_domains\": ' + JSON.stringify($json.options.allowed_domains) : '' }}\n    {{ $json.options.blocked_domains.length > 0 ? ', \"blocked_domains\": ' + JSON.stringify($json.options.blocked_domains) : '' }}\n  }],\n  \"messages\": [{\n    \"role\": \"user\",\n    \"content\": \"Recherche sur le web les meilleures recettes pour: {{ $json.query }}. Trouve {{ $json.options.max_results }} recettes avec leurs sources et URLs. Réponds en {{ $json.options.language === 'fr' ? 'français' : 'anglais' }}.\"\n  }]\n}",
+        "jsonBody": "={\n  \"model\": \"{{ $json.provider === 'claude-haiku' ? 'claude-3-5-haiku-latest' : 'claude-sonnet-4-20250514' }}\",\n  \"max_tokens\": 4096,\n  \"tools\": [{\n    \"type\": \"web_search_20250305\",\n    \"name\": \"web_search\",\n    \"max_uses\": {{ $json.options.max_results || 5 }}{{ $json.options.allowed_domains.length > 0 ? ', \"allowed_domains\": ' + JSON.stringify($json.options.allowed_domains) : '' }}{{ $json.options.blocked_domains.length > 0 ? ', \"blocked_domains\": ' + JSON.stringify($json.options.blocked_domains) : '' }}\n  }],\n  \"messages\": [{\n    \"role\": \"user\",\n    \"content\": \"Recherche sur le web les meilleures recettes pour: {{ $json.query }}. Trouve {{ $json.options.max_results }} recettes avec leurs sources et URLs. Réponds en {{ $json.options.language === 'fr' ? 'français' : 'anglais' }}.\"\n  }]\n}",
         "options": { "timeout": 60000 }
       },
       "onError": "continueRegularOutput"


### PR DESCRIPTION
## Summary
- Removed obsolete `anthropic-beta: web-search-2024-10-22` header
- Updated tool type from `web_search` to `web_search_20250305` (new Anthropic API format)
- Added `max_uses` parameter to control search limit

## Context
The Claude web search API was returning an error because the beta header was obsolete. The new API format uses the tool type `web_search_20250305` without requiring a beta header.

## Test plan
- [ ] Test recipes-web-search workflow with Claude provider
- [ ] Verify `allowed_domains` and `blocked_domains` filtering works
- [ ] Confirm `max_uses` limits the number of searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)