### PR TITLE
feat(shopping): Phase 2 - Checkout & Orders workflows

### DIFF
--- a/workflows/SHOPPING---Cart-Apply-Coupon.json
+++ b/workflows/SHOPPING---Cart-Apply-Coupon.json
@@ -1,0 +1,228 @@
+{
+  "name": "SHOPPING---Cart-Apply-Coupon",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "cart-apply-coupon",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "id": "coupon-apply-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "cart-apply-coupon-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || {};\nconst headers = input.headers || {};\n\n// --- Extraction Project ID ---\nconst projectId = headers['x-project-id'] \n  || headers['X-Project-ID'] \n  || headers['X-Project-Id']\n  || 'unknown';\n\n// --- Validation discord_user_id ---\nif (!body.discord_user_id) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le champ \"discord_user_id\" est requis'\n  };\n}\n\n// --- Validation coupon_code ---\nif (!body.coupon_code || typeof body.coupon_code !== 'string') {\n  return {\n    error: true,\n    error_code: 'MISSING_COUPON_CODE',\n    message: 'Le champ \"coupon_code\" est requis'\n  };\n}\n\n// --- Retour des donnees validees ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: body.discord_user_id,\n    coupon_code: body.coupon_code.trim().toUpperCase(),\n    project_id: projectId\n  }\n};"
+      },
+      "id": "coupon-apply-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "coupon-apply-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/cart/webhook/{{ $json.data.discord_user_id }}/coupon",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.data.project_id }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"coupon_code\": {{ JSON.stringify($json.data.coupon_code) }}\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "coupon-apply-0004",
+      "name": "Call API Apply Coupon",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE\n// ============================================\n\nconst apiResponse = $input.first().json;\nconst validationData = $('Validate Input').first().json;\n\n// --- Check API errors ---\nif (apiResponse.error || apiResponse.success === false) {\n  return {\n    success: false,\n    error: {\n      code: apiResponse.error?.code || 'COUPON_ERROR',\n      message: apiResponse.error?.message || 'Erreur application coupon',\n      http_status: apiResponse.error?.http_status || 400\n    }\n  };\n}\n\n// --- Format cart totals ---\nconst cart = apiResponse.cart || apiResponse;\nconst totalEuros = (cart.total_cents || 0) / 100;\nconst totalDisplay = totalEuros.toLocaleString('fr-FR', {\n  minimumFractionDigits: 2,\n  maximumFractionDigits: 2\n}) + ' EUR';\n\nconst discountEuros = (cart.discount_cents || 0) / 100;\nconst discountDisplay = discountEuros.toLocaleString('fr-FR', {\n  minimumFractionDigits: 2,\n  maximumFractionDigits: 2\n}) + ' EUR';\n\n// --- Success response ---\nreturn {\n  success: true,\n  coupon: {\n    code: validationData.data.coupon_code,\n    discount_cents: cart.discount_cents || 0,\n    discount_display: discountDisplay,\n    type: cart.coupon?.type || 'percent'\n  },\n  cart: {\n    subtotal_cents: cart.subtotal_cents || 0,\n    discount_cents: cart.discount_cents || 0,\n    total_cents: cart.total_cents || 0,\n    total_display: totalDisplay\n  }\n};"
+      },
+      "id": "coupon-apply-0005",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ERROR RESPONSE (Validation)\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "coupon-apply-0006",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "coupon-apply-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "coupon-apply-0008",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call API Apply Coupon",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API Apply Coupon": {
+      "main": [
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "shopping"
+    },
+    {
+      "name": "rfc-001"
+    },
+    {
+      "name": "checkout"
+    }
+  ]
+}

--- a/workflows/SHOPPING---Cart-Checkout.json
+++ b/workflows/SHOPPING---Cart-Checkout.json
@@ -1,0 +1,228 @@
+{
+  "name": "SHOPPING---Cart-Checkout",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "cart-checkout",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "id": "checkout-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "cart-checkout-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || {};\nconst headers = input.headers || {};\n\n// --- Extraction Project ID ---\nconst projectId = headers['x-project-id'] \n  || headers['X-Project-ID'] \n  || headers['X-Project-Id']\n  || 'unknown';\n\n// --- Validation discord_user_id ---\nif (!body.discord_user_id) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le champ \"discord_user_id\" est requis'\n  };\n}\n\n// --- URLs de retour (optionnelles) ---\nconst successUrl = body.success_url || null;\nconst cancelUrl = body.cancel_url || null;\n\n// --- Retour des donnees validees ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: body.discord_user_id,\n    project_id: projectId,\n    success_url: successUrl,\n    cancel_url: cancelUrl,\n    customer_email: body.customer_email || null,\n    metadata: body.metadata || {}\n  }\n};"
+      },
+      "id": "checkout-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "checkout-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/checkout/webhook/{{ $json.data.discord_user_id }}/create-session",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.data.project_id }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"success_url\": {{ JSON.stringify($json.data.success_url) }},\n  \"cancel_url\": {{ JSON.stringify($json.data.cancel_url) }},\n  \"customer_email\": {{ JSON.stringify($json.data.customer_email) }},\n  \"metadata\": {{ JSON.stringify($json.data.metadata) }}\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "checkout-0004",
+      "name": "Call API Create Checkout",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE\n// ============================================\n\nconst apiResponse = $input.first().json;\nconst validationData = $('Validate Input').first().json;\n\n// --- Check API errors ---\nif (apiResponse.error || apiResponse.success === false) {\n  return {\n    success: false,\n    error: {\n      code: apiResponse.error?.code || 'CHECKOUT_ERROR',\n      message: apiResponse.error?.message || 'Erreur creation checkout',\n      http_status: apiResponse.error?.http_status || 500\n    }\n  };\n}\n\n// --- Success response ---\nreturn {\n  success: true,\n  checkout: {\n    session_id: apiResponse.session_id || apiResponse.checkout?.session_id,\n    checkout_url: apiResponse.checkout_url || apiResponse.checkout?.url,\n    expires_at: apiResponse.expires_at || null\n  },\n  order: {\n    id: apiResponse.order_id || apiResponse.order?.id,\n    order_number: apiResponse.order_number || apiResponse.order?.order_number\n  }\n};"
+      },
+      "id": "checkout-0005",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ERROR RESPONSE (Validation)\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "checkout-0006",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "checkout-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "checkout-0008",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call API Create Checkout",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API Create Checkout": {
+      "main": [
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "shopping"
+    },
+    {
+      "name": "rfc-001"
+    },
+    {
+      "name": "checkout"
+    }
+  ]
+}

--- a/workflows/SHOPPING---Cart-Remove-Coupon.json
+++ b/workflows/SHOPPING---Cart-Remove-Coupon.json
@@ -1,0 +1,221 @@
+{
+  "name": "SHOPPING---Cart-Remove-Coupon",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "cart-remove-coupon",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "id": "coupon-remove-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "cart-remove-coupon-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || {};\nconst headers = input.headers || {};\n\n// --- Extraction Project ID ---\nconst projectId = headers['x-project-id'] \n  || headers['X-Project-ID'] \n  || headers['X-Project-Id']\n  || 'unknown';\n\n// --- Validation discord_user_id ---\nif (!body.discord_user_id) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le champ \"discord_user_id\" est requis'\n  };\n}\n\n// --- Retour des donnees validees ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: body.discord_user_id,\n    project_id: projectId\n  }\n};"
+      },
+      "id": "coupon-remove-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "coupon-remove-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "={{ $env.TORAH_API_URL }}/api/cart/webhook/{{ $json.data.discord_user_id }}/coupon",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.data.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "coupon-remove-0004",
+      "name": "Call API Remove Coupon",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE\n// ============================================\n\nconst apiResponse = $input.first().json;\n\n// --- Check API errors ---\nif (apiResponse.error || apiResponse.success === false) {\n  return {\n    success: false,\n    error: {\n      code: apiResponse.error?.code || 'COUPON_ERROR',\n      message: apiResponse.error?.message || 'Erreur suppression coupon',\n      http_status: apiResponse.error?.http_status || 400\n    }\n  };\n}\n\n// --- Format cart totals ---\nconst cart = apiResponse.cart || apiResponse;\nconst totalEuros = (cart.total_cents || 0) / 100;\nconst totalDisplay = totalEuros.toLocaleString('fr-FR', {\n  minimumFractionDigits: 2,\n  maximumFractionDigits: 2\n}) + ' EUR';\n\n// --- Success response ---\nreturn {\n  success: true,\n  message: 'Coupon retire',\n  cart: {\n    subtotal_cents: cart.subtotal_cents || 0,\n    discount_cents: 0,\n    total_cents: cart.total_cents || cart.subtotal_cents || 0,\n    total_display: totalDisplay\n  }\n};"
+      },
+      "id": "coupon-remove-0005",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ERROR RESPONSE (Validation)\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "coupon-remove-0006",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "coupon-remove-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "coupon-remove-0008",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call API Remove Coupon",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API Remove Coupon": {
+      "main": [
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "shopping"
+    },
+    {
+      "name": "rfc-001"
+    },
+    {
+      "name": "checkout"
+    }
+  ]
+}

--- a/workflows/SHOPPING---Orders-Get.json
+++ b/workflows/SHOPPING---Orders-Get.json
@@ -1,0 +1,221 @@
+{
+  "name": "SHOPPING---Orders-Get",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "orders-get",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "id": "orders-get-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "orders-get-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst query = input.query || {};\nconst headers = input.headers || {};\n\n// --- Extraction Project ID ---\nconst projectId = headers['x-project-id'] \n  || headers['X-Project-ID'] \n  || headers['X-Project-Id']\n  || 'unknown';\n\n// --- Validation discord_user_id ---\nconst discordUserId = query.discord_user_id;\n\nif (!discordUserId) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le parametre \"discord_user_id\" est requis'\n  };\n}\n\n// --- Validation order_id ou order_number ---\nconst orderId = query.order_id;\nconst orderNumber = query.order_number;\n\nif (!orderId && !orderNumber) {\n  return {\n    error: true,\n    error_code: 'MISSING_ORDER_ID',\n    message: 'Le parametre \"order_id\" ou \"order_number\" est requis'\n  };\n}\n\n// --- Retour des donnees validees ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: discordUserId,\n    order_id: orderId,\n    order_number: orderNumber,\n    project_id: projectId\n  }\n};"
+      },
+      "id": "orders-get-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "orders-get-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/orders/webhook/{{ $json.data.discord_user_id }}/{{ $json.data.order_id || $json.data.order_number }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.data.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "orders-get-0004",
+      "name": "Call API Get Order",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE\n// ============================================\n\nconst apiResponse = $input.first().json;\nconst validationData = $('Validate Input').first().json;\n\n// --- Check API errors ---\nif (apiResponse.error || apiResponse.success === false) {\n  return {\n    success: false,\n    error: {\n      code: apiResponse.error?.code || 'ORDER_NOT_FOUND',\n      message: apiResponse.error?.message || 'Commande non trouvee',\n      http_status: apiResponse.error?.http_status || 404\n    }\n  };\n}\n\n// --- Format order ---\nconst order = apiResponse.order || apiResponse;\n\nconst totalEuros = (order.total_cents || 0) / 100;\nconst totalDisplay = totalEuros.toLocaleString('fr-FR', {\n  minimumFractionDigits: 2,\n  maximumFractionDigits: 2\n}) + ' EUR';\n\nconst subtotalEuros = (order.subtotal_cents || 0) / 100;\nconst subtotalDisplay = subtotalEuros.toLocaleString('fr-FR', {\n  minimumFractionDigits: 2,\n  maximumFractionDigits: 2\n}) + ' EUR';\n\n// --- Format items ---\nconst items = (order.items || []).map(item => {\n  const itemTotalEuros = (item.total_cents || item.unit_price_cents * item.quantity) / 100;\n  return {\n    id: item.id,\n    product_snapshot: item.product_snapshot,\n    quantity: item.quantity,\n    unit_price_cents: item.unit_price_cents,\n    total_cents: item.total_cents,\n    total_display: itemTotalEuros.toLocaleString('fr-FR', {\n      minimumFractionDigits: 2,\n      maximumFractionDigits: 2\n    }) + ' EUR'\n  };\n});\n\n// --- Success response ---\nreturn {\n  success: true,\n  order: {\n    id: order.id,\n    order_number: order.order_number,\n    discord_user_id: order.discord_user_id,\n    status: order.status,\n    items: items,\n    subtotal_cents: order.subtotal_cents,\n    subtotal_display: subtotalDisplay,\n    discount_cents: order.discount_cents || 0,\n    shipping_cents: order.shipping_cents || 0,\n    total_cents: order.total_cents,\n    total_display: totalDisplay,\n    item_count: items.length,\n    currency: order.currency || 'EUR',\n    coupon_code: order.coupon_code || null,\n    customer_email: order.customer_email || null,\n    stripe_checkout_session_id: order.stripe_checkout_session_id || null,\n    paid_at: order.paid_at || null,\n    completed_at: order.completed_at || null,\n    created_at: order.created_at\n  }\n};"
+      },
+      "id": "orders-get-0005",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ERROR RESPONSE (Validation)\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "orders-get-0006",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "orders-get-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "orders-get-0008",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call API Get Order",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API Get Order": {
+      "main": [
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "shopping"
+    },
+    {
+      "name": "rfc-001"
+    },
+    {
+      "name": "orders"
+    }
+  ]
+}

--- a/workflows/SHOPPING---Orders-List.json
+++ b/workflows/SHOPPING---Orders-List.json
@@ -1,0 +1,221 @@
+{
+  "name": "SHOPPING---Orders-List",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "orders-list",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "id": "orders-list-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "orders-list-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst query = input.query || {};\nconst headers = input.headers || {};\n\n// --- Extraction Project ID ---\nconst projectId = headers['x-project-id'] \n  || headers['X-Project-ID'] \n  || headers['X-Project-Id']\n  || 'unknown';\n\n// --- Validation discord_user_id ---\nconst discordUserId = query.discord_user_id;\n\nif (!discordUserId) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le parametre \"discord_user_id\" est requis'\n  };\n}\n\n// --- Pagination (optionnelle) ---\nconst limit = Math.min(Math.max(parseInt(query.limit) || 10, 1), 50);\nconst offset = Math.max(parseInt(query.offset) || 0, 0);\n\n// --- Filtre status (optionnel) ---\nconst status = query.status || null;\n\n// --- Retour des donnees validees ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: discordUserId,\n    project_id: projectId,\n    limit: limit,\n    offset: offset,\n    status: status\n  }\n};"
+      },
+      "id": "orders-list-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "orders-list-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/orders/webhook/{{ $json.data.discord_user_id }}?limit={{ $json.data.limit }}&offset={{ $json.data.offset }}{{ $json.data.status ? '&status=' + $json.data.status : '' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.data.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "orders-list-0004",
+      "name": "Call API List Orders",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE\n// ============================================\n\nconst apiResponse = $input.first().json;\nconst validationData = $('Validate Input').first().json;\n\n// --- Check API errors ---\nif (apiResponse.error || apiResponse.success === false) {\n  return {\n    success: false,\n    error: {\n      code: apiResponse.error?.code || 'API_ERROR',\n      message: apiResponse.error?.message || 'Erreur API',\n      http_status: apiResponse.error?.http_status || 500\n    }\n  };\n}\n\n// --- Format orders ---\nconst orders = (apiResponse.orders || apiResponse.data || []).map(order => {\n  const totalEuros = (order.total_cents || 0) / 100;\n  const totalDisplay = totalEuros.toLocaleString('fr-FR', {\n    minimumFractionDigits: 2,\n    maximumFractionDigits: 2\n  }) + ' EUR';\n  \n  return {\n    id: order.id,\n    order_number: order.order_number,\n    status: order.status,\n    total_cents: order.total_cents,\n    total_display: totalDisplay,\n    item_count: order.item_count || order.items?.length || 0,\n    currency: order.currency || 'EUR',\n    created_at: order.created_at,\n    paid_at: order.paid_at\n  };\n});\n\n// --- Success response ---\nreturn {\n  success: true,\n  orders: orders,\n  pagination: {\n    total: apiResponse.total || orders.length,\n    limit: validationData.data.limit,\n    offset: validationData.data.offset,\n    has_more: apiResponse.has_more || false\n  }\n};"
+      },
+      "id": "orders-list-0005",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ERROR RESPONSE (Validation)\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "orders-list-0006",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "orders-list-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "orders-list-0008",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call API List Orders",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API List Orders": {
+      "main": [
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "shopping"
+    },
+    {
+      "name": "rfc-001"
+    },
+    {
+      "name": "orders"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add 5 new workflows for Phase 2 (Checkout + Commandes) of RFC-001
- All workflows use `$env.TORAH_API_URL` for API calls

## Workflows created

| Workflow | Method | Path | Description |
|----------|--------|------|-------------|
| Cart-Checkout | POST | `cart-checkout` | Create Stripe checkout session |
| Cart-Apply-Coupon | POST | `cart-apply-coupon` | Apply promo code |
| Cart-Remove-Coupon | POST | `cart-remove-coupon` | Remove promo code |
| Orders-List | GET | `orders-list` | List user orders (paginated) |
| Orders-Get | GET | `orders-get` | Get single order details |

## API Endpoints called

| Workflow | API Endpoint |
|----------|-------------|
| Cart-Checkout | `POST /api/checkout/webhook/{user_id}/create-session` |
| Cart-Apply-Coupon | `POST /api/cart/webhook/{user_id}/coupon` |
| Cart-Remove-Coupon | `DELETE /api/cart/webhook/{user_id}/coupon` |
| Orders-List | `GET /api/orders/webhook/{user_id}` |
| Orders-Get | `GET /api/orders/webhook/{user_id}/{order_id}` |

## Test plan

- [ ] Verify workflows load correctly in n8n
- [ ] Test Cart-Checkout creates Stripe session
- [ ] Test coupon apply/remove
- [ ] Test orders list pagination
- [ ] Test order details retrieval

🤖 Generated with [Claude Code](https://claude.com/claude-code)