### PR TITLE
feat(members): implement RFC-006 member join credits workflow

### DIFF
--- a/workflows/MEMBERS---On-Join-Grant-Credits.json
+++ b/workflows/MEMBERS---On-Join-Grant-Credits.json
@@ -1,0 +1,308 @@
+{
+  "name": "MEMBERS---On-Join-Grant-Credits",
+  "description": "RFC-006: Attribution automatique de crédits quand un membre rejoint le serveur Discord",
+  "active": true,
+  "isArchived": false,
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "member-join",
+        "options": {}
+      },
+      "id": "member-join-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "member-join-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE INPUT (RFC-006)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || {};\n\n// --- Validate required fields ---\nif (!body.discord_user_id) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le champ \"discord_user_id\" est requis'\n  };\n}\n\nif (!body.guild_id) {\n  return {\n    error: true,\n    error_code: 'MISSING_GUILD_ID',\n    message: 'Le champ \"guild_id\" est requis'\n  };\n}\n\n// --- Return validated data ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: body.discord_user_id,\n    discord_username: body.discord_username || 'unknown',\n    guild_id: body.guild_id,\n    guild_name: body.guild_name || null,\n    joined_at: body.joined_at || null\n  }\n};"
+      },
+      "id": "member-join-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "member-join-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/webhook/account/init",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"discord_user_id\": {{ JSON.stringify($json.data.discord_user_id) }},\n  \"discord_username\": {{ JSON.stringify($json.data.discord_username) }},\n  \"guild_id\": {{ JSON.stringify($json.data.guild_id) }}\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "member-join-0004",
+      "name": "Call API Init Credits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-api-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "member-join-0005",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE (RFC-006)\n// ============================================\n\nconst apiResponse = $input.first().json;\nconst validationData = $('Validate Input').first().json.data;\n\nreturn {\n  success: true,\n  status: apiResponse.status,  // 'created' ou 'already_exists'\n  plan_id: apiResponse.plan_id,\n  credits_remaining: apiResponse.credits_remaining,\n  discord_user_id: validationData.discord_user_id,\n  message: apiResponse.message\n};"
+      },
+      "id": "member-join-0006",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT API ERROR RESPONSE\n// ============================================\n\nconst apiResponse = $input.first().json;\nconst validationData = $('Validate Input').first().json.data;\n\nreturn {\n  success: false,\n  error: {\n    code: apiResponse.error || 'API_ERROR',\n    message: apiResponse.message || 'Erreur API',\n    http_status: 500\n  },\n  discord_user_id: validationData.discord_user_id\n};"
+      },
+      "id": "member-join-0007",
+      "name": "Format API Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT VALIDATION ERROR RESPONSE\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "member-join-0008",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "member-join-0009",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 500 }}"
+        }
+      },
+      "id": "member-join-0010",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "member-join-0011",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call API Init Credits",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API Init Credits": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Format API Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format API Error": {
+      "main": [
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false
+  },
+  "staticData": null,
+  "meta": null,
+  "pinData": null,
+  "tags": []
+}


### PR DESCRIPTION
## Summary

Implémentation du workflow n8n pour RFC-006 (Attribution automatique de crédits).

### Workflow: `MEMBERS---On-Join-Grant-Credits`

```
Webhook POST /member-join
    │
    ▼
Validate Input (discord_user_id, guild_id)
    │
    ▼
POST /api/webhook/account/init
    │
    ├─► success: true, status: "created"      → 200 OK (nouveau membre)
    └─► success: true, status: "already_exists" → 200 OK (membre existant)
```

### Idempotence

Le workflow délègue l'idempotence à l'API:
- **Nouveau membre** → crédits attribués, status: `created`
- **Membre existant** → aucun changement, status: `already_exists`

### Dépendances

- [x] RFC-006 documentation
- [ ] API endpoint `POST /api/webhook/account/init` (équipe API)
- [ ] Chatbot-Core `MemberJoinService` (équipe Chatbot-Core)

## Test Plan

```bash
# Test nouveau membre
curl -X POST http://localhost:5678/webhook/member-join \
  -H "Content-Type: application/json" \
  -d '{"discord_user_id": "123", "guild_id": "456", "discord_username": "test"}'

# Attendu: {"success": true, "status": "created", ...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)