### PR TITLE
docs(rfc-007): add mention service spec and n8n team response

### DIFF
--- a/docs/rfc/RFC-007-MENTION-SERVICE.md
+++ b/docs/rfc/RFC-007-MENTION-SERVICE.md
@@ -1,0 +1,840 @@
+# RFC-007: Mention Service (Gestion des @Bot)
+
+**Status:** Draft
+**Date:** 2026-01-15
+**Author:** Framework Team (chatbot-core)
+**Version:** 0.6.27 (proposée)
+
+---
+
+## Résumé
+
+Service de gestion des mentions @Bot dans les salons publics Discord, avec rate limiting intégré, délégation vers n8n pour le traitement, et support de conversations contextuelles.
+
+---
+
+## Problème
+
+Actuellement, lorsqu'un utilisateur mentionne le bot (`@BotName message`) dans un salon public :
+
+1. **Aucune gestion native** - Le framework ne gère pas les mentions @Bot
+2. **Pas de rate limiting** - Risque de spam/abus
+3. **Pas de contexte conversationnel** - Chaque message traité isolément
+4. **Logique dupliquée** - Chaque plugin doit réimplémenter la même logique
+5. **Pas de fallback** - Aucune réponse si le message ne matche aucune commande
+
+### Cas d'usage non couverts
+
+| Situation | Message | Comportement actuel |
+|-----------|---------|---------------------|
+| Question | `@Bot c'est quoi une béchamel ?` | Ignoré |
+| Salutation | `@Bot bonjour !` | Ignoré |
+| Mention vide | `@Bot` | Ignoré |
+| Question aléatoire | `@Bot quelle heure est-il ?` | Ignoré |
+| Liste ingrédients | `@Bot Appetit quelle liste d'ingrédient pour une pizza ?` | Ignoré |
+
+> **Note:** Les interactions avec le bot se feront **uniquement** via mentions `@BotName`.
+> Les slash commands (`/recette`, `/help`) restent disponibles mais la mention est le mode d'interaction principal pour les questions libres.
+
+---
+
+## Exemple concret
+
+**Interaction utilisateur :**
+```
+User: @Bot Appetit quelle liste d'ingrédient pour une pizza ?
+```
+
+**Flow de traitement :**
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ @Bot Appetit quelle liste d'ingrédient pour une pizza ?                      │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ MentionService.on_message()                                                  │
+│ ├── Extraction contenu: "quelle liste d'ingrédient pour une pizza ?"        │
+│ ├── Rate limit check: OK (2/5 dans la fenêtre)                              │
+│ └── Typing indicator: "Bot Appetit is typing..."                            │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ POST n8n /webhook/mention                                                    │
+│ {                                                                            │
+│   "content": "quelle liste d'ingrédient pour une pizza ?",                  │
+│   "user_id": "123456789",                                                    │
+│   "guild_id": "987654321",                                                   │
+│   "username": "chef_john",                                                   │
+│   "display_name": "Chef John"                                                │
+│ }                                                                            │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ n8n: Intent detection → "question" (confiance: 0.98)                         │
+│      Router → POST /api/ai/chat                                              │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ API/LLM Response:                                                            │
+│ {                                                                            │
+│   "success": true,                                                           │
+│   "intent": "question",                                                      │
+│   "response": "Pour une pizza Margherita, il te faut :\n                    │
+│                - 250g de farine\n                                            │
+│                - 150ml d'eau tiède\n                                         │
+│                - 7g de levure\n                                              │
+│                - Sauce tomate\n                                              │
+│                - Mozzarella\n                                                │
+│                - Basilic frais\n\n                                           │
+│                Tape /recette pizza pour la recette complète !"               │
+│ }                                                                            │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Discord Reply:                                                               │
+│ ┌─────────────────────────────────────────────────────────────────────────┐ │
+│ │ @Chef John Pour une pizza Margherita, il te faut :                      │ │
+│ │ - 250g de farine                                                        │ │
+│ │ - 150ml d'eau tiède                                                     │ │
+│ │ - 7g de levure                                                          │ │
+│ │ - Sauce tomate                                                          │ │
+│ │ - Mozzarella                                                            │ │
+│ │ - Basilic frais                                                         │ │
+│ │                                                                         │ │
+│ │ Tape /recette pizza pour la recette complète !                          │ │
+│ └─────────────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Solution
+
+### Architecture
+
+```
+Discord: on_message avec @Bot
+            │
+            ▼
+    ┌───────────────────┐
+    │  MentionService   │
+    │  (chatbot-core)   │
+    └─────────┬─────────┘
+              │
+    ┌─────────┴─────────┐
+    │                   │
+    ▼                   ▼
+┌─────────┐      ┌─────────────┐
+│ Rate    │      │ Mention     │
+│ Limiter │      │ Handler     │
+│         │      │ (protocol)  │
+└────┬────┘      └──────┬──────┘
+     │                  │
+     │    ┌─────────────┴──────────────┐
+     │    │                            │
+     ▼    ▼                            ▼
+┌────────────────┐            ┌────────────────┐
+│ Rejet (spam)   │            │ n8n Webhook    │
+│ Message limite │            │ /mention       │
+└────────────────┘            └───────┬────────┘
+                                      │
+                                      ▼
+                              ┌────────────────┐
+                              │ API/LLM        │
+                              │ Traitement     │
+                              └───────┬────────┘
+                                      │
+                                      ▼
+                              ┌────────────────┐
+                              │ Réponse        │
+                              │ Discord        │
+                              └────────────────┘
+```
+
+---
+
+## Composants Framework (chatbot-core)
+
+### 1. MentionConfig
+
+```python
+@dataclass
+class MentionConfig:
+    """Configuration du MentionService."""
+
+    # Callback n8n
+    callback_url: str                          # URL webhook n8n
+
+    # Rate limiting
+    rate_limit_enabled: bool = True            # Activer le rate limiting
+    rate_limit_messages: int = 5               # Nombre de messages
+    rate_limit_window_seconds: float = 60.0    # Par fenêtre de temps
+    rate_limit_cooldown_seconds: float = 30.0  # Cooldown après limite
+
+    # Filtrage
+    enabled_guilds: list[str] | None = None    # None = tous les guilds
+    allowed_channels: list[str] | None = None  # None = tous les channels
+    ignored_channels: list[str] | None = None  # Channels à ignorer (ex: #bot-spam)
+    ignore_bots: bool = True                   # Ignorer les bots
+
+    # Réponses
+    typing_indicator: bool = True              # Afficher "Bot is typing..."
+    reply_to_message: bool = True              # Répondre au message original
+
+    # Timeout
+    timeout_seconds: float = 30.0              # Timeout pour callback n8n
+
+    # Messages par défaut
+    rate_limit_message: str | None = "Doucement ! Réessaie dans {cooldown}s."
+    error_message: str | None = "Désolé, je n'ai pas pu traiter ta demande."
+```
+
+### 2. MentionContext
+
+```python
+@dataclass
+class MentionContext:
+    """Contexte d'une mention @Bot."""
+
+    # Identifiants
+    message_id: str
+    channel_id: str
+    guild_id: str
+    user_id: str
+
+    # Contenu
+    content: str              # Message sans la mention
+    raw_content: str          # Message complet original
+
+    # Métadonnées
+    username: str
+    display_name: str
+    is_reply: bool            # Le message répond-il à un autre ?
+    replied_to_bot: bool      # Répond-il à un message du bot ?
+
+    # Contexte conversationnel (optionnel)
+    conversation_id: str | None = None
+    previous_messages: list[dict] | None = None
+```
+
+### 3. MentionResult
+
+```python
+@dataclass
+class MentionResult:
+    """Résultat du traitement d'une mention."""
+
+    success: bool
+    response: str | None = None        # Texte de réponse
+    embed: dict | None = None          # Embed Discord (optionnel)
+    error: str | None = None
+
+    # Métadonnées
+    intent: str | None = None          # Intent détecté (greeting, question, etc.)
+    confidence: float | None = None    # Score de confiance
+
+    @classmethod
+    def from_response(cls, data: dict) -> "MentionResult":
+        """Créer depuis réponse n8n."""
+        return cls(
+            success=data.get("success", False),
+            response=data.get("response"),
+            embed=data.get("embed"),
+            error=data.get("error"),
+            intent=data.get("intent"),
+            confidence=data.get("confidence"),
+        )
+
+    @classmethod
+    def failure(cls, error: str) -> "MentionResult":
+        """Créer un résultat d'échec."""
+        return cls(success=False, error=error)
+```
+
+### 4. MentionHandler (Protocol)
+
+```python
+from typing import Protocol
+
+class MentionHandler(Protocol):
+    """Protocol pour handlers de mentions personnalisés."""
+
+    async def handle_mention(
+        self,
+        context: MentionContext,
+    ) -> MentionResult | None:
+        """
+        Traiter une mention.
+
+        Retourne:
+            - MentionResult si traité
+            - None pour passer au handler suivant
+        """
+        ...
+```
+
+### 5. MentionService
+
+```python
+class MentionService:
+    """Service de gestion des mentions @Bot."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        config: MentionConfig,
+        handler: MentionHandler | None = None,
+    ):
+        self.bot = bot
+        self.config = config
+        self.handler = handler or DefaultMentionHandler(config)
+        self._rate_limiter = RateLimiter(
+            max_requests=config.rate_limit_messages,
+            window_seconds=config.rate_limit_window_seconds,
+        )
+
+    async def on_message(self, message: discord.Message) -> MentionResult | None:
+        """Handler pour on_message event."""
+        # 1. Vérifications préliminaires
+        if not self._should_process(message):
+            return None
+
+        # 2. Extraire le contenu sans la mention
+        content = self._extract_content(message)
+
+        # 3. Vérifier rate limit
+        if self._is_rate_limited(message.author.id):
+            await self._send_rate_limit_response(message)
+            return MentionResult.failure("rate_limited")
+
+        # 4. Construire le contexte
+        context = await self._build_context(message, content)
+
+        # 5. Afficher typing indicator
+        if self.config.typing_indicator:
+            await message.channel.typing()
+
+        # 6. Déléguer au handler
+        result = await self.handler.handle_mention(context)
+
+        # 7. Envoyer la réponse
+        if result and result.success:
+            await self._send_response(message, result)
+        elif result and result.error and self.config.error_message:
+            await self._send_error(message)
+
+        return result
+
+    def _should_process(self, message: discord.Message) -> bool:
+        """Vérifier si le message doit être traité."""
+        # Ignorer les bots
+        if self.config.ignore_bots and message.author.bot:
+            return False
+
+        # Vérifier si le bot est mentionné
+        if self.bot.user not in message.mentions:
+            return False
+
+        # Vérifier guild
+        if self.config.enabled_guilds:
+            if str(message.guild.id) not in self.config.enabled_guilds:
+                return False
+
+        # Vérifier channels ignorés
+        if self.config.ignored_channels:
+            if str(message.channel.id) in self.config.ignored_channels:
+                return False
+
+        # Vérifier channels autorisés
+        if self.config.allowed_channels:
+            if str(message.channel.id) not in self.config.allowed_channels:
+                return False
+
+        return True
+```
+
+### 6. DefaultMentionHandler
+
+```python
+class DefaultMentionHandler:
+    """Handler par défaut qui délègue à n8n."""
+
+    def __init__(self, config: MentionConfig):
+        self.config = config
+        self._session: aiohttp.ClientSession | None = None
+
+    async def handle_mention(
+        self,
+        context: MentionContext,
+    ) -> MentionResult | None:
+        """Envoyer à n8n pour traitement."""
+        payload = {
+            "message_id": context.message_id,
+            "channel_id": context.channel_id,
+            "guild_id": context.guild_id,
+            "user_id": context.user_id,
+            "content": context.content,
+            "username": context.username,
+            "display_name": context.display_name,
+            "is_reply": context.is_reply,
+            "replied_to_bot": context.replied_to_bot,
+            "conversation_id": context.conversation_id,
+        }
+
+        try:
+            async with self._get_session() as session:
+                async with session.post(
+                    self.config.callback_url,
+                    json=payload,
+                    timeout=aiohttp.ClientTimeout(total=self.config.timeout_seconds),
+                ) as response:
+                    if response.status < 300:
+                        data = await response.json()
+                        return MentionResult.from_response(data)
+                    else:
+                        return MentionResult.failure(f"HTTP {response.status}")
+        except asyncio.TimeoutError:
+            return MentionResult.failure("Timeout")
+        except aiohttp.ClientError as e:
+            return MentionResult.failure(f"Connection error: {e}")
+```
+
+### 7. RateLimiter
+
+```python
+class RateLimiter:
+    """Rate limiter simple basé sur sliding window."""
+
+    def __init__(
+        self,
+        max_requests: int,
+        window_seconds: float,
+    ):
+        self.max_requests = max_requests
+        self.window_seconds = window_seconds
+        self._requests: dict[str, list[float]] = {}  # user_id -> timestamps
+
+    def is_limited(self, user_id: str) -> bool:
+        """Vérifier si l'utilisateur est rate limited."""
+        now = time.time()
+
+        # Nettoyer les anciennes requêtes
+        if user_id in self._requests:
+            self._requests[user_id] = [
+                ts for ts in self._requests[user_id]
+                if now - ts < self.window_seconds
+            ]
+
+        # Vérifier le nombre de requêtes
+        request_count = len(self._requests.get(user_id, []))
+        return request_count >= self.max_requests
+
+    def record(self, user_id: str) -> None:
+        """Enregistrer une requête."""
+        if user_id not in self._requests:
+            self._requests[user_id] = []
+        self._requests[user_id].append(time.time())
+
+    def get_cooldown(self, user_id: str) -> float:
+        """Obtenir le temps restant avant reset."""
+        if user_id not in self._requests or not self._requests[user_id]:
+            return 0.0
+
+        oldest = min(self._requests[user_id])
+        remaining = self.window_seconds - (time.time() - oldest)
+        return max(0.0, remaining)
+```
+
+---
+
+## Payload n8n
+
+### Request (chatbot-core → n8n)
+
+```json
+{
+  "message_id": "123456789",
+  "channel_id": "987654321",
+  "guild_id": "111222333",
+  "user_id": "444555666",
+  "content": "c'est quoi une béchamel ?",
+  "username": "john_doe",
+  "display_name": "John Doe",
+  "is_reply": false,
+  "replied_to_bot": false,
+  "conversation_id": null
+}
+```
+
+### Response (n8n → chatbot-core)
+
+```json
+{
+  "success": true,
+  "response": "La béchamel est une sauce blanche de base...",
+  "intent": "question",
+  "confidence": 0.95,
+  "embed": null
+}
+```
+
+### Réponses avec embed (optionnel)
+
+```json
+{
+  "success": true,
+  "response": null,
+  "embed": {
+    "title": "Sauce Béchamel",
+    "description": "La béchamel est une sauce...",
+    "color": 16753920,
+    "fields": [
+      {"name": "Ingrédients", "value": "- 50g beurre\n- 50g farine\n- 500ml lait"},
+      {"name": "Temps", "value": "15 minutes"}
+    ],
+    "footer": {"text": "Recette classique"}
+  },
+  "intent": "question"
+}
+```
+
+---
+
+## Responsabilités par équipe
+
+### 1. chatbot-core (Framework)
+
+| Composant | Responsabilité |
+|-----------|----------------|
+| `MentionService` | Écouter on_message, filtrer mentions, rate limit |
+| `MentionHandler` | Protocol pour handler personnalisé |
+| `DefaultMentionHandler` | Déléguer à n8n via webhook |
+| `RateLimiter` | Rate limiting en mémoire |
+| `MentionConfig` | Configuration (rate limit, channels, etc.) |
+
+### 2. n8n (Orchestration)
+
+| Workflow | Responsabilité |
+|----------|----------------|
+| `MENTION---On-Mention-Handler` | Recevoir webhook, router vers traitement |
+| `MENTION---Process-Question` | Détecter intent, appeler API/LLM |
+| `MENTION---Format-Response` | Formatter réponse Discord |
+
+### 3. API (Backend)
+
+| Endpoint | Responsabilité |
+|----------|----------------|
+| `POST /api/ai/chat` | Traitement LLM (question → réponse) |
+| `POST /api/mention/log` | Logger les mentions (analytics) |
+| `GET /api/mention/context/{user_id}` | Récupérer contexte conversation |
+
+### 4. Plugin (Implémentation)
+
+| Tâche | Responsabilité |
+|-------|----------------|
+| Configurer `MentionService` | Instancier avec config projet |
+| Handler personnalisé (optionnel) | Logique métier spécifique |
+| Variables d'environnement | `N8N_MENTION_WEBHOOK_URL` |
+
+---
+
+## Flow complet
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 1. User: @BotAppetit c'est quoi une béchamel ?                               │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 2. Discord Event: on_message                                                 │
+│    → MentionService.on_message()                                             │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                          ┌──────────┴──────────┐
+                          │ Rate limit check    │
+                          └──────────┬──────────┘
+                                     │
+               ┌─────────────────────┼─────────────────────┐
+               │ Limited             │ OK                  │
+               ▼                     ▼                     │
+     ┌─────────────────┐   ┌─────────────────┐            │
+     │ "Doucement !    │   │ Build context   │            │
+     │  Réessaie..."   │   │ → MentionContext│            │
+     └─────────────────┘   └────────┬────────┘            │
+                                    │                     │
+                                    ▼                     │
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 3. POST n8n /webhook/mention                                                 │
+│    payload: { content, user_id, guild_id, ... }                              │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 4. n8n: MENTION---On-Mention-Handler                                         │
+│    - Détecter intent (question, greeting, empty, unknown)                    │
+│    - Router vers traitement approprié                                        │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+          ┌──────────────────────────┼──────────────────────────┐
+          │ intent: question         │ intent: greeting         │
+          ▼                          ▼                          │
+┌─────────────────┐        ┌─────────────────┐                 │
+│ POST /api/ai/   │        │ Réponse         │                 │
+│ chat            │        │ prédéfinie      │                 │
+│                 │        │ "Bonjour !"     │                 │
+└────────┬────────┘        └────────┬────────┘                 │
+         │                          │                          │
+         └──────────────────────────┼──────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 5. n8n Response → chatbot-core                                               │
+│    { success: true, response: "La béchamel est...", intent: "question" }     │
+└────────────────────────────────────┬────────────────────────────────────────┘
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ 6. MentionService._send_response()                                           │
+│    → message.reply("La béchamel est...")                                     │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Intents supportés
+
+| Intent | Description | Traitement |
+|--------|-------------|------------|
+| `question` | Question sur le domaine du bot | API/LLM |
+| `greeting` | Salutation (bonjour, salut, etc.) | Réponse prédéfinie |
+| `help` | Demande d'aide | Liste commandes |
+| `empty` | Mention sans contenu | Réponse guide |
+| `unknown` | Non reconnu | Fallback générique |
+| `out_of_scope` | Hors domaine du bot | Réponse de redirection |
+
+---
+
+## Configuration Plugin
+
+### Variables d'environnement
+
+```bash
+# n8n webhook
+N8N_MENTION_WEBHOOK_URL=http://pi6.local:5678/webhook/mention
+
+# Rate limiting (optionnel - défauts utilisés sinon)
+MENTION_RATE_LIMIT_MESSAGES=5
+MENTION_RATE_LIMIT_WINDOW=60
+```
+
+### Code Plugin (bot.py)
+
+```python
+import os
+from chatbot_core.services import (
+    MentionConfig,
+    MentionService,
+)
+
+# Configuration
+mention_config = MentionConfig(
+    callback_url=os.getenv("N8N_MENTION_WEBHOOK_URL", ""),
+
+    # Rate limiting
+    rate_limit_enabled=True,
+    rate_limit_messages=5,
+    rate_limit_window_seconds=60.0,
+
+    # Messages personnalisés
+    rate_limit_message="Doucement {name} ! Réessaie dans {cooldown}s.",
+    error_message="Oups, je n'ai pas pu répondre. Réessaie !",
+
+    # Typing indicator
+    typing_indicator=True,
+)
+
+# Service
+mention_service = MentionService(bot, mention_config)
+
+# Enregistrement
+@bot.event
+async def on_ready():
+    bot.add_listener(mention_service.on_message, "on_message")
+```
+
+### Handler personnalisé (optionnel)
+
+```python
+from chatbot_core.services import MentionHandler, MentionContext, MentionResult
+
+class MyMentionHandler:
+    """Handler personnalisé pour logique métier spécifique."""
+
+    def __init__(self, config, n8n_handler):
+        self.config = config
+        self.n8n_handler = n8n_handler  # Fallback
+
+    async def handle_mention(self, context: MentionContext) -> MentionResult | None:
+        # Traitement local pour certains cas
+        if context.content.lower() in ["prix", "tarif", "combien"]:
+            return MentionResult(
+                success=True,
+                response="Consulte nos tarifs avec /prix !",
+                intent="redirect",
+            )
+
+        # Déléguer au handler n8n pour le reste
+        return await self.n8n_handler.handle_mention(context)
+
+# Usage
+mention_service = MentionService(
+    bot=bot,
+    config=mention_config,
+    handler=MyMentionHandler(mention_config, DefaultMentionHandler(mention_config)),
+)
+```
+
+---
+
+## Considérations
+
+### Rate Limiting distribué (v2)
+
+Pour une v2 avec plusieurs instances du bot :
+
+```python
+# Utiliser Redis au lieu du rate limiter en mémoire
+from chatbot_core.services.redis import RedisRateLimiter
+
+rate_limiter = RedisRateLimiter(
+    redis_url=os.getenv("REDIS_URL"),
+    prefix="mention:ratelimit",
+    max_requests=5,
+    window_seconds=60,
+)
+
+mention_service = MentionService(
+    bot=bot,
+    config=mention_config,
+    rate_limiter=rate_limiter,  # Injection
+)
+```
+
+### Contexte conversationnel (v2)
+
+Pour supporter les conversations multi-tours :
+
+```python
+@dataclass
+class ConversationConfig:
+    enabled: bool = False
+    max_history: int = 5                    # Nombre de messages à garder
+    context_ttl_minutes: int = 30           # Durée de vie du contexte
+    storage: Literal["memory", "redis"] = "memory"
+```
+
+### Logging et Analytics (optionnel)
+
+```python
+# n8n peut logger vers l'API
+POST /api/mention/log
+{
+    "guild_id": "...",
+    "user_id": "...",
+    "intent": "question",
+    "response_time_ms": 1234,
+    "success": true
+}
+```
+
+---
+
+## Implémentation
+
+### Phase 1 - chatbot-core (Priorité P0)
+
+| Tâche | Effort |
+|-------|--------|
+| `MentionConfig` dataclass | S |
+| `MentionContext` dataclass | S |
+| `MentionResult` dataclass | S |
+| `RateLimiter` (mémoire) | M |
+| `MentionService` | M |
+| `DefaultMentionHandler` | M |
+| Tests unitaires | M |
+| Documentation guide | S |
+
+### Phase 2 - n8n (Priorité P1)
+
+| Workflow | Effort |
+|----------|--------|
+| Webhook `/mention` | S |
+| Intent detection | M |
+| Router par intent | M |
+| Integration API/LLM | M |
+
+### Phase 3 - API (Priorité P1)
+
+| Endpoint | Effort |
+|----------|--------|
+| `POST /api/ai/chat` | M |
+| `POST /api/mention/log` | S |
+
+### Phase 4 - Plugin (Priorité P2)
+
+| Tâche | Effort |
+|-------|--------|
+| Configuration | S |
+| Handler personnalisé | S-M |
+| Tests intégration | S |
+
+---
+
+## Exports proposés
+
+```python
+# chatbot_core/services/__init__.py
+from chatbot_core.services.mention import (
+    MentionConfig,
+    MentionContext,
+    MentionResult,
+    MentionHandler,
+    MentionService,
+    DefaultMentionHandler,
+    RateLimiter,
+)
+```
+
+---
+
+## Questions ouvertes
+
+1. **Persistance rate limit ?** Redis pour multi-instance ou mémoire suffit pour v1 ?
+   → **Proposition:** Mémoire pour v1, Redis optionnel v2
+
+2. **Contexte conversationnel ?** Supporter les conversations multi-tours ?
+   → **Proposition:** Non pour v1, prévoir interface pour v2
+
+3. **Embed vs texte ?** n8n retourne-t-il des embeds ou juste du texte ?
+   → **Proposition:** Supporter les deux (response OU embed)
+
+4. **Intent detection côté framework ?** Détecter localement ou déléguer à n8n ?
+   → **Proposition:** Déléguer à n8n (flexibilité LLM)
+
+5. **DM support ?** Gérer aussi les DM au bot ?
+   → **Proposition:** Non pour v1 (différent use case)
+
+---
+
+## Références
+
+- [RFC-005: Welcome Message System](./RFC-005-WELCOME-MESSAGE.md) - Pattern provider
+- [RFC-006: Member Join Credits](./RFC-006-MEMBER-JOIN-CREDITS.md) - Pattern callback n8n
+- [Guide Welcome & Member Join](../guides/GUIDE-WELCOME-MEMBER-JOIN.md) - Guide plugin

--- a/docs/rfc/RFC-007b-REPONSE-N8N-MENTION-SERVICE.md
+++ b/docs/rfc/RFC-007b-REPONSE-N8N-MENTION-SERVICE.md
@@ -1,0 +1,404 @@
+# RFC-007b: Réponse équipe n8n - Mention Service
+
+**Date:** 2026-01-15
+**En réponse à:** RFC-007-MENTION-SERVICE.md
+**Auteur:** Équipe n8n
+
+---
+
+## Résumé
+
+Analyse du RFC-007 Mention Service du point de vue de l'équipe n8n. Ce document identifie les points à clarifier avant implémentation et propose un plan de travail.
+
+---
+
+## Évaluation globale
+
+| Aspect | Note | Commentaire |
+|--------|------|-------------|
+| Clarté architecture | ✅ Excellent | Responsabilités bien définies |
+| Specs chatbot-core | ✅ Excellent | Code complet, prêt à implémenter |
+| Specs n8n | ⚠️ Partiel | Manque détails sur intent detection |
+| Specs API | ⚠️ Partiel | Endpoint `/api/ai/chat` non spécifié |
+| Extensibilité | ✅ Excellent | Protocol pattern bien pensé |
+
+---
+
+## Points positifs
+
+### 1. Architecture claire
+
+```
+Discord → MentionService → n8n → API/LLM → Response
+```
+
+La séparation des responsabilités est bien définie:
+- **chatbot-core**: Rate limiting, filtrage, contexte
+- **n8n**: Orchestration, routing, intent detection
+- **API**: Traitement LLM, logging
+
+### 2. Rate limiting bien conçu
+
+Configuration flexible avec:
+- Sliding window
+- Cooldown configurable
+- Messages personnalisables
+- Prévu pour Redis (v2)
+
+### 3. Payload bien défini
+
+Request et Response clairement spécifiés:
+
+```json
+// Request → n8n
+{
+  "message_id": "123456789",
+  "channel_id": "987654321",
+  "guild_id": "111222333",
+  "user_id": "444555666",
+  "content": "c'est quoi une béchamel ?",
+  "username": "john_doe",
+  "display_name": "John Doe",
+  "is_reply": false,
+  "replied_to_bot": false,
+  "conversation_id": null
+}
+
+// Response ← n8n
+{
+  "success": true,
+  "response": "La béchamel est...",
+  "intent": "question",
+  "confidence": 0.95,
+  "embed": null
+}
+```
+
+### 4. Support embeds Discord
+
+Possibilité de retourner des embeds riches en plus du texte simple.
+
+---
+
+## Points à clarifier
+
+### 1. Intent Detection - Mécanisme non spécifié
+
+**Problème:** Le RFC dit "Déléguer à n8n" mais ne précise pas comment détecter les intents.
+
+**Options possibles:**
+
+| Option | Avantages | Inconvénients |
+|--------|-----------|---------------|
+| **A. Patterns/Regex** | Simple, rapide, pas de coût | Limité, maintenance |
+| **B. LLM externe** | Précis, flexible | Coût, latence |
+| **C. Classification locale** | Équilibre | Complexité setup |
+
+**Question:** Quelle approche pour v1 ?
+
+**Proposition n8n:** Option A (patterns) pour v1, avec possibilité d'évoluer vers B.
+
+```javascript
+// Exemple patterns v1
+const INTENT_PATTERNS = {
+  greeting: /^(bonjour|salut|hello|hey|coucou|bonsoir)/i,
+  help: /^(aide|help|commandes?|comment)/i,
+  empty: /^\s*$/,
+  question: /.+\?$|^(c'est quoi|qu'est-ce|comment|pourquoi|où|quand|qui|quel)/i
+};
+```
+
+### 2. Endpoint `/api/ai/chat` - Non documenté
+
+**Problème:** Le RFC mentionne `POST /api/ai/chat` mais cet endpoint n'est pas spécifié.
+
+**Questions pour l'équipe API:**
+
+1. Cet endpoint existe-t-il déjà ?
+2. Si non, quelles sont les specs attendues ?
+
+**Proposition de specs:**
+
+```http
+POST /api/ai/chat
+Content-Type: application/json
+X-Project-ID: bot-appetit
+
+{
+  "message": "c'est quoi une béchamel ?",
+  "user_id": "444555666",
+  "context": {
+    "guild_id": "111222333",
+    "channel_id": "987654321"
+  }
+}
+```
+
+**Response attendue:**
+
+```json
+{
+  "success": true,
+  "response": "La béchamel est une sauce blanche...",
+  "tokens_used": 150,
+  "model": "gpt-4"
+}
+```
+
+### 3. Réponses prédéfinies - Où sont-elles définies ?
+
+**Problème:** Pour les intents `greeting`, `help`, `empty`, le RFC ne précise pas où stocker les réponses.
+
+**Options:**
+
+| Emplacement | Avantages | Inconvénients |
+|-------------|-----------|---------------|
+| **n8n (hardcodé)** | Simple | Pas flexible |
+| **Config API** | Centralisé | Dépendance API |
+| **Variables d'env** | Flexible | Limité |
+
+**Proposition:** Hardcodé dans n8n pour v1, configurable via API pour v2.
+
+### 4. Références incorrectes
+
+**Ligne 838:**
+```markdown
+- [RFC-005: Welcome Message System](./RFC-005-WELCOME-MESSAGE.md)
+```
+
+Ce fichier n'existe pas. On a:
+- `RFC-005-USER-DATA-MODEL.md`
+
+**Action:** Corriger la référence ou créer le RFC manquant.
+
+### 5. Scope v1 - Quels intents implémenter ?
+
+**Problème:** Le RFC liste 6 intents mais ne précise pas le scope v1.
+
+| Intent | Complexité | v1 ? |
+|--------|------------|------|
+| `question` | Haute (LLM) | ⚠️ Dépend API |
+| `greeting` | Basse | ✅ Oui |
+| `help` | Basse | ✅ Oui |
+| `empty` | Basse | ✅ Oui |
+| `unknown` | Basse | ✅ Oui (fallback) |
+| `out_of_scope` | Moyenne | ❌ v2 |
+
+**Proposition v1:** Tous sauf `out_of_scope` et `question` simplifié (si API pas prête).
+
+### 6. Workflows n8n - Architecture
+
+**RFC propose 3 workflows:**
+```
+MENTION---On-Mention-Handler
+MENTION---Process-Question
+MENTION---Format-Response
+```
+
+**Proposition n8n:** Un seul workflow pour v1.
+
+**Justification:**
+- Moins de complexité
+- Pas de dépendances inter-workflows
+- Plus facile à débugger
+- Peut être splitté en v2 si nécessaire
+
+---
+
+## Plan de travail n8n
+
+### Workflow: `MENTION---Handler`
+
+```
+┌─────────────────┐
+│ Webhook Trigger │  POST /mention
+│                 │  Body: MentionContext payload
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Validate Input  │  Vérifier champs requis
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Detect Intent   │  Patterns/Regex v1
+│                 │  → greeting, help, empty, question, unknown
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Switch Intent   │
+└────────┬────────┘
+         │
+    ┌────┼────┬────────┬──────────┐
+    │    │    │        │          │
+    ▼    ▼    ▼        ▼          ▼
+greeting help empty question  unknown
+    │    │    │        │          │
+    ▼    ▼    ▼        ▼          ▼
+┌────────────────────────────────────┐
+│ Format Response (MentionResult)    │
+└────────────────┬───────────────────┘
+                 │
+                 ▼
+┌─────────────────┐
+│ Respond Webhook │  200 OK
+└─────────────────┘
+```
+
+### Nodes détaillés
+
+| Node | Type | Description |
+|------|------|-------------|
+| Webhook Trigger | Webhook | `POST /mention` |
+| Validate Input | Code | Valider payload |
+| Detect Intent | Code | Patterns matching |
+| Switch Intent | Switch | Router par intent |
+| Handle Greeting | Set | Réponse "Bonjour !" |
+| Handle Help | Set | Liste commandes |
+| Handle Empty | Set | Guide d'utilisation |
+| Handle Question | HTTP Request | `POST /api/ai/chat` |
+| Handle Unknown | Set | Fallback générique |
+| Format Response | Code | Construire MentionResult |
+| Respond | Respond Webhook | Retourner résultat |
+
+### Réponses prédéfinies v1
+
+```javascript
+const RESPONSES = {
+  greeting: {
+    response: "Bonjour ! Comment puis-je t'aider ? Pose-moi une question ou tape /help pour voir les commandes disponibles.",
+    intent: "greeting",
+    confidence: 1.0
+  },
+  help: {
+    response: "Voici ce que je peux faire :\n" +
+              "• Réponds à tes questions culinaires\n" +
+              "• `/recette [nom]` - Chercher une recette\n" +
+              "• `/liste` - Voir ta liste de courses\n" +
+              "• `/panier` - Gérer ton panier",
+    intent: "help",
+    confidence: 1.0
+  },
+  empty: {
+    response: "Tu m'as mentionné mais sans message ! Pose-moi une question ou tape /help.",
+    intent: "empty",
+    confidence: 1.0
+  },
+  unknown: {
+    response: "Je n'ai pas bien compris ta demande. Peux-tu reformuler ou taper /help ?",
+    intent: "unknown",
+    confidence: 0.5
+  }
+};
+```
+
+---
+
+## Dépendances
+
+### Bloquant pour n8n
+
+| Dépendance | Équipe | Status | Impact |
+|------------|--------|--------|--------|
+| `POST /api/ai/chat` | API | ❓ À confirmer | Intent `question` |
+| Specs réponses | Tous | ❓ À valider | Contenu réponses |
+
+### Non bloquant
+
+| Item | Équipe | Note |
+|------|--------|------|
+| MentionService | chatbot-core | Peut avancer en parallèle |
+| Config plugin | Plugin | Après chatbot-core |
+
+---
+
+## Questions pour les équipes
+
+### Équipe API
+
+1. **L'endpoint `POST /api/ai/chat` existe-t-il ?**
+   - Si oui, quelles sont les specs ?
+   - Si non, qui l'implémente et quand ?
+
+2. **Faut-il logger les mentions ?**
+   - `POST /api/mention/log` est-il prioritaire pour v1 ?
+
+### Équipe chatbot-core
+
+1. **Intent detection côté framework ?**
+   - Le RFC dit "déléguer à n8n" - confirmé ?
+   - Ou préférez-vous une pré-classification locale ?
+
+2. **Typing indicator timing ?**
+   - Activer avant ou après le rate limit check ?
+
+### Équipe Plugin
+
+1. **Réponses personnalisées ?**
+   - Le plugin doit-il pouvoir override les réponses par défaut ?
+   - Si oui, via config ou handler custom ?
+
+---
+
+## Proposition de planning
+
+```
+Semaine 1:
+├── [API] Confirmer/créer POST /api/ai/chat
+├── [chatbot-core] Implémenter MentionService (sans LLM)
+└── [n8n] Créer workflow MENTION---Handler (patterns only)
+
+Semaine 2:
+├── [API] Endpoint prêt
+├── [n8n] Intégrer POST /api/ai/chat
+└── [chatbot-core] Tests intégration
+
+Semaine 3:
+├── [Plugin] Configuration MentionService
+├── [Tous] Tests end-to-end
+└── [Tous] Documentation
+```
+
+---
+
+## Checklist avant implémentation
+
+### n8n
+
+- [ ] Confirmation specs `/api/ai/chat`
+- [ ] Validation patterns intent detection
+- [ ] Accord sur réponses prédéfinies
+- [ ] Clarification scope v1 (avec/sans LLM)
+
+### API
+
+- [ ] Specs `POST /api/ai/chat`
+- [ ] Décision sur `POST /api/mention/log` (v1 ou v2?)
+
+### chatbot-core
+
+- [ ] Confirmation: intent detection = n8n only
+- [ ] Review code MentionService
+
+---
+
+## Conclusion
+
+Le RFC-007 est bien structuré mais nécessite des clarifications sur:
+
+1. **Mécanisme intent detection** → Proposition: patterns v1
+2. **Endpoint `/api/ai/chat`** → À spécifier par équipe API
+3. **Réponses prédéfinies** → À valider par tous
+4. **Scope v1** → Proposition: tous intents sauf `out_of_scope`
+
+**Prêt à démarrer** dès que les dépendances API sont clarifiées.
+
+---
+
+## Historique
+
+| Date | Auteur | Modification |
+|------|--------|--------------|
+| 2026-01-15 | Équipe n8n | Création du document de réponse |


### PR DESCRIPTION
## Summary

Ajout du RFC-007 Mention Service et de la réponse de l'équipe n8n.

### RFC-007: Mention Service (chatbot-core)
- Gestion des mentions `@Bot` dans les salons publics
- Rate limiting intégré (sliding window)
- Délégation vers n8n pour le traitement
- Support embeds Discord
- Protocol pattern pour handlers personnalisés

### RFC-007b: Réponse équipe n8n

**Points à clarifier avant implémentation:**

| Point | Question |
|-------|----------|
| Intent detection | Patterns/Regex ou LLM ? |
| `/api/ai/chat` | Endpoint existe ? Specs ? |
| Réponses prédéfinies | Où les stocker ? |
| Scope v1 | Quels intents implémenter ? |

**Proposition n8n:**
- Un seul workflow `MENTION---Handler`
- Patterns pour intent detection v1
- Tous intents sauf `out_of_scope`

## Questions ouvertes

1. **API:** Specs de `POST /api/ai/chat` ?
2. **chatbot-core:** Intent detection = n8n only (confirmé) ?
3. **Tous:** Scope v1 validé ?

## Test Plan

- [ ] Review par équipe API
- [ ] Review par équipe chatbot-core
- [ ] Accord sur scope v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)