### PR TITLE
feat(config): implement RFC-008 admin config workflows

### DIFF
--- a/docs/rfc/RFC-008-ADMIN-CONFIG-SCREENS.md
+++ b/docs/rfc/RFC-008-ADMIN-CONFIG-SCREENS.md
@@ -1,0 +1,1038 @@
+# RFC-008: Admin Config Screens
+
+**Status:** Approved
+**Date:** 2026-01-15
+**Author:** Framework Team (chatbot-core)
+**Version:** 2.0.0
+
+---
+
+## Résumé
+
+Écrans d'administration pour configurer le branding et l'aide du bot via Discord (slash commands avec UI interactive). Le **framework pilote**, les **plugins proposent** leur configuration.
+
+---
+
+## Décisions validées
+
+Suite aux réponses des équipes API et n8n (RFC-008b), les décisions suivantes sont actées :
+
+| Sujet | Décision | Source |
+|-------|----------|--------|
+| **Table `guild_branding`** | Migration (étendre table existante RFC-003) | API |
+| **Table `guild_help_config`** | Nouvelle table avec JSONB | API + n8n |
+| **Namespace API** | `/api/config` (rétrocompat RFC-003 maintenue) | API |
+| **Cache Redis** | Non pour v1, oui pour v2 (TTL 5min) | n8n |
+| **Historique modifs** | Non pour v1 | API |
+| **Validation URLs** | Côté API avec domaines whitelist | API |
+
+### Développement en parallèle
+
+Toutes les équipes travaillent **en parallèle**. Aucune équipe n'est bloquante.
+
+```
+        ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+        │    API      │     │    n8n      │     │ chatbot-core│
+        │  (backend)  │     │ (workflows) │     │ (framework) │
+        └──────┬──────┘     └──────┬──────┘     └──────┬──────┘
+               │                   │                   │
+               ▼                   ▼                   ▼
+        ┌─────────────────────────────────────────────────────┐
+        │                    INTÉGRATION                       │
+        └─────────────────────────────────────────────────────┘
+                                   │
+                                   ▼
+                          ┌─────────────┐
+                          │   Plugin    │
+                          └─────────────┘
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              FRAMEWORK (chatbot-core)                        │
+│                                                                              │
+│  ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐          │
+│  │ ConfigCommands  │    │ ConfigViews     │    │ ConfigService   │          │
+│  │ /config branding│    │ Modals, Selects │    │ CRUD operations │          │
+│  │ /config help    │    │ Buttons         │    │                 │          │
+│  └────────┬────────┘    └────────┬────────┘    └────────┬────────┘          │
+│           │                      │                      │                    │
+│           └──────────────────────┼──────────────────────┘                    │
+│                                  │                                           │
+└──────────────────────────────────┼───────────────────────────────────────────┘
+                                   │
+                    ┌──────────────┴──────────────┐
+                    │                             │
+                    ▼                             ▼
+            ┌───────────────┐           ┌───────────────┐
+            │ n8n           │           │ API           │
+            │ Orchestration │           │ Persistance   │
+            └───────────────┘           └───────────────┘
+```
+
+---
+
+## Responsabilités
+
+| Composant | Responsabilité |
+|-----------|----------------|
+| **chatbot-core** | Views, Modals, Commandes `/config`, ConfigService |
+| **n8n** | Mapping `guild_id → project_id`, orchestration |
+| **API** | Persistance branding et help config, CRUD endpoints |
+| **Plugin** | Enregistrer commandes, fournir valeurs par défaut |
+
+---
+
+## Commandes
+
+| Commande | Description | Permission |
+|----------|-------------|------------|
+| `/config branding` | Configurer l'identité visuelle | Administrator |
+| `/config help` | Configurer les catégories d'aide | Administrator |
+
+---
+
+## 1. `/config branding` - Configuration du Branding
+
+### Écran Principal
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚙️ Configuration du Branding                                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  **Nom du bot**                                                 │
+│  Bot Appetit                                                    │
+│                                                                 │
+│  **Slogan**                                                     │
+│  Votre assistant culinaire Discord                              │
+│                                                                 │
+│  **Emoji**          **Couleur**                                 │
+│  🍽️                 #E67E22 (Orange)                            │
+│                     ████████                                    │
+│                                                                 │
+│  **Logo**                                                       │
+│  https://example.com/logo.png                                   │
+│                                                                 │
+│  **Bannière**                                                   │
+│  https://example.com/banner.png                                 │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│  **Liens**                                                      │
+│  🌐 Site web: https://botappetit.fr                             │
+│  💬 Support: https://discord.gg/support                         │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  [🏷️ Identité]  [🎨 Apparence]  [🔗 Liens]  [👁️ Preview]        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Boutons d'action
+
+| Bouton | Action |
+|--------|--------|
+| 🏷️ Identité | Ouvre modal pour nom, slogan, emoji |
+| 🎨 Apparence | Ouvre select couleur + modal logos |
+| 🔗 Liens | Ouvre modal pour URLs |
+| 👁️ Preview | Affiche un aperçu du /help avec le branding |
+
+---
+
+### Modal: Identité (🏷️)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Modifier l'identité                                       [X]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Nom du bot                                                     │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ Bot Appetit                                              │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Max 32 caractères                                              │
+│                                                                 │
+│  Slogan                                                         │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ Votre assistant culinaire Discord                        │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Max 100 caractères                                             │
+│                                                                 │
+│  Emoji principal                                                │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ 🍽️                                                       │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Un seul emoji                                                  │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                        [Annuler]  [Sauvegarder] │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Select Menu: Couleur (🎨)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Choisir une couleur                                            │
+├─────────────────────────────────────────────────────────────────┤
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ 🟠 Orange Cuisine (#E67E22)                         [v] │   │
+│  ├─────────────────────────────────────────────────────────┤   │
+│  │ 🔴 Rouge Tomate (#E74C3C)                               │   │
+│  │ 🟠 Orange Cuisine (#E67E22)                        [✓]  │   │
+│  │ 🟡 Jaune Citron (#F1C40F)                               │   │
+│  │ 🟢 Vert Basilic (#2ECC71)                               │   │
+│  │ 🔵 Bleu Ocean (#3498DB)                                 │   │
+│  │ 🟣 Violet Aubergine (#9B59B6)                           │   │
+│  │ ⬛ Noir Truffe (#2C3E50)                                │   │
+│  │ ⚪ Personnalisé...                                      │   │
+│  └─────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Si "Personnalisé" sélectionné:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Couleur personnalisée                                     [X]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Code hexadécimal                                               │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ #E67E22                                                  │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Format: #RRGGBB (ex: #FF5733)                                  │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                        [Annuler]  [Appliquer]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Modal: Logos (après couleur)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configurer les images                                     [X]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  URL du logo (carré, 256x256 recommandé)                        │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ https://example.com/logo.png                             │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Laissez vide pour utiliser l'avatar du bot                     │
+│                                                                 │
+│  URL de la bannière (1200x400 recommandé)                       │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ https://example.com/banner.png                           │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Affichée dans /help et les embeds principaux                   │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                        [Annuler]  [Sauvegarder] │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Modal: Liens (🔗)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Configurer les liens                                      [X]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Site web                                                       │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ https://botappetit.fr                                    │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  Lien de support                                                │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ https://discord.gg/support                               │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+│  Version du bot                                                 │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ 1.0.0                                                    │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                        [Annuler]  [Sauvegarder] │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Preview (👁️)
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  [BANNER IMAGE]                                                 │
+│  ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░   │
+├─────────────────────────────────────────────────────────────────┤
+│  🍽️ Bot Appetit                                          [IMG] │
+│  Votre assistant culinaire Discord                              │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  **🔍 Découverte**                                              │
+│  `/recette` `/suggestion` `/ingredients`                        │
+│                                                                 │
+│  **💾 Mes Recettes**                                            │
+│  `/sauvegarder` `/mes-recettes` `/favoris`                      │
+│                                                                 │
+│  **🛒 Liste de courses**                                        │
+│  `/liste show` `/liste add` `/liste clear`                      │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  Bot Appetit v1.0.0 | botappetit.fr                             │
+├─────────────────────────────────────────────────────────────────┤
+│                    [✅ Looks good!]  [🔙 Retour]                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. `/config help` - Configuration de l'Aide
+
+### Écran Principal - Liste des Catégories
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  📚 Configuration de l'Aide                                     │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  **Catégories d'aide** (5)                                      │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐ │
+│  │ 1. 🔍 Découverte                             7 commandes  │ │
+│  │    Recherche et découverte de nouvelles recettes          │ │
+│  ├───────────────────────────────────────────────────────────┤ │
+│  │ 2. 💾 Mes Recettes                           5 commandes  │ │
+│  │    Gestion de vos recettes sauvegardées                   │ │
+│  ├───────────────────────────────────────────────────────────┤ │
+│  │ 3. 🛒 Liste de courses                       5 commandes  │ │
+│  │    Gestion de votre liste d'achats                        │ │
+│  ├───────────────────────────────────────────────────────────┤ │
+│  │ 4. ⏱️ Timers                                 3 commandes  │ │
+│  │    Minuteries de cuisson avec notifications               │ │
+│  ├───────────────────────────────────────────────────────────┤ │
+│  │ 5. 👤 Compte                                 3 commandes  │ │
+│  │    Gestion de votre compte et abonnement                  │ │
+│  └───────────────────────────────────────────────────────────┘ │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  [➕ Ajouter]     [Sélectionner une catégorie      v]           │
+├─────────────────────────────────────────────────────────────────┤
+│  [🔄 Reset défaut]                              [👁️ Preview]    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Modal: Ajouter/Modifier une Catégorie
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Modifier la catégorie                                     [X]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Nom de la catégorie                                            │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ Découverte                                               │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Max 25 caractères                                              │
+│                                                                 │
+│  Emoji                                                          │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ 🔍                                                       │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Un seul emoji                                                  │
+│                                                                 │
+│  Description                                                    │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ Recherche et découverte de nouvelles recettes            │   │
+│  │                                                          │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Max 100 caractères                                             │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                        [Annuler]  [Sauvegarder] │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Modal: Ajouter/Modifier une Commande
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Ajouter une commande                                      [X]  │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  Nom de la commande                                             │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ /recette                                                 │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Commencer par / (ex: /macommande)                              │
+│                                                                 │
+│  Description                                                    │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ Rechercher une recette par nom                           │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Courte description de la commande                              │
+│                                                                 │
+│  Usage                                                          │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ /recette <plat>                                          │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Syntaxe avec paramètres                                        │
+│                                                                 │
+│  Exemple                                                        │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │ /recette pizza margherita                                │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│  Exemple concret d'utilisation                                  │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│                                        [Annuler]  [Sauvegarder] │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Structures de données
+
+### BrandingConfig
+
+```python
+@dataclass
+class BrandingConfig:
+    """Configuration du branding."""
+
+    # Identité
+    name: str                          # Nom du bot (max 32)
+    tagline: str | None = None         # Slogan (max 100)
+    emoji: str | None = None           # Emoji principal
+
+    # Apparence
+    primary_color: str = "#10B981"     # Couleur hex
+    logo_url: str | None = None        # URL logo (256x256)
+    banner_url: str | None = None      # URL bannière (1200x400)
+
+    # Liens
+    website_url: str | None = None
+    support_url: str | None = None
+    version: str | None = None
+```
+
+### HelpCategory
+
+```python
+@dataclass
+class HelpCommand:
+    """Commande dans une catégorie d'aide."""
+
+    name: str              # /recette
+    description: str       # Rechercher une recette
+    usage: str | None = None      # /recette <plat>
+    example: str | None = None    # /recette pizza
+
+@dataclass
+class HelpCategory:
+    """Catégorie d'aide."""
+
+    id: str                # UUID
+    name: str              # Découverte (max 25)
+    emoji: str             # 🔍
+    description: str       # Description (max 100)
+    commands: list[HelpCommand]
+    order: int = 0         # Ordre d'affichage
+```
+
+### HelpConfig
+
+```python
+@dataclass
+class HelpConfig:
+    """Configuration complète de l'aide."""
+
+    guild_id: str
+    categories: list[HelpCategory]
+    updated_at: datetime | None = None
+```
+
+---
+
+## 4. Limites
+
+| Élément | Limite | Raison |
+|---------|--------|--------|
+| Nom bot | 32 caractères | Discord limit |
+| Slogan | 100 caractères | UI lisibilité |
+| Emoji | 1 caractère | Simplicité |
+| Catégories | 10 max | Select menu limit |
+| Commandes/catégorie | 25 max | Select menu limit |
+| URL logo/banner | Validé | Sécurité |
+
+---
+
+## 5. Validation URLs
+
+```python
+ALLOWED_IMAGE_DOMAINS = [
+    "cdn.discordapp.com",
+    "media.discordapp.net",
+    "i.imgur.com",
+    "images.unsplash.com",
+    # + domaines configurés par projet
+]
+
+ALLOWED_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"]
+
+def validate_image_url(url: str) -> bool:
+    """Valider une URL d'image."""
+    parsed = urlparse(url)
+
+    # HTTPS obligatoire
+    if parsed.scheme != "https":
+        return False
+
+    # Domaine autorisé
+    if parsed.netloc not in ALLOWED_IMAGE_DOMAINS:
+        return False
+
+    # Extension autorisée
+    if not any(parsed.path.lower().endswith(ext) for ext in ALLOWED_EXTENSIONS):
+        return False
+
+    return True
+```
+
+---
+
+## 6. Persistance (API)
+
+### Endpoints requis
+
+#### Branding
+
+```http
+# Récupérer le branding
+GET /api/config/branding
+Headers: X-Project-ID: bot-appetit
+Query: guild_id=123456789
+
+Response:
+{
+  "success": true,
+  "data": {
+    "name": "Bot Appetit",
+    "tagline": "Votre assistant culinaire",
+    "emoji": "🍽️",
+    "primary_color": "#E67E22",
+    "logo_url": "https://...",
+    "banner_url": "https://...",
+    "website_url": "https://botappetit.fr",
+    "support_url": "https://discord.gg/...",
+    "version": "1.0.0"
+  }
+}
+```
+
+```http
+# Mettre à jour le branding
+PUT /api/config/branding
+Headers: X-Project-ID: bot-appetit
+Content-Type: application/json
+
+{
+  "guild_id": "123456789",
+  "name": "Bot Appetit",
+  "tagline": "Votre assistant culinaire",
+  "emoji": "🍽️",
+  "primary_color": "#E67E22"
+}
+
+Response:
+{
+  "success": true,
+  "message": "Branding updated"
+}
+```
+
+#### Help Config
+
+```http
+# Récupérer la config help
+GET /api/config/help
+Headers: X-Project-ID: bot-appetit
+Query: guild_id=123456789
+
+Response:
+{
+  "success": true,
+  "data": {
+    "categories": [
+      {
+        "id": "uuid-1",
+        "name": "Découverte",
+        "emoji": "🔍",
+        "description": "Recherche de recettes",
+        "order": 0,
+        "commands": [
+          {
+            "name": "/recette",
+            "description": "Rechercher une recette",
+            "usage": "/recette <plat>",
+            "example": "/recette pizza"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+```http
+# Mettre à jour la config help
+PUT /api/config/help
+Headers: X-Project-ID: bot-appetit
+Content-Type: application/json
+
+{
+  "guild_id": "123456789",
+  "categories": [...]
+}
+```
+
+```http
+# Reset aux valeurs par défaut
+POST /api/config/help/reset
+Headers: X-Project-ID: bot-appetit
+
+{
+  "guild_id": "123456789"
+}
+```
+
+---
+
+## 7. Flow n8n
+
+### Mapping guild_id → project_id
+
+Comme pour RFC-007, n8n maintient le mapping.
+
+```
+chatbot-core                        n8n                           API
+     │                               │                             │
+     │ PUT /webhook/config/branding  │                             │
+     │ { guild_id, name, color... } ─┼────────────────────────────►│
+     │                               │                             │
+     │                               │  Mapping: guild_id →        │
+     │                               │           project_id        │
+     │                               │                             │
+     │                               │  PUT /api/config/branding   │
+     │                               │  { project_id, ... } ───────►
+     │                               │                             │
+     │◄──────────────────────────────┼─────────────────────────────┤
+     │        { success: true }      │                             │
+```
+
+---
+
+## 8. Responsabilités par équipe
+
+### chatbot-core (Framework)
+
+| Composant | Description |
+|-----------|-------------|
+| `ConfigCommands` | Slash commands `/config branding`, `/config help` |
+| `BrandingConfigView` | View avec boutons Identité, Apparence, Liens, Preview |
+| `HelpConfigView` | View avec liste catégories, boutons CRUD |
+| `BrandingModals` | Modals pour identité, couleur, logos, liens |
+| `HelpModals` | Modals pour catégorie, commande |
+| `ConfigService` | Client HTTP vers n8n pour persist |
+| `BrandingConfig` | Dataclass configuration branding |
+| `HelpConfig` | Dataclass configuration help |
+
+### n8n (Orchestration)
+
+| Workflow | Description |
+|----------|-------------|
+| `CONFIG---On-Branding-Update` | Recevoir update branding, mapper, persist API |
+| `CONFIG---On-Help-Update` | Recevoir update help, mapper, persist API |
+| `CONFIG---Get-Branding` | Récupérer branding depuis API |
+| `CONFIG---Get-Help` | Récupérer help config depuis API |
+
+### API (Backend)
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/config/branding` | Récupérer branding par project_id + guild_id |
+| `PUT /api/config/branding` | Mettre à jour branding |
+| `GET /api/config/help` | Récupérer help config |
+| `PUT /api/config/help` | Mettre à jour help config |
+| `POST /api/config/help/reset` | Reset help aux défauts |
+
+### Plugin (Implémentation)
+
+| Tâche | Description |
+|-------|-------------|
+| Enregistrer commandes | `setup_config_commands(bot, config)` |
+| Valeurs par défaut | Fournir `HelpConfig` par défaut du plugin |
+| Domaines autorisés | Liste domaines images autorisés |
+
+---
+
+## 9. Tables API
+
+### Table `guild_branding`
+
+```sql
+CREATE TABLE guild_branding (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id VARCHAR(50) NOT NULL,
+    guild_id VARCHAR(50) NOT NULL,
+
+    -- Identité
+    name VARCHAR(32) NOT NULL,
+    tagline VARCHAR(100),
+    emoji VARCHAR(10),
+
+    -- Apparence
+    primary_color VARCHAR(7) DEFAULT '#10B981',
+    logo_url TEXT,
+    banner_url TEXT,
+
+    -- Liens
+    website_url TEXT,
+    support_url TEXT,
+    version VARCHAR(20),
+
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT uix_guild_branding UNIQUE(project_id, guild_id)
+);
+```
+
+### Table `guild_help_config`
+
+```sql
+CREATE TABLE guild_help_config (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id VARCHAR(50) NOT NULL,
+    guild_id VARCHAR(50) NOT NULL,
+
+    -- Config JSON
+    categories JSONB NOT NULL DEFAULT '[]',
+
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+    CONSTRAINT uix_guild_help UNIQUE(project_id, guild_id)
+);
+
+-- Index pour queries
+CREATE INDEX idx_help_config_lookup ON guild_help_config(project_id, guild_id);
+```
+
+---
+
+## 10. Effort estimé
+
+Toutes les équipes travaillent en parallèle. Voir §13 pour les checklists détaillées.
+
+| Équipe | Effort total | Priorité |
+|--------|--------------|----------|
+| **API** | M | P0 |
+| **n8n** | S (~2h) | P0 |
+| **chatbot-core** | L | P0 |
+| **Plugin** | S | P1 (après intégration) |
+
+**Légende:** S = Small (< 2h), M = Medium (2-4h), L = Large (> 4h)
+
+---
+
+## 11. Exports proposés (chatbot-core)
+
+```python
+# chatbot_core/services/__init__.py
+from chatbot_core.services.config import (
+    ConfigService,
+    BrandingConfig,
+    HelpConfig,
+    HelpCategory,
+    HelpCommand,
+)
+
+# chatbot_core/discord_ui/config/__init__.py
+from chatbot_core.discord_ui.config import (
+    BrandingConfigView,
+    HelpConfigView,
+    setup_config_commands,
+)
+```
+
+---
+
+## 12. Usage Plugin
+
+```python
+from chatbot_core.services import ConfigService, BrandingConfig, HelpConfig
+from chatbot_core.discord_ui.config import setup_config_commands
+
+# Service de configuration
+config_service = ConfigService(
+    n8n_branding_url=os.getenv("N8N_CONFIG_BRANDING_URL"),
+    n8n_help_url=os.getenv("N8N_CONFIG_HELP_URL"),
+)
+
+# Valeurs par défaut pour ce plugin
+default_help = HelpConfig(
+    guild_id="",  # Sera rempli dynamiquement
+    categories=[
+        HelpCategory(
+            id="discovery",
+            name="Découverte",
+            emoji="🔍",
+            description="Recherche de recettes",
+            commands=[
+                HelpCommand(
+                    name="/recette",
+                    description="Rechercher une recette",
+                    usage="/recette <plat>",
+                    example="/recette pizza",
+                ),
+            ],
+        ),
+    ],
+)
+
+# Enregistrer les commandes
+setup_config_commands(
+    bot=bot,
+    config_service=config_service,
+    default_help=default_help,
+    allowed_image_domains=["cdn.discordapp.com", "i.imgur.com"],
+)
+```
+
+---
+
+## 13. Plan de travail par équipe
+
+Toutes les équipes travaillent **en parallèle**.
+
+---
+
+### Équipe API
+
+#### Migration `guild_branding` (existante)
+
+```sql
+-- Ajouter colonnes manquantes à guild_branding (RFC-003)
+ALTER TABLE guild_branding
+    ADD COLUMN IF NOT EXISTS tagline VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS emoji VARCHAR(10),
+    ADD COLUMN IF NOT EXISTS banner_url TEXT,
+    ADD COLUMN IF NOT EXISTS website_url TEXT,
+    ADD COLUMN IF NOT EXISTS version VARCHAR(20);
+
+-- Renommer discord_invite_url → support_url
+ALTER TABLE guild_branding
+    RENAME COLUMN discord_invite_url TO support_url;
+```
+
+#### Nouvelle table `guild_help_config`
+
+```sql
+CREATE TABLE guild_help_config (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id VARCHAR(50) NOT NULL,
+    guild_id VARCHAR(50) NOT NULL,
+    categories JSONB NOT NULL DEFAULT '[]',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT uix_guild_help UNIQUE(project_id, guild_id)
+);
+
+CREATE INDEX idx_help_config_lookup ON guild_help_config(project_id, guild_id);
+```
+
+#### Checklist API
+
+- [ ] Migration table `guild_branding` (ajout colonnes)
+- [ ] Création table `guild_help_config`
+- [ ] Models Pydantic (`BrandingConfigRequest`, `HelpConfigRequest`)
+- [ ] Router `/api/config`
+- [ ] `GET /api/config/branding` (query: guild_id, header: X-Project-ID)
+- [ ] `PUT /api/config/branding`
+- [ ] `GET /api/config/help`
+- [ ] `PUT /api/config/help`
+- [ ] `POST /api/config/help/reset`
+- [ ] Validation URLs images (domaines whitelist)
+- [ ] Tests unitaires
+
+---
+
+### Équipe n8n
+
+#### Workflows à créer
+
+| Workflow | Méthode | Path | Description |
+|----------|---------|------|-------------|
+| `CONFIG---On-Branding-Update` | PUT | `/webhook/config/branding` | Recevoir update, mapper guild→project, persist API |
+| `CONFIG---Get-Branding` | GET | `/webhook/config/branding` | Récupérer branding via API |
+| `CONFIG---On-Help-Update` | PUT | `/webhook/config/help` | Recevoir update help, persist API |
+| `CONFIG---Get-Help` | GET | `/webhook/config/help` | Récupérer help config via API |
+| `CONFIG---Help-Reset` | POST | `/webhook/config/help/reset` | Reset aux valeurs par défaut |
+
+#### Pattern workflow (exemple Branding Update)
+
+```
+Webhook Trigger (PUT /webhook/config/branding)
+    │
+    ▼
+Validate Input (guild_id requis)
+    │
+    ▼
+Get Project Mapping (GET /api/branding/guild/{guild_id})
+    │
+    ▼
+PUT API (/api/config/branding avec X-Project-ID)
+    │
+    ▼
+Respond Success
+```
+
+#### Checklist n8n
+
+- [ ] `CONFIG---On-Branding-Update`
+- [ ] `CONFIG---Get-Branding`
+- [ ] `CONFIG---On-Help-Update`
+- [ ] `CONFIG---Get-Help`
+- [ ] `CONFIG---Help-Reset`
+- [ ] Tests avec Postman/curl
+
+**Effort estimé:** ~2h (patterns identiques RFC-007)
+
+---
+
+### Équipe chatbot-core (Framework)
+
+#### Composants à créer
+
+| Composant | Description | Effort |
+|-----------|-------------|--------|
+| `BrandingConfig` | Dataclass configuration branding | S |
+| `HelpConfig`, `HelpCategory`, `HelpCommand` | Dataclasses configuration aide | S |
+| `ConfigService` | Client HTTP vers webhooks n8n | M |
+| `BrandingConfigView` | View principale avec boutons | M |
+| `BrandingIdentityModal` | Modal nom, slogan, emoji | S |
+| `BrandingColorSelect` | Select menu couleurs | S |
+| `BrandingCustomColorModal` | Modal couleur personnalisée | S |
+| `BrandingLogosModal` | Modal URLs logo/banner | S |
+| `BrandingLinksModal` | Modal URLs site/support | S |
+| `BrandingPreviewView` | Aperçu du /help avec branding | S |
+| `HelpConfigView` | Liste des catégories | M |
+| `HelpCategoryDetailView` | Détail d'une catégorie | M |
+| `HelpCategoryModal` | Modal ajout/edit catégorie | S |
+| `HelpCommandModal` | Modal ajout/edit commande | S |
+| `HelpCategorySelect` | Select menu catégories | S |
+| `/config branding` | Slash command | S |
+| `/config help` | Slash command | S |
+| `setup_config_commands()` | Helper d'enregistrement pour plugins | S |
+
+#### Checklist chatbot-core
+
+- [ ] Dataclasses (`BrandingConfig`, `HelpConfig`, `HelpCategory`, `HelpCommand`)
+- [ ] `ConfigService` (client HTTP n8n)
+- [ ] Views Branding (principal, preview)
+- [ ] Modals Branding (identité, couleur, logos, liens)
+- [ ] Select couleur + modal custom
+- [ ] Views Help (liste, détail)
+- [ ] Modals Help (catégorie, commande)
+- [ ] Slash commands `/config branding`, `/config help`
+- [ ] `setup_config_commands()` helper
+- [ ] Exports dans `__init__.py`
+- [ ] Tests unitaires
+- [ ] Documentation guide
+
+---
+
+### Équipe Plugin (Bot Appetit, Torah Bot, etc.)
+
+#### Configuration requise
+
+```python
+from chatbot_core.services import ConfigService, HelpConfig, HelpCategory, HelpCommand
+from chatbot_core.discord_ui.config import setup_config_commands
+
+# 1. Créer le service de configuration
+config_service = ConfigService(
+    n8n_branding_url=os.getenv("N8N_CONFIG_BRANDING_URL"),
+    n8n_help_url=os.getenv("N8N_CONFIG_HELP_URL"),
+)
+
+# 2. Définir les valeurs par défaut du plugin
+default_help = HelpConfig(
+    guild_id="",  # Rempli dynamiquement
+    categories=[
+        HelpCategory(
+            id="discovery",
+            name="Découverte",
+            emoji="🔍",
+            description="Recherche de recettes",
+            commands=[
+                HelpCommand(
+                    name="/recette",
+                    description="Rechercher une recette",
+                    usage="/recette <plat>",
+                    example="/recette pizza",
+                ),
+            ],
+        ),
+        # ... autres catégories
+    ],
+)
+
+# 3. Enregistrer les commandes /config
+setup_config_commands(
+    bot=bot,
+    config_service=config_service,
+    default_help=default_help,
+    allowed_image_domains=["cdn.discordapp.com", "i.imgur.com"],
+)
+```
+
+#### Variables d'environnement
+
+```bash
+# .env du plugin
+N8N_CONFIG_BRANDING_URL=https://n8n.example.com/webhook/config/branding
+N8N_CONFIG_HELP_URL=https://n8n.example.com/webhook/config/help
+```
+
+#### Checklist Plugin
+
+- [ ] Ajouter variables d'environnement n8n
+- [ ] Créer `ConfigService` avec URLs
+- [ ] Définir `default_help` avec catégories du plugin
+- [ ] Appeler `setup_config_commands()` au démarrage
+- [ ] Définir domaines images autorisés si besoin
+- [ ] Tests des commandes `/config branding` et `/config help`
+
+---
+
+## 14. Références
+
+- [RFC-003: Branding Multi-tenant](./RFC-003-BRANDING.md) - Branding existant
+- [RFC-007: Mention Service](./RFC-007-MENTION-SERVICE.md) - Pattern n8n similaire
+- [RFC-008b: Réponse API](./RFC-008b-RESPONSE-API-ADMIN-CONFIG.md) - Décisions API
+- [RFC-008b: Réponse n8n](./RFC-008b-REPONSE-N8N-ADMIN-CONFIG.md) - Décisions n8n
+- [Guide Mention Service](../guides/GUIDE-MENTION-SERVICE.md) - Pattern guide

--- a/docs/rfc/RFC-008b-REPONSE-N8N-ADMIN-CONFIG.md
+++ b/docs/rfc/RFC-008b-REPONSE-N8N-ADMIN-CONFIG.md
@@ -1,0 +1,296 @@
+# RFC-008b: Réponse équipe n8n - Admin Config Screens
+
+**Date:** 2026-01-15
+**En réponse à:** RFC-008-ADMIN-CONFIG-SCREENS.md
+**Auteur:** Équipe n8n
+
+---
+
+## Résumé
+
+Analyse du RFC-008 Admin Config Screens du point de vue de l'équipe n8n. Ce document valide l'architecture proposée et détaille le plan d'implémentation des workflows.
+
+---
+
+## Évaluation globale
+
+| Aspect | Note | Commentaire |
+|--------|------|-------------|
+| Architecture | ✅ Excellent | Pattern cohérent avec RFC-007 |
+| Specs chatbot-core | ✅ Excellent | UI/UX bien documentée |
+| Specs n8n | ✅ Clair | 4 workflows simples à créer |
+| Specs API | ✅ Complet | Endpoints bien définis |
+| Sécurité | ✅ Bon | Validation URLs, domaines whitelist |
+
+---
+
+## Points validés
+
+### 1. Centralisation via n8n
+
+Tous les appels API passent par n8n - pas d'appels directs depuis chatbot-core.
+
+```
+chatbot-core → n8n → API
+     ↑                 │
+     └─────────────────┘
+```
+
+**Avantages:**
+- Point unique d'orchestration
+- Mapping `guild_id → project_id` centralisé
+- Logging et monitoring unifiés
+- Cohérence avec RFC-007 (Mention Service)
+
+### 2. Table `guild_branding` existante
+
+**Recommandation:** Étendre la table existante (RFC-003) plutôt que créer une nouvelle.
+
+Champs à ajouter:
+```sql
+-- Nouveaux champs à ajouter à guild_branding
+ALTER TABLE guild_branding ADD COLUMN IF NOT EXISTS tagline VARCHAR(100);
+ALTER TABLE guild_branding ADD COLUMN IF NOT EXISTS logo_url TEXT;
+ALTER TABLE guild_branding ADD COLUMN IF NOT EXISTS banner_url TEXT;
+ALTER TABLE guild_branding ADD COLUMN IF NOT EXISTS website_url TEXT;
+ALTER TABLE guild_branding ADD COLUMN IF NOT EXISTS support_url TEXT;
+ALTER TABLE guild_branding ADD COLUMN IF NOT EXISTS version VARCHAR(20);
+```
+
+### 3. Nouvelle table `guild_help_config`
+
+La structure JSONB proposée est OK pour v1:
+
+```sql
+CREATE TABLE guild_help_config (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id VARCHAR(50) NOT NULL,
+    guild_id VARCHAR(50) NOT NULL,
+    categories JSONB NOT NULL DEFAULT '[]',
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT uix_guild_help UNIQUE(project_id, guild_id)
+);
+```
+
+---
+
+## Plan de travail n8n
+
+### Workflows à créer
+
+| Workflow | Type | Description |
+|----------|------|-------------|
+| `CONFIG---On-Branding-Update` | Webhook | Recevoir PUT branding depuis chatbot-core |
+| `CONFIG---On-Help-Update` | Webhook | Recevoir PUT help config depuis chatbot-core |
+| `CONFIG---Get-Branding` | Webhook | Retourner branding pour un guild |
+| `CONFIG---Get-Help` | Webhook | Retourner help config pour un guild |
+
+### Architecture des workflows
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    CONFIG---On-Branding-Update                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────┐    ┌──────────────┐    ┌──────────────┐       │
+│  │   Webhook    │    │ Get Project  │    │  PUT API     │       │
+│  │ PUT /config/ │───►│   Mapping    │───►│  /branding   │       │
+│  │   branding   │    │              │    │              │       │
+│  └──────────────┘    └──────────────┘    └──────────────┘       │
+│                                                  │               │
+│                                                  ▼               │
+│                                          ┌──────────────┐       │
+│                                          │   Respond    │       │
+│                                          │   Success    │       │
+│                                          └──────────────┘       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Détail: CONFIG---On-Branding-Update
+
+```
+Webhook Trigger (PUT /config/branding)
+    │
+    ▼
+Validate Input
+    │ - guild_id requis
+    │ - Au moins un champ à modifier
+    │
+    ▼
+Get Project Mapping
+    │ GET /api/branding/guild/{guild_id}
+    │ → project_id
+    │
+    ▼
+Has Project?
+    ├─ Non → Respond 400 "Guild non configuré"
+    │
+    └─ Oui ▼
+        PUT API Branding
+            │ PUT /api/config/branding
+            │ Headers: X-Project-ID
+            │ Body: { guild_id, name, tagline, ... }
+            │
+            ▼
+        Respond Success
+            │ { success: true, message: "Branding updated" }
+```
+
+### Détail: CONFIG---Get-Branding
+
+```
+Webhook Trigger (GET /config/branding?guild_id=xxx)
+    │
+    ▼
+Validate Input
+    │ - guild_id requis (query param)
+    │
+    ▼
+Get Project Mapping
+    │ GET /api/branding/guild/{guild_id}
+    │ → project_id
+    │
+    ▼
+Has Project?
+    ├─ Non → Respond 400 "Guild non configuré"
+    │
+    └─ Oui ▼
+        GET API Branding
+            │ GET /api/config/branding?guild_id=xxx
+            │ Headers: X-Project-ID
+            │
+            ▼
+        Respond Success
+            │ { success: true, data: { name, tagline, ... } }
+```
+
+### Patterns identiques pour Help
+
+- `CONFIG---On-Help-Update`: Même pattern que Branding-Update
+- `CONFIG---Get-Help`: Même pattern que Get-Branding
+
+---
+
+## Endpoints n8n (webhooks)
+
+| Méthode | Path | Description |
+|---------|------|-------------|
+| `PUT` | `/webhook/config/branding` | Mettre à jour branding |
+| `GET` | `/webhook/config/branding` | Récupérer branding |
+| `PUT` | `/webhook/config/help` | Mettre à jour help config |
+| `GET` | `/webhook/config/help` | Récupérer help config |
+| `POST` | `/webhook/config/help/reset` | Reset help aux défauts |
+
+---
+
+## Réponses aux questions §13
+
+### Question 1: Workflows existants ?
+
+**Réponse:** Non, pas de workflows branding existants. À créer selon le plan ci-dessus.
+
+### Question 2: Cache Redis ?
+
+**Réponse:** Recommandé pour v2.
+
+Pour v1: pas de cache, appels directs à l'API.
+
+Pour v2:
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  chatbot    │────►│    n8n      │────►│   Redis     │
+│    core     │     │             │     │   Cache     │
+└─────────────┘     └──────┬──────┘     └─────────────┘
+                          │                    │
+                          │ Cache miss         │
+                          ▼                    │
+                   ┌─────────────┐             │
+                   │    API      │◄────────────┘
+                   └─────────────┘      Update cache
+```
+
+Clés Redis proposées:
+- `config:branding:{project_id}:{guild_id}`
+- `config:help:{project_id}:{guild_id}`
+
+TTL: 5 minutes (config change peu fréquemment)
+
+---
+
+## Dépendances
+
+### Bloquant pour n8n
+
+| Dépendance | Équipe | Status | Impact |
+|------------|--------|--------|--------|
+| `PUT /api/config/branding` | API | À créer | Workflow Update |
+| `GET /api/config/branding` | API | À créer | Workflow Get |
+| `PUT /api/config/help` | API | À créer | Workflow Update |
+| `GET /api/config/help` | API | À créer | Workflow Get |
+| Migration table | API | À faire | Nouveaux champs branding |
+
+### Non bloquant
+
+| Item | Équipe | Note |
+|------|--------|------|
+| ConfigService | chatbot-core | Peut avancer en parallèle |
+| Views/Modals | chatbot-core | Indépendant |
+| Plugin config | Plugin | Après chatbot-core |
+
+---
+
+## Estimation effort n8n
+
+| Workflow | Effort | Complexité |
+|----------|--------|------------|
+| `CONFIG---On-Branding-Update` | S | Simple |
+| `CONFIG---Get-Branding` | S | Simple |
+| `CONFIG---On-Help-Update` | S | Simple |
+| `CONFIG---Get-Help` | S | Simple |
+| `CONFIG---Help-Reset` | S | Simple |
+| **Total** | **~2h** | Patterns identiques RFC-007 |
+
+---
+
+## Checklist avant implémentation
+
+### n8n
+
+- [ ] Endpoints API créés et testés
+- [ ] Migration table `guild_branding` effectuée
+- [ ] Table `guild_help_config` créée
+
+### API
+
+- [ ] `PUT /api/config/branding`
+- [ ] `GET /api/config/branding`
+- [ ] `PUT /api/config/help`
+- [ ] `GET /api/config/help`
+- [ ] `POST /api/config/help/reset`
+
+### chatbot-core
+
+- [ ] ConfigService avec URLs n8n configurées
+
+---
+
+## Conclusion
+
+Le RFC-008 est bien structuré et cohérent avec l'architecture existante (RFC-007).
+
+**Points clés:**
+1. ✅ Tous les appels passent par n8n (pas d'appels directs API)
+2. ✅ Réutilisation table `guild_branding` existante
+3. ✅ 5 workflows simples à créer (~2h de travail)
+4. ⏳ Cache Redis en v2
+
+**Prêt à démarrer** dès que les endpoints API sont disponibles.
+
+---
+
+## Historique
+
+| Date | Auteur | Modification |
+|------|--------|--------------|
+| 2026-01-15 | Équipe n8n | Création du document de réponse |

--- a/workflows/CONFIG---Get-Branding.json
+++ b/workflows/CONFIG---Get-Branding.json
@@ -1,0 +1,303 @@
+{
+  "name": "CONFIG---Get-Branding",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RFC-008: Get Branding\n\n**Webhook:** GET /config/branding\n\n**Query params:**\n- guild_id (requis)\n\n**Flow:**\n1. Validate guild_id\n2. Map guild_id → project_id\n3. GET /api/config/branding\n4. Return BrandingConfig",
+        "width": 280,
+        "height": 220,
+        "color": 6
+      },
+      "id": "get-branding-note",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-280, 180]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "config/branding",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "get-branding-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "config-get-branding"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE INPUT (RFC-008)\n// ============================================\n\nconst input = $input.first().json;\nconst query = input.query || {};\n\nif (!query.guild_id) {\n  return {\n    valid: false,\n    error: {\n      code: 'VALIDATION_ERROR',\n      message: 'guild_id requis',\n      http_status: 400\n    }\n  };\n}\n\nreturn {\n  valid: true,\n  guild_id: query.guild_id\n};"
+      },
+      "id": "get-branding-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "get-branding-0003",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/branding/guild/{{ $json.guild_id }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "get-branding-0004",
+      "name": "Get Project Mapping",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-project",
+              "leftValue": "={{ $json.project_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "get-branding-0005",
+      "name": "Has Project?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/config/branding",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "guild_id",
+              "value": "={{ $('Validate Input').item.json.guild_id }}"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "get-branding-0006",
+      "name": "Get Branding from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 100],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "get-branding-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "get-branding-0008",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'UNKNOWN_GUILD', message: 'Guild non configuré', http_status: 400 } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "get-branding-0009",
+      "name": "Respond Unknown Guild",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'API_ERROR', message: 'Erreur API branding', http_status: 500 } }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "get-branding-0010",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Project Mapping",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Mapping": {
+      "main": [
+        [
+          {
+            "node": "Has Project?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Project?": {
+      "main": [
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Branding from API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Branding from API": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/CONFIG---Get-Help.json
+++ b/workflows/CONFIG---Get-Help.json
@@ -1,0 +1,303 @@
+{
+  "name": "CONFIG---Get-Help",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RFC-008: Get Help Config\n\n**Webhook:** GET /config/help\n\n**Query params:**\n- guild_id (requis)\n\n**Flow:**\n1. Validate guild_id\n2. Map guild_id → project_id\n3. GET /api/config/help\n4. Return HelpConfig",
+        "width": 280,
+        "height": 220,
+        "color": 6
+      },
+      "id": "get-help-note",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-280, 180]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "config/help",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "get-help-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "config-get-help"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE INPUT (RFC-008)\n// ============================================\n\nconst input = $input.first().json;\nconst query = input.query || {};\n\nif (!query.guild_id) {\n  return {\n    valid: false,\n    error: {\n      code: 'VALIDATION_ERROR',\n      message: 'guild_id requis',\n      http_status: 400\n    }\n  };\n}\n\nreturn {\n  valid: true,\n  guild_id: query.guild_id\n};"
+      },
+      "id": "get-help-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "get-help-0003",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/branding/guild/{{ $json.guild_id }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "get-help-0004",
+      "name": "Get Project Mapping",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-project",
+              "leftValue": "={{ $json.project_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "get-help-0005",
+      "name": "Has Project?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/config/help",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "guild_id",
+              "value": "={{ $('Validate Input').item.json.guild_id }}"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "get-help-0006",
+      "name": "Get Help from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 100],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "get-help-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "get-help-0008",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'UNKNOWN_GUILD', message: 'Guild non configuré', http_status: 400 } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "get-help-0009",
+      "name": "Respond Unknown Guild",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'API_ERROR', message: 'Erreur API help config', http_status: 500 } }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "get-help-0010",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Project Mapping",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Mapping": {
+      "main": [
+        [
+          {
+            "node": "Has Project?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Project?": {
+      "main": [
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Help from API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Help from API": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/CONFIG---Help-Reset.json
+++ b/workflows/CONFIG---Help-Reset.json
@@ -1,0 +1,301 @@
+{
+  "name": "CONFIG---Help-Reset",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RFC-008: Reset Help Config\n\n**Webhook:** POST /config/help/reset\n\n**Body:**\n- guild_id (requis)\n\n**Flow:**\n1. Validate guild_id\n2. Map guild_id → project_id\n3. POST /api/config/help/reset\n4. Return success",
+        "width": 280,
+        "height": 220,
+        "color": 6
+      },
+      "id": "reset-help-note",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-280, 180]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "config/help/reset",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "reset-help-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "config-reset-help"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE INPUT (RFC-008)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.guild_id) {\n  return {\n    valid: false,\n    error: {\n      code: 'VALIDATION_ERROR',\n      message: 'guild_id requis',\n      http_status: 400\n    }\n  };\n}\n\nreturn {\n  valid: true,\n  guild_id: body.guild_id\n};"
+      },
+      "id": "reset-help-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "reset-help-0003",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/branding/guild/{{ $json.guild_id }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "reset-help-0004",
+      "name": "Get Project Mapping",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-project",
+              "leftValue": "={{ $json.project_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "reset-help-0005",
+      "name": "Has Project?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/config/help/reset",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"guild_id\": {{ JSON.stringify($('Validate Input').item.json.guild_id) }}\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "reset-help-0006",
+      "name": "Reset Help API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 100],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: true, message: 'Help config reset to defaults' }) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "reset-help-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "reset-help-0008",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'UNKNOWN_GUILD', message: 'Guild non configuré', http_status: 400 } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "reset-help-0009",
+      "name": "Respond Unknown Guild",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'API_ERROR', message: 'Erreur API reset help', http_status: 500 } }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "reset-help-0010",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Project Mapping",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Mapping": {
+      "main": [
+        [
+          {
+            "node": "Has Project?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Project?": {
+      "main": [
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Reset Help API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Reset Help API": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/CONFIG---On-Branding-Update.json
+++ b/workflows/CONFIG---On-Branding-Update.json
@@ -1,0 +1,301 @@
+{
+  "name": "CONFIG---On-Branding-Update",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RFC-008: Update Branding\n\n**Webhook:** PUT /config/branding\n\n**Body:**\n- guild_id (requis)\n- name, tagline, emoji\n- primary_color, logo_url, banner_url\n- website_url, support_url, version\n\n**Flow:**\n1. Validate input\n2. Map guild_id → project_id\n3. PUT /api/config/branding\n4. Return success",
+        "width": 280,
+        "height": 280,
+        "color": 6
+      },
+      "id": "update-branding-note",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-280, 180]
+    },
+    {
+      "parameters": {
+        "httpMethod": "PUT",
+        "path": "config/branding",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "update-branding-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "config-update-branding"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE INPUT (RFC-008)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst errors = [];\n\nif (!body.guild_id) errors.push('guild_id requis');\n\n// Au moins un champ de branding doit être présent\nconst brandingFields = ['name', 'tagline', 'emoji', 'primary_color', 'logo_url', 'banner_url', 'website_url', 'support_url', 'version'];\nconst hasField = brandingFields.some(f => body[f] !== undefined);\n\nif (!hasField) {\n  errors.push('Au moins un champ de branding requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    error: {\n      code: 'VALIDATION_ERROR',\n      message: errors.join(', '),\n      http_status: 400\n    }\n  };\n}\n\nreturn {\n  valid: true,\n  data: {\n    guild_id: body.guild_id,\n    name: body.name,\n    tagline: body.tagline,\n    emoji: body.emoji,\n    primary_color: body.primary_color,\n    logo_url: body.logo_url,\n    banner_url: body.banner_url,\n    website_url: body.website_url,\n    support_url: body.support_url,\n    version: body.version\n  }\n};"
+      },
+      "id": "update-branding-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "update-branding-0003",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/branding/guild/{{ $json.data.guild_id }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-branding-0004",
+      "name": "Get Project Mapping",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-project",
+              "leftValue": "={{ $json.project_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "update-branding-0005",
+      "name": "Has Project?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.TORAH_API_URL }}/api/config/branding",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($('Validate Input').item.json.data) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "update-branding-0006",
+      "name": "Update Branding API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 100],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: true, message: 'Branding updated' }) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "update-branding-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "update-branding-0008",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'UNKNOWN_GUILD', message: 'Guild non configuré', http_status: 400 } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "update-branding-0009",
+      "name": "Respond Unknown Guild",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'API_ERROR', message: 'Erreur API branding', http_status: 500 } }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "update-branding-0010",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Project Mapping",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Mapping": {
+      "main": [
+        [
+          {
+            "node": "Has Project?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Project?": {
+      "main": [
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Update Branding API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Branding API": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/CONFIG---On-Help-Update.json
+++ b/workflows/CONFIG---On-Help-Update.json
@@ -1,0 +1,301 @@
+{
+  "name": "CONFIG---On-Help-Update",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## RFC-008: Update Help Config\n\n**Webhook:** PUT /config/help\n\n**Body:**\n- guild_id (requis)\n- categories (array de HelpCategory)\n\n**Flow:**\n1. Validate input\n2. Map guild_id → project_id\n3. PUT /api/config/help\n4. Return success",
+        "width": 280,
+        "height": 220,
+        "color": 6
+      },
+      "id": "update-help-note",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-280, 180]
+    },
+    {
+      "parameters": {
+        "httpMethod": "PUT",
+        "path": "config/help",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "update-help-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "config-update-help"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE INPUT (RFC-008)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst errors = [];\n\nif (!body.guild_id) errors.push('guild_id requis');\nif (!body.categories) errors.push('categories requis');\nif (body.categories && !Array.isArray(body.categories)) {\n  errors.push('categories doit être un array');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    error: {\n      code: 'VALIDATION_ERROR',\n      message: errors.join(', '),\n      http_status: 400\n    }\n  };\n}\n\nreturn {\n  valid: true,\n  data: {\n    guild_id: body.guild_id,\n    categories: body.categories\n  }\n};"
+      },
+      "id": "update-help-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "update-help-0003",
+      "name": "Is Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/branding/guild/{{ $json.data.guild_id }}",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "update-help-0004",
+      "name": "Get Project Mapping",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-project",
+              "leftValue": "={{ $json.project_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "update-help-0005",
+      "name": "Has Project?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.TORAH_API_URL }}/api/config/help",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($('Validate Input').item.json.data) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "update-help-0006",
+      "name": "Update Help API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 100],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: true, message: 'Help config updated' }) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "update-help-0007",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "update-help-0008",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'UNKNOWN_GUILD', message: 'Guild non configuré', http_status: 400 } }) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "update-help-0009",
+      "name": "Respond Unknown Guild",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'API_ERROR', message: 'Erreur API help config', http_status: 500 } }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "id": "update-help-0010",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1320, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Is Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Is Valid?": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Project Mapping",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Project Mapping": {
+      "main": [
+        [
+          {
+            "node": "Has Project?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Project?": {
+      "main": [
+        [
+          {
+            "node": "Respond Unknown Guild",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Update Help API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Help API": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Add 5 workflows for admin configuration screens (branding & help)
- Add RFC-008 spec document and n8n response document

## Workflows

| Workflow | Method | Endpoint |
|----------|--------|----------|
| `CONFIG---Get-Branding` | GET | `/webhook/config/branding` |
| `CONFIG---On-Branding-Update` | PUT | `/webhook/config/branding` |
| `CONFIG---Get-Help` | GET | `/webhook/config/help` |
| `CONFIG---On-Help-Update` | PUT | `/webhook/config/help` |
| `CONFIG---Help-Reset` | POST | `/webhook/config/help/reset` |

## Pattern (all workflows)

```
Webhook → Validate Input → Get Project Mapping → Call API → Respond
```

## Documents

- `docs/rfc/RFC-008-ADMIN-CONFIG-SCREENS.md` - Spec document
- `docs/rfc/RFC-008b-REPONSE-N8N-ADMIN-CONFIG.md` - n8n team response

## Test plan
- [ ] Import all 5 workflows in n8n
- [ ] Activate all workflows
- [ ] Test GET/PUT branding endpoints
- [ ] Test GET/PUT/POST help endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)