### PR TITLE
fix(mention): fix X-Project-ID header reference in Process-Question

### DIFF
--- a/workflows/MENTION---Process-Question.json
+++ b/workflows/MENTION---Process-Question.json
@@ -84,13 +84,13 @@
             },
             {
               "name": "X-Project-ID",
-              "value": "={{ $json.project_id }}"
+              "value": "={{ $('Detect Intent').item.json.project_id }}"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"project_id\": {{ JSON.stringify($json.project_id) }},\n  \"content\": {{ JSON.stringify($json.data.content) }},\n  \"user_id\": {{ JSON.stringify($json.data.user_id) }},\n  \"username\": {{ JSON.stringify($json.data.username) }},\n  \"guild_id\": {{ JSON.stringify($json.data.guild_id) }}\n}",
+        "jsonBody": "={\n  \"project_id\": {{ JSON.stringify($('Detect Intent').item.json.project_id) }},\n  \"content\": {{ JSON.stringify($('Detect Intent').item.json.data.content) }},\n  \"user_id\": {{ JSON.stringify($('Detect Intent').item.json.data.user_id) }},\n  \"username\": {{ JSON.stringify($('Detect Intent').item.json.data.username) }},\n  \"guild_id\": {{ JSON.stringify($('Detect Intent').item.json.data.guild_id) }}\n}",
         "options": {
           "timeout": 30000
         }


### PR DESCRIPTION
## Summary
- Fix missing X-Project-ID header error (422) in MENTION---Process-Question workflow

## Problem
The `Call AI Chat API` node was referencing `$json.project_id` which is not available after the IF node "Skip LLM?".

## Solution
Changed references to use `$('Detect Intent').item.json` to ensure project_id and data are correctly accessed.

```diff
- "X-Project-ID": "={{ $json.project_id }}"
+ "X-Project-ID": "={{ $('Detect Intent').item.json.project_id }}"
```

## Test plan
- [x] Re-import MENTION---Process-Question workflow
- [ ] Test @Bot mention with a question

🤖 Generated with [Claude Code](https://claude.com/claude-code)