### PR TITLE
fix(mention): ensure success:true in webhook response

### DIFF
--- a/workflows/MENTION---On-Mention-Handler.json
+++ b/workflows/MENTION---On-Mention-Handler.json
@@ -170,7 +170,7 @@
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ JSON.stringify($json) }}",
+        "responseBody": "={{ JSON.stringify({ success: true, response: $json.response || null, intent: $json.intent || 'unknown', confidence: $json.confidence || 0.5, credits_used: $json.credits_consumed || 0 }) }}",
         "options": {
           "responseCode": 200
         }


### PR DESCRIPTION
Force explicit success: true in Respond Success node to guarantee chatbot-core receives the expected format:

{
  "success": true,
  "response": "...",
  "intent": "...",
  "confidence": 0.5,
  "credits_used": 0
}