### PR TITLE
feat: add torah-document-callback workflow and fix MCP workflows

### DIFF
--- a/workflows/JOBS---Admin-Cleanup.json
+++ b/workflows/JOBS---Admin-Cleanup.json
@@ -1,0 +1,355 @@
+{
+  "name": "JOBS---Admin-Cleanup",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 5
+            }
+          ]
+        }
+      },
+      "id": "jobs-admin-0001",
+      "name": "Cron Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        0,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/admin/document-jobs/stats?max_age_minutes=15",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "jobs-admin-0002",
+      "name": "Get Stats",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        220,
+        300
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// CHECK FOR ZOMBIES\n// ============================================\n\nconst stats = $input.first().json;\n\n// --- Check API errors ---\nif (!stats.success) {\n  return {\n    has_zombies: false,\n    error: true,\n    message: 'Erreur API stats: ' + (stats.error?.message || 'Unknown')\n  };\n}\n\nreturn {\n  has_zombies: (stats.zombie_jobs || 0) > 0,\n  zombie_count: stats.zombie_jobs || 0,\n  total_jobs: stats.total_jobs || 0,\n  active_jobs: stats.active_jobs || 0,\n  jobs_by_user: stats.jobs_by_user || {}\n};"
+      },
+      "id": "jobs-admin-0003",
+      "name": "Check Zombies",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        440,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-zombies",
+              "leftValue": "={{ $json.has_zombies }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "jobs-admin-0004",
+      "name": "Has Zombies?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        660,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/admin/document-jobs/cleanup?max_age_minutes=15",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "jobs-admin-0005",
+      "name": "Call Cleanup API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        880,
+        200
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS CLEANUP RESULT\n// ============================================\n\nconst result = $input.first().json;\n\n// --- Check API errors ---\nif (!result.success) {\n  return {\n    cleanup_success: false,\n    refund_required: false,\n    error: result.error?.message || 'Cleanup failed'\n  };\n}\n\n// --- Extract refund details ---\nconst refundDetails = result.refund_details || [];\n\nreturn {\n  cleanup_success: true,\n  cleaned_count: result.cleaned_count || 0,\n  refund_required: result.refund_required === true && refundDetails.length > 0,\n  refund_details: refundDetails,\n  cleaned_jobs: result.cleaned_jobs || []\n};"
+      },
+      "id": "jobs-admin-0006",
+      "name": "Process Cleanup Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1100,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-refund",
+              "leftValue": "={{ $json.refund_required }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "jobs-admin-0007",
+      "name": "Refund Required?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1320,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE REFUND ITEMS\n// ============================================\n\nconst data = $input.first().json;\nconst refundDetails = data.refund_details || [];\n\n// --- Return array of refund items for loop ---\nreturn refundDetails.map(item => ({\n  user_id: item.user_id,\n  job_id: item.job_id,\n  guild_id: item.guild_id,\n  filename: item.filename,\n  age_minutes: item.age_minutes,\n  credits_to_refund: item.credits_to_refund || 1\n}));"
+      },
+      "id": "jobs-admin-0008",
+      "name": "Prepare Refund Items",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1540,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/webhook/account/credit",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  discord_user_id: $json.user_id,\n  guild_id: $json.guild_id,\n  amount: $json.credits_to_refund,\n  reason: 'Refund job zombie: ' + $json.filename + ' (age: ' + Math.round($json.age_minutes) + ' min)'\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "jobs-admin-0009",
+      "name": "Refund Credits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1760,
+        100
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG REFUND RESULT\n// ============================================\n\nconst refundResult = $input.first().json;\nconst refundItem = $('Prepare Refund Items').first().json;\n\nreturn {\n  action: 'refund',\n  user_id: refundItem.user_id,\n  credits_refunded: refundItem.credits_to_refund,\n  job_id: refundItem.job_id,\n  refund_success: refundResult.success !== false,\n  refund_response: refundResult\n};"
+      },
+      "id": "jobs-admin-0010",
+      "name": "Log Refund Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1980,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG NO REFUND NEEDED\n// ============================================\n\nconst data = $input.first().json;\n\nreturn {\n  action: 'cleanup_only',\n  cleaned_count: data.cleaned_count,\n  refund_required: false,\n  message: 'Cleanup terminé sans remboursement nécessaire'\n};"
+      },
+      "id": "jobs-admin-0011",
+      "name": "Log No Refund",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1540,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG NO ZOMBIES\n// ============================================\n\nconst stats = $input.first().json;\n\nreturn {\n  action: 'no_action',\n  total_jobs: stats.total_jobs,\n  active_jobs: stats.active_jobs,\n  zombie_count: 0,\n  message: 'Aucun job zombie détecté'\n};"
+      },
+      "id": "jobs-admin-0012",
+      "name": "Log No Zombies",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        880,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Cron Trigger": {
+      "main": [
+        [
+          {
+            "node": "Get Stats",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Stats": {
+      "main": [
+        [
+          {
+            "node": "Check Zombies",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Zombies": {
+      "main": [
+        [
+          {
+            "node": "Has Zombies?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Zombies?": {
+      "main": [
+        [
+          {
+            "node": "Call Cleanup API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log No Zombies",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Cleanup API": {
+      "main": [
+        [
+          {
+            "node": "Process Cleanup Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Cleanup Result": {
+      "main": [
+        [
+          {
+            "node": "Refund Required?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Refund Required?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Refund Items",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log No Refund",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Refund Items": {
+      "main": [
+        [
+          {
+            "node": "Refund Credits",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Refund Credits": {
+      "main": [
+        [
+          {
+            "node": "Log Refund Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false
+  },
+  "tags": []
+}

--- a/workflows/JOBS---User-Cleanup.json
+++ b/workflows/JOBS---User-Cleanup.json
@@ -1,0 +1,536 @@
+{
+  "name": "JOBS---User-Cleanup",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "jobs/user-cleanup",
+        "options": {
+          "responseMode": "responseNode"
+        }
+      },
+      "id": "jobs-clean-0001",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        0,
+        300
+      ],
+      "webhookId": "jobs-user-cleanup-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || {};\nconst headers = input.headers || {};\n\n// --- Extraction Project ID ---\nconst projectId = headers['x-project-id'] \n  || headers['X-Project-ID'] \n  || headers['X-Project-Id']\n  || 'unknown';\n\n// --- Validation discord_user_id ---\nif (!body.discord_user_id) {\n  return {\n    error: true,\n    error_code: 'MISSING_USER_ID',\n    message: 'Le champ \"discord_user_id\" est requis'\n  };\n}\n\n// --- Optional: max_age_minutes (default 15) ---\nconst maxAgeMinutes = body.max_age_minutes || 15;\n\n// --- Optional: dry_run (default false) ---\nconst dryRun = body.dry_run === true;\n\n// --- Retour des donnees validees ---\nreturn {\n  error: false,\n  data: {\n    discord_user_id: String(body.discord_user_id),\n    max_age_minutes: maxAgeMinutes,\n    dry_run: dryRun,\n    project_id: projectId\n  }\n};"
+      },
+      "id": "jobs-clean-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        220,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-error",
+              "leftValue": "={{ $json.error }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "jobs-clean-0003",
+      "name": "Check Validation Error",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        440,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/admin/document-jobs/stats?max_age_minutes={{ $json.data.max_age_minutes }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.data.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "jobs-clean-0004",
+      "name": "Get Stats",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        660,
+        200
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FILTER STATS FOR USER & PREPARE CLEANUP\n// ============================================\n\nconst stats = $input.first().json;\nconst userData = $('Validate Input').first().json.data;\nconst userId = userData.discord_user_id;\n\n// --- Check API errors ---\nif (!stats.success) {\n  return {\n    error: true,\n    error_code: 'STATS_API_ERROR',\n    message: stats.error?.message || 'Erreur lors de la récupération des stats'\n  };\n}\n\n// --- Get user's job count ---\nconst userJobCount = stats.jobs_by_user?.[userId] || 0;\n\n// --- Return filtered stats ---\nreturn {\n  error: false,\n  user_stats: {\n    discord_user_id: userId,\n    total_jobs: userJobCount,\n    zombie_jobs_global: stats.zombie_jobs || 0\n  },\n  global_stats: {\n    total_jobs: stats.total_jobs,\n    active_jobs: stats.active_jobs,\n    zombie_jobs: stats.zombie_jobs,\n    jobs_by_status: stats.jobs_by_status\n  },\n  should_cleanup: stats.zombie_jobs > 0,\n  dry_run: userData.dry_run,\n  max_age_minutes: userData.max_age_minutes,\n  project_id: userData.project_id\n};"
+      },
+      "id": "jobs-clean-0005",
+      "name": "Filter User Stats",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        880,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-cleanup",
+              "leftValue": "={{ $json.should_cleanup }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "jobs-clean-0006",
+      "name": "Has Zombies?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1100,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/admin/document-jobs/cleanup?max_age_minutes={{ $json.max_age_minutes }}&dry_run={{ $json.dry_run }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.project_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "jobs-clean-0007",
+      "name": "Call Cleanup API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1320,
+        100
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS CLEANUP & CHECK REFUND\n// ============================================\n\nconst cleanupResult = $input.first().json;\nconst statsData = $('Filter User Stats').first().json;\n\n// --- Check API errors ---\nif (!cleanupResult.success) {\n  return {\n    error: true,\n    error_code: 'CLEANUP_API_ERROR',\n    message: cleanupResult.error?.message || 'Erreur lors du cleanup'\n  };\n}\n\n// --- Extract refund details ---\nconst refundDetails = cleanupResult.refund_details || [];\n\nreturn {\n  error: false,\n  dry_run: statsData.dry_run,\n  stats_before: statsData.global_stats,\n  cleaned_count: cleanupResult.cleaned_count || 0,\n  refund_required: cleanupResult.refund_required === true && refundDetails.length > 0 && !statsData.dry_run,\n  refund_details: refundDetails,\n  cleaned_jobs: cleanupResult.cleaned_jobs || []\n};"
+      },
+      "id": "jobs-clean-0008",
+      "name": "Process Cleanup Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1540,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-refund",
+              "leftValue": "={{ $json.refund_required }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "jobs-clean-0009",
+      "name": "Refund Required?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1760,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE REFUND ITEMS\n// ============================================\n\nconst data = $input.first().json;\nconst refundDetails = data.refund_details || [];\n\n// --- Store cleanup data for later ---\nconst cleanupData = {\n  dry_run: data.dry_run,\n  stats_before: data.stats_before,\n  cleaned_count: data.cleaned_count,\n  cleaned_jobs: data.cleaned_jobs\n};\n\n// --- Return array of refund items for loop ---\nreturn refundDetails.map(item => ({\n  user_id: item.user_id,\n  job_id: item.job_id,\n  guild_id: item.guild_id,\n  filename: item.filename,\n  age_minutes: item.age_minutes,\n  credits_to_refund: item.credits_to_refund || 1,\n  _cleanup_data: cleanupData\n}));"
+      },
+      "id": "jobs-clean-0010",
+      "name": "Prepare Refund Items",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1980,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/webhook/account/credit",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  discord_user_id: $json.user_id,\n  guild_id: $json.guild_id,\n  amount: $json.credits_to_refund,\n  reason: 'Refund job zombie: ' + $json.filename + ' (age: ' + Math.round($json.age_minutes) + ' min)'\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "jobs-clean-0011",
+      "name": "Refund Credits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2200,
+        0
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// AGGREGATE REFUND RESULTS\n// ============================================\n\nconst items = $input.all();\nconst refundItems = $('Prepare Refund Items').all();\n\nlet totalRefunded = 0;\nconst refundResults = [];\n\nfor (let i = 0; i < items.length; i++) {\n  const result = items[i].json;\n  const original = refundItems[i]?.json || {};\n  \n  const success = result.success !== false;\n  if (success) {\n    totalRefunded += original.credits_to_refund || 1;\n  }\n  \n  refundResults.push({\n    user_id: original.user_id,\n    credits: original.credits_to_refund || 1,\n    success: success\n  });\n}\n\n// --- Get cleanup data from first item ---\nconst cleanupData = refundItems[0]?.json?._cleanup_data || {};\n\nreturn {\n  success: true,\n  message: 'Jobs zombies nettoyés avec remboursement',\n  dry_run: false,\n  stats_before: cleanupData.stats_before,\n  cleanup_result: {\n    cleaned_count: cleanupData.cleaned_count || 0,\n    refunds_processed: refundResults.length,\n    total_credits_refunded: totalRefunded,\n    refund_details: refundResults\n  }\n};"
+      },
+      "id": "jobs-clean-0012",
+      "name": "Aggregate Refund Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2420,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT NO REFUND RESPONSE\n// ============================================\n\nconst data = $input.first().json;\n\nreturn {\n  success: true,\n  message: data.dry_run ? 'Prévisualisation du nettoyage' : 'Jobs zombies nettoyés (pas de remboursement nécessaire)',\n  dry_run: data.dry_run,\n  stats_before: data.stats_before,\n  cleanup_result: {\n    cleaned_count: data.cleaned_count || 0,\n    refunds_processed: 0,\n    total_credits_refunded: 0\n  }\n};"
+      },
+      "id": "jobs-clean-0013",
+      "name": "Format No Refund Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1980,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT NO ZOMBIES RESPONSE\n// ============================================\n\nconst statsData = $input.first().json;\n\nreturn {\n  success: true,\n  message: 'Aucun job zombie à nettoyer',\n  user_stats: statsData.user_stats,\n  global_stats: statsData.global_stats,\n  cleanup_result: {\n    cleaned_count: 0,\n    refunds_processed: 0,\n    total_credits_refunded: 0\n  }\n};"
+      },
+      "id": "jobs-clean-0014",
+      "name": "Format No Zombies Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1320,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ERROR RESPONSE (Validation)\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: input.error_code || 'VALIDATION_ERROR',\n    message: input.message || 'Erreur de validation',\n    http_status: 400\n  }\n};"
+      },
+      "id": "jobs-clean-0015",
+      "name": "Format Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        660,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "jobs-clean-0016",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        2640,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.http_status || 400 }}"
+        }
+      },
+      "id": "jobs-clean-0017",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        880,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Check Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Format Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Stats",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Stats": {
+      "main": [
+        [
+          {
+            "node": "Filter User Stats",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter User Stats": {
+      "main": [
+        [
+          {
+            "node": "Has Zombies?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Zombies?": {
+      "main": [
+        [
+          {
+            "node": "Call Cleanup API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format No Zombies Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Cleanup API": {
+      "main": [
+        [
+          {
+            "node": "Process Cleanup Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Cleanup Result": {
+      "main": [
+        [
+          {
+            "node": "Refund Required?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Refund Required?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Refund Items",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format No Refund Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Refund Items": {
+      "main": [
+        [
+          {
+            "node": "Refund Credits",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Refund Credits": {
+      "main": [
+        [
+          {
+            "node": "Aggregate Refund Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate Refund Results": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format No Refund Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format No Zombies Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false
+  },
+  "tags": []
+}

--- a/workflows/MCP-Documents-Process.json
+++ b/workflows/MCP-Documents-Process.json
@@ -1,6 +1,5 @@
 {
   "name": "MCP - Documents Process",
-  "active": true,
   "nodes": [
     {
       "parameters": {
@@ -13,24 +12,18 @@
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        304
-      ],
+      "position": [240, 304],
       "webhookId": "documents-process-webhook"
     },
     {
       "parameters": {
-        "jsCode": "const body = $input.first().json.body || {};\n\n// Support RFC-014 structure: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// Valider l'entrée - check both structures\nconst hasFile = !!(ctx.file_url || ctx.file_base64 || body.file_url || body.file_base64);\nconst hasJobId = !!(body.job_id || ctx.job_id);\n\nif (!hasFile || !hasJobId) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_FORMAT',\n          message: 'Missing required fields: file_url/file_base64 and job_id'\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\n// Extraire le contexte - prefer context.* over root level (RFC-014)\nconst context = {\n  job_id: body.job_id || ctx.job_id,\n  conversation_id: body.conversation_id || ctx.conversation_id,\n  user_id: body.user_id || ctx.user_id,\n  guild_id: body.guild_id || ctx.guild_id,\n  channel_id: body.channel_id || ctx.channel_id,\n  file_url: ctx.file_url || body.file_url,\n  file_base64: ctx.file_base64 || body.file_base64,\n  file_type: ctx.file_type || body.file_type || 'pdf',\n  action: body.action || ctx.action || 'translate',\n  params: body.params || ctx.params || {},\n  plugin_context: body.plugin_context || ctx.plugin_context || {},\n  callback_url: body.callback_url || ctx.callback_url,\n  start_time: Date.now()\n};\n\n// Vérifier si custom action et récupérer l'URL\nconst customActions = context.plugin_context?.custom_actions || {};\nconst isCustomAction = Object.keys(customActions).includes(context.action);\nconst customWebhookUrl = isCustomAction ? customActions[context.action]?.webhook_url : null;\n\n// Valider l'URL du webhook custom\nif (isCustomAction && !customWebhookUrl) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_CONFIG',\n          message: `Custom action '${context.action}' has no webhook_url configured`\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    response: {\n      success: true,\n      message: 'Processing started',\n      job_id: context.job_id\n    },\n    status_code: 200,\n    context: context,\n    is_custom_action: isCustomAction,\n    custom_webhook_url: customWebhookUrl\n  }\n};"
+        "jsCode": "const body = $input.first().json.body || {};\n\n// Support RFC-014 structure: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// Valider l'entrée - check both structures\nconst hasFile = !!(ctx.file_url || ctx.file_base64 || body.file_url || body.file_base64);\nconst hasJobId = !!(body.job_id || ctx.job_id);\n\nif (!hasFile || !hasJobId) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_FORMAT',\n          message: 'Missing required fields: file_url/file_base64 and job_id'\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\n// Extraire le contexte - prefer context.* over root level (RFC-014)\nconst context = {\n  job_id: body.job_id || ctx.job_id,\n  project_id: ctx.project_id || body.project_id || body.plugin_context?.plugin_id,\n  conversation_id: body.conversation_id || ctx.conversation_id,\n  user_id: body.user_id || ctx.user_id,\n  guild_id: body.guild_id || ctx.guild_id,\n  channel_id: body.channel_id || ctx.channel_id,\n  file_url: ctx.file_url || body.file_url,\n  file_base64: ctx.file_base64 || body.file_base64,\n  file_type: ctx.file_type || body.file_type || 'pdf',\n  action: body.action || ctx.action || 'translate',\n  params: body.params || ctx.params || {},\n  plugin_context: body.plugin_context || ctx.plugin_context || {},\n  callback_url: body.callback_url || ctx.callback_url,\n  start_time: Date.now()\n};\n\n// Vérifier si custom action et récupérer l'URL\nconst customActions = context.plugin_context?.custom_actions || {};\nconst isCustomAction = Object.keys(customActions).includes(context.action);\nconst customWebhookUrl = isCustomAction ? customActions[context.action]?.webhook_url : null;\n\n// Valider l'URL du webhook custom\nif (isCustomAction && !customWebhookUrl) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_CONFIG',\n          message: `Custom action '${context.action}' has no webhook_url configured`\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    response: {\n      success: true,\n      message: 'Processing started',\n      job_id: context.job_id\n    },\n    status_code: 200,\n    context: context,\n    is_custom_action: isCustomAction,\n    custom_webhook_url: customWebhookUrl\n  }\n};"
       },
       "id": "validate-and-ack",
       "name": "Validate and Acknowledge",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        480,
-        304
-      ]
+      "position": [480, 304]
     },
     {
       "parameters": {
@@ -44,10 +37,7 @@
       "name": "Respond ACK",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        720,
-        304
-      ]
+      "position": [720, 304]
     },
     {
       "parameters": {
@@ -57,10 +47,7 @@
       "name": "Check Valid",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        960,
-        304
-      ]
+      "position": [960, 304]
     },
     {
       "parameters": {
@@ -77,7 +64,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "= {{ JSON.stringify($json.is_custom_action ? { file_url: $json.context.file_url, file_base64:\n  $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id:\n  $json.context.user_id, channel_id: $json.context.channel_id }, params: $json.context.params, plugin_context:\n  $json.context.plugin_context, job_id: $json.context.job_id } : ($json.context.action === 'translate' ? { file_url:\n  $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: {\n  guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id },\n  target_language: $json.context.params.target_language || 'en', mistral_api_key:\n  $json.context.plugin_context.api_keys?.mistral, api_key: $json.context.plugin_context.api_keys?.anthropic,\n  openai_api_key: $json.context.plugin_context.api_keys?.openai, ocr_thresholds:\n  $json.context.plugin_context.ocr_thresholds } : { image_url: $json.context.file_url, image_base64:\n  $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id:\n  $json.context.user_id, channel_id: $json.context.channel_id }, mistral_api_key:\n  $json.context.plugin_context.api_keys?.mistral, ocr_thresholds: $json.context.plugin_context.ocr_thresholds })) }}",
+        "jsonBody": "={{ JSON.stringify($json.is_custom_action ? { file_url: $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: { project_id: $json.context.project_id, guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id }, params: $json.context.params, plugin_context: $json.context.plugin_context, job_id: $json.context.job_id } : ($json.context.action === 'translate' ? { file_url: $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: { project_id: $json.context.project_id, guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id }, target_language: $json.context.params.target_language || 'en', mistral_api_key: $json.context.plugin_context.api_keys?.mistral, api_key: $json.context.plugin_context.api_keys?.anthropic, openai_api_key: $json.context.plugin_context.api_keys?.openai, ocr_thresholds: $json.context.plugin_context.ocr_thresholds } : { image_url: $json.context.file_url, image_base64: $json.context.file_base64, file_type: $json.context.file_type, context: { project_id: $json.context.project_id, guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id }, mistral_api_key: $json.context.plugin_context.api_keys?.mistral, ocr_thresholds: $json.context.plugin_context.ocr_thresholds })) }}",
         "options": {
           "timeout": 300000
         }
@@ -86,10 +73,7 @@
       "name": "Route and Process",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1200,
-        304
-      ],
+      "position": [1200, 304],
       "onError": "continueRegularOutput"
     },
     {
@@ -100,39 +84,86 @@
       "name": "Format Callback",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1440,
-        304
-      ]
+      "position": [1440, 304]
     },
     {
       "parameters": {
-        "jsCode": "const input = $input.first().json;\n\n// Si pas de callback URL, on log seulement\nif (!input.callback_url) {\n  return {\n    json: {\n      status: 'no_callback',\n      callback: input.callback\n    }\n  };\n}\n\n// Envoyer le callback\ntry {\n  const response = await fetch(input.callback_url, {\n    method: 'POST',\n    headers: { 'Content-Type': 'application/json' },\n    body: JSON.stringify(input.callback)\n  });\n  \n  return {\n    json: {\n      status: 'callback_sent',\n      callback_status: response.status,\n      callback: input.callback\n    }\n  };\n} catch (error) {\n  return {\n    json: {\n      status: 'callback_failed',\n      error: error.message,\n      callback: input.callback\n    }\n  };\n}"
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "check-callback-url",
+              "leftValue": "={{ $json.callback_url }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "has-callback-url",
+      "name": "Has Callback URL?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1680, 304]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.callback_url }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.callback) }}",
+        "options": {
+          "timeout": 30000
+        }
       },
       "id": "send-callback",
       "name": "Send Callback",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        1680,
-        304
-      ]
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1920, 200],
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "content": "## MCP - Documents Process (RFC-014 Phase 2)\n\n**Endpoint:** POST /webhook/documents/process\n\n**Purpose:** Process document with async callback\n\n**RFC-014 Input Structure:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"context\": {\n    \"file_url\": \"https://...\" OR \"file_base64\": \"...\",\n    \"action\": \"translate|summarize|ocr\",\n    \"params\": { \"target_language\": \"fr\" }\n  },\n  \"plugin_context\": { \"api_keys\": {...} },\n  \"callback_url\": \"https://...\"\n}\n```\n\n**Legacy Input (also supported):**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"file_url\": \"https://...\",\n  \"action\": \"translate\",\n  \"params\": {...},\n  \"callback_url\": \"...\"\n}\n```\n\n**Response:** Immediate ACK with job_id, result via callback",
-        "height": 300,
-        "width": 650,
+        "jsCode": "// Log no callback\nconst input = $input.first().json;\nreturn {\n  status: 'no_callback_url',\n  callback: input.callback\n};"
+      },
+      "id": "log-no-callback",
+      "name": "Log No Callback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1920, 400]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Documents Process (RFC-014)\n\n**Endpoint:** POST /webhook/documents/process\n\n**Input:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"context\": {\n    \"project_id\": \"...\",\n    \"file_url\": \"https://...\",\n    \"action\": \"translate|process\"\n  },\n  \"plugin_context\": { \"api_keys\": {...} },\n  \"callback_url\": \"https://...\"\n}\n```\n\n**Response:** ACK then callback",
+        "height": 280,
+        "width": 400,
         "color": 6
       },
       "id": "sticky-note-doc",
       "name": "API Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        64
-      ]
+      "position": [240, 64]
     }
   ],
   "connections": {
@@ -195,7 +226,25 @@
       "main": [
         [
           {
+            "node": "Has Callback URL?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Callback URL?": {
+      "main": [
+        [
+          {
             "node": "Send Callback",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log No Callback",
             "type": "main",
             "index": 0
           }
@@ -204,220 +253,6 @@
     }
   },
   "settings": {
-    "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "tags": [],
-  "activeVersion": {
-    "updatedAt": "2026-01-20T16:30:06.350Z",
-    "createdAt": "2026-01-20T16:30:06.350Z",
-    "versionId": "7559ac35-5067-4b76-9749-b6e547e25343",
-    "workflowId": "XLp1gPkeRwEvpdWE",
-    "nodes": [
-      {
-        "parameters": {
-          "httpMethod": "POST",
-          "path": "documents/process",
-          "responseMode": "responseNode",
-          "options": {}
-        },
-        "id": "webhook-process",
-        "name": "Webhook",
-        "type": "n8n-nodes-base.webhook",
-        "typeVersion": 2,
-        "position": [
-          240,
-          304
-        ],
-        "webhookId": "documents-process-webhook"
-      },
-      {
-        "parameters": {
-          "jsCode": "const body = $input.first().json.body || {};\n\n// Support RFC-014 structure: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// Valider l'entrée - check both structures\nconst hasFile = !!(ctx.file_url || ctx.file_base64 || body.file_url || body.file_base64);\nconst hasJobId = !!(body.job_id || ctx.job_id);\n\nif (!hasFile || !hasJobId) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_FORMAT',\n          message: 'Missing required fields: file_url/file_base64 and job_id'\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\n// Extraire le contexte - prefer context.* over root level (RFC-014)\nconst context = {\n  job_id: body.job_id || ctx.job_id,\n  conversation_id: body.conversation_id || ctx.conversation_id,\n  user_id: body.user_id || ctx.user_id,\n  guild_id: body.guild_id || ctx.guild_id,\n  channel_id: body.channel_id || ctx.channel_id,\n  file_url: ctx.file_url || body.file_url,\n  file_base64: ctx.file_base64 || body.file_base64,\n  file_type: ctx.file_type || body.file_type || 'pdf',\n  action: body.action || ctx.action || 'translate',\n  params: body.params || ctx.params || {},\n  plugin_context: body.plugin_context || ctx.plugin_context || {},\n  callback_url: body.callback_url || ctx.callback_url,\n  start_time: Date.now()\n};\n\n// Vérifier si custom action et récupérer l'URL\nconst customActions = context.plugin_context?.custom_actions || {};\nconst isCustomAction = Object.keys(customActions).includes(context.action);\nconst customWebhookUrl = isCustomAction ? customActions[context.action]?.webhook_url : null;\n\n// Valider l'URL du webhook custom\nif (isCustomAction && !customWebhookUrl) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_CONFIG',\n          message: `Custom action '${context.action}' has no webhook_url configured`\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    response: {\n      success: true,\n      message: 'Processing started',\n      job_id: context.job_id\n    },\n    status_code: 200,\n    context: context,\n    is_custom_action: isCustomAction,\n    custom_webhook_url: customWebhookUrl\n  }\n};"
-        },
-        "id": "validate-and-ack",
-        "name": "Validate and Acknowledge",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          480,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "respondWith": "json",
-          "responseBody": "={{ $json.response }}",
-          "options": {
-            "responseCode": "={{ $json.status_code }}"
-          }
-        },
-        "id": "respond-ack",
-        "name": "Respond ACK",
-        "type": "n8n-nodes-base.respondToWebhook",
-        "typeVersion": 1,
-        "position": [
-          720,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "jsCode": "const input = $input.first().json;\n\n// Si invalide, on s'arrête\nif (!input.valid) {\n  return [];\n}\n\n// Continuer avec le contexte\nreturn {\n  json: input\n};"
-        },
-        "id": "check-valid",
-        "name": "Check Valid",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          960,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "method": "POST",
-          "url": "={{ $json.is_custom_action ? $json.custom_webhook_url : ($json.context.action === 'translate' ? ($env.N8N_WEBHOOK_BASE_URL || 'http://localhost:5678') + '/webhook/pdf-layout-translator' : ($env.N8N_WEBHOOK_BASE_URL || 'http://localhost:5678') + '/webhook/image-ocr') }}",
-          "sendHeaders": true,
-          "headerParameters": {
-            "parameters": [
-              {
-                "name": "Content-Type",
-                "value": "application/json"
-              }
-            ]
-          },
-          "sendBody": true,
-          "specifyBody": "json",
-          "jsonBody": "= {{ JSON.stringify($json.is_custom_action ? { file_url: $json.context.file_url, file_base64:\n  $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id:\n  $json.context.user_id, channel_id: $json.context.channel_id }, params: $json.context.params, plugin_context:\n  $json.context.plugin_context, job_id: $json.context.job_id } : ($json.context.action === 'translate' ? { file_url:\n  $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: {\n  guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id },\n  target_language: $json.context.params.target_language || 'en', mistral_api_key:\n  $json.context.plugin_context.api_keys?.mistral, api_key: $json.context.plugin_context.api_keys?.anthropic,\n  openai_api_key: $json.context.plugin_context.api_keys?.openai, ocr_thresholds:\n  $json.context.plugin_context.ocr_thresholds } : { image_url: $json.context.file_url, image_base64:\n  $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id:\n  $json.context.user_id, channel_id: $json.context.channel_id }, mistral_api_key:\n  $json.context.plugin_context.api_keys?.mistral, ocr_thresholds: $json.context.plugin_context.ocr_thresholds })) }}",
-          "options": {
-            "timeout": 300000
-          }
-        },
-        "id": "route-and-process",
-        "name": "Route and Process",
-        "type": "n8n-nodes-base.httpRequest",
-        "typeVersion": 4.2,
-        "position": [
-          1200,
-          304
-        ],
-        "onError": "continueRegularOutput"
-      },
-      {
-        "parameters": {
-          "jsCode": "const result = $input.first().json;\nconst prevNode = $('Check Valid').first().json;\nconst context = prevNode.context;\nconst startTime = context.start_time;\nconst processingTime = Date.now() - startTime;\n\n// Déterminer si succès ou erreur\nconst isSuccess = result.success !== false && !result.error;\nconst hasData = result.data || result.text || result.result;\n\nlet callback;\n\nif (isSuccess && hasData) {\n  // Succès\n  const text = result.data?.text || result.data?.translated_text || result.text || JSON.stringify(result.data || result);\n  callback = {\n    job_id: context.job_id,\n    conversation_id: context.conversation_id,\n    user_id: context.user_id,\n    guild_id: context.guild_id,\n    channel_id: context.channel_id,\n    success: true,\n    result: {\n      text: text,\n      output_type: 'text',\n      word_count: text.split(/\\s+/).length\n    },\n    metrics: {\n      tokens_used: result.meta?.usage?.total_tokens || result.usage?.total_tokens || Math.ceil(text.length / 4),\n      processing_time_ms: processingTime,\n      ocr_confidence: result.meta?.ocr_confidence || result.data?.ocr_confidence || 0.9,\n      pages_processed: result.meta?.usage?.pages_processed || result.data?.page_count || 1\n    },\n    error: null\n  };\n} else {\n  // Erreur\n  const errorCode = result.error?.code || result.error?.status || 'INTERNAL_ERROR';\n  const errorMessage = result.error?.message || 'Processing failed';\n  \n  callback = {\n    job_id: context.job_id,\n    conversation_id: context.conversation_id,\n    user_id: context.user_id,\n    guild_id: context.guild_id,\n    channel_id: context.channel_id,\n    success: false,\n    result: null,\n    metrics: {\n      tokens_used: 0,\n      processing_time_ms: processingTime,\n      ocr_confidence: 0,\n      pages_processed: 0\n    },\n    error: {\n      code: errorCode,\n      message: errorMessage,\n      retriable: ['LLM_RATE_LIMITED', 'TIMEOUT', 'INTERNAL_ERROR'].includes(errorCode),\n      refund: {\n        recommended: true,\n        percentage: errorCode === 'PARTIAL_SUCCESS' ? 50 : 100,\n        reason: `Processing failed: ${errorMessage}`\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    callback: callback,\n    callback_url: context.callback_url\n  }\n};"
-        },
-        "id": "format-callback",
-        "name": "Format Callback",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          1440,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "jsCode": "const input = $input.first().json;\n\n// Si pas de callback URL, on log seulement\nif (!input.callback_url) {\n  return {\n    json: {\n      status: 'no_callback',\n      callback: input.callback\n    }\n  };\n}\n\n// Envoyer le callback\ntry {\n  const response = await fetch(input.callback_url, {\n    method: 'POST',\n    headers: { 'Content-Type': 'application/json' },\n    body: JSON.stringify(input.callback)\n  });\n  \n  return {\n    json: {\n      status: 'callback_sent',\n      callback_status: response.status,\n      callback: input.callback\n    }\n  };\n} catch (error) {\n  return {\n    json: {\n      status: 'callback_failed',\n      error: error.message,\n      callback: input.callback\n    }\n  };\n}"
-        },
-        "id": "send-callback",
-        "name": "Send Callback",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          1680,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "content": "## MCP - Documents Process (RFC-014 Phase 2)\n\n**Endpoint:** POST /webhook/documents/process\n\n**Purpose:** Process document with async callback\n\n**RFC-014 Input Structure:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"context\": {\n    \"file_url\": \"https://...\" OR \"file_base64\": \"...\",\n    \"action\": \"translate|summarize|ocr\",\n    \"params\": { \"target_language\": \"fr\" }\n  },\n  \"plugin_context\": { \"api_keys\": {...} },\n  \"callback_url\": \"https://...\"\n}\n```\n\n**Legacy Input (also supported):**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"file_url\": \"https://...\",\n  \"action\": \"translate\",\n  \"params\": {...},\n  \"callback_url\": \"...\"\n}\n```\n\n**Response:** Immediate ACK with job_id, result via callback",
-          "height": 300,
-          "width": 650,
-          "color": 6
-        },
-        "id": "sticky-note-doc",
-        "name": "API Documentation",
-        "type": "n8n-nodes-base.stickyNote",
-        "typeVersion": 1,
-        "position": [
-          240,
-          64
-        ]
-      }
-    ],
-    "connections": {
-      "Webhook": {
-        "main": [
-          [
-            {
-              "node": "Validate and Acknowledge",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Validate and Acknowledge": {
-        "main": [
-          [
-            {
-              "node": "Respond ACK",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Respond ACK": {
-        "main": [
-          [
-            {
-              "node": "Check Valid",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Check Valid": {
-        "main": [
-          [
-            {
-              "node": "Route and Process",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Route and Process": {
-        "main": [
-          [
-            {
-              "node": "Format Callback",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Format Callback": {
-        "main": [
-          [
-            {
-              "node": "Send Callback",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      }
-    },
-    "authors": "Franck Sebbah",
-    "name": null,
-    "description": null
+    "executionOrder": "v1"
   }
 }

--- a/workflows/MCP-Image-OCR.json
+++ b/workflows/MCP-Image-OCR.json
@@ -1,22 +1,18 @@
 {
   "name": "MCP - Image OCR",
-  "active": true,
   "nodes": [
     {
       "parameters": {
-        "content": "## MCP - Image OCR (RFC-014)\n\n**Endpoint:** POST /webhook/image-ocr\n\n**RFC-014 Input:**\n```json\n{\n  \"context\": {\n    \"image_url\": \"https://...\" OR \"image_base64\": \"...\",\n    \"file_type\": \"jpg\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Legacy Input (also supported):**\n```json\n{\n  \"image_url\": \"https://...\",\n  \"mistral_api_key\": \"...\"\n}\n```\n\n**Response:** OCR result with text and metadata",
-        "height": 340,
-        "width": 320,
+        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**Input (RFC-014):**\n```json\n{\n  \"context\": {\n    \"image_url\": \"https://...\",\n    \"file_type\": \"jpg\",\n    \"project_id\": \"...\",\n    \"guild_id\": \"...\",\n    \"user_id\": \"...\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Legacy Input:**\n```json\n{\n  \"image_url\": \"https://...\",\n  \"mistral_api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"text\": \"...\", \"pages\": [...] },\n  \"meta\": { \"provider\": \"mistral\" }\n}\n```",
+        "height": 420,
+        "width": 340,
         "color": 6
       },
-      "id": "sticky-doc",
+      "id": "doc-sticky",
       "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        -16,
-        -112
-      ]
+      "position": [-60, -140]
     },
     {
       "parameters": {
@@ -25,28 +21,22 @@
         "responseMode": "responseNode",
         "options": {}
       },
-      "id": "webhook",
+      "id": "webhook-ocr",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        -48,
-        304
-      ],
+      "position": [0, 300],
       "webhookId": "image-ocr"
     },
     {
       "parameters": {
-        "jsCode": "const input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// Validation - check both structures\nconst hasImage = !!(ctx.image_url || ctx.image_base64 || ctx.file_url || ctx.file_base64 || body.image_url || body.image_base64);\nconst mistralKey = body.mistral_api_key || ctx.mistral_api_key || body.plugin_context?.api_keys?.mistral || ctx.plugin_context?.api_keys?.mistral;\nconst hasMistralKey = !!mistralKey;\n\nconst errors = [];\nif (!hasImage) errors.push('image_url ou image_base64 requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\n\n// Fonction pour détecter le MIME type depuis les magic bytes base64\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  if (prefix.startsWith('Qk')) return 'image/bmp';\n  return 'image/png';\n}\n\n// Fonction pour obtenir le MIME type depuis l'extension\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp',\n    'tiff': 'image/tiff', 'tif': 'image/tiff'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// Extract image - prefer context.* (RFC-014) over root level\nconst imageUrl_raw = ctx.image_url || ctx.file_url || body.image_url;\nconst imageBase64_raw = ctx.image_base64 || ctx.file_base64 || body.image_base64;\nconst fileType = ctx.file_type || body.file_type;\n\n// Préparer l'image avec détection MIME intelligente\nlet imageUrl = '';\nlet detectedMime = 'image/png';\n\nif (imageUrl_raw) {\n  imageUrl = imageUrl_raw;\n} else if (imageBase64_raw) {\n  // 1. Essayer depuis file_type param\n  if (fileType) {\n    detectedMime = getMimeFromExtension(fileType) || 'image/png';\n  } else {\n    // 2. Détecter depuis magic bytes\n    detectedMime = detectMimeFromBase64(imageBase64_raw);\n  }\n  imageUrl = 'data:' + detectedMime + ';base64,' + imageBase64_raw;\n}\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    imageUrl: imageUrl,\n    detectedMime: detectedMime,\n    mistralApiKey: mistralKey,\n    includeImages: body.include_images || ctx.include_images || false,\n    source: imageUrl_raw ? 'url' : 'base64'\n  }\n}];"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - RFC-014 Compatible\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// --- Extract image ---\nconst imageUrl_raw = ctx.image_url || ctx.file_url || body.image_url;\nconst imageBase64_raw = ctx.image_base64 || ctx.file_base64 || body.image_base64;\nconst fileType = ctx.file_type || body.file_type;\n\n// --- Extract API key ---\nconst mistralKey = body.mistral_api_key \n  || ctx.mistral_api_key \n  || body.plugin_context?.api_keys?.mistral \n  || ctx.plugin_context?.api_keys?.mistral;\n\n// --- Extract context fields ---\nconst projectId = ctx.project_id || body.project_id || body.plugin_context?.plugin_id;\nconst guildId = ctx.guild_id || body.guild_id;\nconst userId = ctx.user_id || body.user_id;\nconst channelId = ctx.channel_id || body.channel_id;\n\n// --- Validation ---\nconst hasImage = !!(imageUrl_raw || imageBase64_raw);\nconst hasMistralKey = !!mistralKey;\n\nconst errors = [];\nif (!hasImage) errors.push('image_url ou image_base64 requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors\n  };\n}\n\n// --- Detect MIME type ---\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  return 'image/png';\n}\n\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// --- Prepare image URL ---\nlet imageUrl = '';\nlet detectedMime = 'image/png';\n\nif (imageUrl_raw) {\n  imageUrl = imageUrl_raw;\n} else if (imageBase64_raw) {\n  detectedMime = fileType ? (getMimeFromExtension(fileType) || 'image/png') : detectMimeFromBase64(imageBase64_raw);\n  imageUrl = 'data:' + detectedMime + ';base64,' + imageBase64_raw;\n}\n\nreturn {\n  valid: true,\n  imageUrl: imageUrl,\n  detectedMime: detectedMime,\n  mistralApiKey: mistralKey,\n  includeImages: body.include_images || ctx.include_images || false,\n  source: imageUrl_raw ? 'url' : 'base64',\n  context: {\n    project_id: projectId,\n    guild_id: guildId,\n    user_id: userId,\n    channel_id: channelId\n  }\n};"
       },
-      "id": "validation",
-      "name": "Validation",
+      "id": "validate-input",
+      "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        176,
-        304
-      ]
+      "position": [220, 300]
     },
     {
       "parameters": {
@@ -75,10 +65,7 @@
       "name": "Input Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        352,
-        304
-      ]
+      "position": [440, 300]
     },
     {
       "parameters": {
@@ -113,31 +100,35 @@
       "name": "Mistral OCR",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1072,
-        224
-      ],
+      "position": [660, 200],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Extract Job ID').first().json;\n\n  const data = input.body || input;\n  const statusCode = input.statusCode || 200;\n\n  // Vérifier erreur\n  if (statusCode >= 400) {\n    return [{\n      json: {\n        success: false,\n        jobId: prevData.jobId,\n        error: {\n          code: statusCode,\n          message: data.message || data.error?.message || 'Mistral API error',\n          status: 'API_ERROR'\n        }\n      }\n    }];\n  }\n\n  // Extraire le texte\n  const text = data.pages?.map(p => p.markdown).join('\\n\\n') || '';\n\n  return [{\n    json: {\n      success: true,\n      jobId: prevData.jobId,\n      data: {\n        text: text,\n        pages: data.pages || [],\n        model: data.model || 'mistral-ocr-latest',\n        source: prevData.source\n      },\n      meta: {\n        provider: 'mistral',\n        usage: {\n          pages_processed: data.usage_info?.pages_processed || 1,\n          doc_size_bytes: data.usage_info?.doc_size_bytes || 0\n        }\n      }\n    }\n  }];\n"
+        "jsCode": "// ============================================\n// FORMAT SUCCESS/ERROR RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// --- Check for API error ---\nif (statusCode >= 400 || input.error) {\n  const errorMessage = data.message || data.error?.message || input.error?.message || 'Mistral API error';\n  return {\n    success: false,\n    error: {\n      code: 'OCR_API_ERROR',\n      message: errorMessage,\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    context: prevData.context\n  };\n}\n\n// --- Extract text from pages ---\nconst text = data.pages?.map(p => p.markdown).join('\\n\\n') || '';\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    pages: data.pages || [],\n    model: data.model || 'mistral-ocr-latest',\n    source: prevData.source\n  },\n  meta: {\n    provider: 'mistral',\n    usage: {\n      pages_processed: data.usage_info?.pages_processed || 1,\n      doc_size_bytes: data.usage_info?.doc_size_bytes || 0\n    }\n  },\n  context: prevData.context\n};"
       },
       "id": "format-response",
       "name": "Format Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1280,
-        224
-      ]
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  }\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
     },
     {
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
           "responseHeaders": {
             "entries": [
               {
@@ -152,23 +143,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1840,
-        224
-      ]
-    },
-    {
-      "parameters": {
-        "jsCode": "const input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
-      },
-      "id": "build-error",
-      "name": "Build Error Response",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        1072,
-        432
-      ]
+      "position": [1100, 200]
     },
     {
       "parameters": {
@@ -190,80 +165,7 @@
       "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1280,
-        432
-      ]
-    },
-    {
-      "parameters": {
-        "method": "POST",
-        "url": "={{ $env.API_URL }}/api/v2/jobs",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
-            {
-              "name": "Content-Type",
-              "value": "application/json"
-            }
-          ]
-        },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ project_id: \"mcp-documents\", job_type: \"image_ocr\", status: \"pending\", priority: 1, input: {image_source: $json.source, detected_mime: $json.detectedMime } }) }}",
-        "options": {}
-      },
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.3,
-      "position": [
-        608,
-        224
-      ],
-      "id": "561328cf-4be0-4db2-88c6-887689a25228",
-      "name": "Create Job",
-      "onError": "continueRegularOutput"
-    },
-    {
-      "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validation').first().json;\n\n  // Extraire job_id de la réponse API ou utiliser un ID local\n  const data = input.body || input;\n  const jobId = data.job_id || data.id || ('job_' + Date.now().toString(36));\n\n  return [{\n    json: {\n      ...prevData,\n      jobId: jobId\n    }\n  }];"
-      },
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        848,
-        224
-      ],
-      "id": "4e72bf8e-9fa8-4656-b0e9-7cf1d30ca9c0",
-      "name": "Extract Job ID"
-    },
-    {
-      "parameters": {
-        "method": "PATCH",
-        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
-            {
-              "name": " Content-Type",
-              "value": "application/json"
-            }
-          ]
-        },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ status: $json.success ? \"completed\" : \"failed\", output: $json.success ? { text_length:\n  $json.data.text.length, pages_processed: $json.meta.usage.pages_processed } : null, error: $json.success ? null :\n  $json.error }) }}",
-        "options": {}
-      },
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.3,
-      "position": [
-        1488,
-        224
-      ],
-      "id": "5546a2f6-4b7d-41f9-b415-76b632752a34",
-      "name": "Update Job",
-      "retryOnFail": false,
-      "onError": "continueRegularOutput"
+      "position": [880, 400]
     }
   ],
   "connections": {
@@ -271,14 +173,14 @@
       "main": [
         [
           {
-            "node": "Validation",
+            "node": "Validate Input",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Validation": {
+    "Validate Input": {
       "main": [
         [
           {
@@ -293,7 +195,7 @@
       "main": [
         [
           {
-            "node": "Create Job",
+            "node": "Mistral OCR",
             "type": "main",
             "index": 0
           }
@@ -322,7 +224,7 @@
       "main": [
         [
           {
-            "node": "Update Job",
+            "node": "Respond",
             "type": "main",
             "index": 0
           }
@@ -339,427 +241,9 @@
           }
         ]
       ]
-    },
-    "Create Job": {
-      "main": [
-        [
-          {
-            "node": "Extract Job ID",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Extract Job ID": {
-      "main": [
-        [
-          {
-            "node": "Mistral OCR",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Update Job": {
-      "main": [
-        [
-          {
-            "node": "Respond",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
     }
   },
   "settings": {
-    "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "tags": [],
-  "activeVersion": {
-    "updatedAt": "2026-01-20T19:32:42.636Z",
-    "createdAt": "2026-01-20T19:32:42.636Z",
-    "versionId": "f0f7f118-cf79-4806-bd07-10590d89b9c4",
-    "workflowId": "xVpr6ouGAAUsNK8u",
-    "nodes": [
-      {
-        "parameters": {
-          "content": "## MCP - Image OCR (RFC-014)\n\n**Endpoint:** POST /webhook/image-ocr\n\n**RFC-014 Input:**\n```json\n{\n  \"context\": {\n    \"image_url\": \"https://...\" OR \"image_base64\": \"...\",\n    \"file_type\": \"jpg\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Legacy Input (also supported):**\n```json\n{\n  \"image_url\": \"https://...\",\n  \"mistral_api_key\": \"...\"\n}\n```\n\n**Response:** OCR result with text and metadata",
-          "height": 340,
-          "width": 320,
-          "color": 6
-        },
-        "id": "sticky-doc",
-        "name": "Documentation",
-        "type": "n8n-nodes-base.stickyNote",
-        "typeVersion": 1,
-        "position": [
-          -16,
-          -112
-        ]
-      },
-      {
-        "parameters": {
-          "httpMethod": "POST",
-          "path": "image-ocr",
-          "responseMode": "responseNode",
-          "options": {}
-        },
-        "id": "webhook",
-        "name": "Webhook",
-        "type": "n8n-nodes-base.webhook",
-        "typeVersion": 2,
-        "position": [
-          -48,
-          304
-        ],
-        "webhookId": "image-ocr"
-      },
-      {
-        "parameters": {
-          "jsCode": "const input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// Validation - check both structures\nconst hasImage = !!(ctx.image_url || ctx.image_base64 || ctx.file_url || ctx.file_base64 || body.image_url || body.image_base64);\nconst mistralKey = body.mistral_api_key || ctx.mistral_api_key || body.plugin_context?.api_keys?.mistral || ctx.plugin_context?.api_keys?.mistral;\nconst hasMistralKey = !!mistralKey;\n\nconst errors = [];\nif (!hasImage) errors.push('image_url ou image_base64 requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\n\n// Fonction pour détecter le MIME type depuis les magic bytes base64\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  if (prefix.startsWith('Qk')) return 'image/bmp';\n  return 'image/png';\n}\n\n// Fonction pour obtenir le MIME type depuis l'extension\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp',\n    'tiff': 'image/tiff', 'tif': 'image/tiff'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// Extract image - prefer context.* (RFC-014) over root level\nconst imageUrl_raw = ctx.image_url || ctx.file_url || body.image_url;\nconst imageBase64_raw = ctx.image_base64 || ctx.file_base64 || body.image_base64;\nconst fileType = ctx.file_type || body.file_type;\n\n// Préparer l'image avec détection MIME intelligente\nlet imageUrl = '';\nlet detectedMime = 'image/png';\n\nif (imageUrl_raw) {\n  imageUrl = imageUrl_raw;\n} else if (imageBase64_raw) {\n  // 1. Essayer depuis file_type param\n  if (fileType) {\n    detectedMime = getMimeFromExtension(fileType) || 'image/png';\n  } else {\n    // 2. Détecter depuis magic bytes\n    detectedMime = detectMimeFromBase64(imageBase64_raw);\n  }\n  imageUrl = 'data:' + detectedMime + ';base64,' + imageBase64_raw;\n}\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    imageUrl: imageUrl,\n    detectedMime: detectedMime,\n    mistralApiKey: mistralKey,\n    includeImages: body.include_images || ctx.include_images || false,\n    source: imageUrl_raw ? 'url' : 'base64'\n  }\n}];"
-        },
-        "id": "validation",
-        "name": "Validation",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          176,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "conditions": {
-            "options": {
-              "caseSensitive": true,
-              "leftValue": "",
-              "typeValidation": "strict"
-            },
-            "conditions": [
-              {
-                "id": "check-valid",
-                "leftValue": "={{ $json.valid }}",
-                "rightValue": true,
-                "operator": {
-                  "type": "boolean",
-                  "operation": "equals"
-                }
-              }
-            ],
-            "combinator": "and"
-          },
-          "options": {}
-        },
-        "id": "if-valid",
-        "name": "Input Valid?",
-        "type": "n8n-nodes-base.if",
-        "typeVersion": 2.2,
-        "position": [
-          352,
-          304
-        ]
-      },
-      {
-        "parameters": {
-          "method": "POST",
-          "url": "https://api.mistral.ai/v1/ocr",
-          "sendHeaders": true,
-          "headerParameters": {
-            "parameters": [
-              {
-                "name": "Authorization",
-                "value": "=Bearer {{ $json.mistralApiKey }}"
-              },
-              {
-                "name": "Content-Type",
-                "value": "application/json"
-              }
-            ]
-          },
-          "sendBody": true,
-          "specifyBody": "json",
-          "jsonBody": "={{ JSON.stringify({ model: 'mistral-ocr-latest', document: { type: 'image_url', image_url: $json.imageUrl }, include_image_base64: $json.includeImages }) }}",
-          "options": {
-            "response": {
-              "response": {
-                "fullResponse": true
-              }
-            },
-            "timeout": 120000
-          }
-        },
-        "id": "mistral-ocr",
-        "name": "Mistral OCR",
-        "type": "n8n-nodes-base.httpRequest",
-        "typeVersion": 4.2,
-        "position": [
-          1072,
-          224
-        ],
-        "onError": "continueRegularOutput"
-      },
-      {
-        "parameters": {
-          "jsCode": "  const input = $input.first().json;\n  const prevData = $('Extract Job ID').first().json;\n\n  const data = input.body || input;\n  const statusCode = input.statusCode || 200;\n\n  // Vérifier erreur\n  if (statusCode >= 400) {\n    return [{\n      json: {\n        success: false,\n        jobId: prevData.jobId,\n        error: {\n          code: statusCode,\n          message: data.message || data.error?.message || 'Mistral API error',\n          status: 'API_ERROR'\n        }\n      }\n    }];\n  }\n\n  // Extraire le texte\n  const text = data.pages?.map(p => p.markdown).join('\\n\\n') || '';\n\n  return [{\n    json: {\n      success: true,\n      jobId: prevData.jobId,\n      data: {\n        text: text,\n        pages: data.pages || [],\n        model: data.model || 'mistral-ocr-latest',\n        source: prevData.source\n      },\n      meta: {\n        provider: 'mistral',\n        usage: {\n          pages_processed: data.usage_info?.pages_processed || 1,\n          doc_size_bytes: data.usage_info?.doc_size_bytes || 0\n        }\n      }\n    }\n  }];\n"
-        },
-        "id": "format-response",
-        "name": "Format Response",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          1280,
-          224
-        ]
-      },
-      {
-        "parameters": {
-          "respondWith": "json",
-          "responseBody": "={{ JSON.stringify($json) }}",
-          "options": {
-            "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
-            "responseHeaders": {
-              "entries": [
-                {
-                  "name": "Content-Type",
-                  "value": "application/json"
-                }
-              ]
-            }
-          }
-        },
-        "id": "respond-success",
-        "name": "Respond",
-        "type": "n8n-nodes-base.respondToWebhook",
-        "typeVersion": 1.1,
-        "position": [
-          1840,
-          224
-        ]
-      },
-      {
-        "parameters": {
-          "jsCode": "const input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
-        },
-        "id": "build-error",
-        "name": "Build Error Response",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          1072,
-          432
-        ]
-      },
-      {
-        "parameters": {
-          "respondWith": "json",
-          "responseBody": "={{ JSON.stringify($json) }}",
-          "options": {
-            "responseCode": 400,
-            "responseHeaders": {
-              "entries": [
-                {
-                  "name": "Content-Type",
-                  "value": "application/json"
-                }
-              ]
-            }
-          }
-        },
-        "id": "respond-error",
-        "name": "Respond Error",
-        "type": "n8n-nodes-base.respondToWebhook",
-        "typeVersion": 1.1,
-        "position": [
-          1280,
-          432
-        ]
-      },
-      {
-        "parameters": {
-          "method": "POST",
-          "url": "={{ $env.API_URL }}/api/v2/jobs",
-          "sendHeaders": true,
-          "headerParameters": {
-            "parameters": [
-              {
-                "name": "Content-Type",
-                "value": "application/json"
-              }
-            ]
-          },
-          "sendBody": true,
-          "specifyBody": "json",
-          "jsonBody": "={{ JSON.stringify({ project_id: \"mcp-documents\", job_type: \"image_ocr\", status: \"pending\", priority: 1, input: {image_source: $json.source, detected_mime: $json.detectedMime } }) }}",
-          "options": {}
-        },
-        "type": "n8n-nodes-base.httpRequest",
-        "typeVersion": 4.3,
-        "position": [
-          608,
-          224
-        ],
-        "id": "561328cf-4be0-4db2-88c6-887689a25228",
-        "name": "Create Job",
-        "onError": "continueRegularOutput"
-      },
-      {
-        "parameters": {
-          "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validation').first().json;\n\n  // Extraire job_id de la réponse API ou utiliser un ID local\n  const data = input.body || input;\n  const jobId = data.job_id || data.id || ('job_' + Date.now().toString(36));\n\n  return [{\n    json: {\n      ...prevData,\n      jobId: jobId\n    }\n  }];"
-        },
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          848,
-          224
-        ],
-        "id": "4e72bf8e-9fa8-4656-b0e9-7cf1d30ca9c0",
-        "name": "Extract Job ID"
-      },
-      {
-        "parameters": {
-          "method": "PATCH",
-          "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
-          "sendHeaders": true,
-          "headerParameters": {
-            "parameters": [
-              {
-                "name": " Content-Type",
-                "value": "application/json"
-              }
-            ]
-          },
-          "sendBody": true,
-          "specifyBody": "json",
-          "jsonBody": "={{ JSON.stringify({ status: $json.success ? \"completed\" : \"failed\", output: $json.success ? { text_length:\n  $json.data.text.length, pages_processed: $json.meta.usage.pages_processed } : null, error: $json.success ? null :\n  $json.error }) }}",
-          "options": {}
-        },
-        "type": "n8n-nodes-base.httpRequest",
-        "typeVersion": 4.3,
-        "position": [
-          1488,
-          224
-        ],
-        "id": "5546a2f6-4b7d-41f9-b415-76b632752a34",
-        "name": "Update Job",
-        "retryOnFail": false,
-        "onError": "continueRegularOutput"
-      }
-    ],
-    "connections": {
-      "Webhook": {
-        "main": [
-          [
-            {
-              "node": "Validation",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Validation": {
-        "main": [
-          [
-            {
-              "node": "Input Valid?",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Input Valid?": {
-        "main": [
-          [
-            {
-              "node": "Create Job",
-              "type": "main",
-              "index": 0
-            }
-          ],
-          [
-            {
-              "node": "Build Error Response",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Mistral OCR": {
-        "main": [
-          [
-            {
-              "node": "Format Response",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Format Response": {
-        "main": [
-          [
-            {
-              "node": "Update Job",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Build Error Response": {
-        "main": [
-          [
-            {
-              "node": "Respond Error",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Create Job": {
-        "main": [
-          [
-            {
-              "node": "Extract Job ID",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Extract Job ID": {
-        "main": [
-          [
-            {
-              "node": "Mistral OCR",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Update Job": {
-        "main": [
-          [
-            {
-              "node": "Respond",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      }
-    },
-    "authors": "Franck Sebbah",
-    "name": null,
-    "description": null
+    "executionOrder": "v1"
   }
 }

--- a/workflows/TORAH-Document-Callback.json
+++ b/workflows/TORAH-Document-Callback.json
@@ -1,0 +1,351 @@
+{
+  "name": "TORAH---Document-Callback",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## TORAH - Document Callback\n\n**Endpoint:** POST /webhook/torah-document-callback\n\n**Receives callback from MCP-Documents-Process:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"conversation_id\": \"...\",\n  \"user_id\": \"discord_user_id\",\n  \"guild_id\": \"...\",\n  \"channel_id\": \"...\",\n  \"success\": true,\n  \"result\": { \"text\": \"...\", \"output_type\": \"text\", \"word_count\": 100 },\n  \"metrics\": { \"tokens_used\": 1000, \"processing_time_ms\": 5000 },\n  \"error\": null\n}\n```\n\n**Actions:**\n1. Update job status in Redis\n2. Send Discord notification",
+        "height": 340,
+        "width": 380,
+        "color": 6
+      },
+      "id": "doc-callback-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-60, -100]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-document-callback",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "doc-callback-0001",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "torah-document-callback"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATE CALLBACK INPUT\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// --- Required fields ---\nconst jobId = body.job_id;\nconst userId = body.user_id;\nconst guildId = body.guild_id;\nconst channelId = body.channel_id;\nconst success = body.success;\n\nconst errors = [];\nif (!jobId) errors.push('job_id');\nif (!userId) errors.push('user_id');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    message: 'Missing required fields: ' + errors.join(', ')\n  };\n}\n\n// --- Extract result data ---\nconst result = body.result || {};\nconst metrics = body.metrics || {};\nconst error = body.error || null;\n\nreturn {\n  valid: true,\n  data: {\n    job_id: jobId,\n    user_id: userId,\n    guild_id: guildId,\n    channel_id: channelId,\n    conversation_id: body.conversation_id,\n    success: success === true,\n    result: {\n      text: result.text || '',\n      output_type: result.output_type || 'text',\n      word_count: result.word_count || 0\n    },\n    metrics: {\n      tokens_used: metrics.tokens_used || 0,\n      processing_time_ms: metrics.processing_time_ms || 0,\n      ocr_confidence: metrics.ocr_confidence || 0,\n      pages_processed: metrics.pages_processed || 0\n    },\n    error: error\n  }\n};"
+      },
+      "id": "doc-callback-0002",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "doc-callback-0003",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/document-jobs/{{ $json.data.job_id }}/{{ $json.data.success ? 'complete' : 'fail' }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.data.success ? { result: $json.data.result, metrics: $json.data.metrics } : { error: $json.data.error }) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "doc-callback-0004",
+      "name": "Update Job Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [660, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE DISCORD NOTIFICATION\n// ============================================\n\nconst data = $('Validate Input').first().json.data;\nconst jobUpdateResult = $input.first().json;\n\n// --- Build notification message ---\nlet message;\nif (data.success) {\n  const text = data.result.text;\n  const truncated = text.length > 1500 ? text.substring(0, 1500) + '...' : text;\n  const processingTime = (data.metrics.processing_time_ms / 1000).toFixed(1);\n  \n  message = `**Document traité avec succès**\\n\\n` +\n    `**Résultat:**\\n${truncated}\\n\\n` +\n    `**Statistiques:**\\n` +\n    `- Mots: ${data.result.word_count}\\n` +\n    `- Temps: ${processingTime}s\\n` +\n    `- Pages: ${data.metrics.pages_processed}`;\n} else {\n  const errorCode = data.error?.code || 'UNKNOWN_ERROR';\n  const errorMessage = data.error?.message || 'Une erreur est survenue';\n  const retriable = data.error?.retriable ? 'Oui' : 'Non';\n  \n  message = `**Erreur de traitement**\\n\\n` +\n    `**Code:** ${errorCode}\\n` +\n    `**Message:** ${errorMessage}\\n` +\n    `**Réessayable:** ${retriable}`;\n  \n  if (data.error?.refund?.recommended) {\n    message += `\\n**Remboursement:** ${data.error.refund.percentage}% recommandé`;\n  }\n}\n\nreturn {\n  channel_id: data.channel_id,\n  user_id: data.user_id,\n  guild_id: data.guild_id,\n  message: message,\n  success: data.success,\n  job_id: data.job_id\n};"
+      },
+      "id": "doc-callback-0005",
+      "name": "Prepare Discord Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [880, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "id": "check-channel",
+              "leftValue": "={{ $json.channel_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "doc-callback-0006",
+      "name": "Has Channel?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/discord/channels/{{ $json.channel_id }}/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ content: $json.message }) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "doc-callback-0007",
+      "name": "Send Discord Notification",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1320, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE\n// ============================================\n\nconst discordResult = $input.first().json;\nconst msgData = $('Prepare Discord Message').first().json;\n\nreturn {\n  success: true,\n  job_id: msgData.job_id,\n  notification_sent: discordResult.id ? true : false,\n  message: 'Callback processed successfully'\n};"
+      },
+      "id": "doc-callback-0008",
+      "name": "Format Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1540, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT NO CHANNEL RESPONSE\n// ============================================\n\nconst msgData = $input.first().json;\n\nreturn {\n  success: true,\n  job_id: msgData.job_id,\n  notification_sent: false,\n  message: 'Callback processed (no channel to notify)'\n};"
+      },
+      "id": "doc-callback-0009",
+      "name": "Format No Channel Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.message || 'Invalid callback data',\n    http_status: 400\n  }\n};"
+      },
+      "id": "doc-callback-0010",
+      "name": "Format Error Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "doc-callback-0011",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1760, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "id": "doc-callback-0012",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 400]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Update Job Status",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format Error Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Job Status": {
+      "main": [
+        [
+          {
+            "node": "Prepare Discord Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Discord Message": {
+      "main": [
+        [
+          {
+            "node": "Has Channel?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Channel?": {
+      "main": [
+        [
+          {
+            "node": "Send Discord Notification",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format No Channel Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Discord Notification": {
+      "main": [
+        [
+          {
+            "node": "Format Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format No Channel Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Error Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary

- **TORAH-Document-Callback**: New workflow to receive document processing results from MCP-Documents-Process and send Discord notifications to users
- **JOBS---Admin-Cleanup**: Cron-based (every 5min) automatic cleanup of zombie jobs with credit refund
- **JOBS---User-Cleanup**: User-triggered webhook for cleaning up their own stuck jobs
- **MCP-Image-OCR**: Fixed project_id extraction, removed Create/Update Job nodes (document jobs use Redis, not /api/v2/jobs)
- **MCP-Documents-Process**: Added project_id forwarding, replaced `fetch()` with HTTP Request node (fetch not available in n8n Code nodes)

## Test plan

- [ ] Import `TORAH-Document-Callback.json` and activate
- [ ] Import updated `MCP-Documents-Process.json`
- [ ] Import updated `MCP-Image-OCR.json`
- [ ] Test document processing flow: chatbot-core → MCP-Documents-Process → MCP-Image-OCR → callback
- [ ] Verify Discord notification is received after processing
- [ ] Test JOBS cleanup workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)