### PR TITLE
feat: RFC-016/017 Job Lifecycle & Credits API Implementation

### DIFF
--- a/docs/issues/JOB-LIFECYCLE-CREDITS-API.md
+++ b/docs/issues/JOB-LIFECYCLE-CREDITS-API.md
@@ -1,0 +1,392 @@
+# API Jobs & Credits pour n8n (RFC-016/RFC-017)
+
+Documentation des endpoints pour l'intégration n8n avec le système de jobs et crédits.
+
+---
+
+## 1. Mise à jour d'un Job
+
+### `PATCH /api/v2/jobs/{job_id}`
+
+Met à jour le statut, la progression et les crédits d'un job.
+
+#### Transitions d'état valides
+
+```
+pending → processing, cancelled
+processing → completed, cancelled, failed
+completed/cancelled/failed → (aucune transition permise)
+```
+
+#### Request
+
+```json
+{
+  "status": "processing",
+  "progress": {
+    "current": 5,
+    "total": 15,
+    "percentage": 33,
+    "step": "translating"
+  },
+  "credits": {
+    "consumed": {
+      "claude_tokens": {
+        "input": 5000,
+        "output": 2500,
+        "total": 7500
+      },
+      "gpt_tokens": null,
+      "total_tokens": 7500,
+      "cost_usd": 0.015
+    },
+    "estimated_total": {
+      "total_tokens": 22500,
+      "cost_usd": 0.045
+    }
+  },
+  "output": {
+    "translated_url": "https://cdn.example.com/result.pdf",
+    "page_count": 15
+  },
+  "error": null
+}
+```
+
+#### Champs
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `status` | string | `pending`, `processing`, `completed`, `cancelled`, `failed` |
+| `progress.current` | int | Nombre d'éléments traités |
+| `progress.total` | int | Nombre total d'éléments |
+| `progress.percentage` | int | 0-100 |
+| `progress.step` | string | Étape actuelle (ex: `ocr`, `translating`, `formatting`) |
+| `credits.consumed` | object | Tokens consommés jusqu'à présent |
+| `credits.estimated_total` | object | Estimation totale pour le job |
+| `output` | object | Résultat du traitement (quand completed) |
+| `error` | object | Erreur (quand failed) |
+
+#### Response (200 OK)
+
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "project_id": "bot-appetit",
+  "job_type": "pdf_translation",
+  "status": "processing",
+  "priority": 1,
+  "context": {
+    "guild_id": "123456789",
+    "user_id": "987654321",
+    "channel_id": "111222333"
+  },
+  "input": {
+    "file_url": "https://cdn.discord.com/...",
+    "filename": "menu.pdf",
+    "source_lang": "en",
+    "target_lang": "fr"
+  },
+  "progress": {
+    "current": 5,
+    "total": 15,
+    "percentage": 33,
+    "step": "translating"
+  },
+  "credits": {
+    "consumed": {
+      "total_tokens": 7500,
+      "cost_usd": 0.015
+    }
+  },
+  "output": null,
+  "error": null,
+  "created_at": "2026-01-22T10:00:00+00:00",
+  "updated_at": "2026-01-22T10:05:00+00:00",
+  "completed_at": null,
+  "cancelled_at": null,
+  "failed_at": null
+}
+```
+
+#### Erreurs
+
+**400 - Transition invalide**
+```json
+{
+  "detail": {
+    "code": "INVALID_STATE_TRANSITION",
+    "message": "Cannot transition from 'completed' to 'cancelled'",
+    "current_status": "completed",
+    "requested_status": "cancelled",
+    "allowed_transitions": []
+  }
+}
+```
+
+**404 - Job non trouvé**
+```json
+{
+  "detail": "Job 550e8400-... not found"
+}
+```
+
+---
+
+## 2. Exemples de Workflows n8n
+
+### 2.1 Démarrer le traitement
+
+```json
+PATCH /api/v2/jobs/{job_id}
+{
+  "status": "processing"
+}
+```
+
+### 2.2 Mise à jour de progression (pendant le traitement)
+
+```json
+PATCH /api/v2/jobs/{job_id}
+{
+  "progress": {
+    "current": 10,
+    "total": 15,
+    "percentage": 67,
+    "step": "translating"
+  },
+  "credits": {
+    "consumed": {
+      "total_tokens": 15000,
+      "cost_usd": 0.03
+    }
+  }
+}
+```
+
+### 2.3 Marquer comme terminé
+
+```json
+PATCH /api/v2/jobs/{job_id}
+{
+  "status": "completed",
+  "progress": {
+    "current": 15,
+    "total": 15,
+    "percentage": 100,
+    "step": "done"
+  },
+  "credits": {
+    "consumed": {
+      "total_tokens": 22500,
+      "cost_usd": 0.045
+    }
+  },
+  "output": {
+    "translated_url": "https://cdn.example.com/result.pdf",
+    "page_count": 15,
+    "words_translated": 5000
+  }
+}
+```
+
+### 2.4 Marquer comme échoué
+
+```json
+PATCH /api/v2/jobs/{job_id}
+{
+  "status": "failed",
+  "error": {
+    "code": "OCR_FAILED",
+    "message": "Unable to extract text from image",
+    "details": "Page 3 is blank or corrupted"
+  }
+}
+```
+
+### 2.5 Annuler un job
+
+```json
+PATCH /api/v2/jobs/{job_id}
+{
+  "status": "cancelled"
+}
+```
+
+---
+
+## 3. Gestion des Crédits
+
+### 3.1 Débiter des crédits
+
+#### `POST /api/subscription/credits/{discord_user_id}/debit`
+
+Débite des crédits d'un utilisateur avant ou après traitement.
+
+#### Query Parameters
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project_id` | string | `torah` | ID du projet |
+
+#### Request
+
+```json
+{
+  "amount": 100,
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "reason": "pdf_translation"
+}
+```
+
+| Champ | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | int | ✅ | Nombre de crédits à débiter (> 0) |
+| `job_id` | string | ❌ | ID du job associé (traçabilité) |
+| `reason` | string | ❌ | Raison du débit |
+
+#### Response (200 OK)
+
+```json
+{
+  "success": true,
+  "project_id": "torah",
+  "discord_user_id": "987654321",
+  "operation": "debit",
+  "amount": 100,
+  "credits_before": 500,
+  "credits_after": 400,
+  "job_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Erreurs
+
+**400 - Crédits insuffisants**
+```json
+{
+  "detail": {
+    "error": "INSUFFICIENT_CREDITS",
+    "message": "User has 50 credits, needs 100",
+    "credits_available": 50,
+    "credits_requested": 100
+  }
+}
+```
+
+**404 - Utilisateur non trouvé**
+```json
+{
+  "detail": {
+    "found": false,
+    "project_id": "torah",
+    "discord_user_id": "987654321",
+    "message": "User not found"
+  }
+}
+```
+
+---
+
+### 3.2 Rembourser des crédits
+
+#### `POST /api/subscription/credits/{discord_user_id}/refund`
+
+Rembourse des crédits à un utilisateur (annulation, erreur, remboursement partiel).
+
+#### Query Parameters
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project_id` | string | `torah` | ID du projet |
+
+#### Request
+
+```json
+{
+  "amount": 50,
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "reason": "job_cancelled"
+}
+```
+
+| Champ | Type | Required | Description |
+|-------|------|----------|-------------|
+| `amount` | int | ✅ | Nombre de crédits à rembourser (> 0) |
+| `job_id` | string | ❌ | ID du job associé (traçabilité) |
+| `reason` | string | ❌ | Raison du remboursement |
+
+#### Response (200 OK)
+
+```json
+{
+  "success": true,
+  "project_id": "torah",
+  "discord_user_id": "987654321",
+  "operation": "refund",
+  "amount": 50,
+  "credits_before": 400,
+  "credits_after": 450,
+  "job_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+---
+
+## 4. Consulter les crédits
+
+### `GET /api/subscription/credits/{discord_user_id}`
+
+#### Query Parameters
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `project_id` | string | `torah` | ID du projet |
+
+#### Response (200 OK)
+
+```json
+{
+  "project_id": "torah",
+  "discord_user_id": "987654321",
+  "credits": 450,
+  "has_credits": true
+}
+```
+
+---
+
+## 5. Flow complet recommandé
+
+```
+1. Job créé (status: pending)
+         ↓
+2. PATCH status: processing
+         ↓
+3. Vérifier crédits: GET /api/subscription/credits/{user_id}
+         ↓
+4. Si crédits insuffisants → PATCH status: failed + error
+         ↓
+5. Traitement avec mises à jour de progress
+         ↓
+6. Si succès:
+   - PATCH status: completed + output
+   - POST /credits/{user_id}/debit (crédits réels consommés)
+         ↓
+7. Si échec:
+   - PATCH status: failed + error
+   - (pas de débit)
+         ↓
+8. Si annulation:
+   - PATCH status: cancelled
+   - POST /credits/{user_id}/refund (si déjà débité)
+```
+
+---
+
+## 6. Base URL
+
+| Environnement | URL |
+|---------------|-----|
+| Développement | `http://localhost:3031` |
+| Production | `https://api.torah-solutions.com` |

--- a/docs/issues/WORK-API-TORAH.md
+++ b/docs/issues/WORK-API-TORAH.md
@@ -1,0 +1,482 @@
+# Travail Équipe API Torah
+
+**Source:** RFC-016 + RFC-017
+**Date:** 2026-01-22
+**Priorité globale:** 🔴 Haute (Phase 1 - Fondations)
+
+---
+
+## Résumé
+
+L'équipe API doit adapter le modèle Job pour supporter la progression en temps réel et créer les endpoints de gestion des crédits.
+
+---
+
+## Actions à réaliser
+
+| # | Action | Priorité | Complexité | Dépendances |
+|---|--------|----------|------------|-------------|
+| 1 | Ajouter champ `progress` au modèle Job | 🔴 Haute | Faible | Aucune |
+| 2 | Créer `POST /api/credits/{user_id}/debit` | 🔴 Haute | Moyenne | Aucune |
+| 3 | Créer `POST /api/credits/{user_id}/refund` | 🔴 Haute | Moyenne | Aucune |
+| 4 | Valider transitions d'état | 🟡 Moyenne | Faible | Aucune |
+| 5 | Auto-set timestamps | 🟡 Moyenne | Faible | Aucune |
+| 6 | Supporter `credits` dans PATCH /api/v2/jobs | 🟡 Moyenne | Faible | Action 1 |
+
+---
+
+## Action 1 : Ajouter champ `progress` au modèle Job
+
+### Contexte
+
+Actuellement, la progression est stockée dans `output` de manière non structurée. Un champ dédié permet un affichage cohérent côté plugins.
+
+### Modification requise
+
+```python
+# models/job.py ou équivalent
+class Job:
+    id: str
+    job_type: str
+    status: str  # pending, processing, completed, cancelled, failed
+    progress: dict | None  # ← NOUVEAU
+    output: dict | None
+    error: dict | None
+    created_at: datetime
+    updated_at: datetime
+
+class JobUpdateRequest:
+    status: str | None
+    progress: dict | None  # ← NOUVEAU
+    output: dict | None
+    error: dict | None
+```
+
+### Format du champ `progress`
+
+```json
+{
+  "current": 5,
+  "total": 15,
+  "percentage": 33,
+  "step": "translating"
+}
+```
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `current` | int | Élément en cours (1-indexed) |
+| `total` | int | Nombre total d'éléments |
+| `percentage` | int | Pourcentage calculé (0-100) |
+| `step` | string | Étape actuelle (optionnel) |
+
+### Valeurs de `step`
+
+| Valeur | Description |
+|--------|-------------|
+| `extracting` | Extraction PDF/OCR en cours |
+| `translating` | Traduction en cours |
+| `verifying` | Vérification GPT en cours |
+| `saving` | Sauvegarde en cours |
+
+### Endpoint concerné
+
+```bash
+PATCH /api/v2/jobs/{job_id}
+Content-Type: application/json
+
+{
+  "status": "processing",
+  "progress": {
+    "current": 5,
+    "total": 15,
+    "percentage": 33,
+    "step": "translating"
+  }
+}
+```
+
+### Tests à ajouter
+
+- [ ] PATCH avec progress valide → 200 OK
+- [ ] PATCH avec progress partiel (current only) → 200 OK
+- [ ] GET job retourne progress correctement
+- [ ] progress est nullable (jobs sans progression)
+
+---
+
+## Action 2 : Créer endpoint débit crédits
+
+### Endpoint
+
+```
+POST /api/credits/{discord_user_id}/debit
+```
+
+### Request
+
+```json
+{
+  "project_id": "torah",
+  "amount": 10,
+  "reason": "document_translation",
+  "job_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `project_id` | string | ✅ | Identifiant projet (torah, recipes) |
+| `amount` | int | ✅ | Nombre de crédits à débiter |
+| `reason` | string | ✅ | Raison du débit |
+| `job_id` | string | ❌ | Job associé (traçabilité) |
+
+### Response - Succès (200)
+
+```json
+{
+  "success": true,
+  "credits_remaining": 90,
+  "credits_debited": 10,
+  "transaction_id": "txn_abc123"
+}
+```
+
+### Response - Crédits insuffisants (402)
+
+```json
+{
+  "success": false,
+  "error": "insufficient_credits",
+  "credits_remaining": 5,
+  "credits_requested": 10,
+  "message": "Crédits insuffisants. Solde: 5, Demandé: 10"
+}
+```
+
+### Response - Utilisateur non trouvé (404)
+
+```json
+{
+  "success": false,
+  "error": "user_not_found",
+  "message": "Utilisateur non trouvé"
+}
+```
+
+### Logique métier
+
+```python
+async def debit_credits(discord_user_id: str, request: DebitRequest):
+    # 1. Récupérer le solde actuel
+    user_credits = await get_user_credits(discord_user_id, request.project_id)
+
+    if not user_credits:
+        raise HTTPException(404, "user_not_found")
+
+    # 2. Vérifier solde suffisant
+    if user_credits.credits_remaining < request.amount:
+        raise HTTPException(402, {
+            "error": "insufficient_credits",
+            "credits_remaining": user_credits.credits_remaining,
+            "credits_requested": request.amount
+        })
+
+    # 3. Débiter
+    new_balance = user_credits.credits_remaining - request.amount
+
+    await update_user_credits(
+        discord_user_id,
+        request.project_id,
+        credits_remaining=new_balance
+    )
+
+    # 4. Logger la transaction
+    transaction = await create_transaction(
+        user_id=discord_user_id,
+        project_id=request.project_id,
+        type="debit",
+        amount=request.amount,
+        reason=request.reason,
+        job_id=request.job_id
+    )
+
+    return {
+        "success": True,
+        "credits_remaining": new_balance,
+        "credits_debited": request.amount,
+        "transaction_id": transaction.id
+    }
+```
+
+### Table SQL suggérée (transactions)
+
+```sql
+CREATE TABLE credit_transactions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    discord_user_id VARCHAR(255) NOT NULL,
+    project_id VARCHAR(50) NOT NULL,
+    type VARCHAR(20) NOT NULL,  -- 'debit', 'refund', 'purchase'
+    amount INTEGER NOT NULL,
+    reason VARCHAR(255),
+    job_id UUID,
+    created_at TIMESTAMP DEFAULT NOW(),
+
+    FOREIGN KEY (discord_user_id, project_id)
+        REFERENCES user_credits(discord_user_id, project_id)
+);
+```
+
+---
+
+## Action 3 : Créer endpoint remboursement crédits
+
+### Endpoint
+
+```
+POST /api/credits/{discord_user_id}/refund
+```
+
+### Request
+
+```json
+{
+  "project_id": "torah",
+  "amount": 5,
+  "reason": "job_cancelled",
+  "job_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+### Response - Succès (200)
+
+```json
+{
+  "success": true,
+  "credits_remaining": 95,
+  "credits_refunded": 5,
+  "transaction_id": "txn_xyz789"
+}
+```
+
+### Logique métier
+
+```python
+async def refund_credits(discord_user_id: str, request: RefundRequest):
+    # 1. Récupérer le solde actuel
+    user_credits = await get_user_credits(discord_user_id, request.project_id)
+
+    if not user_credits:
+        raise HTTPException(404, "user_not_found")
+
+    # 2. Créditer (pas de vérification de plafond pour les refunds)
+    new_balance = user_credits.credits_remaining + request.amount
+
+    await update_user_credits(
+        discord_user_id,
+        request.project_id,
+        credits_remaining=new_balance
+    )
+
+    # 3. Logger la transaction
+    transaction = await create_transaction(
+        user_id=discord_user_id,
+        project_id=request.project_id,
+        type="refund",
+        amount=request.amount,
+        reason=request.reason,
+        job_id=request.job_id
+    )
+
+    return {
+        "success": True,
+        "credits_remaining": new_balance,
+        "credits_refunded": request.amount,
+        "transaction_id": transaction.id
+    }
+```
+
+---
+
+## Action 4 : Valider transitions d'état
+
+### Transitions valides
+
+```python
+VALID_TRANSITIONS = {
+    "pending": ["processing", "cancelled"],
+    "processing": ["completed", "cancelled", "failed"],
+    "completed": [],  # État final
+    "cancelled": [],  # État final
+    "failed": [],     # État final
+}
+```
+
+### Implémentation
+
+```python
+async def update_job(job_id: str, request: JobUpdateRequest):
+    job = await get_job(job_id)
+
+    if request.status and request.status != job.status:
+        # Vérifier transition valide
+        allowed = VALID_TRANSITIONS.get(job.status, [])
+        if request.status not in allowed:
+            raise HTTPException(400, {
+                "error": "invalid_state_transition",
+                "current_status": job.status,
+                "requested_status": request.status,
+                "allowed_transitions": allowed
+            })
+
+    # Continuer avec la mise à jour...
+```
+
+### Response - Transition invalide (400)
+
+```json
+{
+  "error": "invalid_state_transition",
+  "current_status": "completed",
+  "requested_status": "cancelled",
+  "allowed_transitions": [],
+  "message": "Cannot transition from 'completed' to 'cancelled'"
+}
+```
+
+---
+
+## Action 5 : Auto-set timestamps
+
+### Timestamps à gérer
+
+| Status | Timestamp |
+|--------|-----------|
+| `completed` | `completed_at` |
+| `cancelled` | `cancelled_at` |
+| `failed` | `failed_at` |
+
+### Implémentation
+
+```python
+async def update_job(job_id: str, request: JobUpdateRequest):
+    job = await get_job(job_id)
+
+    update_data = request.dict(exclude_unset=True)
+
+    # Auto-set timestamp selon le status
+    if request.status:
+        now = datetime.utcnow()
+        if request.status == "completed":
+            update_data["completed_at"] = now
+        elif request.status == "cancelled":
+            update_data["cancelled_at"] = now
+        elif request.status == "failed":
+            update_data["failed_at"] = now
+
+    # Toujours mettre à jour updated_at
+    update_data["updated_at"] = datetime.utcnow()
+
+    await db.jobs.update_one({"_id": job_id}, {"$set": update_data})
+```
+
+### Modèle Job mis à jour
+
+```python
+class Job:
+    id: str
+    job_type: str
+    status: str
+    progress: dict | None
+    output: dict | None
+    error: dict | None
+    created_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None  # ← NOUVEAU
+    cancelled_at: datetime | None  # ← NOUVEAU
+    failed_at: datetime | None     # ← NOUVEAU
+```
+
+---
+
+## Action 6 : Supporter `credits` dans PATCH
+
+### Request
+
+```bash
+PATCH /api/v2/jobs/{job_id}
+Content-Type: application/json
+
+{
+  "status": "processing",
+  "progress": {
+    "current": 5,
+    "total": 15,
+    "percentage": 33
+  },
+  "credits": {
+    "consumed": {
+      "claude_tokens": { "input": 5000, "output": 2500, "total": 7500 },
+      "gpt_tokens": { "input": 1000, "output": 500, "total": 1500 },
+      "total_tokens": 9000,
+      "cost_usd": 0.015
+    }
+  }
+}
+```
+
+### Modèle
+
+```python
+class JobCredits:
+    consumed: dict  # Tokens consommés jusqu'à présent
+    estimated_total: dict | None  # Estimation totale (optionnel)
+
+class JobUpdateRequest:
+    status: str | None
+    progress: dict | None
+    credits: JobCredits | None  # ← NOUVEAU
+    output: dict | None
+    error: dict | None
+```
+
+---
+
+## Checklist finale
+
+### Phase 1 (Priorité haute)
+
+- [ ] Ajouter champ `progress` au modèle Job
+- [ ] Créer `POST /api/credits/{user_id}/debit`
+- [ ] Créer `POST /api/credits/{user_id}/refund`
+- [ ] Créer table `credit_transactions` (si nécessaire)
+- [ ] Tests unitaires pour les nouveaux endpoints
+
+### Phase 2 (Priorité moyenne)
+
+- [ ] Valider transitions d'état dans PATCH
+- [ ] Auto-set timestamps (completed_at, cancelled_at, failed_at)
+- [ ] Supporter `credits` dans PATCH /api/v2/jobs
+- [ ] Documentation API mise à jour
+
+### Tests d'intégration
+
+- [ ] Scénario complet : créer job → progress → complete
+- [ ] Scénario annulation : créer job → progress → cancel
+- [ ] Scénario crédits : check → debit → refund
+
+---
+
+## Questions en suspens
+
+1. **Table transactions** : Existe-t-elle déjà ou à créer ?
+2. **Historique crédits** : Faut-il exposer un endpoint GET /api/credits/{user_id}/history ?
+3. **Plafond remboursement** : Peut-on rembourser plus que le montant débité initialement ?
+
+---
+
+## Contact
+
+Pour questions sur ces spécifications :
+- RFC-016 : Architecture globale
+- RFC-017 : Détails job lifecycle

--- a/docs/issues/WORK-CHATBOT-CORE.md
+++ b/docs/issues/WORK-CHATBOT-CORE.md
@@ -1,0 +1,699 @@
+# Travail Équipe chatbot-core
+
+**Source:** RFC-016 + RFC-017
+**Date:** 2026-01-22
+**Priorité globale:** 🔴 Haute (Phase 2 - Adaptation plugins)
+
+---
+
+## Résumé
+
+L'équipe chatbot-core doit migrer le polling vers l'endpoint autoritaire, ajouter le support de l'annulation serveur via `cancel_url`, et supprimer le système Redis obsolète.
+
+---
+
+## Actions à réaliser
+
+| # | Action | Priorité | Impact | Dépendances |
+|---|--------|----------|--------|-------------|
+| 1 | Migrer polling vers `/api/v2/jobs/{id}` | 🔴 Haute | `DocumentTranslationClient` | n8n: aucune |
+| 2 | Supprimer `DocumentJobStore` (Redis) | 🔴 Haute | Nettoyage | Action 1 |
+| 3 | Ajouter `cancel_url` au PollingService | 🔴 Haute | Voir RFC-017 | n8n: Action 1 |
+| 4 | Adapter `CreditsClient` | 🟡 Moyenne | Via webhooks n8n | n8n: Actions 2-4 |
+| 5 | Créer `DocumentWorkflowService` | 🟡 Moyenne | Nouveau service | Actions 1-3 |
+
+---
+
+## Action 1 : Migrer polling vers /api/v2/jobs/{id}
+
+### Contexte
+
+Deux endpoints de polling coexistent :
+- `/api/v2/jobs/{job_id}` (API Torah - **AUTORITAIRE**)
+- `/webhook/torah-job-status` (n8n - **DÉPRÉCIÉ**)
+
+### Fichiers à modifier
+
+```
+services/n8n/document_translation.py
+```
+
+### Modification
+
+```python
+# AVANT
+class DocumentTranslationClient:
+    def __init__(self, n8n_client: N8NClient):
+        self.status_endpoint = "/webhook/torah-job-status"
+
+    async def get_job_status(self, job_id: str) -> TranslationJobStatus:
+        response = await self.n8n_client.call_webhook(
+            self.status_endpoint,
+            params={"job_id": job_id}
+        )
+        # ...
+
+# APRÈS
+class DocumentTranslationClient:
+    def __init__(self, n8n_client: N8NClient, api_url: str = None):
+        self.api_url = api_url or os.getenv("API_URL", "http://localhost:3031")
+
+    async def get_job_status(self, job_id: str) -> TranslationJobStatus:
+        async with aiohttp.ClientSession() as session:
+            url = f"{self.api_url}/api/v2/jobs/{job_id}"
+            async with session.get(url) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    return self._parse_job_status(data)
+                elif response.status == 404:
+                    raise JobNotFoundError(job_id)
+                else:
+                    raise APIError(f"Failed to get job status: {response.status}")
+
+    def _parse_job_status(self, data: dict) -> TranslationJobStatus:
+        """Parse API response to TranslationJobStatus."""
+        progress = data.get("progress", {})
+        return TranslationJobStatus(
+            job_id=data["id"],
+            status=data["status"],
+            progress=TranslationProgress(
+                current=progress.get("current", 0),
+                total=progress.get("total", 0),
+                percentage=progress.get("percentage", 0),
+                step=progress.get("step")
+            ) if progress else None,
+            output=data.get("output"),
+            error=data.get("error"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at")
+        )
+```
+
+### Dataclass mise à jour
+
+```python
+@dataclass
+class TranslationProgress:
+    current: int
+    total: int
+    percentage: int
+    step: str | None = None
+
+@dataclass
+class TranslationJobStatus:
+    job_id: str
+    status: str  # pending, processing, completed, cancelled, failed
+    progress: TranslationProgress | None = None
+    output: dict | None = None
+    error: dict | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    completed_at: str | None = None
+    cancelled_at: str | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        return self.status in ("completed", "cancelled", "failed")
+
+    @property
+    def is_success(self) -> bool:
+        return self.status == "completed"
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.status == "cancelled"
+```
+
+### Tests à mettre à jour
+
+```python
+# tests/services/test_document_translation.py
+
+@pytest.mark.asyncio
+async def test_get_job_status_from_api():
+    """Test polling from /api/v2/jobs/{id}."""
+    client = DocumentTranslationClient(n8n_client, api_url="http://test-api:3031")
+
+    with aioresponses() as m:
+        m.get(
+            "http://test-api:3031/api/v2/jobs/test-job-123",
+            payload={
+                "id": "test-job-123",
+                "status": "processing",
+                "progress": {"current": 5, "total": 15, "percentage": 33},
+                "output": None
+            }
+        )
+
+        status = await client.get_job_status("test-job-123")
+
+        assert status.status == "processing"
+        assert status.progress.current == 5
+        assert status.progress.percentage == 33
+```
+
+---
+
+## Action 2 : Supprimer DocumentJobStore (Redis)
+
+### Contexte
+
+Le système Redis `document:job:*` est déprécié. MongoDB `/api/v2/jobs` est la source de vérité unique.
+
+### Fichiers à supprimer ou modifier
+
+```
+services/jobs/document_job_store.py  → SUPPRIMER
+tests/services/test_document_job_store.py → SUPPRIMER
+```
+
+### Références à nettoyer
+
+Rechercher et supprimer toutes les références à :
+- `DocumentJobStore`
+- `document:job:`
+- `redis.get("document:job:*")`
+
+### Migration des données existantes
+
+```python
+# Script de migration one-shot (optionnel)
+async def migrate_redis_jobs_to_mongodb():
+    """Migrate existing Redis jobs to MongoDB."""
+    redis_client = get_redis_client()
+    api_client = get_api_client()
+
+    # Récupérer tous les jobs Redis
+    keys = await redis_client.keys("document:job:*")
+
+    for key in keys:
+        job_data = await redis_client.get(key)
+        if job_data:
+            job = json.loads(job_data)
+            # Créer dans MongoDB si n'existe pas
+            try:
+                await api_client.post("/api/v2/jobs", json={
+                    "id": job["id"],
+                    "job_type": "document_translation",
+                    "status": job["status"],
+                    "output": job.get("result"),
+                    "created_at": job.get("created_at")
+                })
+            except Exception as e:
+                logger.warning(f"Job {job['id']} already exists or error: {e}")
+
+    logger.info(f"Migrated {len(keys)} jobs from Redis to MongoDB")
+```
+
+---
+
+## Action 3 : Ajouter cancel_url au PollingService
+
+### Contexte
+
+Actuellement, le bouton Stop arrête uniquement le polling côté client. Le job continue sur le serveur.
+
+### Fichiers à modifier
+
+```
+services/polling/polling_service.py
+```
+
+### Modification PollingService
+
+```python
+# AVANT
+class PollingService:
+    def __init__(
+        self,
+        status_url: str,
+        interval: float = 2.0,
+        timeout: float = 600.0
+    ):
+        self.status_url = status_url
+        self.interval = interval
+        self.timeout = timeout
+        self._cancelled = False
+
+    async def cancel(self) -> PollingResult:
+        self._cancelled = True
+        return PollingResult(status=PollingStatus.CANCELLED)
+
+# APRÈS
+class PollingService:
+    def __init__(
+        self,
+        status_url: str,
+        cancel_url: str | None = None,
+        cancel_params: dict | None = None,
+        interval: float = 2.0,
+        timeout: float = 600.0
+    ):
+        self.status_url = status_url
+        self.cancel_url = cancel_url
+        self.cancel_params = cancel_params or {}
+        self.interval = interval
+        self.timeout = timeout
+        self._cancelled = False
+
+    async def cancel(self) -> PollingResult:
+        """Cancel polling and notify server."""
+        self._cancelled = True
+
+        # Notify server if cancel_url is provided
+        if self.cancel_url:
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(
+                        self.cancel_url,
+                        json=self.cancel_params,
+                        timeout=aiohttp.ClientTimeout(total=5)
+                    ) as response:
+                        if response.status == 200:
+                            result = await response.json()
+                            return PollingResult(
+                                status=PollingStatus.CANCELLED,
+                                data={
+                                    "credits_consumed": result.get("credits_consumed"),
+                                    "credits_saved": result.get("credits_saved"),
+                                    "message": result.get("message"),
+                                    "server_cancelled": True
+                                }
+                            )
+                        else:
+                            logger.warning(f"Cancel request failed: {response.status}")
+            except asyncio.TimeoutError:
+                logger.warning("Cancel request timed out")
+            except Exception as e:
+                logger.error(f"Failed to cancel job on server: {e}")
+
+        return PollingResult(
+            status=PollingStatus.CANCELLED,
+            data={"server_cancelled": False}
+        )
+```
+
+### Utilisation dans DocumentTranslationClient
+
+```python
+class DocumentTranslationClient:
+    async def translate_document(
+        self,
+        document: Document,
+        target_language: str,
+        user_id: str,
+        on_progress: Callable[[TranslationProgress], None] | None = None
+    ) -> TranslationResult:
+        # 1. Start translation
+        job = await self._start_translation(document, target_language)
+
+        # 2. Create polling service with cancel_url
+        polling_service = PollingService(
+            status_url=f"{self.api_url}/api/v2/jobs/{job.job_id}",
+            cancel_url=f"{self.webhook_url}/webhook/document-cancel",
+            cancel_params={
+                "job_id": job.job_id,
+                "user_id": user_id,
+                "reason": "user_requested"
+            },
+            interval=2.0,
+            timeout=600.0
+        )
+
+        # 3. Store reference for potential cancellation
+        self._active_polling[job.job_id] = polling_service
+
+        try:
+            # 4. Poll until complete
+            result = await polling_service.poll(on_progress=on_progress)
+            return self._process_result(result)
+        finally:
+            del self._active_polling[job.job_id]
+
+    async def cancel_translation(self, job_id: str) -> CancellationResult:
+        """Cancel an active translation."""
+        if job_id in self._active_polling:
+            polling_service = self._active_polling[job_id]
+            result = await polling_service.cancel()
+            return CancellationResult(
+                job_id=job_id,
+                success=True,
+                credits_consumed=result.data.get("credits_consumed"),
+                credits_saved=result.data.get("credits_saved"),
+                server_cancelled=result.data.get("server_cancelled", False)
+            )
+        else:
+            raise JobNotFoundError(f"No active translation for job {job_id}")
+```
+
+### Dataclass pour résultat d'annulation
+
+```python
+@dataclass
+class CancellationResult:
+    job_id: str
+    success: bool
+    credits_consumed: dict | None = None
+    credits_saved: dict | None = None
+    server_cancelled: bool = False
+
+    @property
+    def message(self) -> str:
+        if self.credits_consumed:
+            consumed = self.credits_consumed.get("cost_usd", 0)
+            saved = (self.credits_saved or {}).get("cost_usd", 0)
+            segments = self.credits_consumed.get("segments_completed", 0)
+            total = self.credits_consumed.get("segments_total", "?")
+            return f"Annulé. {segments}/{total} segments. {consumed:.3f}$ consommés, {saved:.3f}$ économisés."
+        return "Traitement annulé."
+```
+
+---
+
+## Action 4 : Adapter CreditsClient
+
+### Contexte
+
+Les crédits passent maintenant par les webhooks n8n.
+
+### Fichiers à modifier
+
+```
+services/credits/credits_client.py
+```
+
+### Modification
+
+```python
+class CreditsClient:
+    def __init__(self, webhook_url: str):
+        self.webhook_url = webhook_url
+
+    async def check_credits(self, discord_user_id: str, project_id: str) -> CreditsBalance:
+        """Check user credits balance."""
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.webhook_url}/webhook/credits-check",
+                json={
+                    "discord_user_id": discord_user_id,
+                    "project_id": project_id
+                }
+            ) as response:
+                data = await response.json()
+                return CreditsBalance(
+                    remaining=data.get("credits_remaining", 0),
+                    total=data.get("credits_total", 0)
+                )
+
+    async def debit_credits(
+        self,
+        discord_user_id: str,
+        project_id: str,
+        amount: int,
+        reason: str,
+        job_id: str | None = None
+    ) -> DebitResult:
+        """Debit credits from user account."""
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.webhook_url}/webhook/credits-debit",
+                json={
+                    "discord_user_id": discord_user_id,
+                    "project_id": project_id,
+                    "amount": amount,
+                    "reason": reason,
+                    "job_id": job_id
+                }
+            ) as response:
+                if response.status == 402:
+                    data = await response.json()
+                    raise InsufficientCreditsError(
+                        remaining=data.get("credits_remaining", 0),
+                        requested=amount
+                    )
+                data = await response.json()
+                return DebitResult(
+                    success=data.get("success", False),
+                    credits_remaining=data.get("credits_remaining", 0),
+                    credits_debited=data.get("credits_debited", 0)
+                )
+
+    async def refund_credits(
+        self,
+        discord_user_id: str,
+        project_id: str,
+        amount: int,
+        reason: str,
+        job_id: str | None = None
+    ) -> RefundResult:
+        """Refund credits to user account."""
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{self.webhook_url}/webhook/credits-refund",
+                json={
+                    "discord_user_id": discord_user_id,
+                    "project_id": project_id,
+                    "amount": amount,
+                    "reason": reason,
+                    "job_id": job_id
+                }
+            ) as response:
+                data = await response.json()
+                return RefundResult(
+                    success=data.get("success", False),
+                    credits_remaining=data.get("credits_remaining", 0),
+                    credits_refunded=data.get("credits_refunded", 0)
+                )
+```
+
+### Dataclasses
+
+```python
+@dataclass
+class CreditsBalance:
+    remaining: int
+    total: int
+
+    @property
+    def used(self) -> int:
+        return self.total - self.remaining
+
+@dataclass
+class DebitResult:
+    success: bool
+    credits_remaining: int
+    credits_debited: int
+
+@dataclass
+class RefundResult:
+    success: bool
+    credits_remaining: int
+    credits_refunded: int
+
+class InsufficientCreditsError(Exception):
+    def __init__(self, remaining: int, requested: int):
+        self.remaining = remaining
+        self.requested = requested
+        super().__init__(f"Insufficient credits: {remaining} remaining, {requested} requested")
+```
+
+---
+
+## Action 5 : Créer DocumentWorkflowService (Optionnel)
+
+### Contexte
+
+Service haut niveau RFC-016 compliant pour le flux conversationnel complet.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  DocumentWorkflowService (RFC-016 compliant)                     │
+│  ─────────────────────────────────────────────────────────────   │
+│  - Appelle mcp-llm-intention pour analyse                        │
+│  - Gère proposed_actions et confirmation utilisateur             │
+│  - Crée job via /api/v2/jobs                                     │
+│  - Utilise DocumentTranslationClient pour l'exécution            │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  DocumentTranslationClient (Low-level)                           │
+│  ─────────────────────────────────────────────────────────────   │
+│  - Appel direct au worker                                        │
+│  - Polling                                                       │
+│  - Annulation                                                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Squelette
+
+```python
+class DocumentWorkflowService:
+    """High-level service for conversational document processing (RFC-016)."""
+
+    def __init__(
+        self,
+        n8n_client: N8NClient,
+        api_client: APIClient,
+        translation_client: DocumentTranslationClient,
+        credits_client: CreditsClient
+    ):
+        self.n8n = n8n_client
+        self.api = api_client
+        self.translation = translation_client
+        self.credits = credits_client
+
+    async def analyze_intent(
+        self,
+        query: str,
+        history: list[dict],
+        context: dict,
+        user: dict
+    ) -> IntentResult:
+        """Analyze user intent via MCP-LLM-Intention."""
+        response = await self.n8n.call_webhook(
+            "/webhook/mcp-llm-intention",
+            json={
+                "query": query,
+                "history": history,
+                "context": context,
+                "user": user
+            }
+        )
+
+        if response.get("response_type") == "action_proposal":
+            return IntentResult(
+                type="action_proposal",
+                message=response.get("message"),
+                proposed_actions=[
+                    ProposedAction(**action)
+                    for action in response.get("proposed_actions", [])
+                ],
+                requires_confirmation=response.get("requires_confirmation", True)
+            )
+        else:
+            return IntentResult(
+                type="message",
+                message=response.get("message")
+            )
+
+    async def execute_action(
+        self,
+        action: ProposedAction,
+        user_id: str,
+        on_progress: Callable | None = None
+    ) -> ActionResult:
+        """Execute a proposed action after user confirmation."""
+        # 1. Check credits
+        estimate = action.estimate or {}
+        estimated_cost = estimate.get("cost_estimated_credits", 0)
+
+        if estimated_cost > 0:
+            balance = await self.credits.check_credits(user_id, action.project_id)
+            if balance.remaining < estimated_cost:
+                raise InsufficientCreditsError(balance.remaining, estimated_cost)
+
+        # 2. Create job
+        job = await self.api.create_job(
+            job_type=action.params.get("job_type", "document_processing"),
+            input=action.params
+        )
+
+        try:
+            # 3. Debit credits
+            if estimated_cost > 0:
+                await self.credits.debit_credits(
+                    user_id,
+                    action.project_id,
+                    estimated_cost,
+                    reason=action.id,
+                    job_id=job.id
+                )
+
+            # 4. Execute via appropriate worker
+            result = await self._execute_worker(
+                action.webhook,
+                job.id,
+                action.params,
+                on_progress
+            )
+
+            return ActionResult(
+                success=True,
+                job_id=job.id,
+                result=result
+            )
+
+        except Exception as e:
+            # Cleanup: delete job on failure
+            await self.api.delete_job(job.id)
+            raise
+
+    async def _execute_worker(
+        self,
+        webhook: str,
+        job_id: str,
+        params: dict,
+        on_progress: Callable | None
+    ):
+        """Execute the appropriate worker based on webhook."""
+        if webhook == "document-translate-worker":
+            return await self.translation.translate_document(
+                job_id=job_id,
+                params=params,
+                on_progress=on_progress
+            )
+        # Add other workers as needed
+        else:
+            raise ValueError(f"Unknown webhook: {webhook}")
+```
+
+---
+
+## Checklist finale
+
+### Phase 1 (Priorité haute)
+
+- [ ] Migrer `get_job_status()` vers `/api/v2/jobs/{id}`
+- [ ] Mettre à jour `TranslationJobStatus` dataclass
+- [ ] Ajouter `cancel_url` et `cancel_params` au `PollingService`
+- [ ] Implémenter `cancel()` avec appel serveur
+- [ ] Tester annulation avec crédits retournés
+
+### Phase 2 (Priorité haute)
+
+- [ ] Supprimer `DocumentJobStore` (Redis)
+- [ ] Nettoyer toutes les références Redis
+- [ ] Exécuter migration one-shot (si données existantes)
+
+### Phase 3 (Priorité moyenne)
+
+- [ ] Adapter `CreditsClient` pour webhooks n8n
+- [ ] Créer `DocumentWorkflowService` (optionnel)
+- [ ] Intégrer avec `DocumentMentionHandler`
+
+### Tests
+
+- [ ] Test polling depuis `/api/v2/jobs/{id}`
+- [ ] Test annulation avec `cancel_url`
+- [ ] Test crédits check/debit/refund via webhooks
+
+---
+
+## Variables d'environnement
+
+```python
+# .env ou config
+API_URL=http://pi6.local:3031
+WEBHOOK_URL=http://pi6.local:5678
+```
+
+---
+
+## Contact
+
+Pour questions sur ces spécifications :
+- RFC-016 : Architecture globale
+- RFC-017 : Détails job lifecycle

--- a/docs/issues/WORK-N8N.md
+++ b/docs/issues/WORK-N8N.md
@@ -1,0 +1,644 @@
+# Travail Équipe n8n
+
+**Source:** RFC-016 + RFC-017
+**Date:** 2026-01-22
+**Priorité globale:** 🔴 Haute (Phase 1 - Fondations)
+
+---
+
+## Résumé
+
+L'équipe n8n doit créer les webhooks de gestion des crédits et d'annulation, puis modifier les workers existants pour implémenter le pattern "check-before-process".
+
+---
+
+## Actions à réaliser
+
+| # | Action | Priorité | Fichier | Dépendances |
+|---|--------|----------|---------|-------------|
+| 1 | Créer `/webhook/document-cancel` | 🔴 Haute | `Document-Cancel.json` | API: aucune |
+| 2 | Créer `/webhook/credits-check` | 🔴 Haute | `Credits-Check.json` | API: endpoint existant |
+| 3 | Créer `/webhook/credits-debit` | 🔴 Haute | `Credits-Debit.json` | API: Action 2 |
+| 4 | Créer `/webhook/credits-refund` | 🔴 Haute | `Credits-Refund.json` | API: Action 3 |
+| 5 | Modifier Torah-Translate-Worker | 🔴 Haute | `Torah-Translate-Worker.json` | Action 1 |
+| 6 | Confirmer `auto_web_search` | 🔴 Haute | `MCP-LLM-Intention.json` | Aucune |
+| 7 | Migrer format `response_type` | 🟡 Moyenne | `LLM-Intention.json` | Aucune |
+
+---
+
+## Action 1 : Créer webhook document-cancel
+
+### Endpoint
+
+```
+POST /webhook/document-cancel
+```
+
+### Request
+
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "user_id": "123456789",
+  "reason": "user_requested"
+}
+```
+
+### Workflow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Document-Cancel Workflow                      │
+└─────────────────────────────────────────────────────────────────┘
+
+┌─────────────────┐
+│ Webhook Trigger │ POST /webhook/document-cancel
+│ responseMode:   │
+│ responseNode    │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Validate Input  │ job_id requis
+│ Code Node       │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ GET Job Status  │ GET $env.API_URL/api/v2/jobs/{job_id}
+│ HTTP Request    │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Check Status    │ IF status in ['processing', 'pending']
+│ IF Node         │
+└────────┬────────┘
+         │
+    ┌────┴────────────────┐
+    │                     │
+    ▼                     ▼
+ Can Cancel          Cannot Cancel
+    │                     │
+    ▼                     ▼
+┌─────────────────┐  ┌─────────────────┐
+│ PATCH Job       │  │ Return Error    │
+│ status:cancelled│  │ "Cannot cancel" │
+│ HTTP Request    │  │ Respond Node    │
+└────────┬────────┘  └─────────────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Build Response  │ credits_consumed, credits_saved
+│ Code Node       │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐
+│ Respond         │ Return JSON
+│ Respond Node    │
+└─────────────────┘
+```
+
+### Nodes détaillés
+
+#### Node: Validate Input
+
+```javascript
+const body = $input.first().json.body || $input.first().json;
+
+if (!body.job_id) {
+  throw new Error('job_id is required');
+}
+
+return [{
+  json: {
+    jobId: body.job_id,
+    userId: body.user_id || null,
+    reason: body.reason || 'user_requested'
+  }
+}];
+```
+
+#### Node: Check Status (IF)
+
+```
+Condition: {{ $json.status }} is equal to "processing"
+OR
+Condition: {{ $json.status }} is equal to "pending"
+```
+
+#### Node: Build Response
+
+```javascript
+const job = $('GET Job Status').first().json;
+const input = $('Validate Input').first().json;
+
+// Extraire les crédits du job
+const credits = job.credits || job.output?.credits || {};
+const consumed = credits.consumed || { total_tokens: 0, cost_usd: 0 };
+const estimated = credits.estimated_total || consumed;
+
+// Calculer les économies
+const saved = {
+  tokens_not_used: Math.max(0, (estimated.total_tokens || 0) - (consumed.total_tokens || 0)),
+  cost_usd: Math.max(0, (estimated.cost_usd || 0) - (consumed.cost_usd || 0))
+};
+
+// Extraire la progression
+const progress = job.progress || {};
+
+return [{
+  json: {
+    success: true,
+    job_id: input.jobId,
+    previous_status: job.status,
+    new_status: 'cancelled',
+    cancelled_at: new Date().toISOString(),
+    credits_consumed: {
+      total_tokens: consumed.total_tokens || 0,
+      cost_usd: consumed.cost_usd || 0,
+      segments_completed: progress.current || 0,
+      segments_total: progress.total || 0
+    },
+    credits_saved: saved,
+    message: `Job annulé. ${progress.current || 0}/${progress.total || '?'} segments traités. ${(consumed.cost_usd || 0).toFixed(3)}$ consommés, ${saved.cost_usd.toFixed(3)}$ économisés.`
+  }
+}];
+```
+
+### Response - Succès
+
+```json
+{
+  "success": true,
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "previous_status": "processing",
+  "new_status": "cancelled",
+  "cancelled_at": "2026-01-22T10:02:15Z",
+  "credits_consumed": {
+    "total_tokens": 9000,
+    "cost_usd": 0.015,
+    "segments_completed": 5,
+    "segments_total": 15
+  },
+  "credits_saved": {
+    "tokens_not_used": 18000,
+    "cost_usd": 0.030
+  },
+  "message": "Job annulé. 5/15 segments traités. 0.015$ consommés, 0.030$ économisés."
+}
+```
+
+### Response - Erreur (job déjà terminé)
+
+```json
+{
+  "success": false,
+  "error": "cannot_cancel",
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "current_status": "completed",
+  "message": "Cannot cancel job with status 'completed'"
+}
+```
+
+---
+
+## Action 2 : Créer webhook credits-check
+
+### Endpoint
+
+```
+POST /webhook/credits-check
+```
+
+### Request
+
+```json
+{
+  "discord_user_id": "123456789",
+  "project_id": "torah"
+}
+```
+
+### Workflow simplifié
+
+```
+Webhook Trigger
+    │
+    ▼
+HTTP Request: GET $env.API_URL/api/subscription/credits/{discord_user_id}
+    │
+    ▼
+Respond with result
+```
+
+### Response
+
+```json
+{
+  "success": true,
+  "discord_user_id": "123456789",
+  "project_id": "torah",
+  "credits_remaining": 100,
+  "credits_total": 150
+}
+```
+
+---
+
+## Action 3 : Créer webhook credits-debit
+
+### Endpoint
+
+```
+POST /webhook/credits-debit
+```
+
+### Request
+
+```json
+{
+  "discord_user_id": "123456789",
+  "project_id": "torah",
+  "amount": 10,
+  "reason": "document_translation",
+  "job_id": "xxx"
+}
+```
+
+### Workflow
+
+```
+Webhook Trigger
+    │
+    ▼
+Validate Input (amount > 0, etc.)
+    │
+    ▼
+HTTP Request: POST $env.API_URL/api/credits/{discord_user_id}/debit
+    body: { project_id, amount, reason, job_id }
+    │
+    ▼
+Respond with result (passthrough API response)
+```
+
+---
+
+## Action 4 : Créer webhook credits-refund
+
+### Endpoint
+
+```
+POST /webhook/credits-refund
+```
+
+### Request
+
+```json
+{
+  "discord_user_id": "123456789",
+  "project_id": "torah",
+  "amount": 5,
+  "reason": "job_cancelled",
+  "job_id": "xxx"
+}
+```
+
+### Workflow
+
+Identique à credits-debit, mais appelle `POST /api/credits/{user_id}/refund`.
+
+---
+
+## Action 5 : Modifier Torah-Translate-Worker
+
+### Pattern Check-Before-Process
+
+Ajouter une vérification du status du job **avant chaque segment** dans la boucle.
+
+### Modification du workflow
+
+```
+AVANT:
+Loop Segments → Needs Pivot? → Claude → GPT → Save → Update Progress → Loop
+
+APRÈS:
+Loop Segments → [Check Job Status] → [IF cancelled?] → ...
+                                           │
+                                    ┌──────┴──────┐
+                                    │             │
+                                    ▼             ▼
+                              Exit Early    Continue Normal
+                              (cancelled)   (Needs Pivot? → ...)
+```
+
+### Nouveaux nodes à ajouter
+
+#### Node: Check Job Status (Code)
+
+**Position:** Après "Loop Segments", avant "Needs Pivot?"
+
+```javascript
+// Check if job has been cancelled
+const jobId = $json.jobId;
+const apiUrl = $env.API_URL;
+
+try {
+  const response = await fetch(`${apiUrl}/api/v2/jobs/${jobId}`);
+  const job = await response.json();
+
+  if (job.status === 'cancelled') {
+    return [{
+      json: {
+        ...$json,
+        shouldStop: true,
+        stopReason: 'user_cancelled',
+        cancelledAt: new Date().toISOString()
+      }
+    }];
+  }
+
+  if (job.status === 'failed') {
+    return [{
+      json: {
+        ...$json,
+        shouldStop: true,
+        stopReason: 'job_failed'
+      }
+    }];
+  }
+
+  // Continue normally
+  return [{
+    json: {
+      ...$json,
+      shouldStop: false
+    }
+  }];
+} catch (error) {
+  // En cas d'erreur réseau, continuer (fail-open)
+  console.error('Failed to check job status:', error);
+  return [{
+    json: {
+      ...$json,
+      shouldStop: false
+    }
+  }];
+}
+```
+
+#### Node: Should Stop? (IF)
+
+**Condition:** `{{ $json.shouldStop }}` equals `true`
+
+- **True branch:** → Exit Early
+- **False branch:** → Needs Pivot? (flux normal)
+
+#### Node: Exit Early (Code)
+
+```javascript
+// Préparer le résumé pour sortie anticipée
+const data = $json;
+
+const consumed = data.accumulatedCredits || {
+  total_tokens: 0,
+  cost_usd: 0
+};
+
+const estimated = data.estimatedTotal || {
+  total_tokens: consumed.total_tokens * (data.totalSegments / Math.max(1, data.segmentIndex + 1)),
+  cost_usd: consumed.cost_usd * (data.totalSegments / Math.max(1, data.segmentIndex + 1))
+};
+
+const saved = {
+  tokens_not_used: Math.max(0, estimated.total_tokens - consumed.total_tokens),
+  cost_usd: Math.max(0, estimated.cost_usd - consumed.cost_usd)
+};
+
+return [{
+  json: {
+    jobId: data.jobId,
+    status: 'cancelled',
+    reason: data.stopReason,
+    credits_consumed: {
+      ...consumed,
+      segments_completed: data.segmentIndex || 0,
+      segments_total: data.totalSegments || 0
+    },
+    credits_saved: saved,
+    partial_results: data.allTranslations || []
+  }
+}];
+```
+
+#### Node: PATCH Cancelled Status (HTTP Request)
+
+```
+Method: PATCH
+URL: {{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}
+Body:
+{
+  "status": "cancelled",
+  "output": {
+    "credits": {
+      "consumed": {{ $json.credits_consumed }},
+      "saved": {{ $json.credits_saved }}
+    },
+    "partial_results": {{ $json.partial_results }}
+  }
+}
+```
+
+### Connexions à modifier
+
+```
+Loop Segments (output 1: done) → Prepare Final Result (inchangé)
+Loop Segments (output 2: loop) → Check Job Status (NOUVEAU)
+
+Check Job Status → Should Stop?
+
+Should Stop? (true) → Exit Early → PATCH Cancelled → Done
+Should Stop? (false) → Needs Pivot? (flux existant)
+```
+
+### Accumulation des crédits
+
+Modifier le node "Prepare Update" pour accumuler les crédits :
+
+```javascript
+// Dans Prepare Update, ajouter l'accumulation
+const prevAccumulated = $json.accumulatedCredits || {
+  claude_tokens: { input: 0, output: 0, total: 0 },
+  gpt_tokens: { input: 0, output: 0, total: 0 },
+  total_tokens: 0,
+  cost_usd: 0
+};
+
+const claudeUsage = prevData.claudeUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+const gptUsage = prevData.gptUsage || { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+
+const accumulatedCredits = {
+  claude_tokens: {
+    input: prevAccumulated.claude_tokens.input + claudeUsage.input_tokens,
+    output: prevAccumulated.claude_tokens.output + claudeUsage.output_tokens,
+    total: prevAccumulated.claude_tokens.total + claudeUsage.total_tokens
+  },
+  gpt_tokens: {
+    input: prevAccumulated.gpt_tokens.input + gptUsage.input_tokens,
+    output: prevAccumulated.gpt_tokens.output + gptUsage.output_tokens,
+    total: prevAccumulated.gpt_tokens.total + gptUsage.total_tokens
+  },
+  total_tokens: prevAccumulated.total_tokens + claudeUsage.total_tokens + gptUsage.total_tokens
+};
+
+// Calculer le coût
+const RATES = {
+  claude: { input: 3.00 / 1_000_000, output: 15.00 / 1_000_000 },
+  gpt: { input: 2.50 / 1_000_000, output: 10.00 / 1_000_000 }
+};
+
+accumulatedCredits.cost_usd = (
+  accumulatedCredits.claude_tokens.input * RATES.claude.input +
+  accumulatedCredits.claude_tokens.output * RATES.claude.output +
+  accumulatedCredits.gpt_tokens.input * RATES.gpt.input +
+  accumulatedCredits.gpt_tokens.output * RATES.gpt.output
+);
+
+// Ajouter à la sortie
+return [{
+  json: {
+    ...prevData,
+    accumulatedCredits: accumulatedCredits,
+    // ... reste du code existant
+  }
+}];
+```
+
+---
+
+## Action 6 : Confirmer auto_web_search
+
+### Vérification
+
+Le flag `auto_web_search` a été ajouté au workflow `MCP-LLM-Intention.json`.
+
+### Comportement attendu
+
+| `auto_web_search` | Comportement |
+|-------------------|--------------|
+| `true` (défaut) | Lance la recherche web automatiquement |
+| `false` | Retourne `response_type: "action_proposal"` avec action `web_search` |
+
+### Test à effectuer
+
+```bash
+# Test avec auto_web_search: false
+curl -X POST http://localhost:5678/webhook/mcp-llm-intention \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "recette pizza",
+    "context": {
+      "type": "recipe",
+      "auto_web_search": false
+    }
+  }'
+
+# Doit retourner response_type: "action_proposal" avec proposed_actions
+```
+
+---
+
+## Action 7 : Migrer format response_type
+
+### Workflows concernés
+
+- `LLM-Intention.json` (si distinct de mcp-llm-intention)
+
+### Format de sortie standard
+
+```json
+{
+  "success": true,
+  "response_type": "message | action_proposal | error",
+  "message": "...",
+  "proposed_actions": [
+    {
+      "id": "translate",
+      "label": "🌐 Traduire",
+      "description": "Traduction complète du document",
+      "webhook": "document-translate-worker",
+      "params": { ... },
+      "estimate": {
+        "tokens_estimated": 45000,
+        "cost_estimated_eur": 0.05,
+        "time_estimated_seconds": 120
+      }
+    }
+  ],
+  "requires_confirmation": true
+}
+```
+
+### Valeurs de `response_type`
+
+| Valeur | Description |
+|--------|-------------|
+| `message` | Réponse textuelle simple |
+| `action_proposal` | Proposition d'actions avec boutons |
+| `error` | Erreur avec message |
+
+---
+
+## Checklist finale
+
+### Phase 1 (Priorité haute)
+
+- [ ] Créer `Document-Cancel.json`
+- [ ] Créer `Credits-Check.json`
+- [ ] Créer `Credits-Debit.json`
+- [ ] Créer `Credits-Refund.json`
+- [ ] Tester chaque webhook individuellement
+- [ ] Confirmer `auto_web_search` fonctionne
+
+### Phase 2 (Priorité haute)
+
+- [ ] Modifier `Torah-Translate-Worker.json`
+  - [ ] Ajouter node "Check Job Status"
+  - [ ] Ajouter node "Should Stop?" (IF)
+  - [ ] Ajouter node "Exit Early"
+  - [ ] Ajouter node "PATCH Cancelled"
+  - [ ] Modifier connexions
+  - [ ] Accumuler les crédits
+
+### Phase 3 (Priorité moyenne)
+
+- [ ] Migrer format `response_type` dans LLM-Intention
+- [ ] Modifier `Document-Translate-Worker.json` (même pattern)
+- [ ] Documenter le pattern pour les futurs workers
+
+### Tests d'intégration
+
+- [ ] Scénario complet : lancer traduction → annuler mid-process → vérifier crédits
+- [ ] Scénario crédits : check → debit → refund
+- [ ] Scénario auto_web_search: false → vérifier action_proposal
+
+---
+
+## Variables d'environnement requises
+
+```javascript
+// ecosystem.config.js
+{
+  API_URL: 'http://pi6.local:3031',
+  // ... autres variables existantes
+}
+```
+
+---
+
+## Contact
+
+Pour questions sur ces spécifications :
+- RFC-016 : Architecture globale
+- RFC-017 : Détails job lifecycle et pattern check-before-process

--- a/docs/issues/WORK-PLUGIN-RECIPES.md
+++ b/docs/issues/WORK-PLUGIN-RECIPES.md
@@ -1,0 +1,599 @@
+# Travail Équipe plugin-recipes (Bot Appetit)
+
+**Source:** RFC-016 + RFC-017
+**Date:** 2026-01-22
+**Priorité globale:** 🔴 Haute (Phase 2 - Adaptation plugins)
+
+---
+
+## Résumé
+
+L'équipe plugin-recipes doit migrer vers le nouveau format de réponse `response_type` + `proposed_actions` et confirmer que le flag `auto_web_search` fonctionne correctement.
+
+---
+
+## Actions à réaliser
+
+| # | Action | Priorité | Dépendances |
+|---|--------|----------|-------------|
+| 1 | Migrer vers format `response_type` | 🔴 Haute | n8n: Action 7 |
+| 2 | Confirmer `auto_web_search: false` | 🔴 Haute | n8n: Action 6 |
+| 3 | Implémenter mémoire conversationnelle | 🟢 Quand pertinent | Aucune |
+| 4 | Supporter OCR recettes | 🟢 Quand pertinent | Aucune |
+
+---
+
+## Action 1 : Migrer vers format response_type
+
+### Contexte
+
+Le format de réponse du workflow `llm-intention` change :
+
+| Ancien format (DÉPRÉCIÉ) | Nouveau format (RFC-016) |
+|-------------------------|--------------------------|
+| `next_action: "propose_web_search"` | `response_type: "action_proposal"` |
+| Champs éparpillés | Structure `proposed_actions[]` |
+
+**IMPORTANT:** Pas de rétrocompatibilité. Migration directe requise.
+
+### Fichiers à modifier
+
+```
+mentions.py (ou équivalent)
+```
+
+### Avant
+
+```python
+# mentions.py - ANCIEN CODE À SUPPRIMER
+
+async def handle_llm_response(self, response: dict, message: discord.Message):
+    """Handle response from llm-intention workflow."""
+
+    # Ancien format
+    next_action = response.get("next_action")
+    llm_message = response.get("message", "")
+
+    if next_action == "propose_web_search":
+        # Proposer la recherche web
+        view = WebSearchView(
+            query=response.get("search_query"),
+            message=llm_message
+        )
+        await message.reply(content=llm_message, view=view)
+
+    elif next_action == "web_search":
+        # Lancer directement la recherche
+        await self._execute_web_search(response.get("search_query"), message)
+
+    elif next_action == "direct_response":
+        # Réponse directe
+        await message.reply(content=llm_message)
+
+    else:
+        # Fallback
+        await message.reply(content=llm_message or "Je n'ai pas compris.")
+```
+
+### Après
+
+```python
+# mentions.py - NOUVEAU CODE
+
+async def handle_llm_response(self, response: dict, message: discord.Message):
+    """Handle response from llm-intention workflow (RFC-016 format)."""
+
+    response_type = response.get("response_type", "message")
+    llm_message = response.get("message", "")
+
+    if response_type == "action_proposal":
+        # Proposition d'actions avec boutons
+        proposed_actions = response.get("proposed_actions", [])
+        requires_confirmation = response.get("requires_confirmation", True)
+
+        if requires_confirmation and proposed_actions:
+            # Afficher les boutons pour chaque action
+            view = ActionProposalView(
+                actions=proposed_actions,
+                original_message=message
+            )
+            await message.reply(content=llm_message, view=view)
+        elif proposed_actions:
+            # Exécuter la première action automatiquement
+            action = proposed_actions[0]
+            await self._execute_action(action, message)
+        else:
+            # Pas d'actions, afficher le message
+            await message.reply(content=llm_message)
+
+    elif response_type == "message":
+        # Réponse textuelle simple
+        await message.reply(content=llm_message)
+
+    elif response_type == "error":
+        # Erreur
+        error_msg = response.get("error", "Une erreur est survenue.")
+        await message.reply(content=f"❌ {error_msg}")
+
+    else:
+        # Fallback pour types inconnus
+        await message.reply(content=llm_message or "Je n'ai pas compris.")
+```
+
+### Nouveau View pour propositions d'actions
+
+```python
+# views/action_proposal_view.py
+
+class ActionProposalView(discord.ui.View):
+    """View for displaying proposed actions as buttons."""
+
+    def __init__(
+        self,
+        actions: list[dict],
+        original_message: discord.Message,
+        timeout: float = 300.0  # 5 minutes
+    ):
+        super().__init__(timeout=timeout)
+        self.actions = {action["id"]: action for action in actions}
+        self.original_message = original_message
+
+        # Créer un bouton pour chaque action (max 5)
+        for action in actions[:5]:
+            button = discord.ui.Button(
+                label=action.get("label", action["id"]),
+                style=self._get_button_style(action),
+                custom_id=f"action_{action['id']}"
+            )
+            button.callback = self._make_callback(action)
+            self.add_item(button)
+
+        # Ajouter bouton Annuler
+        cancel_button = discord.ui.Button(
+            label="❌ Annuler",
+            style=discord.ButtonStyle.secondary,
+            custom_id="action_cancel"
+        )
+        cancel_button.callback = self._cancel_callback
+        self.add_item(cancel_button)
+
+    def _get_button_style(self, action: dict) -> discord.ButtonStyle:
+        """Determine button style based on action type."""
+        action_id = action.get("id", "")
+        if "search" in action_id or "web" in action_id:
+            return discord.ButtonStyle.primary  # Bleu
+        elif "translate" in action_id:
+            return discord.ButtonStyle.success  # Vert
+        else:
+            return discord.ButtonStyle.secondary  # Gris
+
+    def _make_callback(self, action: dict):
+        """Create callback for action button."""
+        async def callback(interaction: discord.Interaction):
+            # Désactiver les boutons
+            for item in self.children:
+                item.disabled = True
+            await interaction.response.edit_message(view=self)
+
+            # Exécuter l'action
+            await self._execute_action(action, interaction)
+
+        return callback
+
+    async def _execute_action(self, action: dict, interaction: discord.Interaction):
+        """Execute the selected action."""
+        webhook = action.get("webhook")
+        params = action.get("params", {})
+        estimate = action.get("estimate", {})
+
+        # Afficher estimation si disponible
+        if estimate:
+            cost = estimate.get("cost_estimated_eur", 0)
+            time_sec = estimate.get("time_estimated_seconds", 0)
+            await interaction.followup.send(
+                f"⏳ Exécution en cours... (estimé: {cost:.2f}€, ~{time_sec}s)",
+                ephemeral=True
+            )
+
+        # Appeler le webhook approprié
+        if webhook == "llm-web-search":
+            await self._execute_web_search(params, interaction)
+        # Ajouter d'autres webhooks selon besoin
+
+    async def _execute_web_search(self, params: dict, interaction: discord.Interaction):
+        """Execute web search action."""
+        query = params.get("query", "")
+        # ... logique de recherche web existante
+
+    async def _cancel_callback(self, interaction: discord.Interaction):
+        """Handle cancel button click."""
+        await interaction.response.edit_message(
+            content="Action annulée.",
+            view=None
+        )
+```
+
+### Structure proposed_actions
+
+```json
+{
+  "response_type": "action_proposal",
+  "message": "Pas de recette en base pour 'tajine végétarien'. Voulez-vous chercher sur le web ?",
+  "proposed_actions": [
+    {
+      "id": "web_search",
+      "label": "🌐 Chercher sur le web",
+      "description": "Rechercher des recettes sur internet",
+      "webhook": "llm-web-search",
+      "params": {
+        "query": "tajine végétarien recette",
+        "type": "recipe"
+      },
+      "estimate": {
+        "tokens_estimated": 2000,
+        "cost_estimated_eur": 0.01,
+        "time_estimated_seconds": 10
+      }
+    },
+    {
+      "id": "suggest_similar",
+      "label": "📚 Recettes similaires",
+      "description": "Voir des recettes similaires en base",
+      "webhook": "recipe-search",
+      "params": {
+        "query": "tajine végétarien",
+        "limit": 5
+      }
+    }
+  ],
+  "requires_confirmation": true
+}
+```
+
+---
+
+## Action 2 : Confirmer auto_web_search: false
+
+### Contexte
+
+Le flag `auto_web_search` contrôle si la recherche web se lance automatiquement ou propose d'abord à l'utilisateur.
+
+### Payload actuel à vérifier
+
+```python
+# mentions.py
+async def call_llm_intention(self, content: str, context: dict):
+    payload = {
+        "query": content,
+        "context": {
+            "type": "recipe",
+            "auto_web_search": False,  # ← VÉRIFIÉ: Ne pas lancer auto
+            **context
+        }
+    }
+    return await self.n8n_client.call_webhook("/webhook/llm-intention", json=payload)
+```
+
+### Comportement attendu
+
+| `auto_web_search` | Comportement |
+|-------------------|--------------|
+| `true` (défaut) | LLM décide de lancer la recherche automatiquement |
+| `false` | LLM retourne `response_type: "action_proposal"` avec action `web_search` |
+
+### Test à effectuer
+
+```bash
+# Test avec auto_web_search: false
+curl -X POST http://localhost:5678/webhook/llm-intention \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "recette de pizza maison",
+    "context": {
+      "type": "recipe",
+      "auto_web_search": false
+    }
+  }'
+```
+
+### Réponse attendue
+
+```json
+{
+  "success": true,
+  "response_type": "action_proposal",
+  "message": "Je n'ai pas trouvé de recette de pizza maison dans ma base. Voulez-vous que je cherche sur le web ?",
+  "proposed_actions": [
+    {
+      "id": "web_search",
+      "label": "🌐 Chercher sur le web",
+      "webhook": "llm-web-search",
+      "params": { "query": "recette pizza maison" }
+    }
+  ],
+  "requires_confirmation": true
+}
+```
+
+### Si ça ne fonctionne pas
+
+Contacter l'équipe n8n pour :
+1. Vérifier que le workflow `llm-intention` / `mcp-llm-intention` vérifie le flag
+2. Confirmer que la condition `if (!auto_web_search)` est implémentée
+
+---
+
+## Action 3 : Implémenter mémoire conversationnelle (Optionnel)
+
+### Contexte
+
+La mémoire conversationnelle permet des échanges multi-tours :
+```
+User: "Donne-moi une recette de pâtes"
+Bot: "Pour combien de personnes ?"
+User: "5"
+Bot: "Voici une recette pour 5 personnes..."
+```
+
+### Prérequis
+
+- Décision produit : Est-ce pertinent pour Bot Appetit ?
+- L'architecture est prête côté n8n (le workflow accepte `history[]`)
+
+### Implémentation suggérée
+
+```python
+# conversation_memory.py
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+class ConversationMemory:
+    """Simple in-memory conversation storage."""
+
+    def __init__(self, max_messages: int = 10, ttl_minutes: int = 30):
+        self.max_messages = max_messages
+        self.ttl = timedelta(minutes=ttl_minutes)
+        self._storage: dict[str, list[dict]] = defaultdict(list)
+        self._timestamps: dict[str, datetime] = {}
+
+    def _get_key(self, channel_id: int, user_id: int) -> str:
+        """Generate storage key."""
+        return f"{channel_id}:{user_id}"
+
+    def add_message(self, channel_id: int, user_id: int, role: str, content: str):
+        """Add a message to the conversation history."""
+        key = self._get_key(channel_id, user_id)
+
+        # Check TTL
+        if key in self._timestamps:
+            if datetime.now() - self._timestamps[key] > self.ttl:
+                self._storage[key] = []
+
+        # Add message
+        self._storage[key].append({
+            "role": role,
+            "content": content,
+            "timestamp": datetime.now().isoformat()
+        })
+
+        # Trim to max
+        if len(self._storage[key]) > self.max_messages:
+            self._storage[key] = self._storage[key][-self.max_messages:]
+
+        self._timestamps[key] = datetime.now()
+
+    def get_history(self, channel_id: int, user_id: int) -> list[dict]:
+        """Get conversation history for a user in a channel."""
+        key = self._get_key(channel_id, user_id)
+
+        # Check TTL
+        if key in self._timestamps:
+            if datetime.now() - self._timestamps[key] > self.ttl:
+                self._storage[key] = []
+                return []
+
+        return self._storage[key].copy()
+
+    def clear(self, channel_id: int, user_id: int):
+        """Clear conversation history."""
+        key = self._get_key(channel_id, user_id)
+        self._storage[key] = []
+```
+
+### Utilisation dans mentions.py
+
+```python
+# mentions.py
+class RecipeMentionHandler:
+    def __init__(self, n8n_client, memory: ConversationMemory):
+        self.n8n_client = n8n_client
+        self.memory = memory
+
+    async def handle_mention(self, message: discord.Message):
+        # Récupérer l'historique
+        history = self.memory.get_history(
+            channel_id=message.channel.id,
+            user_id=message.author.id
+        )
+
+        # Ajouter le message actuel à l'historique
+        self.memory.add_message(
+            channel_id=message.channel.id,
+            user_id=message.author.id,
+            role="user",
+            content=message.content
+        )
+
+        # Appeler llm-intention avec l'historique
+        response = await self.call_llm_intention(
+            content=message.content,
+            context={"type": "recipe", "auto_web_search": False},
+            history=history  # ← NOUVEAU
+        )
+
+        # Traiter la réponse
+        bot_response = await self.handle_llm_response(response, message)
+
+        # Sauvegarder la réponse du bot
+        if bot_response:
+            self.memory.add_message(
+                channel_id=message.channel.id,
+                user_id=message.author.id,
+                role="assistant",
+                content=bot_response
+            )
+
+    async def call_llm_intention(self, content: str, context: dict, history: list = None):
+        payload = {
+            "query": content,
+            "context": context,
+            "history": history or []  # ← NOUVEAU
+        }
+        return await self.n8n_client.call_webhook("/webhook/llm-intention", json=payload)
+```
+
+---
+
+## Action 4 : Supporter OCR recettes (Optionnel)
+
+### Contexte
+
+Permettre aux utilisateurs d'envoyer une photo de recette et d'en extraire le texte.
+
+### Prérequis
+
+- Décision produit : Est-ce pertinent pour Bot Appetit ?
+- Webhooks existants : `/webhook/image-ocr` (Mistral)
+
+### Cas d'usage
+
+1. User envoie une photo de recette manuscrite ou imprimée
+2. Bot extrait le texte via OCR
+3. Bot parse la recette (ingrédients, étapes)
+4. Bot sauvegarde la recette en base
+
+### Implémentation suggérée
+
+```python
+# handlers/image_handler.py
+class RecipeImageHandler:
+    async def handle_image(self, message: discord.Message, attachment: discord.Attachment):
+        """Handle image attachment for recipe extraction."""
+
+        # 1. Vérifier que c'est une image
+        if not attachment.content_type.startswith("image/"):
+            return None
+
+        # 2. Appeler OCR
+        ocr_result = await self.n8n_client.call_webhook(
+            "/webhook/image-ocr",
+            json={
+                "image_url": attachment.url,
+                "language": "fr",
+                "extract_type": "recipe"
+            }
+        )
+
+        if not ocr_result.get("success"):
+            await message.reply("❌ Je n'ai pas pu lire cette image.")
+            return
+
+        extracted_text = ocr_result.get("text", "")
+
+        # 3. Parser comme recette (via LLM)
+        parse_result = await self.n8n_client.call_webhook(
+            "/webhook/llm-intention",
+            json={
+                "query": f"Parse cette recette et structure-la : {extracted_text}",
+                "context": {
+                    "type": "recipe_parsing",
+                    "source": "ocr"
+                }
+            }
+        )
+
+        # 4. Afficher le résultat
+        # ...
+```
+
+---
+
+## Checklist finale
+
+### Phase 1 (Priorité haute)
+
+- [ ] Modifier `handle_llm_response()` pour nouveau format
+- [ ] Créer `ActionProposalView` pour boutons
+- [ ] Tester avec réponse `response_type: "action_proposal"`
+- [ ] Vérifier que `auto_web_search: false` est bien envoyé
+- [ ] Tester que le workflow retourne une proposition (pas exécution auto)
+
+### Phase 2 (Priorité moyenne)
+
+- [ ] Documenter la migration dans le code
+- [ ] Supprimer l'ancien code `next_action`
+- [ ] Ajouter logs pour debug
+
+### Phase 3 (Future - Quand pertinent)
+
+- [ ] Implémenter `ConversationMemory`
+- [ ] Ajouter `history[]` aux appels llm-intention
+- [ ] Implémenter `RecipeImageHandler` pour OCR
+
+---
+
+## Tests à effectuer
+
+### Test format response_type
+
+1. Mentionner `@Bot Appetit recette de pizza`
+2. Vérifier que la réponse contient des boutons
+3. Cliquer sur "Chercher sur le web"
+4. Vérifier que la recherche se lance
+
+### Test auto_web_search
+
+1. Mentionner `@Bot Appetit recette de sushi`
+2. Vérifier que le bot **propose** la recherche (ne lance pas automatiquement)
+3. Vérifier les boutons "Chercher" et "Annuler"
+
+### Test annulation
+
+1. Mentionner avec une requête
+2. Cliquer sur "Annuler"
+3. Vérifier que le message est mis à jour
+
+---
+
+## Migration - Checklist de code
+
+### Fichiers à modifier
+
+| Fichier | Modification |
+|---------|--------------|
+| `mentions.py` | Nouveau `handle_llm_response()` |
+| `views/__init__.py` | Ajouter `ActionProposalView` |
+| `views/action_proposal_view.py` | Créer le fichier |
+
+### Imports à ajouter
+
+```python
+from views.action_proposal_view import ActionProposalView
+```
+
+### Ancien code à supprimer
+
+```python
+# Supprimer toute référence à :
+- next_action
+- "propose_web_search"
+- "direct_response"
+```
+
+---
+
+## Contact
+
+Pour questions sur ces spécifications :
+- RFC-016 : Architecture globale et format response_type
+- n8n : Confirmer auto_web_search

--- a/docs/issues/WORK-PLUGIN-TORAH.md
+++ b/docs/issues/WORK-PLUGIN-TORAH.md
@@ -1,0 +1,352 @@
+# Travail Équipe plugin-torah
+
+**Source:** RFC-016 + RFC-017
+**Date:** 2026-01-22
+**Priorité globale:** 🔴 Haute (Phase 2 - Adaptation plugins)
+
+---
+
+## Résumé
+
+L'équipe plugin-torah doit migrer vers l'endpoint de polling autoritaire, implémenter l'annulation serveur via `cancel_url`, et afficher les crédits lors de l'annulation.
+
+---
+
+## Actions à réaliser
+
+| # | Action | Priorité | Dépendances |
+|---|--------|----------|-------------|
+| 1 | Migrer polling vers `/api/v2/jobs/{id}` | 🔴 Haute | chatbot-core: Action 1 |
+| 2 | Passer `cancel_url` au PollingService | 🔴 Haute | n8n: Action 1, chatbot-core: Action 3 |
+| 3 | Afficher crédits à l'annulation | 🟡 Moyenne | Action 2 |
+| 4 | Utiliser DocumentWorkflowService pour mentions | 🟡 Moyenne | chatbot-core: Action 5 |
+
+---
+
+## Action 1 : Migrer polling vers /api/v2/jobs/{id}
+
+### Contexte
+
+| Ancien endpoint (déprécié) | Nouvel endpoint (autoritaire) |
+|---------------------------|------------------------------|
+| `GET /webhook/torah-job-status?job_id=...` | `GET /api/v2/jobs/{job_id}` |
+
+### Impact
+
+Si le plugin utilise `DocumentTranslationClient` de chatbot-core, la migration est **automatique** après mise à jour de chatbot-core.
+
+### Vérification
+
+```python
+# Vérifier que le plugin utilise DocumentTranslationClient
+from chatbot_core.services.n8n import DocumentTranslationClient
+
+client = DocumentTranslationClient(n8n_client, api_url=API_URL)
+# Le polling utilisera automatiquement /api/v2/jobs/{id}
+```
+
+### Si appel direct (legacy)
+
+```python
+# AVANT - À SUPPRIMER
+async def check_job_status(job_id: str):
+    response = await n8n_client.get(
+        "/webhook/torah-job-status",
+        params={"job_id": job_id}
+    )
+    return response
+
+# APRÈS - Utiliser chatbot-core
+from chatbot_core.services.n8n import DocumentTranslationClient
+
+client = DocumentTranslationClient(n8n_client, api_url=API_URL)
+status = await client.get_job_status(job_id)
+```
+
+---
+
+## Action 2 : Passer cancel_url au PollingService
+
+### Contexte
+
+Actuellement, le bouton Stop arrête uniquement le polling côté client. Le job continue sur le serveur, gaspillant des tokens.
+
+### Fichiers à modifier
+
+```
+views/translate_views.py (ou équivalent)
+```
+
+### Avant
+
+```python
+# translate_views.py
+class TranslateView(discord.ui.View):
+    async def start_translation(self, interaction, document):
+        # Démarrer la traduction
+        job = await self.client.start_translation(document)
+
+        # Polling sans cancel_url
+        polling_service = PollingService(
+            status_url=f"{API_URL}/api/v2/jobs/{job.job_id}"
+        )
+
+        self.polling_service = polling_service
+        result = await polling_service.poll()
+        # ...
+
+    @discord.ui.button(label="Stop", style=discord.ButtonStyle.danger)
+    async def stop_button(self, interaction, button):
+        # Arrête uniquement le polling local
+        await self.polling_service.cancel()
+        await interaction.response.edit_message(
+            content="Annulé",
+            view=None
+        )
+```
+
+### Après
+
+```python
+# translate_views.py
+class TranslateView(discord.ui.View):
+    async def start_translation(self, interaction, document):
+        # Démarrer la traduction
+        job = await self.client.start_translation(document)
+
+        # Polling AVEC cancel_url
+        polling_service = PollingService(
+            status_url=f"{API_URL}/api/v2/jobs/{job.job_id}",
+            cancel_url=f"{WEBHOOK_URL}/webhook/document-cancel",  # ← NOUVEAU
+            cancel_params={                                        # ← NOUVEAU
+                "job_id": job.job_id,
+                "user_id": str(interaction.user.id),
+                "reason": "user_requested"
+            }
+        )
+
+        self.polling_service = polling_service
+        self.job_id = job.job_id
+        result = await polling_service.poll()
+        # ...
+
+    @discord.ui.button(label="Stop", style=discord.ButtonStyle.danger)
+    async def stop_button(self, interaction, button):
+        # Annule ET notifie le serveur
+        result = await self.polling_service.cancel()
+
+        # Afficher les crédits (voir Action 3)
+        if result.data and result.data.get("credits_consumed"):
+            await self._show_cancellation_summary(interaction, result.data)
+        else:
+            await interaction.response.edit_message(
+                content="Traitement annulé.",
+                view=None
+            )
+```
+
+### Configuration requise
+
+```python
+# config.py ou .env
+API_URL = os.getenv("API_URL", "http://pi6.local:3031")
+WEBHOOK_URL = os.getenv("WEBHOOK_URL", "http://pi6.local:5678")
+```
+
+---
+
+## Action 3 : Afficher crédits à l'annulation
+
+### Contexte
+
+Quand l'utilisateur annule, afficher :
+- Segments traités vs total
+- Crédits/tokens consommés
+- Crédits/tokens économisés
+
+### Implémentation
+
+```python
+# translate_views.py
+class TranslateView(discord.ui.View):
+
+    async def _show_cancellation_summary(
+        self,
+        interaction: discord.Interaction,
+        data: dict
+    ):
+        """Afficher le résumé après annulation."""
+        credits_consumed = data.get("credits_consumed", {})
+        credits_saved = data.get("credits_saved", {})
+
+        # Extraire les valeurs
+        segments_completed = credits_consumed.get("segments_completed", 0)
+        segments_total = credits_consumed.get("segments_total", "?")
+        cost_consumed = credits_consumed.get("cost_usd", 0)
+        cost_saved = credits_saved.get("cost_usd", 0)
+        tokens_consumed = credits_consumed.get("total_tokens", 0)
+        tokens_saved = credits_saved.get("tokens_not_used", 0)
+
+        # Créer l'embed
+        embed = discord.Embed(
+            title="🛑 Traitement annulé",
+            color=0xE74C3C  # Rouge
+        )
+
+        embed.add_field(
+            name="📊 Progression",
+            value=f"{segments_completed}/{segments_total} segments",
+            inline=True
+        )
+
+        embed.add_field(
+            name="💰 Consommé",
+            value=f"{cost_consumed:.3f} $\n({tokens_consumed:,} tokens)",
+            inline=True
+        )
+
+        embed.add_field(
+            name="💚 Économisé",
+            value=f"{cost_saved:.3f} $\n({tokens_saved:,} tokens)",
+            inline=True
+        )
+
+        # Message optionnel
+        message = data.get("message")
+        if message:
+            embed.set_footer(text=message)
+
+        await interaction.response.edit_message(embed=embed, view=None)
+```
+
+### Exemple d'affichage Discord
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  🛑 Traitement annulé                                           │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  📊 Progression     💰 Consommé        💚 Économisé             │
+│  5/15 segments      0.015 $            0.030 $                  │
+│                     (9,000 tokens)     (18,000 tokens)          │
+│                                                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  Job annulé. 5/15 segments traités.                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Action 4 : Utiliser DocumentWorkflowService pour mentions
+
+### Contexte
+
+Pour les mentions `@Bot` avec fichiers, utiliser le flux conversationnel complet RFC-016.
+
+### Prérequis
+
+- chatbot-core doit avoir implémenté `DocumentWorkflowService`
+- Priorité : 🟡 Moyenne (peut attendre)
+
+### Implémentation future
+
+```python
+# handlers/mention_handler.py
+from chatbot_core.services import DocumentWorkflowService
+
+class DocumentMentionHandler:
+    def __init__(self, workflow_service: DocumentWorkflowService):
+        self.workflow = workflow_service
+
+    async def handle_mention(self, message: discord.Message):
+        # Extraire le contexte
+        context = self._build_context(message)
+
+        # 1. Analyser l'intention via MCP-LLM-Intention
+        intent = await self.workflow.analyze_intent(
+            query=message.content,
+            history=self._get_history(message.channel),
+            context=context,
+            user={"id": str(message.author.id)}
+        )
+
+        # 2. Si proposition d'actions
+        if intent.type == "action_proposal":
+            # Afficher les boutons
+            view = ActionProposalView(
+                actions=intent.proposed_actions,
+                workflow=self.workflow,
+                user_id=str(message.author.id)
+            )
+            await message.reply(
+                content=intent.message,
+                view=view
+            )
+
+        # 3. Si simple message
+        else:
+            await message.reply(content=intent.message)
+```
+
+---
+
+## Checklist finale
+
+### Phase 1 (Priorité haute)
+
+- [ ] Vérifier que le plugin utilise `DocumentTranslationClient`
+- [ ] Mettre à jour chatbot-core vers version avec nouveau polling
+- [ ] Ajouter `cancel_url` et `cancel_params` aux appels PollingService
+- [ ] Tester annulation avec notification serveur
+
+### Phase 2 (Priorité moyenne)
+
+- [ ] Implémenter `_show_cancellation_summary()`
+- [ ] Tester affichage des crédits dans Discord
+- [ ] Vérifier le format des données retournées
+
+### Phase 3 (Priorité basse - Future)
+
+- [ ] Migrer vers `DocumentWorkflowService` pour mentions
+- [ ] Implémenter `ActionProposalView` avec boutons
+- [ ] Intégrer le flux conversationnel complet
+
+---
+
+## Tests à effectuer
+
+### Test annulation manuelle
+
+1. Lancer une traduction de document (15+ pages)
+2. Attendre 2-3 segments traduits
+3. Cliquer sur "Stop"
+4. Vérifier :
+   - [ ] Le serveur reçoit la demande d'annulation
+   - [ ] Le job passe en status "cancelled"
+   - [ ] L'embed affiche les crédits consommés/économisés
+   - [ ] Les segments déjà traduits sont sauvegardés
+
+### Test polling
+
+1. Lancer une traduction
+2. Vérifier que le polling utilise `/api/v2/jobs/{id}`
+3. Vérifier que la progression s'affiche correctement
+
+---
+
+## Variables d'environnement
+
+```bash
+# .env
+API_URL=http://pi6.local:3031
+WEBHOOK_URL=http://pi6.local:5678
+```
+
+---
+
+## Contact
+
+Pour questions sur ces spécifications :
+- RFC-016 : Architecture globale
+- RFC-017 : Détails job lifecycle
+- WORK-CHATBOT-CORE.md : Dépendances chatbot-core

--- a/docs/rfc/RFC-018-RECIPE-ENRICHMENT.md
+++ b/docs/rfc/RFC-018-RECIPE-ENRICHMENT.md
@@ -1,0 +1,1194 @@
+# RFC-018: Enrichissement Automatique des Recettes
+
+**Status:** Draft
+**Date:** 2026-01-22
+**Authors:** Équipe plugin-recipes
+**Target Teams:** plugin-recipes, n8n-workflows, chatbot-core
+**Depends on:** RFC-016 (Document Processing Architecture)
+
+---
+
+## Résumé
+
+Architecture pour enrichir automatiquement les recettes extraites (OCR ou saisie) avec :
+- **Score nutritionnel** (Nutri-Score A→E)
+- **Détection allergènes** (14 INCO obligatoires)
+- **Score de difficulté** (1-3 toques)
+- **Suggestions d'amélioration** (alléger une recette)
+
+---
+
+## Problème
+
+### Situation actuelle
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    EXTRACTION RECETTE ACTUELLE                   │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Image ──→ OCR ──→ Parsing regex ──→ Recette basique            │
+│                                                                  │
+│  Données extraites :                                             │
+│  ✅ Titre                                                        │
+│  ✅ Ingrédients (texte brut)                                     │
+│  ✅ Étapes                                                       │
+│  ✅ Temps / Portions                                             │
+│                                                                  │
+│  Données manquantes :                                            │
+│  ❌ Valeurs nutritionnelles                                      │
+│  ❌ Allergènes INCO                                              │
+│  ❌ Score de difficulté calculé                                  │
+│  ❌ Suggestions santé                                            │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Problèmes identifiés
+
+| Problème | Impact |
+|----------|--------|
+| **Pas de nutrition** | Utilisateur ne connaît pas l'apport calorique |
+| **Pas d'allergènes** | Risque sanitaire, non-conformité INCO |
+| **Difficulté subjective** | "Moyen" dans le texte OCR = imprécis |
+| **Pas de conseils santé** | Opportunité manquée d'engagement |
+
+---
+
+## Solution : Pipeline d'enrichissement
+
+### Vue d'ensemble
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                      PIPELINE ENRICHISSEMENT                     │
+└─────────────────────────────────────────────────────────────────┘
+
+  Image/Texte
+      │
+      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  ÉTAPE 1 : Extraction structurée                                 │
+│  ───────────────────────────────────────────────────────────────│
+│  Webhook: document-structure-extract                             │
+│  Input: texte OCR + schema recette                               │
+│  Output: JSON structuré (title, ingredients[], steps[])          │
+└─────────────────────────────────────────────────────────────────┘
+      │
+      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  ÉTAPE 2 : Enrichissement parallèle                              │
+│  ───────────────────────────────────────────────────────────────│
+│                                                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │  nutrition-  │  │  allergen-   │  │  difficulty- │           │
+│  │  calculate   │  │  detect      │  │  score       │           │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘           │
+│         │                 │                 │                    │
+│         ▼                 ▼                 ▼                    │
+│    Nutri-Score      Allergènes INCO    Toques (1-3)             │
+│    + macros         + traces           + explication            │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+      │
+      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  ÉTAPE 3 : Suggestions (optionnel)                               │
+│  ───────────────────────────────────────────────────────────────│
+│  Webhook: recipe-improve                                         │
+│  Input: recette + Nutri-Score                                    │
+│  Output: suggestions pour améliorer le score                     │
+└─────────────────────────────────────────────────────────────────┘
+      │
+      ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  RECETTE ENRICHIE                                                │
+│  ───────────────────────────────────────────────────────────────│
+│  {                                                               │
+│    "title": "Poulet au curry",                                   │
+│    "ingredients": [...],                                         │
+│    "steps": [...],                                               │
+│    "nutrition": { "nutri_score": "D", "calories": 536, ... },   │
+│    "allergens": { "confirmed": ["lait"], "traces": [...] },     │
+│    "difficulty": { "toques": 2, "level": "Moyen" },             │
+│    "improvements": ["Remplacer beurre par huile d'olive", ...]  │
+│  }                                                               │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Contrats d'API
+
+### 1. Document-Structure-Extract (générique)
+
+**Endpoint:** `POST /webhook/document-structure-extract`
+
+**Responsabilité:** n8n (workflow générique, réutilisable par tous les plugins)
+
+#### Request
+
+```json
+{
+  "text": "# POULET AU CURRY\n\n1. Laver les blancs...",
+  "schema": {
+    "type": "recipe",
+    "fields": {
+      "title": "string",
+      "description": "string (optional)",
+      "servings": "integer",
+      "prep_time": "integer (minutes)",
+      "cook_time": "integer (minutes)",
+      "difficulty": "string (Facile|Moyen|Difficile)",
+      "ingredients": [{
+        "name": "string",
+        "quantity": "number|null",
+        "unit": "string",
+        "notes": "string (optional)"
+      }],
+      "steps": [{
+        "number": "integer",
+        "description": "string"
+      }],
+      "tips": ["string"]
+    }
+  },
+  "context": {
+    "type": "recipe",
+    "language": "fr"
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "success": true,
+  "extracted": {
+    "title": "Poulet au curry",
+    "servings": 4,
+    "prep_time": 25,
+    "cook_time": 37,
+    "difficulty": "Moyen",
+    "ingredients": [
+      {"name": "blancs de poulet", "quantity": 650, "unit": "g"},
+      {"name": "lait de coco", "quantity": 400, "unit": "ml"},
+      {"name": "beurre", "quantity": 1, "unit": "c.s."}
+    ],
+    "steps": [
+      {"number": 1, "description": "Laver les blancs de poulet..."},
+      {"number": 2, "description": "Retirer le panier vapeur..."}
+    ],
+    "tips": ["Servir avec du riz"]
+  },
+  "confidence": 0.92,
+  "missing_fields": ["description"]
+}
+```
+
+#### Autres schemas supportés (exemples)
+
+| Type | Usage |
+|------|-------|
+| `recipe` | Recettes de cuisine |
+| `menu` | Menus de restaurant |
+| `shopping_list` | Listes de courses |
+| `nutrition_label` | Étiquettes nutritionnelles |
+| `invoice` | Factures (hors plugin-recipes) |
+| `cv` | CV (hors plugin-recipes) |
+
+---
+
+### 2. Nutrition-Calculate
+
+**Endpoint:** `POST /webhook/nutrition-calculate`
+
+**Responsabilité:** n8n (appelle CIQUAL/OpenFoodFacts)
+
+#### Request
+
+```json
+{
+  "ingredients": [
+    {"name": "blancs de poulet", "quantity": 650, "unit": "g"},
+    {"name": "lait de coco", "quantity": 400, "unit": "ml"},
+    {"name": "beurre", "quantity": 15, "unit": "g"},
+    {"name": "huile végétale", "quantity": 45, "unit": "ml"},
+    {"name": "curry en poudre", "quantity": 9, "unit": "g"}
+  ],
+  "servings": 4,
+  "options": {
+    "data_source": "ciqual",
+    "calculate_nutri_score": true,
+    "language": "fr"
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "success": true,
+  "per_serving": {
+    "energy_kcal": 536,
+    "energy_kj": 2244,
+    "protein_g": 38,
+    "carbs_g": 12,
+    "carbs_sugar_g": 3,
+    "fat_g": 37,
+    "fat_saturated_g": 18,
+    "fiber_g": 3,
+    "sodium_mg": 480,
+    "salt_g": 1.2
+  },
+  "total_recipe": {
+    "energy_kcal": 2144,
+    "protein_g": 152
+  },
+  "nutri_score": {
+    "letter": "D",
+    "value": 12,
+    "negative_points": {
+      "energy": 4,
+      "sugar": 1,
+      "saturated_fat": 8,
+      "sodium": 4
+    },
+    "positive_points": {
+      "fiber": 1,
+      "protein": 5,
+      "fruit_veg": 0
+    }
+  },
+  "data_quality": {
+    "matched_ingredients": 5,
+    "estimated_ingredients": 0,
+    "missing_ingredients": 0,
+    "confidence": 0.95
+  },
+  "sources": {
+    "blancs de poulet": "ciqual:36006",
+    "lait de coco": "ciqual:19051"
+  }
+}
+```
+
+---
+
+### 3. Allergen-Detect
+
+**Endpoint:** `POST /webhook/allergen-detect`
+
+**Responsabilité:** À déterminer (plugin local OU n8n)
+
+#### Request
+
+```json
+{
+  "ingredients": [
+    "blancs de poulet",
+    "lait de coco",
+    "beurre",
+    "bouillon de légumes",
+    "curry en poudre",
+    "pousses de bambou en bocal"
+  ],
+  "options": {
+    "check_traces": true,
+    "language": "fr",
+    "regulation": "inco_eu"
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "success": true,
+  "allergens": {
+    "confirmed": [
+      {
+        "type": "lait",
+        "label": "Lait",
+        "icon": "🥛",
+        "sources": ["beurre"]
+      }
+    ],
+    "possible_traces": [
+      {
+        "type": "celeri",
+        "label": "Céleri",
+        "sources": ["bouillon de légumes", "curry en poudre"],
+        "reason": "Selon fabricant"
+      },
+      {
+        "type": "moutarde",
+        "label": "Moutarde",
+        "sources": ["curry en poudre"],
+        "reason": "Selon fabricant"
+      },
+      {
+        "type": "gluten",
+        "label": "Gluten",
+        "sources": ["bouillon de légumes"],
+        "reason": "Selon fabricant"
+      },
+      {
+        "type": "soja",
+        "label": "Soja",
+        "sources": ["bouillon de légumes"],
+        "reason": "Selon fabricant"
+      },
+      {
+        "type": "sulfites",
+        "label": "Sulfites",
+        "sources": ["pousses de bambou en bocal"],
+        "reason": "Conservateurs possibles"
+      }
+    ],
+    "warnings": [
+      "Ce plat contient de la noix de coco (non allergène INCO mais risque individuel possible)"
+    ]
+  },
+  "display": {
+    "short": "Allergènes : Lait | Traces possibles : Céleri, moutarde, gluten, soja, sulfites",
+    "html": "<strong>Allergènes :</strong> 🥛 Lait<br><em>Traces possibles :</em> Céleri, moutarde, gluten, soja, sulfites"
+  },
+  "inco_compliant": true
+}
+```
+
+---
+
+### 4. Difficulty-Score
+
+**Endpoint:** `POST /webhook/difficulty-score` OU calcul local
+
+**Responsabilité:** À déterminer (règles simples = local, analyse complexe = LLM)
+
+#### Request
+
+```json
+{
+  "recipe": {
+    "prep_time": 25,
+    "cook_time": 37,
+    "total_time": 62,
+    "steps_count": 6,
+    "steps": [
+      "Laver les blancs de poulet...",
+      "Retirer le panier vapeur...",
+      "Éplucher les carottes..."
+    ],
+    "equipment": ["Thermomix", "panier vapeur"]
+  },
+  "options": {
+    "method": "heuristic"
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "success": true,
+  "difficulty": {
+    "level": "Moyen",
+    "toques": 2,
+    "score": 45,
+    "factors": {
+      "time": {"value": 62, "points": 15, "max": 30},
+      "steps": {"value": 6, "points": 12, "max": 25},
+      "techniques": {"value": 2, "points": 10, "max": 25},
+      "equipment": {"value": 1, "points": 8, "max": 20}
+    },
+    "detected_techniques": ["cuisson vapeur", "hachage", "sauce"],
+    "special_equipment": ["Thermomix"],
+    "explanation": "Difficulté moyenne : temps de préparation conséquent (1h), techniques de base, équipement spécialisé (Thermomix)"
+  }
+}
+```
+
+#### Barème difficulté
+
+| Toques | Niveau | Score | Critères |
+|--------|--------|-------|----------|
+| ⭐ | Facile | 0-30 | < 30 min, < 5 étapes, techniques basiques |
+| ⭐⭐ | Moyen | 31-60 | 30-60 min, 5-10 étapes, quelques techniques |
+| ⭐⭐⭐ | Difficile | 61-100 | > 60 min, > 10 étapes, techniques avancées |
+
+---
+
+### 5. Recipe-Improve (suggestions)
+
+**Endpoint:** `POST /webhook/recipe-improve`
+
+**Responsabilité:** n8n (appel LLM)
+
+#### Request
+
+```json
+{
+  "recipe": {
+    "title": "Poulet au curry",
+    "ingredients": [...],
+    "nutrition": {
+      "nutri_score": "D",
+      "fat_saturated_g": 18
+    }
+  },
+  "goal": "improve_nutri_score",
+  "target_score": "C",
+  "constraints": {
+    "keep_taste": true,
+    "max_ingredient_changes": 3
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "success": true,
+  "suggestions": [
+    {
+      "type": "substitute",
+      "original": "beurre",
+      "replacement": "huile d'olive",
+      "impact": "Réduit graisses saturées de 40%",
+      "nutri_score_gain": "+3 points"
+    },
+    {
+      "type": "substitute",
+      "original": "lait de coco entier",
+      "replacement": "lait de coco allégé (ou 50% lait végétal)",
+      "impact": "Réduit graisses saturées de 25%",
+      "nutri_score_gain": "+2 points"
+    },
+    {
+      "type": "add",
+      "ingredient": "200g de légumes verts (brocolis, pois mange-tout)",
+      "impact": "Augmente fibres et vitamines",
+      "nutri_score_gain": "+2 points fibres, +1 point fruits/légumes"
+    },
+    {
+      "type": "serve_with",
+      "suggestion": "Riz complet au lieu de riz blanc",
+      "impact": "Augmente fibres de l'accompagnement"
+    }
+  ],
+  "projected_score": {
+    "current": "D",
+    "after_all_changes": "B",
+    "after_easy_changes": "C"
+  }
+}
+```
+
+---
+
+## Modèles de données
+
+### Extension de Recipe (src/models.py)
+
+```python
+@dataclass
+class NutriScore:
+    """Score Nutri-Score officiel."""
+    letter: str           # A, B, C, D, E
+    value: int            # -15 à +40
+    negative_points: int  # 0-40
+    positive_points: int  # 0-15
+    calculation_date: str
+    data_source: str      # "ciqual", "openfoodfacts", "estimated"
+    confidence: float     # 0.0-1.0
+
+
+class AllergenType(Enum):
+    """14 allergènes INCO obligatoires UE."""
+    GLUTEN = "gluten"
+    CRUSTACEANS = "crustaces"
+    EGGS = "oeufs"
+    FISH = "poisson"
+    PEANUTS = "arachides"
+    SOY = "soja"
+    MILK = "lait"
+    NUTS = "fruits_a_coque"
+    CELERY = "celeri"
+    MUSTARD = "moutarde"
+    SESAME = "sesame"
+    SULFITES = "sulfites"
+    LUPIN = "lupin"
+    MOLLUSCS = "mollusques"
+
+
+@dataclass
+class AllergenInfo:
+    """Informations allergènes conformes INCO."""
+    confirmed: list[AllergenType]
+    possible_traces: list[AllergenType]
+    sources: dict[str, list[str]]  # ingredient -> allergènes
+    warnings: list[str]
+    inco_compliant: bool = True
+
+
+@dataclass
+class DifficultyScore:
+    """Score de difficulté détaillé."""
+    level: str         # Facile, Moyen, Difficile
+    toques: int        # 1, 2, 3
+    score: int         # 0-100
+    explanation: str
+    detected_techniques: list[str]
+    special_equipment: list[str]
+```
+
+---
+
+## Répartition des responsabilités
+
+| Composant | Responsabilité | Équipe |
+|-----------|----------------|--------|
+| `document-structure-extract` | Extraction LLM générique (tous schemas) | **n8n** |
+| `nutrition-calculate` | Calcul nutrition + Nutri-Score | **n8n** |
+| `allergen-detect` | Détection allergènes INCO | **plugin OU n8n** |
+| `difficulty-score` | Calcul difficulté | **plugin (local)** |
+| `recipe-improve` | Suggestions LLM | **n8n** |
+| Base allergènes JSON | 14 allergènes + mapping | **chatbot-core OU plugin** |
+| Base CIQUAL/OpenFoodFacts | Données nutritionnelles | **n8n (API externe)** |
+| Modèles de données | `NutriScore`, `AllergenInfo`, etc. | **plugin-recipes** |
+
+---
+
+## Questions ouvertes
+
+### Pour l'équipe n8n
+
+1. **Document-Structure-Extract**
+   - Ce workflow existe-t-il déjà ?
+   - Peut-il être générique (schema en paramètre) ?
+   - Quel LLM utiliser (Claude, GPT, Mistral) ?
+
+2. **Nutrition-Calculate**
+   - Quelle source de données privilégier ?
+   - CIQUAL (officiel FR) vs OpenFoodFacts (communautaire)
+   - Gestion des ingrédients non trouvés ?
+
+3. **Coûts**
+   - Faut-il facturer l'enrichissement ?
+   - Combien de crédits par recette enrichie ?
+
+### Pour l'équipe chatbot-core
+
+4. **Base allergènes**
+   - Doit-elle être dans chatbot-core (réutilisable) ?
+   - Ou spécifique à chaque plugin ?
+   - Format : JSON statique ou API ?
+
+5. **Calcul local vs n8n**
+   - Le calcul de difficulté peut être local (règles simples)
+   - La détection allergènes peut être locale (mapping JSON)
+   - Avantage : pas d'appel réseau, gratuit
+   - Inconvénient : maintenance du mapping
+
+### Pour l'équipe plugin-recipes
+
+6. **Enrichissement automatique ou à la demande ?**
+   - Option A : Toujours enrichir après extraction OCR
+   - Option B : Bouton "Analyser nutrition / allergènes"
+   - Option C : Configurable par utilisateur
+
+7. **Affichage Discord**
+   - Tout dans un seul embed ?
+   - Ou plusieurs messages / onglets ?
+
+---
+
+## Annexe A : Calcul Nutri-Score
+
+### Formule officielle
+
+```
+Score final = Points négatifs (A) - Points positifs (C)
+
+Points négatifs (0-40) :
+- Énergie (kJ) : 0-10 points
+- Sucres (g) : 0-10 points
+- Graisses saturées (g) : 0-10 points
+- Sodium (mg) : 0-10 points
+
+Points positifs (0-15) :
+- Fibres (g) : 0-5 points
+- Protéines (g) : 0-5 points
+- Fruits/légumes/noix (%) : 0-5 points
+```
+
+### Conversion score → lettre
+
+| Score | Lettre | Couleur |
+|-------|--------|---------|
+| -15 à -1 | A | 🟢 Vert foncé |
+| 0 à 2 | B | 🟢 Vert clair |
+| 3 à 10 | C | 🟡 Jaune |
+| 11 à 18 | D | 🟠 Orange |
+| 19 à 40 | E | 🔴 Rouge |
+
+---
+
+## Annexe B : 14 Allergènes INCO
+
+| # | Allergène | Exemples d'ingrédients |
+|---|-----------|------------------------|
+| 1 | Gluten | Blé, seigle, orge, avoine, épeautre |
+| 2 | Crustacés | Crevettes, homard, crabe |
+| 3 | Œufs | Œuf, mayonnaise, meringue |
+| 4 | Poisson | Saumon, thon, anchois |
+| 5 | Arachides | Cacahuètes, huile d'arachide |
+| 6 | Soja | Tofu, sauce soja, lécithine |
+| 7 | Lait | Lait, beurre, crème, fromage |
+| 8 | Fruits à coque | Amandes, noisettes, noix, cajou |
+| 9 | Céleri | Céleri branche, céleri-rave |
+| 10 | Moutarde | Moutarde, graines de moutarde |
+| 11 | Sésame | Graines de sésame, tahini |
+| 12 | Sulfites | Vin, fruits secs, conserves |
+| 13 | Lupin | Farine de lupin |
+| 14 | Mollusques | Moules, huîtres, calamars |
+
+### ⚠️ Pièges courants
+
+| Ingrédient | Allergène ? | Note |
+|------------|-------------|------|
+| Lait de coco | ❌ Non | Pas un lait animal |
+| Noix de coco | ❌ Non | Pas un fruit à coque INCO |
+| Beurre de cacao | ❌ Non | Pas de lait |
+| Huile de sésame | ✅ Oui | Sésame |
+| Bouillon cube | ⚠️ Traces | Céleri, gluten, soja possibles |
+
+---
+
+## Annexe C : Exemple complet de sortie
+
+### Recette : Poulet au curry
+
+```json
+{
+  "title": "Poulet au curry",
+  "servings": 4,
+  "prep_time": 25,
+  "cook_time": 37,
+  "ingredients": [
+    {"name": "blancs de poulet", "quantity": 650, "unit": "g"},
+    {"name": "lait de coco", "quantity": 400, "unit": "ml"},
+    {"name": "beurre", "quantity": 15, "unit": "g"},
+    {"name": "curry en poudre", "quantity": 9, "unit": "g"}
+  ],
+  "steps": ["..."],
+
+  "nutrition": {
+    "per_serving": {
+      "energy_kcal": 536,
+      "protein_g": 38,
+      "carbs_g": 12,
+      "fat_g": 37,
+      "fat_saturated_g": 18,
+      "fiber_g": 3,
+      "salt_g": 1.2
+    },
+    "nutri_score": {
+      "letter": "D",
+      "value": 12
+    }
+  },
+
+  "allergens": {
+    "confirmed": ["lait"],
+    "possible_traces": ["celeri", "moutarde", "gluten", "soja", "sulfites"],
+    "warnings": ["Contient noix de coco"]
+  },
+
+  "difficulty": {
+    "toques": 2,
+    "level": "Moyen",
+    "explanation": "1h de préparation, 6 étapes, équipement Thermomix"
+  },
+
+  "improvements": [
+    "Remplacer beurre par huile d'olive → D → C",
+    "Ajouter 200g légumes verts → +2 points fibres",
+    "Lait de coco allégé → réduire graisses saturées"
+  ]
+}
+```
+
+---
+
+## Analyse n8n : Généralisation des workflows
+
+> **Auteur:** Équipe n8n
+> **Date:** 2026-01-22
+
+### Vue d'ensemble
+
+L'analyse des workflows proposés révèle que plusieurs peuvent être **généralisés** pour être réutilisés par d'autres plugins (torah, futurs plugins).
+
+### Classification : Générique vs Spécifique
+
+| Workflow proposé | Générique ? | Pattern abstrait | Réutilisation |
+|------------------|-------------|------------------|---------------|
+| `document-structure-extract` | ✅ 100% | Text + Schema → JSON | Recettes, factures, CV, contrats, textes talmudiques |
+| `allergen-detect` | ✅ 90% | Items + Ruleset → Catégories | Allergènes, tags, thèmes, classifications |
+| `nutrition-calculate` | ⚠️ 50% | Items + DB → Enrichissement | Pattern générique, formule Nutri-Score spécifique |
+| `difficulty-score` | ❌ Spécifique | - | Logique toques = métier cuisine |
+| `recipe-improve` | ⚠️ 50% | Data + Goal → Suggestions LLM | Pattern générique, critères spécifiques |
+
+### Proposition : 4 workflows génériques
+
+#### 1. Document-Structure-Extractor (priorité haute)
+
+**Pattern:** Extraction structurée via LLM avec schema flexible.
+
+```
+POST /webhook/document-structure-extract
+{
+  "text": "...",
+  "schema": { ... },      // Défini par l'appelant
+  "context": {
+    "type": "recipe|invoice|cv|contract|menu|talmud_commentary",
+    "language": "fr|en|he"
+  }
+}
+```
+
+**Cas d'usage multi-plugins:**
+- **plugin-recipes:** Recettes OCR → JSON structuré
+- **plugin-torah:** Commentaires talmudiques → structure (source, commentateur, références)
+- **Futur:** Factures, CV, menus restaurant
+
+#### 2. Category-Detect (remplace allergen-detect)
+
+**Pattern:** Détection de catégories dans une liste d'items via ruleset.
+
+```
+POST /webhook/category-detect
+{
+  "items": ["beurre", "curry", "poulet"],
+  "ruleset": "allergens_inco|cuisine_tags|torah_topics",
+  "options": { "include_possible": true }
+}
+```
+
+**Rulesets disponibles:**
+| Ruleset | Usage | Source |
+|---------|-------|--------|
+| `allergens_inco` | 14 allergènes UE | JSON statique |
+| `cuisine_tags` | Tags cuisine (asiatique, végétarien...) | LLM |
+| `torah_topics` | Thèmes talmudiques | JSON statique |
+
+#### 3. Data-Lookup-Enrich (généralise nutrition-calculate)
+
+**Pattern:** Enrichir des items avec des données externes.
+
+```
+POST /webhook/data-lookup-enrich
+{
+  "items": [
+    {"name": "poulet", "quantity": 650, "unit": "g"}
+  ],
+  "source": "ciqual|openfoodfacts|custom_api",
+  "fields": ["energy_kcal", "protein_g"],
+  "aggregate": { "method": "sum", "divide_by": 4 }
+}
+```
+
+**Note:** Le calcul Nutri-Score reste un **post-processing spécifique** après l'enrichissement générique.
+
+#### 4. Improvement-Suggest (généralise recipe-improve)
+
+**Pattern:** Suggestions d'amélioration via LLM.
+
+```
+POST /webhook/improvement-suggest
+{
+  "data": { ... },
+  "goal": "improve_nutri_score|reduce_complexity|enhance_clarity",
+  "constraints": { "max_changes": 3 }
+}
+```
+
+### Architecture générique proposée
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                 GENERIC DOCUMENT ENRICHMENT PIPELINE            │
+└─────────────────────────────────────────────────────────────────┘
+
+  Document (OCR/Text)
+       │
+       ▼
+┌──────────────────────────────────────────────────────────────┐
+│  ÉTAPE 1: document-structure-extract                          │
+│  ─────────────────────────────────────────────────────────────│
+│  Input: text + schema (flexible)                              │
+│  Output: JSON structuré                                       │
+│  LLM: Claude (structured output)                              │
+└──────────────────────────────────────────────────────────────┘
+       │
+       ├─────────────────┬─────────────────┬─────────────────┐
+       ▼                 ▼                 ▼                 ▼
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│ data-lookup │  │ category-   │  │ improvement │  │ SPÉCIFIQUE  │
+│ enrich      │  │ detect      │  │ suggest     │  │ (plugin)    │
+└─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘
+       │                 │                 │                 │
+       ▼                 ▼                 ▼                 ▼
+  Données           Catégories       Suggestions      Calculs
+  enrichies         détectées        LLM              métier
+  (nutrition,       (allergènes,                      (Nutri-Score,
+   prix...)          tags...)                          toques...)
+```
+
+### Répartition des responsabilités (mise à jour)
+
+| Composant | Type | Responsabilité |
+|-----------|------|----------------|
+| `document-structure-extract` | **Générique** | n8n |
+| `data-lookup-enrich` | **Générique** | n8n |
+| `category-detect` | **Générique** | n8n |
+| `improvement-suggest` | **Générique** | n8n |
+| Calcul Nutri-Score | Spécifique | plugin-recipes (local) |
+| Calcul difficulté toques | Spécifique | plugin-recipes (local) |
+| Rulesets JSON (allergènes, tags) | Données | chatbot-core ou n8n |
+
+### Avantages de cette approche
+
+1. **Réutilisation** - Un workflow pour tous les plugins
+2. **Maintenance** - Un seul endroit à mettre à jour
+3. **Coûts** - Facturation unifiée via RFC-017
+4. **Évolutivité** - Nouveaux schemas sans nouveau code
+
+### Questions résolues
+
+| Question RFC-018 | Réponse |
+|------------------|---------|
+| Document-Structure-Extract existe-t-il ? | Non, **à créer** (priorité haute) |
+| Peut-il être générique ? | **Oui**, schema en paramètre |
+| Quel LLM ? | **Claude** (meilleur pour structured output) |
+| Allergen-detect local ou n8n ? | **n8n** via `category-detect` générique |
+
+---
+
+## Prochaines étapes
+
+1. **Validation RFC** par les équipes n8n et chatbot-core
+2. **Décision** sur répartition des responsabilités
+3. **Implémentation** par ordre de priorité :
+   - ~~Base allergènes JSON (rapide, local)~~ → Ruleset pour `category-detect`
+   - Modèles de données (plugin-recipes)
+   - **Workflows génériques n8n** (document-structure-extract en premier)
+   - Webhooks spécifiques (Nutri-Score, toques)
+
+---
+
+## Réponse équipe API Torah
+
+> **Auteur:** Équipe API Torah
+> **Date:** 2026-01-22
+
+### Verdict : Aucun nouveau développement requis
+
+L'équipe API a analysé le RFC-018 et confirme que **tous les besoins sont déjà couverts** par l'implémentation RFC-016/RFC-017.
+
+### Endpoints disponibles pour l'enrichissement
+
+| Besoin RFC-018 | Endpoint existant | Status |
+|----------------|-------------------|--------|
+| Jobs async pour enrichissement | `POST /api/v2/jobs` | ✅ Prêt |
+| Progress tracking (étapes enrichissement) | `PATCH /api/v2/jobs/{id}` + `progress` | ✅ Prêt |
+| Credits/tokens tracking | `PATCH /api/v2/jobs/{id}` + `credits` | ✅ Prêt |
+| Débit crédits après enrichissement | `POST /api/subscription/credits/{user}/debit` | ✅ Prêt |
+| Refund si échec enrichissement | `POST /api/subscription/credits/{user}/refund` | ✅ Prêt |
+| State transitions (pending→processing→completed) | Validation automatique | ✅ Prêt |
+| Timestamps (completed_at, failed_at) | Auto-set par l'API | ✅ Prêt |
+
+### Rulesets JSON : Hors scope API
+
+**Décision :** Les rulesets (`allergens_inco`, `cuisine_tags`, etc.) ne passent **pas** par l'API Torah.
+
+**Raisons :**
+1. **Données statiques** — JSON qui ne change pas à chaque requête
+2. **Pas de logique métier** — Simple lookup, pas de calcul côté API
+3. **Latence inutile** — Appel API pour lire un fichier JSON = overhead évitable
+4. **Responsabilité plugin/n8n** — Chaque composant embarque ses propres rulesets
+
+**Recommandation :** Les rulesets restent dans :
+- **n8n** pour le workflow `category-detect`
+- **ou** fichier JSON embarqué dans le plugin pour calcul local
+
+### Exemple d'intégration : Enrichissement recette
+
+```
+1. Plugin crée job enrichissement
+   POST /api/v2/jobs
+   { "job_type": "recipe_enrichment", "input": { "recipe_id": "..." } }
+
+2. n8n démarre traitement
+   PATCH /api/v2/jobs/{id}
+   { "status": "processing" }
+
+3. n8n met à jour progression (nutrition)
+   PATCH /api/v2/jobs/{id}
+   { "progress": { "current": 1, "total": 4, "percentage": 25, "step": "nutrition" } }
+
+4. n8n met à jour progression (allergènes)
+   PATCH /api/v2/jobs/{id}
+   { "progress": { "current": 2, "total": 4, "percentage": 50, "step": "allergens" } }
+
+5. n8n termine et débite crédits
+   PATCH /api/v2/jobs/{id}
+   { "status": "completed", "output": { "enriched_recipe": {...} } }
+
+   POST /api/subscription/credits/{user}/debit
+   { "amount": 15, "job_id": "...", "reason": "recipe_enrichment" }
+```
+
+### Documentation
+
+Voir `docs/n8n/JOB-LIFECYCLE-CREDITS-API.md` pour les détails des payloads.
+
+---
+
+## Réponse équipe chatbot-core
+
+> **Auteur:** Équipe chatbot-core
+> **Date:** 2026-01-22
+
+### Verdict : Aucun nouveau développement requis
+
+L'équipe chatbot-core a analysé le RFC-018 et confirme que **l'infrastructure existante couvre tous les besoins**.
+
+### Services disponibles (chatbot-core v0.6.57)
+
+| Besoin RFC-018 | Service chatbot-core | Status |
+|----------------|---------------------|--------|
+| Création/gestion jobs enrichissement | `JobsAPIClient` | ✅ Prêt |
+| Progress tracking (étapes enrichissement) | `JobsAPIClient.update_job()` | ✅ Prêt |
+| Workflow conversationnel (intention → action) | `DocumentWorkflowService` | ✅ Prêt |
+| Gestion crédits (get/debit/credit) | `CreditsClient` | ✅ Prêt |
+| Polling avec annulation | `PollingService` + `cancel_job()` | ✅ Prêt |
+
+### Répartition confirmée
+
+| Composant | chatbot-core ? | Responsable |
+|-----------|----------------|-------------|
+| Workflows génériques (document-structure-extract, etc.) | ❌ Non | n8n |
+| Calculs métier (Nutri-Score, toques) | ❌ Non | plugin-recipes |
+| Rulesets JSON (allergènes, tags) | ❌ Non | n8n ou plugin |
+| Infrastructure jobs/crédits | ✅ Déjà fait | chatbot-core |
+
+### Documentation
+
+Pour intégrer l'enrichissement dans un plugin, voir :
+- `docs/guides/GUIDE-DOCUMENT-WORKFLOW.md` — Guide complet d'utilisation
+
+### Exemple d'utilisation pour enrichissement
+
+```python
+from chatbot_core.services import (
+    DocumentWorkflowService,
+    DocumentWorkflowConfig,
+)
+
+# Le plugin utilise DocumentWorkflowService pour :
+# 1. Analyser l'intention (enrichir une recette)
+# 2. Proposer l'action avec estimation de coût
+# 3. Exécuter après confirmation utilisateur
+# 4. Gérer les crédits automatiquement
+
+service = DocumentWorkflowService(
+    DocumentWorkflowConfig(
+        api_url="http://api.torah:3031",
+        n8n_base_url="http://n8n:5678",
+        project_id="plugin-recipes",
+    )
+)
+
+# L'intention "enrichis cette recette" déclenchera
+# les workflows n8n génériques (document-structure-extract, etc.)
+intent = await service.analyze_intent(
+    query="enrichis cette recette avec nutrition et allergènes",
+    context={"recipe_id": "...", "recipe_data": {...}},
+    user={"id": "123", "name": "User"},
+)
+```
+
+---
+
+# 📋 SYNTHÈSE FINALE
+
+**Date:** 2026-01-22
+**Status:** ✅ Validé par toutes les équipes
+
+---
+
+## 1. Travail par équipe
+
+### 🟠 Équipe n8n
+
+| Action | Priorité | Complexité | Status |
+|--------|----------|------------|--------|
+| Créer `document-structure-extract` | 🔴 Haute | Moyenne | 📋 À faire |
+| Créer `category-detect` (générique) | 🔴 Haute | Faible | 📋 À faire |
+| Créer `data-lookup-enrich` | 🟡 Moyenne | Moyenne | 📋 À faire |
+| Créer `improvement-suggest` | 🟢 Basse | Moyenne | 📋 Backlog |
+| Fournir ruleset `allergens_inco` JSON | 🔴 Haute | Faible | 📋 À faire |
+| Intégrer CIQUAL/OpenFoodFacts | 🟡 Moyenne | Élevée | 📋 À planifier |
+
+**Livrables n8n :**
+- 4 workflows génériques réutilisables
+- Ruleset JSON des 14 allergènes INCO
+- Documentation des payloads
+
+---
+
+### 🔵 Équipe API Torah
+
+| Action | Priorité | Status |
+|--------|----------|--------|
+| Aucun nouveau développement | - | ✅ Déjà couvert |
+
+**Infrastructure existante utilisée :**
+- `POST /api/v2/jobs` — Création jobs enrichissement
+- `PATCH /api/v2/jobs/{id}` — Progress tracking
+- `POST /api/subscription/credits/{user}/debit` — Facturation
+- `POST /api/subscription/credits/{user}/refund` — Remboursement
+
+---
+
+### 🟢 Équipe chatbot-core
+
+| Action | Priorité | Status |
+|--------|----------|--------|
+| Aucun nouveau développement | - | ✅ Déjà couvert |
+
+**Services existants utilisés :**
+- `JobsAPIClient` — Gestion jobs
+- `CreditsClient` — Gestion crédits
+- `DocumentWorkflowService` — Orchestration
+- `PollingService` — Suivi progression
+
+---
+
+### 🟣 Équipe plugin-recipes
+
+| Action | Priorité | Complexité | Status |
+|--------|----------|------------|--------|
+| Ajouter modèles `NutriScore`, `AllergenInfo`, `DifficultyScore` | 🔴 Haute | Faible | 📋 À faire |
+| Implémenter calcul Nutri-Score (local) | 🟡 Moyenne | Moyenne | 📋 À faire |
+| Implémenter calcul difficulté/toques (local) | 🟡 Moyenne | Faible | 📋 À faire |
+| Intégrer enrichissement dans OCR flow | 🟡 Moyenne | Moyenne | 📋 À faire |
+| Créer UI Discord pour affichage enrichi | 🟡 Moyenne | Moyenne | 📋 À faire |
+| Supprimer parsing regex local (remplacé par LLM) | 🟢 Basse | Faible | 📋 Après n8n |
+
+**Livrables plugin-recipes :**
+- Modèles de données enrichis
+- Calculs métier locaux (Nutri-Score, toques)
+- Intégration avec workflows n8n génériques
+- Affichage Discord des données enrichies
+
+---
+
+## 2. Points d'entente ✅
+
+| Sujet | Décision | Consensus |
+|-------|----------|-----------|
+| **Extraction LLM** | `document-structure-extract` générique avec schema en paramètre | ✅ Toutes équipes |
+| **LLM utilisé** | Claude (meilleur pour structured output) | ✅ n8n |
+| **Allergènes** | Via `category-detect` générique + ruleset JSON | ✅ n8n + plugin |
+| **Calculs métier** | Locaux dans plugin (Nutri-Score, toques) | ✅ Toutes équipes |
+| **Rulesets JSON** | Embarqués dans n8n ou plugin (pas API) | ✅ API + n8n |
+| **Jobs/Crédits** | Infrastructure existante RFC-016/017 | ✅ Toutes équipes |
+| **Pas de nouveau dev** | API Torah et chatbot-core déjà prêts | ✅ API + core |
+
+---
+
+## 3. Points d'attention ⚠️
+
+| Point | Risque | Mitigation |
+|-------|--------|------------|
+| **Coût LLM** | Extraction LLM = ~0.01-0.05€/recette | Facturer via crédits (RFC-017) |
+| **Latence** | 4 appels séquentiels = 5-10s | Paralléliser où possible |
+| **Qualité CIQUAL** | Ingrédients non trouvés | Fallback OpenFoodFacts + estimation |
+| **Hallucination LLM** | JSON mal formé ou données inventées | Validation schema + confidence score |
+| **Mise à jour allergènes** | Règlement INCO peut évoluer | Ruleset JSON versionné |
+| **Parsing regex actuel** | Code legacy à maintenir temporairement | Supprimer après validation LLM |
+
+---
+
+## 4. Points en suspens ❓
+
+| # | Question | Équipe concernée | Décision attendue |
+|---|----------|------------------|-------------------|
+| 1 | **Enrichissement auto ou à la demande ?** | plugin-recipes | Option A (auto après OCR) ou Option B (bouton) ? |
+| 2 | **Coût crédits par enrichissement ?** | Product Owner | Combien facturer ? (suggestion: 5-10 crédits) |
+| 3 | **Affichage Discord** | plugin-recipes | Un embed ou plusieurs onglets ? |
+| 4 | **Source nutrition prioritaire** | n8n | CIQUAL (officiel) ou OpenFoodFacts (plus complet) ? |
+| 5 | **Stockage ruleset allergènes** | n8n | Dans le workflow ou fichier externe ? |
+
+---
+
+## 5. Ordre d'implémentation recommandé
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  PHASE 1 : Fondations (1-2 semaines)                            │
+│  ───────────────────────────────────────────────────────────────│
+│  1. [n8n] Créer document-structure-extract                      │
+│  2. [n8n] Créer category-detect + ruleset allergens_inco        │
+│  3. [plugin] Ajouter modèles NutriScore, AllergenInfo           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  PHASE 2 : Enrichissement nutrition (2-3 semaines)              │
+│  ───────────────────────────────────────────────────────────────│
+│  1. [n8n] Créer data-lookup-enrich + intégration CIQUAL         │
+│  2. [plugin] Implémenter calcul Nutri-Score local               │
+│  3. [plugin] Intégrer dans flow OCR                             │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  PHASE 3 : Finalisation (1-2 semaines)                          │
+│  ───────────────────────────────────────────────────────────────│
+│  1. [plugin] Implémenter calcul difficulté/toques               │
+│  2. [plugin] Créer UI Discord enrichie                          │
+│  3. [n8n] Créer improvement-suggest (optionnel)                 │
+│  4. [plugin] Supprimer parsing regex legacy                     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Métriques de succès
+
+| Métrique | Cible | Mesure |
+|----------|-------|--------|
+| Recettes enrichies | 100% des OCR | Logs plugin |
+| Précision Nutri-Score | >90% vs calcul manuel | Tests unitaires |
+| Allergènes détectés | 100% INCO confirmés | Tests unitaires |
+| Temps enrichissement | <10s total | Monitoring |
+| Satisfaction utilisateur | >4/5 | Feedback Discord |
+
+---
+
+## Voir aussi
+
+- **RFC-016**: Document Processing Architecture
+- **RFC-017**: Job Lifecycle & Credits
+- **Règlement INCO (UE) n°1169/2011**: Allergènes obligatoires
+- **Nutri-Score officiel**: https://www.santepubliquefrance.fr/nutri-score

--- a/workflows/Credits-Check.json
+++ b/workflows/Credits-Check.json
@@ -1,0 +1,221 @@
+{
+  "name": "Credits Check",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Credits Check\n\n**Endpoint:** POST /webhook/credits-check\n\n**Purpose:** Check user credits balance\n\n**Request:**\n```json\n{\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\",\n  \"credits\": 450,\n  \"has_credits\": true\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"User not found\",\n    \"status\": \"NOT_FOUND\"\n  }\n}\n```\n\n**API:** GET /api/subscription/credits/{discord_user_id}?project_id=...\n\n**RFC:** RFC-017",
+        "height": 480,
+        "width": 300,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [80, 80]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "credits-check",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "credits-check"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input - return error object instead of throwing\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.discord_user_id) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'discord_user_id is required',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    discordUserId: body.discord_user_id,\n    projectId: body.project_id || 'torah'\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/subscription/credits/{{ $json.discordUserId }}",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "project_id",
+              "value": "={{ $json.projectId }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "get-credits",
+      "name": "Get Credits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build response per API spec with standard error format\nconst input = $input.first().json;\nconst prevData = $('Input Valid?').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst data = input.body || input;\n\n// Handle user not found (404)\nif (statusCode === 404) {\n  return [{\n    json: {\n      error: {\n        code: 404,\n        message: data.detail?.message || 'User not found',\n        status: 'NOT_FOUND',\n        discord_user_id: prevData.discordUserId,\n        project_id: prevData.projectId\n      }\n    }\n  }];\n}\n\n// Handle other errors\nif (statusCode >= 400) {\n  return [{\n    json: {\n      error: {\n        code: statusCode,\n        message: data.detail || data.message || 'API error',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Success\nreturn [{\n  json: {\n    success: true,\n    discord_user_id: data.discord_user_id || prevData.discordUserId,\n    project_id: data.project_id || prevData.projectId,\n    credits: data.credits || 0,\n    has_credits: data.has_credits !== undefined ? data.has_credits : (data.credits > 0)\n  }\n}];"
+      },
+      "id": "build-response",
+      "name": "Build Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? $json.error.code : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1500, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error.code }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Credits",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Credits": {
+      "main": [
+        [
+          {
+            "node": "Build Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Credits-Debit.json
+++ b/workflows/Credits-Debit.json
@@ -1,0 +1,224 @@
+{
+  "name": "Credits Debit",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Credits Debit\n\n**Endpoint:** POST /webhook/credits-debit\n\n**Purpose:** Debit credits from user account\n\n**Request:**\n```json\n{\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\",\n  \"amount\": 100,\n  \"job_id\": \"uuid\",\n  \"reason\": \"pdf_translation\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"operation\": \"debit\",\n  \"amount\": 100,\n  \"credits_before\": 500,\n  \"credits_after\": 400\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Insufficient credits\",\n    \"status\": \"INSUFFICIENT_CREDITS\"\n  }\n}\n```\n\n**API:** POST /api/subscription/credits/{id}/debit\n\n**RFC:** RFC-017",
+        "height": 520,
+        "width": 300,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [80, 80]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "credits-debit",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "credits-debit"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input - return error object instead of throwing\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst errors = [];\nif (!body.discord_user_id) errors.push('discord_user_id is required');\nif (!body.amount || body.amount <= 0) errors.push('amount must be a positive number');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: errors.join(', '),\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    discordUserId: body.discord_user_id,\n    projectId: body.project_id || 'torah',\n    amount: parseInt(body.amount, 10),\n    jobId: body.job_id || null,\n    reason: body.reason || 'unspecified'\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/subscription/credits/{{ $json.discordUserId }}/debit",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "project_id",
+              "value": "={{ $json.projectId }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ amount: $json.amount, job_id: $json.jobId, reason: $json.reason }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "debit-credits",
+      "name": "Debit Credits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build response per API spec with standard error format\nconst input = $input.first().json;\nconst prevData = $('Input Valid?').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst data = input.body || input;\n\n// Handle insufficient credits (400)\nif (statusCode === 400 && data.detail?.error === 'INSUFFICIENT_CREDITS') {\n  return [{\n    json: {\n      error: {\n        code: 400,\n        message: data.detail.message || `Insufficient credits. Available: ${data.detail.credits_available}, Requested: ${prevData.amount}`,\n        status: 'INSUFFICIENT_CREDITS',\n        credits_available: data.detail.credits_available,\n        credits_requested: data.detail.credits_requested || prevData.amount\n      }\n    }\n  }];\n}\n\n// Handle user not found (404)\nif (statusCode === 404) {\n  return [{\n    json: {\n      error: {\n        code: 404,\n        message: data.detail?.message || 'User not found',\n        status: 'NOT_FOUND',\n        discord_user_id: prevData.discordUserId\n      }\n    }\n  }];\n}\n\n// Handle other errors\nif (statusCode >= 400) {\n  return [{\n    json: {\n      error: {\n        code: statusCode,\n        message: data.detail || data.message || 'API error',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Success\nreturn [{\n  json: {\n    success: true,\n    discord_user_id: data.discord_user_id || prevData.discordUserId,\n    project_id: data.project_id || prevData.projectId,\n    operation: 'debit',\n    amount: data.amount || prevData.amount,\n    credits_before: data.credits_before,\n    credits_after: data.credits_after,\n    job_id: data.job_id || prevData.jobId\n  }\n}];"
+      },
+      "id": "build-response",
+      "name": "Build Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? $json.error.code : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1500, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error.code }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Debit Credits",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Debit Credits": {
+      "main": [
+        [
+          {
+            "node": "Build Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Credits-Refund.json
+++ b/workflows/Credits-Refund.json
@@ -1,0 +1,224 @@
+{
+  "name": "Credits Refund",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Credits Refund\n\n**Endpoint:** POST /webhook/credits-refund\n\n**Purpose:** Refund credits to user account\n\n**Request:**\n```json\n{\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\",\n  \"amount\": 50,\n  \"job_id\": \"uuid\",\n  \"reason\": \"job_cancelled\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"operation\": \"refund\",\n  \"amount\": 50,\n  \"credits_before\": 400,\n  \"credits_after\": 450\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"User not found\",\n    \"status\": \"NOT_FOUND\"\n  }\n}\n```\n\n**API:** POST /api/subscription/credits/{id}/refund\n\n**RFC:** RFC-017",
+        "height": 500,
+        "width": 300,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [80, 80]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "credits-refund",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "credits-refund"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input - return error object instead of throwing\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst errors = [];\nif (!body.discord_user_id) errors.push('discord_user_id is required');\nif (!body.amount || body.amount <= 0) errors.push('amount must be a positive number');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: errors.join(', '),\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    discordUserId: body.discord_user_id,\n    projectId: body.project_id || 'torah',\n    amount: parseInt(body.amount, 10),\n    jobId: body.job_id || null,\n    reason: body.reason || 'unspecified'\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/subscription/credits/{{ $json.discordUserId }}/refund",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "project_id",
+              "value": "={{ $json.projectId }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ amount: $json.amount, job_id: $json.jobId, reason: $json.reason }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "refund-credits",
+      "name": "Refund Credits",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build response per API spec with standard error format\nconst input = $input.first().json;\nconst prevData = $('Input Valid?').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst data = input.body || input;\n\n// Handle user not found (404)\nif (statusCode === 404) {\n  return [{\n    json: {\n      error: {\n        code: 404,\n        message: data.detail?.message || 'User not found',\n        status: 'NOT_FOUND',\n        discord_user_id: prevData.discordUserId\n      }\n    }\n  }];\n}\n\n// Handle other errors\nif (statusCode >= 400) {\n  return [{\n    json: {\n      error: {\n        code: statusCode,\n        message: data.detail || data.message || 'API error',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Success\nreturn [{\n  json: {\n    success: true,\n    discord_user_id: data.discord_user_id || prevData.discordUserId,\n    project_id: data.project_id || prevData.projectId,\n    operation: 'refund',\n    amount: data.amount || prevData.amount,\n    credits_before: data.credits_before,\n    credits_after: data.credits_after,\n    job_id: data.job_id || prevData.jobId\n  }\n}];"
+      },
+      "id": "build-response",
+      "name": "Build Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? $json.error.code : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1500, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error.code }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Refund Credits",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Refund Credits": {
+      "main": [
+        [
+          {
+            "node": "Build Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Document-Cancel.json
+++ b/workflows/Document-Cancel.json
@@ -1,0 +1,336 @@
+{
+  "name": "Document Cancel",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Document Cancel\n\n**Endpoint:** POST /webhook/document-cancel\n\n**Purpose:** Cancel a running job and return credits summary\n\n**Request:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"user_id\": \"discord_user_id\",\n  \"reason\": \"user_requested\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"uuid\",\n  \"previous_status\": \"processing\",\n  \"new_status\": \"cancelled\",\n  \"credits\": {\n    \"consumed\": { \"total_tokens\": 7500, \"cost_usd\": 0.015 },\n    \"saved\": { \"total_tokens\": 15000, \"cost_usd\": 0.030 }\n  }\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Cannot cancel completed job\",\n    \"status\": \"INVALID_STATE_TRANSITION\"\n  }\n}\n```\n\n**State transitions:**\n- pending → cancelled ✅\n- processing → cancelled ✅\n- completed/failed → ❌ (400)\n\n**API:** PATCH /api/v2/jobs/{job_id}\n\n**RFC:** RFC-017",
+        "height": 620,
+        "width": 320,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [80, 80]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "document-cancel",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [420, 300],
+      "webhookId": "document-cancel"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate input - return error object instead of throwing\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.job_id) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'job_id is required',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: body.job_id,\n    userId: body.user_id || null,\n    reason: body.reason || 'user_requested'\n  }\n}];"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [640, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Input Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [860, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "get-job-status",
+      "name": "Get Job Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1080, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check if job can be cancelled per API state machine\nconst input = $input.first().json;\nconst prevData = $('Input Valid?').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst job = input.body || input;\n\n// Handle job not found (404)\nif (statusCode === 404) {\n  return [{\n    json: {\n      ...prevData,\n      canCancel: false,\n      error: {\n        code: 404,\n        message: `Job ${prevData.jobId} not found`,\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Check status - only pending and processing can be cancelled\nconst status = job.status || 'unknown';\nconst canCancel = ['pending', 'processing'].includes(status);\n\nif (!canCancel) {\n  return [{\n    json: {\n      ...prevData,\n      canCancel: false,\n      error: {\n        code: 400,\n        message: `Cannot transition from '${status}' to 'cancelled'`,\n        status: 'INVALID_STATE_TRANSITION',\n        current_status: status,\n        allowed_transitions: status === 'pending' ? ['processing', 'cancelled'] : []\n      }\n    }\n  }];\n}\n\n// Extract credits and progress info from job\nconst progress = job.progress || { current: 0, total: 0, percentage: 0 };\nconst credits = job.credits || {};\nconst creditsConsumed = credits.consumed || { total_tokens: 0, cost_usd: 0 };\nconst creditsEstimated = credits.estimated_total || creditsConsumed;\n\nreturn [{\n  json: {\n    ...prevData,\n    canCancel: true,\n    job: job,\n    previousStatus: status,\n    progress: progress,\n    creditsConsumed: creditsConsumed,\n    creditsEstimated: creditsEstimated\n  }\n}];"
+      },
+      "id": "check-can-cancel",
+      "name": "Check Can Cancel",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1300, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "can-cancel",
+              "leftValue": "={{ $json.canCancel }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-can-cancel",
+      "name": "Can Cancel?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1520, 200]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'cancelled' }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "patch-cancelled",
+      "name": "PATCH Cancelled",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1740, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Build success response with credits summary per API spec\nconst patchResult = $input.first().json;\nconst prevData = $('Can Cancel?').first().json;\n\nconst patchStatusCode = patchResult.statusCode || 200;\nconst patchBody = patchResult.body || patchResult;\n\n// Handle PATCH errors (e.g., race condition where status changed)\nif (patchStatusCode >= 400) {\n  if (patchBody.detail?.code === 'INVALID_STATE_TRANSITION') {\n    return [{\n      json: {\n        error: {\n          code: 400,\n          message: patchBody.detail.message,\n          status: 'INVALID_STATE_TRANSITION',\n          current_status: patchBody.detail.current_status\n        }\n      }\n    }];\n  }\n  return [{\n    json: {\n      error: {\n        code: patchStatusCode,\n        message: patchBody.detail || 'Failed to cancel job',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Calculate saved credits\nconst consumed = prevData.creditsConsumed || { total_tokens: 0, cost_usd: 0 };\nconst estimated = prevData.creditsEstimated || consumed;\nconst saved = {\n  total_tokens: Math.max(0, (estimated.total_tokens || 0) - (consumed.total_tokens || 0)),\n  cost_usd: Math.max(0, (estimated.cost_usd || 0) - (consumed.cost_usd || 0))\n};\n\nconst progress = prevData.progress || { current: 0, total: 0 };\n\nreturn [{\n  json: {\n    success: true,\n    job_id: prevData.jobId,\n    previous_status: prevData.previousStatus,\n    new_status: 'cancelled',\n    cancelled_at: patchBody.cancelled_at || new Date().toISOString(),\n    progress: {\n      current: progress.current || 0,\n      total: progress.total || 0,\n      percentage: progress.percentage || 0\n    },\n    credits: {\n      consumed: {\n        total_tokens: consumed.total_tokens || 0,\n        cost_usd: consumed.cost_usd || 0\n      },\n      saved: {\n        total_tokens: saved.total_tokens,\n        cost_usd: saved.cost_usd\n      }\n    },\n    message: `Job annulé. ${progress.current || 0}/${progress.total || '?'} traités. ${(consumed.cost_usd || 0).toFixed(3)}$ consommés, ${saved.cost_usd.toFixed(3)}$ économisés.`\n  }\n}];"
+      },
+      "id": "build-success-response",
+      "name": "Build Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1960, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? $json.error.code : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2180, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error.code }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-cancel-error",
+      "name": "Respond Cancel Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1740, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error.code }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1080, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Input Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Input Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Job Status",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Job Status": {
+      "main": [
+        [
+          {
+            "node": "Check Can Cancel",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Can Cancel": {
+      "main": [
+        [
+          {
+            "node": "Can Cancel?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Can Cancel?": {
+      "main": [
+        [
+          {
+            "node": "PATCH Cancelled",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Cancel Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "PATCH Cancelled": {
+      "main": [
+        [
+          {
+            "node": "Build Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}

--- a/workflows/Torah-Translate-Worker.json
+++ b/workflows/Torah-Translate-Worker.json
@@ -3,8 +3,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Translate Worker (Unified)\n\n**Endpoint:** POST /webhook/torah-translate-worker\n\n**Called by:** torah-discord-translate\n\n**Features:**\n- Single or multi-segment translation\n- Auto-pivot if source ≠ en AND target ≠ en\n- Claude translation + GPT verification\n- Detailed tokens (claude/gpt/total)\n- Stores result for job-status retrieval\n\n**Process:**\n1. Respond immediately (async)\n2. PATCH /api/jobs → in_progress\n3. For each segment:\n   - Check if pivot needed\n   - Claude: translate (1 or 2 steps)\n   - GPT: verify\n   - POST /api/translations/save\n   - PATCH /api/jobs (progress + tokens)\n4. Store final result\n5. PATCH /api/jobs → completed",
-        "height": 420,
+        "content": "## Torah Translate Worker (Unified)\n\n**Endpoint:** POST /webhook/torah-translate-worker\n\n**Called by:** torah-discord-translate\n\n**Features:**\n- Single or multi-segment translation\n- Auto-pivot if source ≠ en AND target ≠ en\n- Claude translation + GPT verification\n- Detailed tokens (claude/gpt/total)\n- **Check-before-process** (cancellation support)\n- Stores result for job-status retrieval\n\n**Process:**\n1. Respond immediately (async)\n2. PATCH /api/jobs → in_progress\n3. For each segment:\n   - **CHECK job status** (exit if cancelled)\n   - Check if pivot needed\n   - Claude: translate (1 or 2 steps)\n   - GPT: verify\n   - POST /api/translations/save\n   - PATCH /api/jobs (progress + tokens)\n4. Store final result\n5. PATCH /api/jobs → completed\n\n**RFC:** RFC-017 (Job Lifecycle)",
+        "height": 480,
         "width": 340,
         "color": 5
       },
@@ -507,6 +507,98 @@
         5040,
         304
       ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 5000
+        }
+      },
+      "id": "check-job-status",
+      "name": "Check Job Status",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1968,
+        200
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Check if job is still active (not cancelled)\nconst input = $input.first().json;\nconst prevData = $('Loop Segments').first().json;\n\nconst statusCode = input.statusCode || 200;\nconst job = input.body || input;\nconst jobStatus = job.status || 'processing';\n\n// If job was cancelled, we should exit\nconst isCancelled = jobStatus === 'cancelled';\n\n// Get accumulated credits so far from static data\nconst staticData = $getWorkflowStaticData('global');\nconst jobId = prevData.jobId;\nconst accumulated = staticData.pendingResults?.[jobId] || {\n  totalClaudeTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },\n  totalGptTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },\n  segments: []\n};\n\nreturn [{\n  json: {\n    ...prevData,\n    jobStatus: jobStatus,\n    isCancelled: isCancelled,\n    segmentsCompleted: accumulated.segments?.length || 0,\n    accumulatedCredits: {\n      claude: accumulated.totalClaudeTokens,\n      gpt: accumulated.totalGptTokens,\n      total: {\n        input_tokens: (accumulated.totalClaudeTokens?.input_tokens || 0) + (accumulated.totalGptTokens?.input_tokens || 0),\n        output_tokens: (accumulated.totalClaudeTokens?.output_tokens || 0) + (accumulated.totalGptTokens?.output_tokens || 0),\n        total_tokens: (accumulated.totalClaudeTokens?.total_tokens || 0) + (accumulated.totalGptTokens?.total_tokens || 0)\n      }\n    }\n  }\n}];"
+      },
+      "id": "parse-job-status",
+      "name": "Parse Job Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2176,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-cancelled",
+              "leftValue": "={{ $json.isCancelled }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "job-still-active",
+      "name": "Job Still Active?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        2400,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Job was cancelled - exit early with credits summary\nconst input = $input.first().json;\n\n// Clean up static data\nconst staticData = $getWorkflowStaticData('global');\nconst jobId = input.jobId;\nif (staticData.pendingResults?.[jobId]) {\n  delete staticData.pendingResults[jobId];\n}\n\nreturn [{\n  json: {\n    jobId: input.jobId,\n    exitReason: 'cancelled',\n    segmentsCompleted: input.segmentsCompleted,\n    totalSegments: input.totalSegments,\n    creditsConsumed: input.accumulatedCredits,\n    message: `Job annulé. ${input.segmentsCompleted}/${input.totalSegments} segments traités.`\n  }\n}];"
+      },
+      "id": "handle-cancellation",
+      "name": "Handle Cancellation",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2624,
+        100
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "exit-cancelled",
+      "name": "Exit (Cancelled)",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        2848,
+        100
+      ]
     }
   ],
   "connections": {
@@ -587,7 +679,58 @@
         ],
         [
           {
+            "node": "Check Job Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Job Status": {
+      "main": [
+        [
+          {
+            "node": "Parse Job Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Job Status": {
+      "main": [
+        [
+          {
+            "node": "Job Still Active?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Job Still Active?": {
+      "main": [
+        [
+          {
             "node": "Needs Pivot?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Handle Cancellation",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Handle Cancellation": {
+      "main": [
+        [
+          {
+            "node": "Exit (Cancelled)",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- Add 4 new webhooks for credits management (Credits-Check, Credits-Debit, Credits-Refund, Document-Cancel)
- Update Torah-Translate-Worker with check-before-process pattern for job cancellation support
- Add RFC-018 analysis for recipe enrichment with generic workflow proposals
- Add team coordination documentation

## Webhooks Added (RFC-017)
| Webhook | Endpoint | Purpose |
|---------|----------|---------|
| Credits-Check | POST /webhook/credits-check | Check user credits balance |
| Credits-Debit | POST /webhook/credits-debit | Debit credits from account |
| Credits-Refund | POST /webhook/credits-refund | Refund credits to account |
| Document-Cancel | POST /webhook/document-cancel | Cancel running job with credits summary |

## Key Changes
- **Torah-Translate-Worker**: Now checks job status before processing each segment, enabling graceful cancellation
- **Standard error format**: All webhooks use `{error: {code, message, status}}`
- **Validation pattern**: IF node branching instead of throwing errors
- **RFC-018**: Analysis of generic vs specific workflows for document processing

## Documentation
- `docs/issues/JOB-LIFECYCLE-CREDITS-API.md` - API specification alignment
- `docs/issues/WORK-*.md` - Team coordination notes
- `docs/rfc/RFC-018-RECIPE-ENRICHMENT.md` - Generic workflow architecture

## Test plan
- [ ] Test Credits-Check webhook with valid/invalid discord_user_id
- [ ] Test Credits-Debit with sufficient/insufficient credits
- [ ] Test Credits-Refund for cancelled jobs
- [ ] Test Document-Cancel state transitions (pending/processing -> cancelled)
- [ ] Verify Torah-Translate-Worker exits gracefully on job cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)