### PR TITLE
feat(infra): add process-pending-events workflow #268

### DIFF
--- a/workflows/INFRA-Process-Pending-Events.json
+++ b/workflows/INFRA-Process-Pending-Events.json
@@ -1,0 +1,815 @@
+{
+  "name": "INFRA---Process-Pending-Events",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## INFRA - Process Pending Events\n\n**Cron:** Toutes les minutes\n\n**Source:** RFC-023 Section 16.2.3\n\n**Description:**\nTraite les events en fallback DB quand Redis était indisponible.\n\n**Flow:**\n1. Vérifie si Redis est disponible (ping)\n2. Si Redis down → exit\n3. Récupère les events pending (< 10 attempts)\n4. Pour chaque event:\n   - Marque comme 'processing'\n   - Publie vers Redis Streams\n   - Marque comme 'completed' ou incrémente attempts\n5. Marque les events >= 10 attempts comme 'failed'\n6. Alerte admin si events failed récents\n\n**Tables:**\n- `pending_events` (status, attempts, stream_name, payload)\n\n**Streams Redis:**\n- `formation:events:stream`\n- `learning:events:stream`",
+        "height": 560,
+        "width": 340,
+        "color": 5
+      },
+      "id": "infra-pending-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 1
+            }
+          ]
+        }
+      },
+      "id": "infra-pending-0001",
+      "name": "Cron Every Minute",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        200,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "get",
+        "propertyName": "redis_ping",
+        "key": "health:ping",
+        "options": {}
+      },
+      "id": "infra-pending-0002",
+      "name": "Check Redis Available",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        420,
+        300
+      ],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      },
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// CHECK REDIS AVAILABILITY\n// ============================================\n\nconst input = $input.first().json;\n\n// Si on a une erreur Redis, on considère qu'il est indisponible\nif (input.error || input.errorMessage) {\n  return {\n    redis_available: false,\n    message: 'Redis unavailable: ' + (input.errorMessage || 'connection error')\n  };\n}\n\n// Redis est disponible\nreturn {\n  redis_available: true,\n  message: 'Redis is available'\n};"
+      },
+      "id": "infra-pending-0003",
+      "name": "Parse Redis Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        640,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-redis-available",
+              "leftValue": "={{ $json.redis_available }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "infra-pending-0004",
+      "name": "Redis Available?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        860,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// REDIS UNAVAILABLE - EXIT\n// ============================================\n\nreturn {\n  action: 'skipped',\n  reason: 'Redis still unavailable',\n  message: 'Skipping pending events processing until Redis recovers'\n};"
+      },
+      "id": "infra-pending-0005",
+      "name": "Log Redis Unavailable",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1080,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT id, stream_name, event_type, guild_id, payload, created_at, attempts, error_message\nFROM pending_events\nWHERE status = 'pending'\nAND attempts < 10\nORDER BY created_at ASC\nLIMIT 100",
+        "options": {}
+      },
+      "id": "infra-pending-0006",
+      "name": "Get Pending Events",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [
+        1080,
+        200
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-pending-events",
+          "name": "PostgreSQL Pending Events"
+        }
+      },
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// CHECK IF EVENTS TO PROCESS\n// ============================================\n\nconst items = $input.all();\n\n// Handle error case\nif (items.length === 1 && items[0].json.error) {\n  return {\n    has_events: false,\n    error: true,\n    message: 'Database error: ' + items[0].json.errorMessage\n  };\n}\n\n// Filter out empty results\nconst events = items.filter(item => item.json.id);\n\nif (events.length === 0) {\n  return {\n    has_events: false,\n    error: false,\n    message: 'No pending events to process'\n  };\n}\n\nreturn {\n  has_events: true,\n  error: false,\n  count: events.length,\n  events: events.map(e => e.json)\n};"
+      },
+      "id": "infra-pending-0007",
+      "name": "Check Events Found",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-has-events",
+              "leftValue": "={{ $json.has_events }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "infra-pending-0008",
+      "name": "Has Events?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1520,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// NO EVENTS - NOTHING TO DO\n// ============================================\n\nreturn {\n  action: 'no_events',\n  message: 'No pending events to process'\n};"
+      },
+      "id": "infra-pending-0009",
+      "name": "Log No Events",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1740,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// SPLIT EVENTS FOR PROCESSING\n// ============================================\n\nconst data = $input.first().json;\nconst events = data.events || [];\n\n// Return each event as separate item for loop\nreturn events.map(event => ({\n  json: {\n    event_id: event.id,\n    stream_name: event.stream_name,\n    event_type: event.event_type,\n    guild_id: event.guild_id,\n    payload: typeof event.payload === 'string' ? JSON.parse(event.payload) : event.payload,\n    attempts: event.attempts,\n    created_at: event.created_at\n  }\n}));"
+      },
+      "id": "infra-pending-0010",
+      "name": "Split Events",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1740,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE pending_events SET status = 'processing', last_attempt_at = NOW() WHERE id = '{{ $json.event_id }}'",
+        "options": {}
+      },
+      "id": "infra-pending-0011",
+      "name": "Mark Processing",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [
+        1960,
+        100
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-pending-events",
+          "name": "PostgreSQL Pending Events"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE REDIS STREAM MESSAGE\n// ============================================\n\nconst event = $('Split Events').item.json;\n\n// Préparer les données pour xAdd\nreturn {\n  event_id: event.event_id,\n  stream_name: event.stream_name,\n  event_type: event.event_type,\n  guild_id: event.guild_id,\n  payload: event.payload,\n  attempts: event.attempts\n};"
+      },
+      "id": "infra-pending-0012",
+      "name": "Prepare Stream Message",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2180,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "xAdd",
+        "key": "={{ $json.stream_name }}",
+        "fieldsUi": {
+          "fieldValues": [
+            {
+              "fieldName": "event",
+              "fieldValue": "={{ JSON.stringify($json.payload) }}"
+            }
+          ]
+        }
+      },
+      "id": "infra-pending-0013",
+      "name": "Publish to Redis Stream",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        2400,
+        100
+      ],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      },
+      "onError": "continueErrorOutput",
+      "notesInFlow": true,
+      "notes": "Publie vers le stream dynamique (formation:events:stream ou learning:events:stream)"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// CHECK PUBLISH RESULT\n// ============================================\n\nconst publishResult = $input.first().json;\nconst eventData = $('Prepare Stream Message').item.json;\n\n// Check for errors - Redis xAdd returns the message ID on success\nconst hasError = publishResult.error || publishResult.errorMessage;\n\nif (hasError) {\n  return {\n    success: false,\n    event_id: eventData.event_id,\n    stream_name: eventData.stream_name,\n    error: publishResult.errorMessage || publishResult.error || 'Publish failed',\n    attempts: eventData.attempts + 1\n  };\n}\n\n// xAdd returns the message ID (format: timestamp-sequence, e.g., '1234567890123-0')\nreturn {\n  success: true,\n  event_id: eventData.event_id,\n  stream_name: eventData.stream_name,\n  message_id: publishResult.messageId || publishResult.id || 'published'\n};"
+      },
+      "id": "infra-pending-0014",
+      "name": "Check Publish Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2620,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-publish-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "infra-pending-0015",
+      "name": "Publish Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        2840,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE pending_events SET status = 'completed' WHERE id = '{{ $json.event_id }}'",
+        "options": {}
+      },
+      "id": "infra-pending-0016",
+      "name": "Mark Completed",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [
+        3060,
+        0
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-pending-events",
+          "name": "PostgreSQL Pending Events"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE pending_events SET status = 'pending', attempts = {{ $json.attempts }}, error_message = '{{ $json.error }}' WHERE id = '{{ $json.event_id }}'",
+        "options": {}
+      },
+      "id": "infra-pending-0017",
+      "name": "Increment Attempts",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [
+        3060,
+        200
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-pending-events",
+          "name": "PostgreSQL Pending Events"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG SUCCESS\n// ============================================\n\nconst data = $input.first().json;\n\nreturn {\n  action: 'published',\n  event_id: $('Check Publish Result').item.json.event_id,\n  stream_name: $('Check Publish Result').item.json.stream_name,\n  status: 'completed'\n};"
+      },
+      "id": "infra-pending-0018",
+      "name": "Log Success",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3280,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG FAILURE\n// ============================================\n\nconst data = $('Check Publish Result').item.json;\n\nreturn {\n  action: 'retry_scheduled',\n  event_id: data.event_id,\n  stream_name: data.stream_name,\n  attempts: data.attempts,\n  error: data.error\n};"
+      },
+      "id": "infra-pending-0019",
+      "name": "Log Failure",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3280,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "UPDATE pending_events SET status = 'failed' WHERE status = 'pending' AND attempts >= 10",
+        "options": {}
+      },
+      "id": "infra-pending-0020",
+      "name": "Mark Failed Events",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [
+        3500,
+        100
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-pending-events",
+          "name": "PostgreSQL Pending Events"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "SELECT COUNT(*) as failed_count FROM pending_events WHERE status = 'failed' AND created_at > NOW() - INTERVAL '1 hour'",
+        "options": {}
+      },
+      "id": "infra-pending-0021",
+      "name": "Count Recent Failures",
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.5,
+      "position": [
+        3720,
+        100
+      ],
+      "credentials": {
+        "postgres": {
+          "id": "postgres-pending-events",
+          "name": "PostgreSQL Pending Events"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// CHECK IF ALERT NEEDED\n// ============================================\n\nconst result = $input.first().json;\nconst failedCount = parseInt(result.failed_count) || 0;\n\nreturn {\n  failed_count: failedCount,\n  alert_needed: failedCount > 0,\n  message: failedCount > 0 \n    ? `⚠️ ${failedCount} events en échec définitif dans pending_events (dernière heure)`\n    : 'No failed events'\n};"
+      },
+      "id": "infra-pending-0022",
+      "name": "Check Alert Needed",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3940,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-alert-needed",
+              "leftValue": "={{ $json.alert_needed }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "infra-pending-0023",
+      "name": "Alert Needed?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        4160,
+        100
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.ALERT_WEBHOOK_URL || $env.DISCORD_ADMIN_WEBHOOK }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  content: $json.message,\n  username: 'n8n Alert',\n  embeds: [{\n    title: '🚨 Pending Events Alert',\n    description: $json.message,\n    color: 15158332,\n    timestamp: new Date().toISOString(),\n    fields: [\n      { name: 'Failed Events', value: String($json.failed_count), inline: true },\n      { name: 'Time Window', value: 'Last hour', inline: true }\n    ]\n  }]\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "infra-pending-0024",
+      "name": "Send Admin Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4380,
+        0
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FINAL STATUS\n// ============================================\n\nconst alertData = $('Check Alert Needed').first().json;\n\nreturn {\n  action: 'completed',\n  alert_sent: alertData.alert_needed,\n  failed_count: alertData.failed_count\n};"
+      },
+      "id": "infra-pending-0025",
+      "name": "Log Final Status",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        4380,
+        200
+      ]
+    }
+  ],
+  "connections": {
+    "Cron Every Minute": {
+      "main": [
+        [
+          {
+            "node": "Check Redis Available",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Redis Available": {
+      "main": [
+        [
+          {
+            "node": "Parse Redis Status",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Parse Redis Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Redis Status": {
+      "main": [
+        [
+          {
+            "node": "Redis Available?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Redis Available?": {
+      "main": [
+        [
+          {
+            "node": "Get Pending Events",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log Redis Unavailable",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Pending Events": {
+      "main": [
+        [
+          {
+            "node": "Check Events Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Events Found": {
+      "main": [
+        [
+          {
+            "node": "Has Events?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Events?": {
+      "main": [
+        [
+          {
+            "node": "Split Events",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log No Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Events": {
+      "main": [
+        [
+          {
+            "node": "Mark Processing",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mark Processing": {
+      "main": [
+        [
+          {
+            "node": "Prepare Stream Message",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Stream Message": {
+      "main": [
+        [
+          {
+            "node": "Publish to Redis Stream",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Publish to Redis Stream": {
+      "main": [
+        [
+          {
+            "node": "Check Publish Result",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Check Publish Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Publish Result": {
+      "main": [
+        [
+          {
+            "node": "Publish Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Publish Success?": {
+      "main": [
+        [
+          {
+            "node": "Mark Completed",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Increment Attempts",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mark Completed": {
+      "main": [
+        [
+          {
+            "node": "Log Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Increment Attempts": {
+      "main": [
+        [
+          {
+            "node": "Log Failure",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log Success": {
+      "main": [
+        [
+          {
+            "node": "Mark Failed Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Log Failure": {
+      "main": [
+        [
+          {
+            "node": "Mark Failed Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mark Failed Events": {
+      "main": [
+        [
+          {
+            "node": "Count Recent Failures",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Count Recent Failures": {
+      "main": [
+        [
+          {
+            "node": "Check Alert Needed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Check Alert Needed": {
+      "main": [
+        [
+          {
+            "node": "Alert Needed?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Alert Needed?": {
+      "main": [
+        [
+          {
+            "node": "Send Admin Alert",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Log Final Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Admin Alert": {
+      "main": [
+        [
+          {
+            "node": "Log Final Status",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": false
+  },
+  "tags": [
+    {
+      "name": "infrastructure"
+    },
+    {
+      "name": "rfc-023"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Implémente le workflow `INFRA-Process-Pending-Events` (N8N-INFRA-001)
- Traite les events en fallback DB quand Redis était indisponible
- Source: RFC-023 Section 16.2.3

## Workflow à importer

| Fichier | Nom dans n8n | Action |
|---------|--------------|--------|
| `workflows/INFRA-Process-Pending-Events.json` | `INFRA---Process-Pending-Events` | Importer et activer |

## Configuration requise

### Credentials à créer dans n8n

| Credential | Type | Description |
|------------|------|-------------|
| `postgres-pending-events` | PostgreSQL | Connexion à la DB contenant `pending_events` |

### Variables d'environnement n8n

```bash
# Dans le fichier .env de n8n ou via l'interface Settings > Environment
ALERT_WEBHOOK_URL=https://discord.com/api/webhooks/xxx/yyy
# OU
DISCORD_ADMIN_WEBHOOK=https://discord.com/api/webhooks/xxx/yyy
```

## Dépendances externes

| Issue | Équipe | Status |
|-------|--------|--------|
| API-INFRA-001 : Table `pending_events` | API | ⏳ En attente |

### Structure table attendue

```sql
CREATE TABLE pending_events (
    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
    stream_name VARCHAR(100) NOT NULL,
    event_type VARCHAR(100) NOT NULL,
    guild_id VARCHAR(20) NOT NULL,
    payload JSONB NOT NULL,
    created_at TIMESTAMP DEFAULT NOW(),
    attempts INTEGER DEFAULT 0,
    last_attempt_at TIMESTAMP,
    error_message TEXT,
    status VARCHAR(20) DEFAULT 'pending'
);

CREATE INDEX idx_pending_events_status ON pending_events(status);
CREATE INDEX idx_pending_events_attempts ON pending_events(attempts);
```

## Test plan

- [ ] Créer la table `pending_events` dans la DB
- [ ] Créer le credential PostgreSQL dans n8n
- [ ] Configurer `ALERT_WEBHOOK_URL` dans n8n
- [ ] Importer le workflow
- [ ] Insérer un event test dans `pending_events`
- [ ] Vérifier que l'event est publié vers Redis Streams
- [ ] Vérifier que l'event est marqué `completed`
- [ ] Tester le cas d'erreur (Redis down) → event reste `pending`, attempts++
- [ ] Tester l'alerte admin après 10 échecs

🤖 Generated with [Claude Code](https://claude.com/claude-code)