### PR TITLE
feat(notifications): add 4 notification workflows #278

### DIFF
--- a/workflows/ALERT-Anomaly-Detected.json
+++ b/workflows/ALERT-Anomaly-Detected.json
@@ -1,0 +1,237 @@
+{
+  "name": "ALERT---Anomaly-Detected",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## ALERT - Anomaly Detected\n\n**Trigger:** Redis event `reconciliation.anomaly`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie une alerte au channel admin Discord\nquand une anomalie est détectée lors de\nla réconciliation (Stripe, cours, etc.).\n\n**Stream:** `system:events:stream`\n**Destination:** Webhook Admin Discord",
+        "height": 280,
+        "width": 320,
+        "color": 1
+      },
+      "id": "alert-anomaly-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "xRead",
+        "key": "system:events:stream",
+        "options": {
+          "block": 5000,
+          "count": 10
+        }
+      },
+      "id": "alert-anomaly-0001",
+      "name": "Redis Subscribe",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        200,
+        300
+      ],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FILTER ANOMALY EVENTS\n// ============================================\n\nconst items = $input.all();\nconst anomalyEvents = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Parse event if stringified\n  let event = data.event || data;\n  if (typeof event === 'string') {\n    try {\n      event = JSON.parse(event);\n    } catch (e) {\n      continue;\n    }\n  }\n  \n  // Filter only reconciliation.anomaly events\n  if (event.event === 'reconciliation.anomaly' || event.type === 'reconciliation.anomaly') {\n    anomalyEvents.push({\n      json: {\n        event_id: data.id || `anomaly_${Date.now()}`,\n        event_type: 'reconciliation.anomaly',\n        guild_id: event.guild_id,\n        anomaly_type: event.data?.anomaly_type || 'unknown',\n        severity: event.data?.severity || 'warning',\n        source: event.data?.source || 'reconciliation',\n        description: event.data?.description || 'Anomalie détectée',\n        details: event.data?.details || {},\n        affected_user_id: event.data?.affected_user_id,\n        affected_discord_id: event.data?.affected_discord_id,\n        expected_value: event.data?.expected_value,\n        actual_value: event.data?.actual_value,\n        timestamp: event.timestamp || new Date().toISOString()\n      }\n    });\n  }\n}\n\nreturn anomalyEvents.length > 0 ? anomalyEvents : [];"
+      },
+      "id": "alert-anomaly-0002",
+      "name": "Filter Anomaly Events",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        420,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-events",
+              "leftValue": "={{ $json.event_type }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "alert-anomaly-0003",
+      "name": "Has Events?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        640,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE ADMIN ALERT EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Severity colors and emojis\nconst severityConfig = {\n  critical: { color: 0xE74C3C, emoji: '🚨', label: 'CRITIQUE' },\n  error: { color: 0xE74C3C, emoji: '❌', label: 'ERREUR' },\n  warning: { color: 0xF39C12, emoji: '⚠️', label: 'ATTENTION' },\n  info: { color: 0x3498DB, emoji: 'ℹ️', label: 'INFO' }\n};\n\nconst config = severityConfig[data.severity] || severityConfig.warning;\n\n// Anomaly type labels\nconst anomalyTypeLabels = {\n  subscription_mismatch: 'Désynchronisation abonnement',\n  payment_missing: 'Paiement manquant',\n  access_without_subscription: 'Accès sans abonnement',\n  subscription_without_access: 'Abonnement sans accès',\n  duplicate_subscription: 'Abonnement dupliqué',\n  expired_access_active: 'Accès expiré encore actif',\n  data_inconsistency: 'Incohérence de données',\n  unknown: 'Anomalie inconnue'\n};\n\nconst anomalyLabel = anomalyTypeLabels[data.anomaly_type] || data.anomaly_type;\n\n// Build fields\nconst fields = [\n  {\n    name: '📋 Type',\n    value: anomalyLabel,\n    inline: true\n  },\n  {\n    name: '📊 Source',\n    value: data.source,\n    inline: true\n  },\n  {\n    name: '⏰ Détecté à',\n    value: new Date(data.timestamp).toLocaleString('fr-FR'),\n    inline: true\n  }\n];\n\n// Add affected user if present\nif (data.affected_discord_id) {\n  fields.push({\n    name: '👤 Utilisateur affecté',\n    value: `<@${data.affected_discord_id}>`,\n    inline: true\n  });\n}\n\n// Add expected vs actual if present\nif (data.expected_value !== undefined && data.actual_value !== undefined) {\n  fields.push({\n    name: '📌 Valeur attendue',\n    value: String(data.expected_value),\n    inline: true\n  });\n  fields.push({\n    name: '📍 Valeur actuelle',\n    value: String(data.actual_value),\n    inline: true\n  });\n}\n\n// Add details if present\nif (data.details && Object.keys(data.details).length > 0) {\n  const detailsStr = Object.entries(data.details)\n    .map(([k, v]) => `**${k}:** ${v}`)\n    .join('\\n');\n  fields.push({\n    name: '🔍 Détails',\n    value: detailsStr.substring(0, 1024),\n    inline: false\n  });\n}\n\nconst embed = {\n  title: `${config.emoji} [${config.label}] Anomalie Détectée`,\n  description: data.description,\n  color: config.color,\n  fields: fields,\n  footer: {\n    text: `Event ID: ${data.event_id}`\n  },\n  timestamp: data.timestamp\n};\n\nreturn {\n  embed: embed,\n  event_id: data.event_id,\n  severity: data.severity,\n  anomaly_type: data.anomaly_type\n};"
+      },
+      "id": "alert-anomaly-0004",
+      "name": "Prepare Alert Embed",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        860,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.DISCORD_ADMIN_WEBHOOK_URL }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  content: $json.severity === 'critical' ? '@here' : null,\n  embeds: [$json.embed]\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "alert-anomaly-0005",
+      "name": "Send to Admin Webhook",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1080,
+        200
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG ALERT RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Alert Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Admin alert ${success ? 'sent' : 'failed'} - ${prepData.anomaly_type} (severity: ${prepData.severity})`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  anomaly_type: prepData.anomaly_type,\n  severity: prepData.severity,\n  alert_type: 'admin_anomaly'\n};"
+      },
+      "id": "alert-anomaly-0006",
+      "name": "Log Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        200
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "alert-anomaly-0007",
+      "name": "No Events",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        860,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Redis Subscribe": {
+      "main": [
+        [
+          {
+            "node": "Filter Anomaly Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter Anomaly Events": {
+      "main": [
+        [
+          {
+            "node": "Has Events?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Events?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Alert Embed",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Alert Embed": {
+      "main": [
+        [
+          {
+            "node": "Send to Admin Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send to Admin Webhook": {
+      "main": [
+        [
+          {
+            "node": "Log Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "alert"
+    },
+    {
+      "name": "rfc-027"
+    },
+    {
+      "name": "admin"
+    }
+  ]
+}

--- a/workflows/NOTIF-Badge-Earned.json
+++ b/workflows/NOTIF-Badge-Earned.json
@@ -1,0 +1,237 @@
+{
+  "name": "NOTIF---Badge-Earned",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## NOTIF - Badge Earned\n\n**Trigger:** Redis event `badge:earned`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie une notification Discord quand\nun utilisateur débloque un badge.\n\n**Stream:** `xp:events:stream`\n**Consumer Group:** `n8n-notifications`",
+        "height": 260,
+        "width": 320,
+        "color": 5
+      },
+      "id": "notif-badge-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "xRead",
+        "key": "xp:events:stream",
+        "options": {
+          "block": 5000,
+          "count": 10
+        }
+      },
+      "id": "notif-badge-0001",
+      "name": "Redis Subscribe",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        200,
+        300
+      ],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FILTER BADGE EARNED EVENTS\n// ============================================\n\nconst items = $input.all();\nconst badgeEvents = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Parse event if stringified\n  let event = data.event || data;\n  if (typeof event === 'string') {\n    try {\n      event = JSON.parse(event);\n    } catch (e) {\n      continue;\n    }\n  }\n  \n  // Filter only badge:earned events\n  if (event.event === 'badge:earned' || event.type === 'badge:earned') {\n    badgeEvents.push({\n      json: {\n        event_id: data.id || `badge_${Date.now()}`,\n        event_type: 'badge:earned',\n        guild_id: event.guild_id,\n        user_id: event.data?.user_id || event.user_id,\n        discord_id: event.data?.discord_id || event.discord_id,\n        badge_id: event.data?.badge_id,\n        badge_name: event.data?.badge_name || 'Badge',\n        badge_emoji: event.data?.badge_emoji || '🏅',\n        badge_description: event.data?.badge_description || '',\n        badge_rarity: event.data?.badge_rarity || 'common',\n        timestamp: event.timestamp || new Date().toISOString()\n      }\n    });\n  }\n}\n\nreturn badgeEvents.length > 0 ? badgeEvents : [];"
+      },
+      "id": "notif-badge-0002",
+      "name": "Filter Badge Events",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        420,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-events",
+              "leftValue": "={{ $json.event_type }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "notif-badge-0003",
+      "name": "Has Events?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        640,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE BADGE EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Rarity colors\nconst rarityColors = {\n  common: 0x95A5A6,      // Gray\n  uncommon: 0x2ECC71,    // Green\n  rare: 0x3498DB,        // Blue\n  epic: 0x9B59B6,        // Purple\n  legendary: 0xF39C12,   // Orange\n  mythic: 0xE74C3C       // Red\n};\n\nconst rarityLabels = {\n  common: 'Commun',\n  uncommon: 'Peu commun',\n  rare: 'Rare',\n  epic: 'Épique',\n  legendary: 'Légendaire',\n  mythic: 'Mythique'\n};\n\nconst color = rarityColors[data.badge_rarity] || 0x95A5A6;\nconst rarityLabel = rarityLabels[data.badge_rarity] || 'Commun';\n\nconst embed = {\n  title: `${data.badge_emoji} Nouveau Badge Débloqué !`,\n  description: `Tu as obtenu le badge **${data.badge_name}** !`,\n  color: color,\n  fields: [\n    {\n      name: '📋 Description',\n      value: data.badge_description || 'Un badge spécial !',\n      inline: false\n    },\n    {\n      name: '💎 Rareté',\n      value: rarityLabel,\n      inline: true\n    }\n  ],\n  footer: {\n    text: 'Consulte ta collection avec /progression'\n  },\n  timestamp: data.timestamp\n};\n\n// Add thumbnail if badge has an image\nif (data.badge_image_url) {\n  embed.thumbnail = { url: data.badge_image_url };\n}\n\nreturn {\n  discord_id: data.discord_id,\n  guild_id: data.guild_id,\n  embed: embed,\n  content: `<@${data.discord_id}> 🎊`,\n  event_id: data.event_id\n};"
+      },
+      "id": "notif-badge-0004",
+      "name": "Prepare Badge Embed",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        860,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.CHATBOT_CORE_URL }}/api/notifications/dm",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  discord_id: $json.discord_id,\n  guild_id: $json.guild_id,\n  content: $json.content,\n  embed: $json.embed,\n  notification_type: 'badge_earned'\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "notif-badge-0005",
+      "name": "Send DM via Chatbot-Core",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1080,
+        200
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG NOTIFICATION RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Badge Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Badge notification ${success ? 'sent' : 'failed'} for user ${prepData.discord_id}`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  notification_type: 'badge_earned'\n};"
+      },
+      "id": "notif-badge-0006",
+      "name": "Log Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        200
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "notif-badge-0007",
+      "name": "No Events",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        860,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Redis Subscribe": {
+      "main": [
+        [
+          {
+            "node": "Filter Badge Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter Badge Events": {
+      "main": [
+        [
+          {
+            "node": "Has Events?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Events?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Badge Embed",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Badge Embed": {
+      "main": [
+        [
+          {
+            "node": "Send DM via Chatbot-Core",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send DM via Chatbot-Core": {
+      "main": [
+        [
+          {
+            "node": "Log Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "notification"
+    },
+    {
+      "name": "rfc-027"
+    },
+    {
+      "name": "badge"
+    }
+  ]
+}

--- a/workflows/NOTIF-Course-Expiring.json
+++ b/workflows/NOTIF-Course-Expiring.json
@@ -1,0 +1,237 @@
+{
+  "name": "NOTIF---Course-Expiring",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## NOTIF - Course Expiring\n\n**Trigger:** Redis event `course.access.expiring`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie un rappel Discord quand l'accès\nà un cours expire bientôt (7 jours).\n\n**Stream:** `learning:events:stream`\n**Consumer Group:** `n8n-notifications`",
+        "height": 260,
+        "width": 320,
+        "color": 5
+      },
+      "id": "notif-course-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "xRead",
+        "key": "learning:events:stream",
+        "options": {
+          "block": 5000,
+          "count": 10
+        }
+      },
+      "id": "notif-course-0001",
+      "name": "Redis Subscribe",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        200,
+        300
+      ],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FILTER COURSE EXPIRING EVENTS\n// ============================================\n\nconst items = $input.all();\nconst expiringEvents = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Parse event if stringified\n  let event = data.event || data;\n  if (typeof event === 'string') {\n    try {\n      event = JSON.parse(event);\n    } catch (e) {\n      continue;\n    }\n  }\n  \n  // Filter only course.access.expiring events\n  if (event.event === 'course.access.expiring' || event.type === 'course.access.expiring') {\n    expiringEvents.push({\n      json: {\n        event_id: data.id || `expiring_${Date.now()}`,\n        event_type: 'course.access.expiring',\n        guild_id: event.guild_id,\n        user_id: event.data?.user_id || event.user_id,\n        discord_id: event.data?.discord_id || event.discord_id,\n        course_id: event.data?.course_id,\n        course_name: event.data?.course_name || 'Cours',\n        expires_at: event.data?.expires_at,\n        days_until_expiration: event.data?.days_until_expiration || 7,\n        notification_type: event.data?.notification_type || 'expires_soon',\n        timestamp: event.timestamp || new Date().toISOString()\n      }\n    });\n  }\n}\n\nreturn expiringEvents.length > 0 ? expiringEvents : [];"
+      },
+      "id": "notif-course-0002",
+      "name": "Filter Expiring Events",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        420,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-events",
+              "leftValue": "={{ $json.event_type }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "notif-course-0003",
+      "name": "Has Events?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        640,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE EXPIRING REMINDER EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Format expiration date\nconst expiresAt = data.expires_at ? new Date(data.expires_at) : null;\nconst formattedDate = expiresAt \n  ? expiresAt.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })\n  : 'bientôt';\n\n// Urgency based on days remaining\nlet urgencyEmoji = '📅';\nlet urgencyColor = 0x3498DB; // Blue\nlet urgencyText = `dans ${data.days_until_expiration} jours`;\n\nif (data.days_until_expiration <= 1) {\n  urgencyEmoji = '🚨';\n  urgencyColor = 0xE74C3C; // Red\n  urgencyText = 'DEMAIN';\n} else if (data.days_until_expiration <= 3) {\n  urgencyEmoji = '⚠️';\n  urgencyColor = 0xF39C12; // Orange\n  urgencyText = `dans ${data.days_until_expiration} jours`;\n}\n\nconst embed = {\n  title: `${urgencyEmoji} Ton accès expire ${urgencyText}`,\n  description: `Ton accès au cours **${data.course_name}** arrive à expiration.`,\n  color: urgencyColor,\n  fields: [\n    {\n      name: '📚 Cours',\n      value: data.course_name,\n      inline: true\n    },\n    {\n      name: '📆 Date d\\'expiration',\n      value: formattedDate,\n      inline: true\n    },\n    {\n      name: '💡 Que faire ?',\n      value: 'Renouvelle ton accès pour continuer à apprendre !\\nUtilise `/cours` pour voir les options.',\n      inline: false\n    }\n  ],\n  footer: {\n    text: 'Ne perds pas ta progression !'\n  },\n  timestamp: data.timestamp\n};\n\nreturn {\n  discord_id: data.discord_id,\n  guild_id: data.guild_id,\n  embed: embed,\n  content: `<@${data.discord_id}>`,\n  event_id: data.event_id,\n  urgency: data.days_until_expiration <= 1 ? 'critical' : (data.days_until_expiration <= 3 ? 'warning' : 'info')\n};"
+      },
+      "id": "notif-course-0004",
+      "name": "Prepare Reminder Embed",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        860,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.CHATBOT_CORE_URL }}/api/notifications/dm",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  discord_id: $json.discord_id,\n  guild_id: $json.guild_id,\n  content: $json.content,\n  embed: $json.embed,\n  notification_type: 'course_expiring',\n  urgency: $json.urgency\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "notif-course-0005",
+      "name": "Send DM via Chatbot-Core",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1080,
+        200
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG NOTIFICATION RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Reminder Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Course expiring notification ${success ? 'sent' : 'failed'} for user ${prepData.discord_id} (urgency: ${prepData.urgency})`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  notification_type: 'course_expiring',\n  urgency: prepData.urgency\n};"
+      },
+      "id": "notif-course-0006",
+      "name": "Log Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        200
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "notif-course-0007",
+      "name": "No Events",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        860,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Redis Subscribe": {
+      "main": [
+        [
+          {
+            "node": "Filter Expiring Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter Expiring Events": {
+      "main": [
+        [
+          {
+            "node": "Has Events?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Events?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Reminder Embed",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Reminder Embed": {
+      "main": [
+        [
+          {
+            "node": "Send DM via Chatbot-Core",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send DM via Chatbot-Core": {
+      "main": [
+        [
+          {
+            "node": "Log Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "notification"
+    },
+    {
+      "name": "rfc-027"
+    },
+    {
+      "name": "course"
+    }
+  ]
+}

--- a/workflows/NOTIF-Level-Up.json
+++ b/workflows/NOTIF-Level-Up.json
@@ -1,0 +1,237 @@
+{
+  "name": "NOTIF---Level-Up",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## NOTIF - Level Up\n\n**Trigger:** Redis event `level:up`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie une notification Discord célébratoire\nquand un utilisateur monte de niveau.\n\n**Stream:** `xp:events:stream`\n**Consumer Group:** `n8n-notifications`",
+        "height": 260,
+        "width": 320,
+        "color": 5
+      },
+      "id": "notif-level-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "xRead",
+        "key": "xp:events:stream",
+        "options": {
+          "block": 5000,
+          "count": 10
+        }
+      },
+      "id": "notif-level-0001",
+      "name": "Redis Subscribe",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        200,
+        300
+      ],
+      "credentials": {
+        "redis": {
+          "id": "2idv3VKZ91q5gOnz",
+          "name": "Redis account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FILTER LEVEL UP EVENTS\n// ============================================\n\nconst items = $input.all();\nconst levelUpEvents = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Parse event if stringified\n  let event = data.event || data;\n  if (typeof event === 'string') {\n    try {\n      event = JSON.parse(event);\n    } catch (e) {\n      continue;\n    }\n  }\n  \n  // Filter only level:up events\n  if (event.event === 'level:up' || event.type === 'level:up') {\n    levelUpEvents.push({\n      json: {\n        event_id: data.id || `level_${Date.now()}`,\n        event_type: 'level:up',\n        guild_id: event.guild_id,\n        user_id: event.data?.user_id || event.user_id,\n        discord_id: event.data?.discord_id || event.discord_id,\n        old_level: event.data?.old_level || 0,\n        new_level: event.data?.new_level || event.data?.level || 1,\n        total_xp: event.data?.total_xp || 0,\n        timestamp: event.timestamp || new Date().toISOString()\n      }\n    });\n  }\n}\n\nreturn levelUpEvents.length > 0 ? levelUpEvents : [];"
+      },
+      "id": "notif-level-0002",
+      "name": "Filter Level Up Events",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        420,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-events",
+              "leftValue": "={{ $json.event_type }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "notif-level-0003",
+      "name": "Has Events?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        640,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE CELEBRATION EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Level emojis based on level\nconst levelEmojis = {\n  5: '⭐',\n  10: '🌟',\n  15: '💫',\n  20: '🏆',\n  25: '👑',\n  30: '🎖️',\n  50: '🏅',\n  100: '💎'\n};\n\n// Find appropriate emoji\nlet emoji = '🎉';\nfor (const [level, e] of Object.entries(levelEmojis).sort((a, b) => b[0] - a[0])) {\n  if (data.new_level >= parseInt(level)) {\n    emoji = e;\n    break;\n  }\n}\n\n// Celebration messages\nconst messages = [\n  `Tu viens d'atteindre le niveau ${data.new_level} !`,\n  `Bravo ! Niveau ${data.new_level} débloqué !`,\n  `Félicitations pour ton niveau ${data.new_level} !`,\n  `Level up ! Tu es maintenant niveau ${data.new_level} !`\n];\nconst message = messages[Math.floor(Math.random() * messages.length)];\n\n// Color based on level (gradient from green to gold)\nconst colors = {\n  1: 0x57F287,   // Green\n  10: 0x3498DB,  // Blue\n  20: 0x9B59B6,  // Purple\n  30: 0xE91E63,  // Pink\n  50: 0xF1C40F,  // Gold\n  100: 0xFFD700  // Bright Gold\n};\n\nlet color = 0x57F287;\nfor (const [level, c] of Object.entries(colors).sort((a, b) => b[0] - a[0])) {\n  if (data.new_level >= parseInt(level)) {\n    color = c;\n    break;\n  }\n}\n\nconst embed = {\n  title: `${emoji} Level Up !`,\n  description: message,\n  color: color,\n  fields: [\n    {\n      name: '📊 Niveau',\n      value: `${data.old_level} → **${data.new_level}**`,\n      inline: true\n    },\n    {\n      name: '✨ XP Total',\n      value: `${data.total_xp.toLocaleString()} XP`,\n      inline: true\n    }\n  ],\n  footer: {\n    text: 'Continue comme ça ! 🚀'\n  },\n  timestamp: data.timestamp\n};\n\nreturn {\n  discord_id: data.discord_id,\n  guild_id: data.guild_id,\n  embed: embed,\n  content: `<@${data.discord_id}>`,\n  event_id: data.event_id\n};"
+      },
+      "id": "notif-level-0004",
+      "name": "Prepare Celebration Embed",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        860,
+        200
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.CHATBOT_CORE_URL }}/api/notifications/dm",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({\n  discord_id: $json.discord_id,\n  guild_id: $json.guild_id,\n  content: $json.content,\n  embed: $json.embed,\n  notification_type: 'level_up'\n}) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "notif-level-0005",
+      "name": "Send DM via Chatbot-Core",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1080,
+        200
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// LOG NOTIFICATION RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Celebration Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Level-Up notification ${success ? 'sent' : 'failed'} for user ${prepData.discord_id}`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  notification_type: 'level_up'\n};"
+      },
+      "id": "notif-level-0006",
+      "name": "Log Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1300,
+        200
+      ]
+    },
+    {
+      "parameters": {},
+      "id": "notif-level-0007",
+      "name": "No Events",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        860,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Redis Subscribe": {
+      "main": [
+        [
+          {
+            "node": "Filter Level Up Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter Level Up Events": {
+      "main": [
+        [
+          {
+            "node": "Has Events?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Events?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Celebration Embed",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Events",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Celebration Embed": {
+      "main": [
+        [
+          {
+            "node": "Send DM via Chatbot-Core",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send DM via Chatbot-Core": {
+      "main": [
+        [
+          {
+            "node": "Log Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "notification"
+    },
+    {
+      "name": "rfc-027"
+    },
+    {
+      "name": "xp"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- **NOTIF-Level-Up.json**: Célèbre les passages de niveau avec embeds dynamiques (couleurs/emojis selon niveau)
- **NOTIF-Badge-Earned.json**: Annonce les badges débloqués avec couleurs par rareté (common → mythic)
- **NOTIF-Course-Expiring.json**: Rappelle les expirations d'accès cours avec urgence (7j → 3j → 1j)
- **ALERT-Anomaly-Detected.json**: Alerte admins Discord via webhook pour anomalies de réconciliation

## Architecture (RFC-027 Option B)
```
Redis Stream Event → n8n workflow → chatbot-core API / Discord Webhook → Discord DM/Channel
```

| Workflow | Stream | Event | Destination |
|----------|--------|-------|-------------|
| NOTIF-Level-Up | `xp:events:stream` | `level:up` | DM via chatbot-core |
| NOTIF-Badge-Earned | `xp:events:stream` | `badge:earned` | DM via chatbot-core |
| NOTIF-Course-Expiring | `learning:events:stream` | `course.access.expiring` | DM via chatbot-core |
| ALERT-Anomaly-Detected | `system:events:stream` | `reconciliation.anomaly` | Admin webhook |

## Test plan
- [ ] Vérifier la connexion Redis avec les credentials existants
- [ ] Tester le filtrage d'événements avec des payloads de test
- [ ] Valider les embeds Discord (couleurs, emojis, champs)
- [ ] Confirmer l'envoi DM via chatbot-core API
- [ ] Tester le webhook admin avec anomalie critique (@here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)