### PR TITLE
feat(rfc-030): implement library architecture with Redis Streams

### DIFF
--- a/docs/rfc/RFC-029-THREE-LAYER-CONVERSATIONAL-ARCHITECTURE.md
+++ b/docs/rfc/RFC-029-THREE-LAYER-CONVERSATIONAL-ARCHITECTURE.md
@@ -1,0 +1,606 @@
+# RFC-029: Architecture Conversationnelle 3 Couches
+
+**Statut**: Draft
+**Auteur**: azy.mcp Team
+**Date**: 2026-02-05
+**Version**: 1.0.0
+
+---
+
+## Resume
+
+Cette RFC definit l'implementation des 3 couches conversationnelles dans azy.mcp :
+
+1. **NLU (Natural Language Understanding)** - Les "oreilles"
+2. **Dialog Management** - La "memoire"
+3. **NLG (Natural Language Generation)** - La "voix"
+
+azy.mcp devient le **cerveau conversationnel central** qui orchestre les interactions entre les differents clients et services.
+
+---
+
+## Motivation
+
+### Probleme actuel
+
+Les interactions actuelles sont lineaires et sans memoire :
+
+```
+User: "Cree une formation"
+Bot: "Quel nom ?"
+User: "Master Cuisine"
+Bot: "?" (contexte perdu)
+```
+
+### Solution
+
+Une architecture conversationnelle qui :
+- Comprend les intentions (NLU)
+- Maintient le contexte multi-tour (Dialog)
+- Genere des reponses naturelles (NLG)
+
+---
+
+## Architecture Globale
+
+```
+                                    CLIENTS
+                    ┌────────────────────────────────────┐
+                    │                                    │
+              ┌─────┴─────┐                        ┌─────┴─────┐
+              │  Discord  │                        │    API    │
+              │(chatbot-  │                        │  Backend  │
+              │  core)    │                        │ (FastAPI) │
+              └─────┬─────┘                        └─────┬─────┘
+                    │                                    │
+                    │ POST /process                      │ POST /process
+                    │ (MentionContext)                   │ (MCPRequest)
+                    │                                    │
+                    └──────────────┬─────────────────────┘
+                                   │
+                                   ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                            azy.mcp                                    │
+│                    (Cerveau Conversationnel)                          │
+│                                                                       │
+│  ┌─────────────────────────────────────────────────────────────────┐ │
+│  │                     1. NLU (Oreilles)                           │ │
+│  │  ┌─────────────────┐     ┌──────────────┐     ┌──────────────┐ │ │
+│  │  │ToolEvaluatorNode│────▶│ N8nLLMClient │────▶│   n8n        │ │ │
+│  │  │                 │◀────│              │◀────│ (LLM webhook)│ │ │
+│  │  └─────────────────┘     └──────────────┘     └──────────────┘ │ │
+│  │           │                                                     │ │
+│  │           ▼                                                     │ │
+│  │  ┌─────────────────┐     ┌──────────────────────────────────┐  │ │
+│  │  │ EntityExtractor │     │ Tool Registry (from chatbot-core)│  │ │
+│  │  └─────────────────┘     └──────────────────────────────────┘  │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+│                                   │                                   │
+│                                   ▼                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐ │
+│  │                  2. Dialog Management (Memoire)                 │ │
+│  │  ┌───────────────────┐   ┌─────────────────┐                   │ │
+│  │  │OrchestrationState │   │ GapAnalyzerNode │                   │ │
+│  │  │ - session_id      │   │ "Donnees        │                   │ │
+│  │  │ - conversation[]  │   │  manquantes?"   │                   │ │
+│  │  │ - resolved_data{} │   └────────┬────────┘                   │ │
+│  │  │ - current_phase   │            │                            │ │
+│  │  └───────────────────┘            ▼                            │ │
+│  │                         ┌─────────────────────┐                │ │
+│  │                         │ ClarificationNode   │                │ │
+│  │                         │ "Quelle date ?"     │                │ │
+│  │                         └─────────────────────┘                │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+│                                   │                                   │
+│                                   ▼                                   │
+│  ┌─────────────────────────────────────────────────────────────────┐ │
+│  │                      3. NLG (Voix)                              │ │
+│  │  ┌──────────────────┐      ┌──────────────┐                    │ │
+│  │  │ResponseFormatter │      │ N8nLLMClient │                    │ │
+│  │  │ - Discord format │      │ (generation) │───▶ n8n ───▶ LLM   │ │
+│  │  │ - API format     │      └──────────────┘                    │ │
+│  │  └──────────────────┘                                          │ │
+│  └─────────────────────────────────────────────────────────────────┘ │
+│                                                                       │
+└───────────────────────────────────┬───────────────────────────────────┘
+                                    │
+                                    ▼
+                              MCPResponse
+                                    │
+                    ┌───────────────┴───────────────┐
+                    │                               │
+                    ▼                               ▼
+             MentionResult                    JSON Response
+             (→ Discord)                      (→ API Backend)
+```
+
+---
+
+## Flux de donnees
+
+### Clients → azy.mcp
+
+| Client | Appelle | Format |
+|--------|---------|--------|
+| chatbot-core (Discord) | POST /process | MentionContext → MCPRequest |
+| API Backend | POST /process | MCPRequest |
+
+### azy.mcp → Services
+
+| Service | Usage | Format |
+|---------|-------|--------|
+| n8n | Appels LLM (intent, generation) | HTTP webhook |
+| API Backend | Donnees CRUD | REST API |
+| chatbot-core tools | Actions Discord | Via client retour |
+
+```
+                    ┌─────────────┐
+                    │   azy.mcp   │
+                    └──────┬──────┘
+                           │
+           ┌───────────────┼───────────────┐
+           │               │               │
+           ▼               ▼               ▼
+    ┌─────────────┐ ┌─────────────┐ ┌─────────────┐
+    │     n8n     │ │ API Backend │ │ chatbot-core│
+    │  (LLM)      │ │  (Data)     │ │  (Discord)  │
+    └─────────────┘ └─────────────┘ └─────────────┘
+```
+
+---
+
+## Web Frontend
+
+Le frontend web ne contacte **jamais** azy.mcp directement.
+
+```
+┌──────────────┐      ┌─────────────┐      ┌─────────────┐
+│ Web Frontend │─────▶│ API Backend │─────▶│   azy.mcp   │
+│ (React/Vue)  │      │  (FastAPI)  │      │             │
+└──────────────┘      └─────────────┘      └─────────────┘
+       │                     │
+       │   REST API          │  Conversationnel
+       │   (CRUD)            │  (si AI needed)
+       ▼                     ▼
+    /api/formations      POST /process
+    /api/users           (MCPRequest)
+```
+
+**Exemples de flux :**
+
+| Action Frontend | API Backend | azy.mcp ? |
+|-----------------|-------------|-----------|
+| Lister formations | GET /api/formations | Non (CRUD simple) |
+| Creer formation (formulaire) | POST /api/formations | Non (donnees completes) |
+| Chat avec assistant | POST /api/chat | Oui (conversationnel) |
+| Recherche intelligente | POST /api/search | Oui (NLU needed) |
+
+---
+
+## Les 3 Couches en Detail
+
+### 1. NLU (Natural Language Understanding)
+
+**Role** : Comprendre ce que l'utilisateur veut
+
+**Composants** :
+- `ToolEvaluatorNode` : Selection du tool approprie
+- `EntityExtractor` : Extraction des entites (dates, noms, etc.)
+- `N8nLLMClient` : Appels LLM via n8n
+
+**Flux** :
+
+```python
+# Input
+user_message = "Je veux creer une formation Master Cuisine pour septembre"
+
+# NLU Output
+{
+    "intent": "CREATE_FORMATION",
+    "confidence": 0.95,
+    "entities": {
+        "formation_name": "Master Cuisine",
+        "date_hint": "septembre"
+    },
+    "selected_tool": "mcp-formations.create"
+}
+```
+
+**Integration n8n** :
+
+```python
+class N8nLLMClient:
+    """Client pour appeler les LLM via n8n webhooks."""
+
+    def __init__(self, base_url: str = "http://n8n:5678"):
+        self.base_url = base_url
+
+    async def analyze_intent(
+        self,
+        message: str,
+        tools: list[dict],
+        context: dict | None = None
+    ) -> dict:
+        """Analyse l'intention via n8n → LLM."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.base_url}/webhook/llm-intent",
+                json={
+                    "message": message,
+                    "available_tools": tools,
+                    "context": context,
+                }
+            )
+            return response.json()
+```
+
+---
+
+### 2. Dialog Management
+
+**Role** : Maintenir le contexte et gerer le multi-tour
+
+**Composants** :
+- `OrchestrationState` : Etat de la conversation
+- `GapAnalyzerNode` : Detection des donnees manquantes
+- `ClarificationNode` : Generation des questions
+
+**OrchestrationState** :
+
+```python
+@dataclass
+class OrchestrationState:
+    # Session
+    session_id: str
+    current_phase: str  # "nlu", "clarification", "execution", "response"
+
+    # Conversation history
+    conversation_history: list[dict]  # [{role, content, timestamp}]
+
+    # Intent & Tool
+    detected_intentions: list[DetectedIntention]
+    selected_tool: str | None
+
+    # Data collection (multi-turn)
+    required_fields: list[str]      # ["name", "date", "capacity"]
+    resolved_data: dict[str, Any]   # {"name": "Master Cuisine"}
+    pending_questions: list[dict]   # Questions a poser
+
+    # Response
+    llm_response: str | None
+    error: str | None
+```
+
+**Exemple multi-tour** :
+
+```
+Turn 1:
+  User: "Cree une formation"
+  State: {
+    intent: CREATE_FORMATION,
+    required_fields: ["name", "date", "capacity"],
+    resolved_data: {},
+    pending_questions: ["Quel nom ?", "Quelle date ?", "Capacite ?"]
+  }
+  Response: "Quel nom pour cette formation ?"
+
+Turn 2:
+  User: "Master Cuisine"
+  State: {
+    resolved_data: {"name": "Master Cuisine"},
+    pending_questions: ["Quelle date ?", "Capacite ?"]
+  }
+  Response: "Quelle date de debut ?"
+
+Turn 3:
+  User: "1er septembre, 20 places"
+  State: {
+    resolved_data: {
+      "name": "Master Cuisine",
+      "date": "2026-09-01",
+      "capacity": 20
+    },
+    pending_questions: []  # Complet !
+  }
+  Response: "Je cree la formation Master Cuisine (20 places) debutant le 1er sept."
+```
+
+---
+
+### 3. NLG (Natural Language Generation)
+
+**Role** : Generer des reponses naturelles et adaptees au canal
+
+**Composants** :
+- `ResponseFormatter` : Formatage par canal (Issue #578)
+- `N8nLLMClient` : Generation de texte via LLM
+
+**ResponseFormatter** :
+
+```python
+class ResponseFormatter:
+    def format(self, state: OrchestrationState, channel: Channel) -> FormattedResponse:
+        if state.pending_questions:
+            return self._format_clarification(state, channel)
+        elif state.error:
+            return self._format_error(state, channel)
+        else:
+            return self._format_response(state, channel)
+```
+
+**Formatage par canal** :
+
+| Canal | Format |
+|-------|--------|
+| Discord | Embeds, boutons, emojis |
+| API | JSON structure |
+| Web | Markdown, HTML-safe |
+
+---
+
+## Tool Registry
+
+Les tools viennent de **chatbot-core** (installe comme dependance).
+
+```python
+# azy.mcp importe les tools depuis chatbot-core
+from chatbot_core.services import N8nClient
+
+# Ou depuis un module dedie si disponible
+# from chatbot_core.tools import DISCORD_TOOLS, FORMATION_TOOLS
+```
+
+**Tools disponibles** :
+
+| Source | Prefix | Exemples |
+|--------|--------|----------|
+| chatbot-core | mcp-discord.* | create_channel, assign_role, send_message |
+| API Backend | mcp-formations.* | create, list, update, delete |
+| API Backend | mcp-users.* | get_profile, update_preferences |
+
+**Structure d'un tool** :
+
+```python
+TOOL_REGISTRY = {
+    "mcp-discord.create_channel": {
+        "name": "mcp-discord.create_channel",
+        "description": "Cree un channel Discord dans une categorie",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "guild_id": {"type": "string", "description": "ID du serveur"},
+                "category_id": {"type": "string", "description": "ID de la categorie"},
+                "name": {"type": "string", "description": "Nom du channel"},
+                "type": {"type": "string", "enum": ["text", "voice"]}
+            },
+            "required": ["guild_id", "category_id", "name"]
+        },
+        "provider": "chatbot-core"  # Qui execute le tool
+    },
+    "mcp-formations.create": {
+        "name": "mcp-formations.create",
+        "description": "Cree une nouvelle formation",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "start_date": {"type": "string", "format": "date"},
+                "capacity": {"type": "integer"}
+            },
+            "required": ["name", "start_date"]
+        },
+        "provider": "api-backend"
+    }
+}
+```
+
+---
+
+## Integration avec MentionService
+
+chatbot-core configure `MentionService` pour appeler azy.mcp :
+
+```python
+# Dans plugin-recipes ou chatbot-core config
+from chatbot_core.services import MentionConfig, MentionService
+
+config = MentionConfig(
+    # azy.mcp au lieu de n8n directement
+    callback_url="http://azy.mcp:8000/process",
+
+    # Autres configs
+    rate_limit_enabled=True,
+    typing_indicator=True,
+    memory_enabled=True,
+)
+
+service = MentionService(bot, config)
+```
+
+**Adaptation du payload** :
+
+```python
+# MentionContext → MCPRequest
+class MCPRequestAdapter:
+    @staticmethod
+    def from_mention_context(ctx: MentionContext) -> MCPRequest:
+        return MCPRequest(
+            message=ctx.content,
+            channel="discord",
+            session_id=ctx.conversation_id,
+            user_id=ctx.user_id,
+            conversation_history=ctx.previous_messages,
+        )
+```
+
+**Adaptation de la reponse** :
+
+```python
+# MCPResponse → MentionResult
+class MentionResultAdapter:
+    @staticmethod
+    def from_mcp_response(resp: MCPResponse) -> MentionResult:
+        return MentionResult(
+            success=resp.success,
+            response=resp.content,
+            intent=resp.detected_intentions[0] if resp.detected_intentions else None,
+            confidence=resp.confidence,
+            conversation_id=resp.session_id,
+            # embed si response_type == "list" ou special formatting
+        )
+```
+
+---
+
+## Composants a implementer
+
+### Existants (deja faits)
+
+| Composant | Issue | Status |
+|-----------|-------|--------|
+| OrchestrationState | - | Done |
+| OrchestrationGraph | - | Done |
+| GapAnalyzerNode | - | Done |
+| ClarificationNode | - | Done |
+| ResponseFormatter | #578 | Done |
+| /process endpoint | #579 | Done |
+
+### A creer
+
+| Composant | Description | Priorite |
+|-----------|-------------|----------|
+| `N8nLLMClient` | Client HTTP pour appeler n8n/LLM | P0 |
+| `ToolRegistry` | Import tools depuis chatbot-core | P0 |
+| `MCPRequestAdapter` | MentionContext → MCPRequest | P1 |
+| `MentionResultAdapter` | MCPResponse → MentionResult | P1 |
+| Workflows n8n | `/webhook/llm-intent`, `/webhook/llm-generate` | P0 |
+
+---
+
+## Workflows n8n requis
+
+### 1. Intent Analysis
+
+```
+POST /webhook/llm-intent
+
+Request:
+{
+  "message": "Je veux creer une formation",
+  "available_tools": [...],
+  "context": {...}
+}
+
+Response:
+{
+  "intent": "CREATE_FORMATION",
+  "confidence": 0.95,
+  "selected_tool": "mcp-formations.create",
+  "entities": {"formation_name": null}
+}
+```
+
+### 2. Response Generation
+
+```
+POST /webhook/llm-generate
+
+Request:
+{
+  "context": {
+    "intent": "CREATE_FORMATION",
+    "resolved_data": {"name": "Master Cuisine"},
+    "pending_questions": ["date"]
+  },
+  "tone": "friendly"
+}
+
+Response:
+{
+  "response": "Super ! Quelle sera la date de debut de Master Cuisine ?"
+}
+```
+
+---
+
+## Plan d'implementation
+
+### Phase 1 : Infrastructure (Sprint 1)
+
+| Tache | Responsable | Dependance |
+|-------|-------------|------------|
+| Creer `N8nLLMClient` | azy.mcp | - |
+| Creer workflows n8n (intent, generate) | n8n | - |
+| Importer tool registry chatbot-core | azy.mcp | chatbot-core 0.7.3 |
+
+### Phase 2 : Integration NLU (Sprint 1)
+
+| Tache | Responsable | Dependance |
+|-------|-------------|------------|
+| Integrer N8nLLMClient dans ToolEvaluatorNode | azy.mcp | Phase 1 |
+| Tests unitaires NLU | azy.mcp | Phase 1 |
+
+### Phase 3 : Integration Discord (Sprint 2)
+
+| Tache | Responsable | Dependance |
+|-------|-------------|------------|
+| MCPRequestAdapter | azy.mcp | - |
+| MentionResultAdapter | azy.mcp | - |
+| Configurer MentionService → azy.mcp | plugin-recipes | Phase 2 |
+
+### Phase 4 : Tests E2E (Sprint 2)
+
+| Tache | Responsable | Dependance |
+|-------|-------------|------------|
+| Tests dialogue multi-tour | azy.mcp | Phase 3 |
+| Tests cross-canal (Discord + API) | All | Phase 3 |
+
+---
+
+## Metriques de succes
+
+| Metrique | Objectif |
+|----------|----------|
+| Dialogues multi-tour completes | > 80% sans erreur |
+| Temps de reponse moyen | < 3s |
+| Taux de clarifications utiles | > 70% repondues |
+| Satisfaction utilisateur | Feedback positif |
+
+---
+
+## Questions ouvertes
+
+### 1. Persistence des sessions
+
+**Question** : Ou stocker les sessions multi-tour ?
+
+| Option | Avantages | Inconvenients |
+|--------|-----------|---------------|
+| Redis | Rapide, TTL natif | Volatil |
+| PostgreSQL | Persistant, queryable | Plus lent |
+| Hybride | Best of both | Complexite |
+
+**Recommandation** : Redis pour v1 (sessions courtes), PostgreSQL pour historique long terme.
+
+### 2. Timeout des clarifications
+
+**Question** : Combien de temps attendre une reponse utilisateur ?
+
+**Proposition** : 5 minutes (configurable), avec message de rappel a 3 min.
+
+### 3. Fallback si n8n indisponible
+
+**Question** : Que faire si n8n ne repond pas ?
+
+**Proposition** :
+- Message d'erreur gracieux
+- Log pour alerting
+- Pas de fallback LLM direct (eviter les couts imprevus)
+
+---
+
+## Changelog
+
+| Date | Version | Modification |
+|------|---------|--------------|
+| 2026-02-05 | 1.0.0 | Creation initiale |

--- a/docs/rfc/RFC-030-LIBRARY-ARCHITECTURE.md
+++ b/docs/rfc/RFC-030-LIBRARY-ARCHITECTURE.md
@@ -1,0 +1,645 @@
+# RFC-030: Architecture Librairies Conversationnelles
+
+**Statut**: Draft
+**Auteur**: Équipe n8n (avec input azy.mcp)
+**Date**: 2026-02-05
+**Version**: 1.0.0
+**Remplace**: RFC-029
+
+---
+
+## Résumé
+
+Cette RFC redéfinit l'architecture conversationnelle en transformant **azy.mcp** en **librairie** plutôt qu'en service HTTP. **chatbot-core** reste une librairie Python comme il l'a toujours été. Cela simplifie l'architecture, réduit la latence, et permet une réutilisation par différents consommateurs.
+
+---
+
+## Motivation
+
+### Problèmes de RFC-029
+
+RFC-029 proposait azy.mcp comme service HTTP :
+
+```
+User → plugin → azy.mcp (HTTP) → n8n (HTTP) → LLM → retour
+         │           │              │
+         └───────────┴──────────────┘
+              4 hops, ~1-2s latence
+```
+
+**Problèmes identifiés :**
+- Latence excessive (4 network hops)
+- n8n inadapté pour LLM temps réel
+- Complexité opérationnelle (3 services à déployer)
+- azy.mcp comme service = single point of failure
+
+### Solution
+
+Transformer azy.mcp en **librairie Python** importable par :
+- `plugin-recipes` (Discord)
+- `api-backend` (FastAPI)
+- Tout futur consommateur
+
+```
+User → plugin (avec azy.mcp intégré) → LLM → retour
+         │
+         └── 1 hop, ~0.5s latence
+```
+
+---
+
+## Architecture
+
+### Vue d'ensemble
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              LIBRAIRIES                                      │
+│                                                                              │
+│   ┌─────────────────────────┐         ┌─────────────────────────┐           │
+│   │      chatbot-core       │         │        azy.mcp          │           │
+│   │      (librairie)        │         │       (librairie)       │           │
+│   │                         │         │                         │           │
+│   │  • Discord.py wrapper   │         │  • NLU (intentions)     │           │
+│   │  • DiscordTools         │         │  • Dialog Management    │           │
+│   │  • Event handlers       │         │  • NLG (réponses)       │           │
+│   │  • Permissions          │         │  • Session management   │           │
+│   └─────────────────────────┘         └─────────────────────────┘           │
+│              │                                   │                           │
+└──────────────┼───────────────────────────────────┼───────────────────────────┘
+               │                                   │
+               │ import                            │ import
+               ▼                                   ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            APPLICATIONS                                      │
+│                                                                              │
+│   ┌─────────────────────────┐         ┌─────────────────────────┐           │
+│   │    plugin-recipes       │         │     api-backend         │           │
+│   │    (Discord bot)        │         │     (FastAPI)           │           │
+│   │                         │         │                         │           │
+│   │  from chatbot_core ...  │         │  from azy_mcp import    │           │
+│   │  from azy_mcp import    │         │    ConversationManager  │           │
+│   │    ConversationManager  │         │                         │           │
+│   └─────────────────────────┘         └─────────────────────────┘           │
+│              │                                   │                           │
+└──────────────┼───────────────────────────────────┼───────────────────────────┘
+               │                                   │
+               │ direct call                       │ direct call
+               ▼                                   ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            SERVICES EXTERNES                                 │
+│                                                                              │
+│   ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐   │
+│   │     LLM      │  │    Redis     │  │  PostgreSQL  │  │     n8n      │   │
+│   │ (Claude API) │  │  (sessions)  │  │   (data)     │  │  (webhooks,  │   │
+│   │              │  │              │  │              │  │   crons)     │   │
+│   └──────────────┘  └──────────────┘  └──────────────┘  └──────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Les 2 Librairies
+
+### 1. chatbot-core (existant)
+
+**Rôle** : Abstraction Discord
+
+```python
+# Ce que chatbot-core fournit
+from chatbot_core import Bot, DiscordTools, MentionService
+from chatbot_core.tools import DISCORD_TOOLS  # Schémas des tools
+
+# Usage dans plugin-recipes
+bot = Bot(config)
+tools = DiscordTools(bot)
+
+# Exécuter une action Discord
+await tools.create_channel(guild_id="123", name="cuisine", category_id="456")
+await tools.assign_role(guild_id="123", user_id="789", role_id="abc")
+```
+
+**Contenu** :
+- `Bot` : Wrapper discord.py
+- `DiscordTools` : Actions Discord (channels, rôles, messages)
+- `MentionService` : Gestion des mentions
+- `DISCORD_TOOLS` : Schémas JSON des tools disponibles
+
+---
+
+### 2. azy.mcp (nouveau paradigme)
+
+**Rôle** : Intelligence conversationnelle (NLU + Dialog + NLG)
+
+```python
+# Ce que azy.mcp fournit
+from azy_mcp import ConversationManager, LLMClient
+from azy_mcp.nlu import IntentDetector, EntityExtractor
+from azy_mcp.dialog import SessionManager, GapAnalyzer
+from azy_mcp.nlg import ResponseGenerator
+
+# Configuration
+llm = LLMClient(
+    provider="anthropic",
+    model="claude-sonnet-4-20250514",
+    api_key=os.getenv("ANTHROPIC_API_KEY")
+)
+
+session_store = RedisSessionStore(redis_url="redis://localhost:6379")
+
+manager = ConversationManager(
+    llm=llm,
+    session_store=session_store,
+    tools=AVAILABLE_TOOLS  # Schémas passés dynamiquement
+)
+```
+
+**Contenu** :
+
+| Module | Classe | Responsabilité |
+|--------|--------|----------------|
+| `azy_mcp` | `ConversationManager` | Orchestrateur principal |
+| `azy_mcp.llm` | `LLMClient` | Appels LLM (Claude, OpenAI, etc.) |
+| `azy_mcp.nlu` | `IntentDetector` | Détection d'intentions |
+| `azy_mcp.nlu` | `EntityExtractor` | Extraction d'entités |
+| `azy_mcp.dialog` | `SessionManager` | Gestion sessions multi-tour |
+| `azy_mcp.dialog` | `GapAnalyzer` | Détection données manquantes |
+| `azy_mcp.nlg` | `ResponseGenerator` | Génération réponses naturelles |
+
+---
+
+## Usage par les Applications
+
+### plugin-recipes (Discord)
+
+```python
+# plugin_recipes/bot.py
+from chatbot_core import Bot, DiscordTools, DISCORD_TOOLS
+from azy_mcp import ConversationManager, LLMClient
+from azy_mcp.session import RedisSessionStore
+
+class RecipesBot:
+    def __init__(self):
+        # Discord
+        self.bot = Bot(config)
+        self.discord_tools = DiscordTools(self.bot)
+
+        # Conversationnel
+        self.conversation = ConversationManager(
+            llm=LLMClient(provider="anthropic", api_key=API_KEY),
+            session_store=RedisSessionStore(REDIS_URL),
+            tools=[
+                *DISCORD_TOOLS,           # Tools Discord
+                *FORMATION_TOOLS,         # Tools métier
+            ]
+        )
+
+    async def on_mention(self, message):
+        """Quand le bot est mentionné."""
+        # 1. Obtenir la décision conversationnelle
+        result = await self.conversation.process(
+            message=message.content,
+            session_id=f"{message.guild.id}:{message.author.id}",
+            context={
+                "guild_id": str(message.guild.id),
+                "user_id": str(message.author.id),
+                "channel_id": str(message.channel.id),
+            }
+        )
+
+        # 2. Exécuter l'action si nécessaire
+        if result.action:
+            if result.action.tool.startswith("mcp-discord."):
+                # Action Discord → exécuter localement
+                await self.discord_tools.execute(
+                    result.action.tool,
+                    result.action.params
+                )
+            elif result.action.tool.startswith("mcp-formations."):
+                # Action métier → appeler API
+                await self.api_client.execute(
+                    result.action.tool,
+                    result.action.params
+                )
+
+        # 3. Répondre à l'utilisateur
+        await message.reply(result.response)
+```
+
+### api-backend (FastAPI)
+
+```python
+# api_backend/routers/chat.py
+from fastapi import APIRouter, Depends
+from azy_mcp import ConversationManager, LLMClient
+from azy_mcp.session import RedisSessionStore
+
+router = APIRouter()
+
+# Conversation manager partagé
+conversation = ConversationManager(
+    llm=LLMClient(provider="anthropic", api_key=API_KEY),
+    session_store=RedisSessionStore(REDIS_URL),
+    tools=FORMATION_TOOLS  # Seulement tools métier, pas Discord
+)
+
+@router.post("/api/chat")
+async def chat(request: ChatRequest, user: User = Depends(get_current_user)):
+    """Endpoint conversationnel pour le web."""
+
+    result = await conversation.process(
+        message=request.message,
+        session_id=f"web:{user.id}",
+        context={"user_id": user.id, "channel": "web"}
+    )
+
+    # Exécuter l'action si nécessaire
+    if result.action:
+        action_result = await execute_action(result.action)
+        result.action_result = action_result
+
+    return ChatResponse(
+        response=result.response,
+        action=result.action,
+        session_id=result.session_id
+    )
+
+@router.post("/api/formations")
+async def create_formation(data: FormationCreate):
+    """CRUD classique - pas de conversation."""
+    return await formation_service.create(data)
+```
+
+---
+
+## Flux de Données
+
+### Discord : Conversation complète
+
+```
+User: "@bot crée un channel cuisine"
+              │
+              ▼
+┌─────────────────────────────────────────────────────────┐
+│                    plugin-recipes                        │
+│                                                          │
+│  1. on_mention() reçoit le message                      │
+│              │                                           │
+│              ▼                                           │
+│  2. conversation.process(message, session_id, context)  │
+│              │                                           │
+│              │  ┌─────────────────────────────────┐     │
+│              └─▶│         azy.mcp (lib)           │     │
+│                 │                                 │     │
+│                 │  NLU: intent=CREATE_CHANNEL    │     │
+│                 │  Dialog: params complets?      │──────────▶ LLM (Claude)
+│                 │  NLG: "Je crée #cuisine"       │◀──────────
+│                 │                                 │     │
+│                 │  return Decision(              │     │
+│                 │    tool="mcp-discord.create",  │     │
+│                 │    params={name:"cuisine"},    │     │
+│                 │    response="Je crée..."       │     │
+│                 │  )                             │     │
+│                 └─────────────────────────────────┘     │
+│              │                                           │
+│              ▼                                           │
+│  3. discord_tools.execute("create_channel", params)     │
+│              │                                           │
+│              ▼                                           │
+│  4. message.reply("Je crée #cuisine")                   │
+└─────────────────────────────────────────────────────────┘
+              │
+              ▼
+User: voit "#cuisine" créé + message de confirmation
+```
+
+### Web : Chat avec assistant
+
+```
+User (web): "Quelles formations sont disponibles ?"
+              │
+              ▼
+┌─────────────────────────────────────────────────────────┐
+│                    api-backend                           │
+│                                                          │
+│  POST /api/chat                                         │
+│              │                                           │
+│              ▼                                           │
+│  conversation.process(message, session_id, context)     │
+│              │                                           │
+│              │  ┌─────────────────────────────────┐     │
+│              └─▶│         azy.mcp (lib)           │     │
+│                 │                                 │     │
+│                 │  NLU: intent=LIST_FORMATIONS   │     │
+│                 │  Dialog: pas de params requis  │──────────▶ LLM (Claude)
+│                 │  NLG: "Voici les formations"   │◀──────────
+│                 │                                 │     │
+│                 │  return Decision(              │     │
+│                 │    tool="mcp-formations.list", │     │
+│                 │    response="Voici..."         │     │
+│                 │  )                             │     │
+│                 └─────────────────────────────────┘     │
+│              │                                           │
+│              ▼                                           │
+│  execute_action() → query database                      │
+│              │                                           │
+│              ▼                                           │
+│  return ChatResponse(formations=[...], response="...")  │
+└─────────────────────────────────────────────────────────┘
+              │
+              ▼
+User (web): voit la liste des formations
+```
+
+### Web : CRUD simple (pas de conversation)
+
+```
+Admin (web): Formulaire "Nouvelle Formation"
+              │
+              ▼
+┌─────────────────────────────────────────────────────────┐
+│                    api-backend                           │
+│                                                          │
+│  POST /api/formations                                   │
+│  {name: "Master Cuisine", date: "2026-09-01"}          │
+│              │                                           │
+│              ▼                                           │
+│  formation_service.create(data)  ← Pas d'azy.mcp !     │
+│              │                                           │
+│              ▼                                           │
+│  Redis: publish("formation:events:stream", event)       │
+│              │                                           │
+│              ▼                                           │
+│  return {id: "uuid", name: "Master Cuisine", ...}       │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Rôle de n8n
+
+**n8n reste focalisé sur l'asynchrone et le background.**
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              n8n - DOMAINE                                   │
+│                                                                              │
+│   ┌─────────────────────────────────────────────────────────────────────┐   │
+│   │                     WEBHOOKS EXTERNES                                │   │
+│   │                                                                      │   │
+│   │   Stripe ──────▶ Stripe-Webhook-Handler.json ──────▶ API            │   │
+│   │   GitHub ──────▶ (futur)                                            │   │
+│   └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                              │
+│   ┌─────────────────────────────────────────────────────────────────────┐   │
+│   │                     JOBS PLANIFIÉS                                   │   │
+│   │                                                                      │   │
+│   │   Cron ────────▶ SUBSCRIPTION-Reconciliation.json ──────▶ API       │   │
+│   │   Cron ────────▶ COURSE-Expiration-Cron.json ──────▶ Redis          │   │
+│   └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                              │
+│   ┌─────────────────────────────────────────────────────────────────────┐   │
+│   │                     NOTIFICATIONS                                    │   │
+│   │                                                                      │   │
+│   │   Redis ───────▶ NOTIF-Level-Up.json ──────▶ Discord DM             │   │
+│   │   Redis ───────▶ NOTIF-Badge-Earned.json ──────▶ Discord DM         │   │
+│   │   Redis ───────▶ NOTIF-Course-Expiring.json ──────▶ Discord DM      │   │
+│   │   Redis ───────▶ ALERT-Anomaly-Detected.json ──────▶ Webhook Admin  │   │
+│   └─────────────────────────────────────────────────────────────────────┘   │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**n8n ne fait PAS :**
+- ❌ Proxy LLM temps réel
+- ❌ Middleware conversationnel
+- ❌ `/webhook/llm-intent` ou `/webhook/llm-generate`
+
+---
+
+## Comparaison RFC-029 vs RFC-030
+
+| Aspect | RFC-029 (Service) | RFC-030 (Librairie) |
+|--------|-------------------|---------------------|
+| Architecture | 4 services runtime | 3 services runtime |
+| Latence conversation | ~1-2s (4 hops) | ~0.5s (1 hop) |
+| n8n pour LLM | Oui (inadapté) | Non |
+| azy.mcp | Service HTTP | Package Python |
+| chatbot-core | Package Python | Package Python (inchangé) |
+| Multi-frontend | Via HTTP | Via import |
+| Déploiement | 4 containers (+DB) | 3 containers (+DB) |
+| Complexité | Élevée | Modérée |
+
+### Composants runtime
+
+**RFC-029 (4 services + DB) :**
+```
+1. plugin-recipes (Discord)
+2. azy.mcp (HTTP service)      ← Supprimé en RFC-030
+3. n8n (LLM proxy + webhooks)
+4. api-backend (FastAPI)
++ Redis + PostgreSQL
+```
+
+**RFC-030 (3 services + DB) :**
+```
+1. plugin-recipes (Discord + azy.mcp lib)
+2. api-backend (FastAPI + azy.mcp lib)
+3. n8n (webhooks + crons seulement)
++ Redis + PostgreSQL
+```
+
+---
+
+## Structure des Packages
+
+### azy.mcp (PyPI)
+
+```
+azy_mcp/
+├── __init__.py
+├── conversation.py      # ConversationManager
+├── llm/
+│   ├── __init__.py
+│   ├── client.py        # LLMClient (abstraction)
+│   ├── anthropic.py     # Claude provider
+│   └── openai.py        # OpenAI provider
+├── nlu/
+│   ├── __init__.py
+│   ├── intent.py        # IntentDetector
+│   └── entities.py      # EntityExtractor
+├── dialog/
+│   ├── __init__.py
+│   ├── session.py       # SessionManager
+│   ├── state.py         # OrchestrationState
+│   └── gap.py           # GapAnalyzer
+├── nlg/
+│   ├── __init__.py
+│   └── generator.py     # ResponseGenerator
+└── session/
+    ├── __init__.py
+    ├── base.py          # SessionStore (abstract)
+    ├── redis.py         # RedisSessionStore
+    └── memory.py        # InMemorySessionStore (tests)
+```
+
+### chatbot-core (PyPI)
+
+```
+chatbot_core/
+├── __init__.py
+├── bot.py               # Bot wrapper
+├── tools/
+│   ├── __init__.py
+│   ├── discord.py       # DiscordTools
+│   └── schemas.py       # DISCORD_TOOLS (JSON schemas)
+├── services/
+│   ├── __init__.py
+│   └── mention.py       # MentionService
+└── utils/
+    └── ...
+```
+
+---
+
+## API de ConversationManager
+
+```python
+class ConversationManager:
+    """Orchestrateur conversationnel principal."""
+
+    def __init__(
+        self,
+        llm: LLMClient,
+        session_store: SessionStore,
+        tools: list[dict],  # Schémas JSON des tools disponibles
+        config: ConversationConfig | None = None
+    ):
+        self.llm = llm
+        self.session_store = session_store
+        self.tools = tools
+        self.config = config or ConversationConfig()
+
+        # Sous-composants
+        self.intent_detector = IntentDetector(llm, tools)
+        self.entity_extractor = EntityExtractor(llm)
+        self.gap_analyzer = GapAnalyzer()
+        self.response_generator = ResponseGenerator(llm)
+
+    async def process(
+        self,
+        message: str,
+        session_id: str,
+        context: dict | None = None
+    ) -> ConversationResult:
+        """
+        Traite un message et retourne la décision.
+
+        Returns:
+            ConversationResult avec:
+            - response: str (texte à afficher)
+            - action: Action | None (tool à exécuter)
+            - session_id: str
+            - needs_clarification: bool
+        """
+        # 1. Charger/créer session
+        session = await self.session_store.get_or_create(session_id)
+        session.add_message("user", message)
+
+        # 2. NLU - Comprendre l'intention
+        intent = await self.intent_detector.detect(
+            message=message,
+            context=context,
+            history=session.history
+        )
+
+        # 3. Dialog - Vérifier données manquantes
+        if intent.selected_tool:
+            gaps = self.gap_analyzer.analyze(
+                tool_schema=self.get_tool_schema(intent.selected_tool),
+                extracted_entities=intent.entities,
+                session_data=session.resolved_data
+            )
+
+            if gaps:
+                # Données manquantes → clarification
+                clarification = await self.response_generator.generate_clarification(
+                    gaps=gaps,
+                    context=context
+                )
+                session.pending_questions = gaps
+                await self.session_store.save(session)
+
+                return ConversationResult(
+                    response=clarification,
+                    action=None,
+                    session_id=session_id,
+                    needs_clarification=True
+                )
+
+        # 4. NLG - Générer réponse
+        response = await self.response_generator.generate(
+            intent=intent,
+            context=context,
+            session=session
+        )
+
+        # 5. Construire action si tool sélectionné
+        action = None
+        if intent.selected_tool and not gaps:
+            action = Action(
+                tool=intent.selected_tool,
+                params={**session.resolved_data, **intent.entities}
+            )
+
+        # 6. Sauvegarder session
+        session.add_message("assistant", response)
+        await self.session_store.save(session)
+
+        return ConversationResult(
+            response=response,
+            action=action,
+            session_id=session_id,
+            needs_clarification=False
+        )
+```
+
+---
+
+## Migration depuis RFC-029
+
+### Ce qui change
+
+| Composant | RFC-029 | RFC-030 |
+|-----------|---------|---------|
+| azy.mcp | Service HTTP autonome | Package Python |
+| Appel LLM | Via n8n webhook | Direct (LLMClient) |
+| Sessions | Dans azy.mcp service | RedisSessionStore |
+| Tools | Importés de chatbot-core | Passés dynamiquement |
+
+### Plan de migration
+
+1. **Créer package azy_mcp** avec structure ci-dessus
+2. **Intégrer dans plugin-recipes** comme dépendance
+3. **Intégrer dans api-backend** pour `/api/chat`
+4. **Supprimer** service HTTP azy.mcp
+5. **Supprimer** workflows n8n `/webhook/llm-*`
+
+---
+
+## Questions résolues
+
+| Question RFC-029 | Réponse RFC-030 |
+|------------------|-----------------|
+| Où stocker sessions ? | `RedisSessionStore` dans azy_mcp |
+| n8n pour LLM ? | Non, `LLMClient` direct |
+| Multi-frontend ? | Import de la même lib |
+| Latence ? | Minimisée (pas de HTTP entre composants) |
+
+---
+
+## Changelog
+
+| Date | Version | Modification |
+|------|---------|--------------|
+| 2026-02-05 | 1.0.0 | Création initiale |

--- a/workflows/ALERT-Anomaly-Detected.json
+++ b/workflows/ALERT-Anomaly-Detected.json
@@ -4,8 +4,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## ALERT - Anomaly Detected\n\n**Trigger:** Redis event `reconciliation.anomaly`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie une alerte au channel admin Discord\nquand une anomalie est détectée lors de\nla réconciliation (Stripe, cours, etc.).\n\n**Stream:** `system:events:stream`\n**Destination:** Webhook Admin Discord",
-        "height": 280,
+        "content": "## ALERT - Anomaly Detected\n\n**Trigger:** Redis event `reconciliation.anomaly`\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPublie une alerte admin sur le stream Redis\nquand une anomalie est détectée.\n\n**Input Stream:** `system:events:stream`\n**Output Stream:** `notifications:stream`\n**Redis DB:** REDIS_DB_NOTIFICATION (5)\n\n**Type:** `webhook` (pour admin channel)",
+        "height": 300,
         "width": 320,
         "color": 1
       },
@@ -89,10 +89,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// PREPARE ADMIN ALERT EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Severity colors and emojis\nconst severityConfig = {\n  critical: { color: 0xE74C3C, emoji: '🚨', label: 'CRITIQUE' },\n  error: { color: 0xE74C3C, emoji: '❌', label: 'ERREUR' },\n  warning: { color: 0xF39C12, emoji: '⚠️', label: 'ATTENTION' },\n  info: { color: 0x3498DB, emoji: 'ℹ️', label: 'INFO' }\n};\n\nconst config = severityConfig[data.severity] || severityConfig.warning;\n\n// Anomaly type labels\nconst anomalyTypeLabels = {\n  subscription_mismatch: 'Désynchronisation abonnement',\n  payment_missing: 'Paiement manquant',\n  access_without_subscription: 'Accès sans abonnement',\n  subscription_without_access: 'Abonnement sans accès',\n  duplicate_subscription: 'Abonnement dupliqué',\n  expired_access_active: 'Accès expiré encore actif',\n  data_inconsistency: 'Incohérence de données',\n  unknown: 'Anomalie inconnue'\n};\n\nconst anomalyLabel = anomalyTypeLabels[data.anomaly_type] || data.anomaly_type;\n\n// Build fields\nconst fields = [\n  {\n    name: '📋 Type',\n    value: anomalyLabel,\n    inline: true\n  },\n  {\n    name: '📊 Source',\n    value: data.source,\n    inline: true\n  },\n  {\n    name: '⏰ Détecté à',\n    value: new Date(data.timestamp).toLocaleString('fr-FR'),\n    inline: true\n  }\n];\n\n// Add affected user if present\nif (data.affected_discord_id) {\n  fields.push({\n    name: '👤 Utilisateur affecté',\n    value: `<@${data.affected_discord_id}>`,\n    inline: true\n  });\n}\n\n// Add expected vs actual if present\nif (data.expected_value !== undefined && data.actual_value !== undefined) {\n  fields.push({\n    name: '📌 Valeur attendue',\n    value: String(data.expected_value),\n    inline: true\n  });\n  fields.push({\n    name: '📍 Valeur actuelle',\n    value: String(data.actual_value),\n    inline: true\n  });\n}\n\n// Add details if present\nif (data.details && Object.keys(data.details).length > 0) {\n  const detailsStr = Object.entries(data.details)\n    .map(([k, v]) => `**${k}:** ${v}`)\n    .join('\\n');\n  fields.push({\n    name: '🔍 Détails',\n    value: detailsStr.substring(0, 1024),\n    inline: false\n  });\n}\n\nconst embed = {\n  title: `${config.emoji} [${config.label}] Anomalie Détectée`,\n  description: data.description,\n  color: config.color,\n  fields: fields,\n  footer: {\n    text: `Event ID: ${data.event_id}`\n  },\n  timestamp: data.timestamp\n};\n\nreturn {\n  embed: embed,\n  event_id: data.event_id,\n  severity: data.severity,\n  anomaly_type: data.anomaly_type\n};"
+        "jsCode": "// ============================================\n// PREPARE ADMIN ALERT PAYLOAD\n// ============================================\n\nconst data = $input.first().json;\n\n// Severity colors and emojis\nconst severityConfig = {\n  critical: { color: 0xE74C3C, emoji: '🚨', label: 'CRITIQUE' },\n  error: { color: 0xE74C3C, emoji: '❌', label: 'ERREUR' },\n  warning: { color: 0xF39C12, emoji: '⚠️', label: 'ATTENTION' },\n  info: { color: 0x3498DB, emoji: 'ℹ️', label: 'INFO' }\n};\n\nconst config = severityConfig[data.severity] || severityConfig.warning;\n\n// Anomaly type labels\nconst anomalyTypeLabels = {\n  subscription_mismatch: 'Désynchronisation abonnement',\n  payment_missing: 'Paiement manquant',\n  access_without_subscription: 'Accès sans abonnement',\n  subscription_without_access: 'Abonnement sans accès',\n  duplicate_subscription: 'Abonnement dupliqué',\n  expired_access_active: 'Accès expiré encore actif',\n  data_inconsistency: 'Incohérence de données',\n  unknown: 'Anomalie inconnue'\n};\n\nconst anomalyLabel = anomalyTypeLabels[data.anomaly_type] || data.anomaly_type;\n\n// Build fields\nconst fields = [\n  {\n    name: '📋 Type',\n    value: anomalyLabel,\n    inline: true\n  },\n  {\n    name: '📊 Source',\n    value: data.source,\n    inline: true\n  },\n  {\n    name: '⏰ Détecté à',\n    value: new Date(data.timestamp).toLocaleString('fr-FR'),\n    inline: true\n  }\n];\n\n// Add affected user if present\nif (data.affected_discord_id) {\n  fields.push({\n    name: '👤 Utilisateur affecté',\n    value: `<@${data.affected_discord_id}>`,\n    inline: true\n  });\n}\n\n// Add expected vs actual if present\nif (data.expected_value !== undefined && data.actual_value !== undefined) {\n  fields.push({\n    name: '📌 Valeur attendue',\n    value: String(data.expected_value),\n    inline: true\n  });\n  fields.push({\n    name: '📍 Valeur actuelle',\n    value: String(data.actual_value),\n    inline: true\n  });\n}\n\n// Add details if present\nif (data.details && Object.keys(data.details).length > 0) {\n  const detailsStr = Object.entries(data.details)\n    .map(([k, v]) => `**${k}:** ${v}`)\n    .join('\\n');\n  fields.push({\n    name: '🔍 Détails',\n    value: detailsStr.substring(0, 1024),\n    inline: false\n  });\n}\n\nconst embed = {\n  title: `${config.emoji} [${config.label}] Anomalie Détectée`,\n  description: data.description,\n  color: config.color,\n  fields: fields,\n  footer: {\n    text: `Event ID: ${data.event_id}`\n  },\n  timestamp: data.timestamp\n};\n\n// RFC-030: Format pour notifications:stream\nreturn {\n  type: 'webhook',  // Pour admin channel, pas DM\n  guild_id: data.guild_id,\n  target: 'admin',  // Indique que c'est pour le channel admin\n  content: data.severity === 'critical' ? '@here' : null,\n  embed: embed,\n  notification_type: 'admin_alert',\n  severity: data.severity,\n  anomaly_type: data.anomaly_type,\n  source: 'n8n:ALERT-Anomaly-Detected',\n  event_id: data.event_id,\n  timestamp: new Date().toISOString()\n};"
       },
       "id": "alert-anomaly-0004",
-      "name": "Prepare Alert Embed",
+      "name": "Prepare Notification Payload",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -102,37 +102,76 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.DISCORD_ADMIN_WEBHOOK_URL }}",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
+        "operation": "xAdd",
+        "key": "notifications:stream",
+        "fieldsUi": {
+          "fieldValues": [
             {
-              "name": "Content-Type",
-              "value": "application/json"
+              "fieldName": "type",
+              "fieldValue": "={{ $json.type }}"
+            },
+            {
+              "fieldName": "guild_id",
+              "fieldValue": "={{ $json.guild_id }}"
+            },
+            {
+              "fieldName": "target",
+              "fieldValue": "={{ $json.target }}"
+            },
+            {
+              "fieldName": "content",
+              "fieldValue": "={{ $json.content }}"
+            },
+            {
+              "fieldName": "embed",
+              "fieldValue": "={{ JSON.stringify($json.embed) }}"
+            },
+            {
+              "fieldName": "notification_type",
+              "fieldValue": "={{ $json.notification_type }}"
+            },
+            {
+              "fieldName": "severity",
+              "fieldValue": "={{ $json.severity }}"
+            },
+            {
+              "fieldName": "anomaly_type",
+              "fieldValue": "={{ $json.anomaly_type }}"
+            },
+            {
+              "fieldName": "source",
+              "fieldValue": "={{ $json.source }}"
+            },
+            {
+              "fieldName": "event_id",
+              "fieldValue": "={{ $json.event_id }}"
+            },
+            {
+              "fieldName": "timestamp",
+              "fieldValue": "={{ $json.timestamp }}"
             }
           ]
         },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({\n  content: $json.severity === 'critical' ? '@here' : null,\n  embeds: [$json.embed]\n}) }}",
-        "options": {
-          "timeout": 10000
-        }
+        "options": {}
       },
       "id": "alert-anomaly-0005",
-      "name": "Send to Admin Webhook",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
+      "name": "Publish to notifications:stream",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
       "position": [
         1080,
         200
       ],
-      "onError": "continueRegularOutput"
+      "credentials": {
+        "redis": {
+          "id": "notifications-redis",
+          "name": "Redis Notifications (DB 5)"
+        }
+      }
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// LOG ALERT RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Alert Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Admin alert ${success ? 'sent' : 'failed'} - ${prepData.anomaly_type} (severity: ${prepData.severity})`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  anomaly_type: prepData.anomaly_type,\n  severity: prepData.severity,\n  alert_type: 'admin_anomaly'\n};"
+        "jsCode": "// ============================================\n// LOG ALERT PUBLISHED\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Notification Payload').first().json;\n\nconsole.log(`Admin alert published to stream - ${prepData.anomaly_type} (severity: ${prepData.severity})`);\n\nreturn {\n  success: true,\n  event_id: prepData.event_id,\n  anomaly_type: prepData.anomaly_type,\n  severity: prepData.severity,\n  notification_type: 'admin_alert',\n  stream: 'notifications:stream'\n};"
       },
       "id": "alert-anomaly-0006",
       "name": "Log Result",
@@ -182,7 +221,7 @@
       "main": [
         [
           {
-            "node": "Prepare Alert Embed",
+            "node": "Prepare Notification Payload",
             "type": "main",
             "index": 0
           }
@@ -196,18 +235,18 @@
         ]
       ]
     },
-    "Prepare Alert Embed": {
+    "Prepare Notification Payload": {
       "main": [
         [
           {
-            "node": "Send to Admin Webhook",
+            "node": "Publish to notifications:stream",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send to Admin Webhook": {
+    "Publish to notifications:stream": {
       "main": [
         [
           {
@@ -228,7 +267,7 @@
       "name": "alert"
     },
     {
-      "name": "rfc-027"
+      "name": "rfc-030"
     },
     {
       "name": "admin"

--- a/workflows/MCP-Tools-Notify.json
+++ b/workflows/MCP-Tools-Notify.json
@@ -1,0 +1,161 @@
+{
+  "name": "MCP---Tools-Notify",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Tools Notify\n\n**Endpoint:** POST /webhook/mcp/tools/notify\n\n**Source:** RFC-030\n\n**Description:**\nNotifie les plugins via Redis Stream\nquand un workflow MCP-* est modifié.\n\n**Input:** {action, workflow_name}\n**Output:** XADD tools:events:stream\n**Redis DB:** REDIS_DB_NOTIFICATION (5)",
+        "height": 300,
+        "width": 320,
+        "color": 4
+      },
+      "id": "mcp-notify-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "mcp/tools/notify",
+        "options": {}
+      },
+      "id": "mcp-notify-0001",
+      "name": "Webhook POST",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        200,
+        300
+      ],
+      "webhookId": "mcp-tools-notify"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE NOTIFICATION PAYLOAD\n// ============================================\n\nconst input = $input.first().json;\n\n// Validate input\nconst action = input.action || 'workflow_updated';\nconst workflowName = input.workflow_name || input.name || 'unknown';\n\n// Valid actions\nconst validActions = ['workflow_added', 'workflow_modified', 'workflow_deleted', 'workflow_updated'];\nif (!validActions.includes(action)) {\n  throw new Error(`Invalid action: ${action}. Valid: ${validActions.join(', ')}`);\n}\n\nreturn {\n  event: 'tools_updated',\n  action: action,\n  workflow_name: workflowName,\n  source: 'n8n:MCP-Tools-Notify',\n  timestamp: new Date().toISOString()\n};"
+      },
+      "id": "mcp-notify-0002",
+      "name": "Prepare Payload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        420,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "operation": "xAdd",
+        "key": "tools:events:stream",
+        "fieldsUi": {
+          "fieldValues": [
+            {
+              "fieldName": "event",
+              "fieldValue": "={{ $json.event }}"
+            },
+            {
+              "fieldName": "action",
+              "fieldValue": "={{ $json.action }}"
+            },
+            {
+              "fieldName": "workflow_name",
+              "fieldValue": "={{ $json.workflow_name }}"
+            },
+            {
+              "fieldName": "source",
+              "fieldValue": "={{ $json.source }}"
+            },
+            {
+              "fieldName": "timestamp",
+              "fieldValue": "={{ $json.timestamp }}"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "mcp-notify-0003",
+      "name": "XADD tools:events:stream",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [
+        640,
+        300
+      ],
+      "credentials": {
+        "redis": {
+          "id": "notifications-redis",
+          "name": "Redis Notifications (DB 5)"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: true, event: $('Prepare Payload').first().json.event, action: $('Prepare Payload').first().json.action, workflow_name: $('Prepare Payload').first().json.workflow_name, stream: 'tools:events:stream' }) }}",
+        "options": {}
+      },
+      "id": "mcp-notify-0004",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        860,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook POST": {
+      "main": [
+        [
+          {
+            "node": "Prepare Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Payload": {
+      "main": [
+        [
+          {
+            "node": "XADD tools:events:stream",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "XADD tools:events:stream": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "mcp"
+    },
+    {
+      "name": "rfc-030"
+    },
+    {
+      "name": "notification"
+    }
+  ]
+}

--- a/workflows/MCP-Tools-Registry.json
+++ b/workflows/MCP-Tools-Registry.json
@@ -1,0 +1,143 @@
+{
+  "name": "MCP---Tools-Registry",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Tools Registry\n\n**Endpoint:** GET /webhook/mcp/tools/registry\n\n**Source:** RFC-030\n\n**Description:**\nRetourne la liste de tous les workflows MCP-*\navec leurs schemas pour intégration azy.mcp.\n\n**Appelé par:** Plugins au startup + après notification\n\n**Output:** JSON avec liste des tools",
+        "height": 300,
+        "width": 320,
+        "color": 4
+      },
+      "id": "mcp-registry-0000",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        60
+      ]
+    },
+    {
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "mcp/tools/registry",
+        "options": {}
+      },
+      "id": "mcp-registry-0001",
+      "name": "Webhook GET",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        200,
+        300
+      ],
+      "webhookId": "mcp-tools-registry"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.N8N_API_URL }}/workflows",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": false
+            }
+          }
+        }
+      },
+      "id": "mcp-registry-0002",
+      "name": "Fetch All Workflows",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        420,
+        300
+      ],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "n8n-api-key",
+          "name": "n8n API Key"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FILTER MCP-* WORKFLOWS AND BUILD REGISTRY\n// ============================================\n\nconst response = $input.first().json;\nconst workflows = response.data || response;\n\n// Filter MCP-* workflows only\nconst mcpWorkflows = workflows.filter(wf => \n  wf.name && wf.name.startsWith('MCP-') && wf.active\n);\n\n// Build tools registry\nconst tools = mcpWorkflows.map(wf => {\n  // Extract tool info from workflow name\n  // MCP-Transcriber → mcp_transcribe\n  // MCP-Image-Generator → mcp_image_generator\n  const toolName = 'mcp_' + wf.name\n    .replace('MCP-', '')\n    .replace(/-/g, '_')\n    .toLowerCase();\n  \n  // Try to extract description from sticky note or first node\n  let description = `Workflow ${wf.name}`;\n  let parameters = {};\n  let metadata = {\n    webhook_path: `/webhook/mcp/${wf.name.replace('MCP-', '').toLowerCase()}`,\n    async: false,\n    timeout_seconds: 30,\n    workflow_id: wf.id,\n    workflow_name: wf.name\n  };\n  \n  // Check if workflow has nodes with documentation\n  if (wf.nodes && Array.isArray(wf.nodes)) {\n    // Find sticky note with documentation\n    const stickyNote = wf.nodes.find(n => \n      n.type === 'n8n-nodes-base.stickyNote' && \n      n.parameters?.content\n    );\n    \n    if (stickyNote) {\n      const content = stickyNote.parameters.content;\n      // Extract description from sticky note\n      const descMatch = content.match(/\\*\\*Description:\\*\\*\\s*([^\\n]+)/i);\n      if (descMatch) {\n        description = descMatch[1].trim();\n      }\n    }\n    \n    // Find webhook node to get actual path\n    const webhookNode = wf.nodes.find(n => \n      n.type === 'n8n-nodes-base.webhook'\n    );\n    \n    if (webhookNode && webhookNode.parameters?.path) {\n      metadata.webhook_path = `/webhook/${webhookNode.parameters.path}`;\n    }\n    \n    // Check for async indicators\n    if (wf.nodes.some(n => \n      n.name?.toLowerCase().includes('callback') ||\n      n.name?.toLowerCase().includes('async')\n    )) {\n      metadata.async = true;\n      metadata.timeout_seconds = 120;\n    }\n  }\n  \n  // Basic parameters schema (can be enhanced per workflow)\n  parameters = {\n    type: 'object',\n    properties: {\n      input: { type: 'string', description: 'Input data for the tool' }\n    },\n    required: []\n  };\n  \n  return {\n    name: toolName,\n    description: description,\n    parameters: parameters,\n    metadata: metadata\n  };\n});\n\n// Exclude this registry workflow and notify workflow\nconst filteredTools = tools.filter(t => \n  !t.name.includes('registry') && \n  !t.name.includes('notify') &&\n  !t.name.includes('watcher')\n);\n\nreturn {\n  version: '1.0',\n  updated_at: new Date().toISOString(),\n  count: filteredTools.length,\n  tools: filteredTools\n};"
+      },
+      "id": "mcp-registry-0003",
+      "name": "Build Tools Registry",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        640,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "options": {}
+      },
+      "id": "mcp-registry-0004",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        860,
+        300
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook GET": {
+      "main": [
+        [
+          {
+            "node": "Fetch All Workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch All Workflows": {
+      "main": [
+        [
+          {
+            "node": "Build Tools Registry",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Tools Registry": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "tags": [
+    {
+      "name": "mcp"
+    },
+    {
+      "name": "rfc-030"
+    },
+    {
+      "name": "registry"
+    }
+  ]
+}

--- a/workflows/NOTIF-Badge-Earned.json
+++ b/workflows/NOTIF-Badge-Earned.json
@@ -4,8 +4,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## NOTIF - Badge Earned\n\n**Trigger:** Redis event `badge:earned`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie une notification Discord quand\nun utilisateur débloque un badge.\n\n**Stream:** `xp:events:stream`\n**Consumer Group:** `n8n-notifications`",
-        "height": 260,
+        "content": "## NOTIF - Badge Earned\n\n**Trigger:** Redis event `badge:earned`\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPublie une notification Discord quand\nun utilisateur débloque un badge.\n\n**Input Stream:** `xp:events:stream`\n**Output Stream:** `notifications:stream`\n**Redis DB:** REDIS_DB_NOTIFICATION (5)",
+        "height": 280,
         "width": 320,
         "color": 5
       },
@@ -89,10 +89,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// PREPARE BADGE EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Rarity colors\nconst rarityColors = {\n  common: 0x95A5A6,      // Gray\n  uncommon: 0x2ECC71,    // Green\n  rare: 0x3498DB,        // Blue\n  epic: 0x9B59B6,        // Purple\n  legendary: 0xF39C12,   // Orange\n  mythic: 0xE74C3C       // Red\n};\n\nconst rarityLabels = {\n  common: 'Commun',\n  uncommon: 'Peu commun',\n  rare: 'Rare',\n  epic: 'Épique',\n  legendary: 'Légendaire',\n  mythic: 'Mythique'\n};\n\nconst color = rarityColors[data.badge_rarity] || 0x95A5A6;\nconst rarityLabel = rarityLabels[data.badge_rarity] || 'Commun';\n\nconst embed = {\n  title: `${data.badge_emoji} Nouveau Badge Débloqué !`,\n  description: `Tu as obtenu le badge **${data.badge_name}** !`,\n  color: color,\n  fields: [\n    {\n      name: '📋 Description',\n      value: data.badge_description || 'Un badge spécial !',\n      inline: false\n    },\n    {\n      name: '💎 Rareté',\n      value: rarityLabel,\n      inline: true\n    }\n  ],\n  footer: {\n    text: 'Consulte ta collection avec /progression'\n  },\n  timestamp: data.timestamp\n};\n\n// Add thumbnail if badge has an image\nif (data.badge_image_url) {\n  embed.thumbnail = { url: data.badge_image_url };\n}\n\nreturn {\n  discord_id: data.discord_id,\n  guild_id: data.guild_id,\n  embed: embed,\n  content: `<@${data.discord_id}> 🎊`,\n  event_id: data.event_id\n};"
+        "jsCode": "// ============================================\n// PREPARE BADGE EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Rarity colors\nconst rarityColors = {\n  common: 0x95A5A6,      // Gray\n  uncommon: 0x2ECC71,    // Green\n  rare: 0x3498DB,        // Blue\n  epic: 0x9B59B6,        // Purple\n  legendary: 0xF39C12,   // Orange\n  mythic: 0xE74C3C       // Red\n};\n\nconst rarityLabels = {\n  common: 'Commun',\n  uncommon: 'Peu commun',\n  rare: 'Rare',\n  epic: 'Épique',\n  legendary: 'Légendaire',\n  mythic: 'Mythique'\n};\n\nconst color = rarityColors[data.badge_rarity] || 0x95A5A6;\nconst rarityLabel = rarityLabels[data.badge_rarity] || 'Commun';\n\nconst embed = {\n  title: `${data.badge_emoji} Nouveau Badge Débloqué !`,\n  description: `Tu as obtenu le badge **${data.badge_name}** !`,\n  color: color,\n  fields: [\n    {\n      name: '📋 Description',\n      value: data.badge_description || 'Un badge spécial !',\n      inline: false\n    },\n    {\n      name: '💎 Rareté',\n      value: rarityLabel,\n      inline: true\n    }\n  ],\n  footer: {\n    text: 'Consulte ta collection avec /progression'\n  },\n  timestamp: data.timestamp\n};\n\n// Add thumbnail if badge has an image\nif (data.badge_image_url) {\n  embed.thumbnail = { url: data.badge_image_url };\n}\n\n// RFC-030: Format pour notifications:stream\nreturn {\n  type: 'dm',\n  guild_id: data.guild_id,\n  discord_id: data.discord_id,\n  content: `<@${data.discord_id}> 🎊`,\n  embed: embed,\n  notification_type: 'badge_earned',\n  source: 'n8n:NOTIF-Badge-Earned',\n  event_id: data.event_id,\n  timestamp: new Date().toISOString()\n};"
       },
       "id": "notif-badge-0004",
-      "name": "Prepare Badge Embed",
+      "name": "Prepare Notification Payload",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -102,37 +102,68 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.CHATBOT_CORE_URL }}/api/notifications/dm",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
+        "operation": "xAdd",
+        "key": "notifications:stream",
+        "fieldsUi": {
+          "fieldValues": [
             {
-              "name": "Content-Type",
-              "value": "application/json"
+              "fieldName": "type",
+              "fieldValue": "={{ $json.type }}"
+            },
+            {
+              "fieldName": "guild_id",
+              "fieldValue": "={{ $json.guild_id }}"
+            },
+            {
+              "fieldName": "discord_id",
+              "fieldValue": "={{ $json.discord_id }}"
+            },
+            {
+              "fieldName": "content",
+              "fieldValue": "={{ $json.content }}"
+            },
+            {
+              "fieldName": "embed",
+              "fieldValue": "={{ JSON.stringify($json.embed) }}"
+            },
+            {
+              "fieldName": "notification_type",
+              "fieldValue": "={{ $json.notification_type }}"
+            },
+            {
+              "fieldName": "source",
+              "fieldValue": "={{ $json.source }}"
+            },
+            {
+              "fieldName": "event_id",
+              "fieldValue": "={{ $json.event_id }}"
+            },
+            {
+              "fieldName": "timestamp",
+              "fieldValue": "={{ $json.timestamp }}"
             }
           ]
         },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({\n  discord_id: $json.discord_id,\n  guild_id: $json.guild_id,\n  content: $json.content,\n  embed: $json.embed,\n  notification_type: 'badge_earned'\n}) }}",
-        "options": {
-          "timeout": 10000
-        }
+        "options": {}
       },
       "id": "notif-badge-0005",
-      "name": "Send DM via Chatbot-Core",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
+      "name": "Publish to notifications:stream",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
       "position": [
         1080,
         200
       ],
-      "onError": "continueRegularOutput"
+      "credentials": {
+        "redis": {
+          "id": "notifications-redis",
+          "name": "Redis Notifications (DB 5)"
+        }
+      }
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// LOG NOTIFICATION RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Badge Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Badge notification ${success ? 'sent' : 'failed'} for user ${prepData.discord_id}`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  notification_type: 'badge_earned'\n};"
+        "jsCode": "// ============================================\n// LOG NOTIFICATION PUBLISHED\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Notification Payload').first().json;\n\nconsole.log(`Badge notification published to stream for user ${prepData.discord_id} in guild ${prepData.guild_id}`);\n\nreturn {\n  success: true,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  guild_id: prepData.guild_id,\n  notification_type: 'badge_earned',\n  stream: 'notifications:stream'\n};"
       },
       "id": "notif-badge-0006",
       "name": "Log Result",
@@ -182,7 +213,7 @@
       "main": [
         [
           {
-            "node": "Prepare Badge Embed",
+            "node": "Prepare Notification Payload",
             "type": "main",
             "index": 0
           }
@@ -196,18 +227,18 @@
         ]
       ]
     },
-    "Prepare Badge Embed": {
+    "Prepare Notification Payload": {
       "main": [
         [
           {
-            "node": "Send DM via Chatbot-Core",
+            "node": "Publish to notifications:stream",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send DM via Chatbot-Core": {
+    "Publish to notifications:stream": {
       "main": [
         [
           {
@@ -228,7 +259,7 @@
       "name": "notification"
     },
     {
-      "name": "rfc-027"
+      "name": "rfc-030"
     },
     {
       "name": "badge"

--- a/workflows/NOTIF-Course-Expiring.json
+++ b/workflows/NOTIF-Course-Expiring.json
@@ -4,8 +4,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## NOTIF - Course Expiring\n\n**Trigger:** Redis event `course.access.expiring`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie un rappel Discord quand l'accès\nà un cours expire bientôt (7 jours).\n\n**Stream:** `learning:events:stream`\n**Consumer Group:** `n8n-notifications`",
-        "height": 260,
+        "content": "## NOTIF - Course Expiring\n\n**Trigger:** Redis event `course.access.expiring`\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPublie un rappel Discord quand l'accès\nà un cours expire bientôt.\n\n**Input Stream:** `learning:events:stream`\n**Output Stream:** `notifications:stream`\n**Redis DB:** REDIS_DB_NOTIFICATION (5)",
+        "height": 280,
         "width": 320,
         "color": 5
       },
@@ -89,10 +89,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// PREPARE EXPIRING REMINDER EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Format expiration date\nconst expiresAt = data.expires_at ? new Date(data.expires_at) : null;\nconst formattedDate = expiresAt \n  ? expiresAt.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })\n  : 'bientôt';\n\n// Urgency based on days remaining\nlet urgencyEmoji = '📅';\nlet urgencyColor = 0x3498DB; // Blue\nlet urgencyText = `dans ${data.days_until_expiration} jours`;\n\nif (data.days_until_expiration <= 1) {\n  urgencyEmoji = '🚨';\n  urgencyColor = 0xE74C3C; // Red\n  urgencyText = 'DEMAIN';\n} else if (data.days_until_expiration <= 3) {\n  urgencyEmoji = '⚠️';\n  urgencyColor = 0xF39C12; // Orange\n  urgencyText = `dans ${data.days_until_expiration} jours`;\n}\n\nconst embed = {\n  title: `${urgencyEmoji} Ton accès expire ${urgencyText}`,\n  description: `Ton accès au cours **${data.course_name}** arrive à expiration.`,\n  color: urgencyColor,\n  fields: [\n    {\n      name: '📚 Cours',\n      value: data.course_name,\n      inline: true\n    },\n    {\n      name: '📆 Date d\\'expiration',\n      value: formattedDate,\n      inline: true\n    },\n    {\n      name: '💡 Que faire ?',\n      value: 'Renouvelle ton accès pour continuer à apprendre !\\nUtilise `/cours` pour voir les options.',\n      inline: false\n    }\n  ],\n  footer: {\n    text: 'Ne perds pas ta progression !'\n  },\n  timestamp: data.timestamp\n};\n\nreturn {\n  discord_id: data.discord_id,\n  guild_id: data.guild_id,\n  embed: embed,\n  content: `<@${data.discord_id}>`,\n  event_id: data.event_id,\n  urgency: data.days_until_expiration <= 1 ? 'critical' : (data.days_until_expiration <= 3 ? 'warning' : 'info')\n};"
+        "jsCode": "// ============================================\n// PREPARE EXPIRING REMINDER EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Format expiration date\nconst expiresAt = data.expires_at ? new Date(data.expires_at) : null;\nconst formattedDate = expiresAt \n  ? expiresAt.toLocaleDateString('fr-FR', { day: 'numeric', month: 'long', year: 'numeric' })\n  : 'bientôt';\n\n// Urgency based on days remaining\nlet urgencyEmoji = '📅';\nlet urgencyColor = 0x3498DB; // Blue\nlet urgencyText = `dans ${data.days_until_expiration} jours`;\n\nif (data.days_until_expiration <= 1) {\n  urgencyEmoji = '🚨';\n  urgencyColor = 0xE74C3C; // Red\n  urgencyText = 'DEMAIN';\n} else if (data.days_until_expiration <= 3) {\n  urgencyEmoji = '⚠️';\n  urgencyColor = 0xF39C12; // Orange\n  urgencyText = `dans ${data.days_until_expiration} jours`;\n}\n\nconst embed = {\n  title: `${urgencyEmoji} Ton accès expire ${urgencyText}`,\n  description: `Ton accès au cours **${data.course_name}** arrive à expiration.`,\n  color: urgencyColor,\n  fields: [\n    {\n      name: '📚 Cours',\n      value: data.course_name,\n      inline: true\n    },\n    {\n      name: '📆 Date d\\'expiration',\n      value: formattedDate,\n      inline: true\n    },\n    {\n      name: '💡 Que faire ?',\n      value: 'Renouvelle ton accès pour continuer à apprendre !\\nUtilise `/cours` pour voir les options.',\n      inline: false\n    }\n  ],\n  footer: {\n    text: 'Ne perds pas ta progression !'\n  },\n  timestamp: data.timestamp\n};\n\nconst urgency = data.days_until_expiration <= 1 ? 'critical' : (data.days_until_expiration <= 3 ? 'warning' : 'info');\n\n// RFC-030: Format pour notifications:stream\nreturn {\n  type: 'dm',\n  guild_id: data.guild_id,\n  discord_id: data.discord_id,\n  content: `<@${data.discord_id}>`,\n  embed: embed,\n  notification_type: 'course_expiring',\n  urgency: urgency,\n  source: 'n8n:NOTIF-Course-Expiring',\n  event_id: data.event_id,\n  timestamp: new Date().toISOString()\n};"
       },
       "id": "notif-course-0004",
-      "name": "Prepare Reminder Embed",
+      "name": "Prepare Notification Payload",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -102,37 +102,72 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.CHATBOT_CORE_URL }}/api/notifications/dm",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
+        "operation": "xAdd",
+        "key": "notifications:stream",
+        "fieldsUi": {
+          "fieldValues": [
             {
-              "name": "Content-Type",
-              "value": "application/json"
+              "fieldName": "type",
+              "fieldValue": "={{ $json.type }}"
+            },
+            {
+              "fieldName": "guild_id",
+              "fieldValue": "={{ $json.guild_id }}"
+            },
+            {
+              "fieldName": "discord_id",
+              "fieldValue": "={{ $json.discord_id }}"
+            },
+            {
+              "fieldName": "content",
+              "fieldValue": "={{ $json.content }}"
+            },
+            {
+              "fieldName": "embed",
+              "fieldValue": "={{ JSON.stringify($json.embed) }}"
+            },
+            {
+              "fieldName": "notification_type",
+              "fieldValue": "={{ $json.notification_type }}"
+            },
+            {
+              "fieldName": "urgency",
+              "fieldValue": "={{ $json.urgency }}"
+            },
+            {
+              "fieldName": "source",
+              "fieldValue": "={{ $json.source }}"
+            },
+            {
+              "fieldName": "event_id",
+              "fieldValue": "={{ $json.event_id }}"
+            },
+            {
+              "fieldName": "timestamp",
+              "fieldValue": "={{ $json.timestamp }}"
             }
           ]
         },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({\n  discord_id: $json.discord_id,\n  guild_id: $json.guild_id,\n  content: $json.content,\n  embed: $json.embed,\n  notification_type: 'course_expiring',\n  urgency: $json.urgency\n}) }}",
-        "options": {
-          "timeout": 10000
-        }
+        "options": {}
       },
       "id": "notif-course-0005",
-      "name": "Send DM via Chatbot-Core",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
+      "name": "Publish to notifications:stream",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
       "position": [
         1080,
         200
       ],
-      "onError": "continueRegularOutput"
+      "credentials": {
+        "redis": {
+          "id": "notifications-redis",
+          "name": "Redis Notifications (DB 5)"
+        }
+      }
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// LOG NOTIFICATION RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Reminder Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Course expiring notification ${success ? 'sent' : 'failed'} for user ${prepData.discord_id} (urgency: ${prepData.urgency})`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  notification_type: 'course_expiring',\n  urgency: prepData.urgency\n};"
+        "jsCode": "// ============================================\n// LOG NOTIFICATION PUBLISHED\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Notification Payload').first().json;\n\nconsole.log(`Course expiring notification published to stream for user ${prepData.discord_id} (urgency: ${prepData.urgency})`);\n\nreturn {\n  success: true,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  guild_id: prepData.guild_id,\n  notification_type: 'course_expiring',\n  urgency: prepData.urgency,\n  stream: 'notifications:stream'\n};"
       },
       "id": "notif-course-0006",
       "name": "Log Result",
@@ -182,7 +217,7 @@
       "main": [
         [
           {
-            "node": "Prepare Reminder Embed",
+            "node": "Prepare Notification Payload",
             "type": "main",
             "index": 0
           }
@@ -196,18 +231,18 @@
         ]
       ]
     },
-    "Prepare Reminder Embed": {
+    "Prepare Notification Payload": {
       "main": [
         [
           {
-            "node": "Send DM via Chatbot-Core",
+            "node": "Publish to notifications:stream",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send DM via Chatbot-Core": {
+    "Publish to notifications:stream": {
       "main": [
         [
           {
@@ -228,7 +263,7 @@
       "name": "notification"
     },
     {
-      "name": "rfc-027"
+      "name": "rfc-030"
     },
     {
       "name": "course"

--- a/workflows/NOTIF-Level-Up.json
+++ b/workflows/NOTIF-Level-Up.json
@@ -4,8 +4,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## NOTIF - Level Up\n\n**Trigger:** Redis event `level:up`\n\n**Source:** RFC-027 (Option B)\n\n**Description:**\nEnvoie une notification Discord célébratoire\nquand un utilisateur monte de niveau.\n\n**Stream:** `xp:events:stream`\n**Consumer Group:** `n8n-notifications`",
-        "height": 260,
+        "content": "## NOTIF - Level Up\n\n**Trigger:** Redis event `level:up`\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPublie une notification Discord célébratoire\nsur le stream Redis notifications.\n\n**Input Stream:** `xp:events:stream`\n**Output Stream:** `notifications:stream`\n**Redis DB:** REDIS_DB_NOTIFICATION (5)",
+        "height": 280,
         "width": 320,
         "color": 5
       },
@@ -89,10 +89,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// PREPARE CELEBRATION EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Level emojis based on level\nconst levelEmojis = {\n  5: '⭐',\n  10: '🌟',\n  15: '💫',\n  20: '🏆',\n  25: '👑',\n  30: '🎖️',\n  50: '🏅',\n  100: '💎'\n};\n\n// Find appropriate emoji\nlet emoji = '🎉';\nfor (const [level, e] of Object.entries(levelEmojis).sort((a, b) => b[0] - a[0])) {\n  if (data.new_level >= parseInt(level)) {\n    emoji = e;\n    break;\n  }\n}\n\n// Celebration messages\nconst messages = [\n  `Tu viens d'atteindre le niveau ${data.new_level} !`,\n  `Bravo ! Niveau ${data.new_level} débloqué !`,\n  `Félicitations pour ton niveau ${data.new_level} !`,\n  `Level up ! Tu es maintenant niveau ${data.new_level} !`\n];\nconst message = messages[Math.floor(Math.random() * messages.length)];\n\n// Color based on level (gradient from green to gold)\nconst colors = {\n  1: 0x57F287,   // Green\n  10: 0x3498DB,  // Blue\n  20: 0x9B59B6,  // Purple\n  30: 0xE91E63,  // Pink\n  50: 0xF1C40F,  // Gold\n  100: 0xFFD700  // Bright Gold\n};\n\nlet color = 0x57F287;\nfor (const [level, c] of Object.entries(colors).sort((a, b) => b[0] - a[0])) {\n  if (data.new_level >= parseInt(level)) {\n    color = c;\n    break;\n  }\n}\n\nconst embed = {\n  title: `${emoji} Level Up !`,\n  description: message,\n  color: color,\n  fields: [\n    {\n      name: '📊 Niveau',\n      value: `${data.old_level} → **${data.new_level}**`,\n      inline: true\n    },\n    {\n      name: '✨ XP Total',\n      value: `${data.total_xp.toLocaleString()} XP`,\n      inline: true\n    }\n  ],\n  footer: {\n    text: 'Continue comme ça ! 🚀'\n  },\n  timestamp: data.timestamp\n};\n\nreturn {\n  discord_id: data.discord_id,\n  guild_id: data.guild_id,\n  embed: embed,\n  content: `<@${data.discord_id}>`,\n  event_id: data.event_id\n};"
+        "jsCode": "// ============================================\n// PREPARE CELEBRATION EMBED\n// ============================================\n\nconst data = $input.first().json;\n\n// Level emojis based on level\nconst levelEmojis = {\n  5: '⭐',\n  10: '🌟',\n  15: '💫',\n  20: '🏆',\n  25: '👑',\n  30: '🎖️',\n  50: '🏅',\n  100: '💎'\n};\n\n// Find appropriate emoji\nlet emoji = '🎉';\nfor (const [level, e] of Object.entries(levelEmojis).sort((a, b) => b[0] - a[0])) {\n  if (data.new_level >= parseInt(level)) {\n    emoji = e;\n    break;\n  }\n}\n\n// Celebration messages\nconst messages = [\n  `Tu viens d'atteindre le niveau ${data.new_level} !`,\n  `Bravo ! Niveau ${data.new_level} débloqué !`,\n  `Félicitations pour ton niveau ${data.new_level} !`,\n  `Level up ! Tu es maintenant niveau ${data.new_level} !`\n];\nconst message = messages[Math.floor(Math.random() * messages.length)];\n\n// Color based on level (gradient from green to gold)\nconst colors = {\n  1: 0x57F287,   // Green\n  10: 0x3498DB,  // Blue\n  20: 0x9B59B6,  // Purple\n  30: 0xE91E63,  // Pink\n  50: 0xF1C40F,  // Gold\n  100: 0xFFD700  // Bright Gold\n};\n\nlet color = 0x57F287;\nfor (const [level, c] of Object.entries(colors).sort((a, b) => b[0] - a[0])) {\n  if (data.new_level >= parseInt(level)) {\n    color = c;\n    break;\n  }\n}\n\nconst embed = {\n  title: `${emoji} Level Up !`,\n  description: message,\n  color: color,\n  fields: [\n    {\n      name: '📊 Niveau',\n      value: `${data.old_level} → **${data.new_level}**`,\n      inline: true\n    },\n    {\n      name: '✨ XP Total',\n      value: `${data.total_xp.toLocaleString()} XP`,\n      inline: true\n    }\n  ],\n  footer: {\n    text: 'Continue comme ça ! 🚀'\n  },\n  timestamp: data.timestamp\n};\n\n// RFC-030: Format pour notifications:stream\nreturn {\n  type: 'dm',\n  guild_id: data.guild_id,\n  discord_id: data.discord_id,\n  content: `<@${data.discord_id}>`,\n  embed: embed,\n  notification_type: 'level_up',\n  source: 'n8n:NOTIF-Level-Up',\n  event_id: data.event_id,\n  timestamp: new Date().toISOString()\n};"
       },
       "id": "notif-level-0004",
-      "name": "Prepare Celebration Embed",
+      "name": "Prepare Notification Payload",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -102,37 +102,68 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.CHATBOT_CORE_URL }}/api/notifications/dm",
-        "sendHeaders": true,
-        "headerParameters": {
-          "parameters": [
+        "operation": "xAdd",
+        "key": "notifications:stream",
+        "fieldsUi": {
+          "fieldValues": [
             {
-              "name": "Content-Type",
-              "value": "application/json"
+              "fieldName": "type",
+              "fieldValue": "={{ $json.type }}"
+            },
+            {
+              "fieldName": "guild_id",
+              "fieldValue": "={{ $json.guild_id }}"
+            },
+            {
+              "fieldName": "discord_id",
+              "fieldValue": "={{ $json.discord_id }}"
+            },
+            {
+              "fieldName": "content",
+              "fieldValue": "={{ $json.content }}"
+            },
+            {
+              "fieldName": "embed",
+              "fieldValue": "={{ JSON.stringify($json.embed) }}"
+            },
+            {
+              "fieldName": "notification_type",
+              "fieldValue": "={{ $json.notification_type }}"
+            },
+            {
+              "fieldName": "source",
+              "fieldValue": "={{ $json.source }}"
+            },
+            {
+              "fieldName": "event_id",
+              "fieldValue": "={{ $json.event_id }}"
+            },
+            {
+              "fieldName": "timestamp",
+              "fieldValue": "={{ $json.timestamp }}"
             }
           ]
         },
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({\n  discord_id: $json.discord_id,\n  guild_id: $json.guild_id,\n  content: $json.content,\n  embed: $json.embed,\n  notification_type: 'level_up'\n}) }}",
-        "options": {
-          "timeout": 10000
-        }
+        "options": {}
       },
       "id": "notif-level-0005",
-      "name": "Send DM via Chatbot-Core",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
+      "name": "Publish to notifications:stream",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
       "position": [
         1080,
         200
       ],
-      "onError": "continueRegularOutput"
+      "credentials": {
+        "redis": {
+          "id": "notifications-redis",
+          "name": "Redis Notifications (DB 5)"
+        }
+      }
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// LOG NOTIFICATION RESULT\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Celebration Embed').first().json;\n\nconst success = !response.error && response.statusCode !== 500;\n\nconsole.log(`Level-Up notification ${success ? 'sent' : 'failed'} for user ${prepData.discord_id}`);\n\nreturn {\n  success: success,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  notification_type: 'level_up'\n};"
+        "jsCode": "// ============================================\n// LOG NOTIFICATION PUBLISHED\n// ============================================\n\nconst response = $input.first().json;\nconst prepData = $('Prepare Notification Payload').first().json;\n\nconsole.log(`Level-Up notification published to stream for user ${prepData.discord_id} in guild ${prepData.guild_id}`);\n\nreturn {\n  success: true,\n  event_id: prepData.event_id,\n  discord_id: prepData.discord_id,\n  guild_id: prepData.guild_id,\n  notification_type: 'level_up',\n  stream: 'notifications:stream'\n};"
       },
       "id": "notif-level-0006",
       "name": "Log Result",
@@ -182,7 +213,7 @@
       "main": [
         [
           {
-            "node": "Prepare Celebration Embed",
+            "node": "Prepare Notification Payload",
             "type": "main",
             "index": 0
           }
@@ -196,18 +227,18 @@
         ]
       ]
     },
-    "Prepare Celebration Embed": {
+    "Prepare Notification Payload": {
       "main": [
         [
           {
-            "node": "Send DM via Chatbot-Core",
+            "node": "Publish to notifications:stream",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send DM via Chatbot-Core": {
+    "Publish to notifications:stream": {
       "main": [
         [
           {
@@ -228,7 +259,7 @@
       "name": "notification"
     },
     {
-      "name": "rfc-027"
+      "name": "rfc-030"
     },
     {
       "name": "xp"


### PR DESCRIPTION
## Summary

- **RFC-030** : Architecture où azy.mcp et chatbot-core sont des **librairies Python** (pas des services HTTP)
- **Option B** : Communication via **Redis Streams** pour les notifications
- **Tools Management** : Registry dynamique des workflows MCP-*

## Changements

### RFC-030 Document
- `docs/rfc/RFC-030-LIBRARY-ARCHITECTURE.md` : Nouvelle architecture

### Workflows notifications (mise à jour Option B)
| Workflow | Input Stream | Output Stream |
|----------|--------------|---------------|
| `NOTIF-Level-Up` | `xp:events:stream` | `notifications:stream` |
| `NOTIF-Badge-Earned` | `xp:events:stream` | `notifications:stream` |
| `NOTIF-Course-Expiring` | `learning:events:stream` | `notifications:stream` |
| `ALERT-Anomaly-Detected` | `system:events:stream` | `notifications:stream` |

### Nouveaux workflows Tools Management
| Workflow | Endpoint | Description |
|----------|----------|-------------|
| `MCP-Tools-Registry` | `GET /webhook/mcp/tools/registry` | Liste tous les MCP-* tools |
| `MCP-Tools-Notify` | `POST /webhook/mcp/tools/notify` | XADD tools:events:stream |

## Architecture

```
STARTUP:
Plugin ──GET /registry──▶ n8n ──▶ tools[]

RUNTIME (nouveau workflow):
n8n ──XADD tools:events:stream──▶ Redis
                                    │
Plugin ◀──XREAD (block)─────────────┘
   │
   └──GET /registry──▶ refresh tools

CONVERSATION:
User ──▶ Plugin ──▶ azy_mcp(tools) ──▶ Action
```

## Test plan

- [ ] Importer les workflows dans n8n
- [ ] Créer credential Redis Notifications (DB 5)
- [ ] Tester GET /webhook/mcp/tools/registry
- [ ] Tester POST /webhook/mcp/tools/notify
- [ ] Vérifier XADD sur tools:events:stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)