### PR TITLE
feat(n8n): add ALERT Intent Clarification High workflow #288

### DIFF
--- a/workflows/ALERT-Intent-Clarification-High.json
+++ b/workflows/ALERT-Intent-Clarification-High.json
@@ -1,0 +1,256 @@
+{
+  "name": "ALERT - Intent Clarification High",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## ALERT - Intent Clarification High\n\n**Issue:** #288\n**RFC:** RFC-031 (Section 13.4)\n\n**Description:**\nSurveille le taux de clarification et alerte si au-dessus du seuil (>30%).\n\n**Fréquence:** Hourly\n\n**Seuils:**\n- WARNING: >30% clarification rate\n- CRITICAL: >50% clarification rate\n\n**Actions:**\n- Log dans MongoDB `intent_alerts`\n- Notification Discord (optionnel)",
+        "height": 300,
+        "width": 360,
+        "color": 3
+      },
+      "id": "doc-note",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-200, 60]
+    },
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "cronExpression",
+              "expression": "0 * * * *"
+            }
+          ]
+        }
+      },
+      "id": "trigger-cron",
+      "name": "Every Hour",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [60, 300]
+    },
+    {
+      "parameters": {
+        "operation": "aggregate",
+        "collection": "intent_history",
+        "query": "=[\n  {\n    \"$match\": {\n      \"created_at\": {\n        \"$gte\": { \"$date\": \"{{ $now.minus({hours: 1}).toISO() }}\" }\n      }\n    }\n  },\n  {\n    \"$group\": {\n      \"_id\": null,\n      \"total\": { \"$sum\": 1 },\n      \"clarification_count\": {\n        \"$sum\": {\n          \"$cond\": [\n            { \"$eq\": [\"$validation_type\", \"clarification\"] },\n            1,\n            0\n          ]\n        }\n      },\n      \"by_domain\": {\n        \"$push\": {\n          \"domain\": \"$domain\",\n          \"needed_clarification\": {\n            \"$cond\": [\n              { \"$eq\": [\"$validation_type\", \"clarification\"] },\n              true,\n              false\n            ]\n          }\n        }\n      }\n    }\n  }\n]"
+      },
+      "id": "mongodb-aggregate",
+      "name": "MongoDB Last Hour",
+      "type": "n8n-nodes-base.mongoDb",
+      "typeVersion": 1,
+      "position": [280, 300],
+      "credentials": {
+        "mongoDb": {
+          "id": "mongodb-intent",
+          "name": "MongoDB Intent"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// CALCULATE CLARIFICATION RATE\n// ============================================\n\nconst data = $input.first().json;\n\n// Handle empty results\nif (!data || !data.total || data.total === 0) {\n  return [{\n    json: {\n      status: 'no_data',\n      message: 'No intent data in the last hour',\n      checked_at: new Date().toISOString()\n    }\n  }];\n}\n\n// Calculate rate\nconst total = data.total;\nconst clarificationCount = data.clarification_count || 0;\nconst clarificationRate = (clarificationCount / total) * 100;\n\n// Determine severity\nlet severity = 'OK';\nif (clarificationRate > 50) {\n  severity = 'CRITICAL';\n} else if (clarificationRate > 30) {\n  severity = 'WARNING';\n}\n\n// Calculate per-domain breakdown\nconst domainStats = {};\nif (data.by_domain) {\n  for (const item of data.by_domain) {\n    const domain = item.domain || 'unknown';\n    if (!domainStats[domain]) {\n      domainStats[domain] = { total: 0, clarifications: 0 };\n    }\n    domainStats[domain].total++;\n    if (item.needed_clarification) {\n      domainStats[domain].clarifications++;\n    }\n  }\n}\n\nreturn [{\n  json: {\n    total_requests: total,\n    clarification_count: clarificationCount,\n    clarification_rate: Math.round(clarificationRate * 100) / 100,\n    severity: severity,\n    threshold_warning: 30,\n    threshold_critical: 50,\n    domain_breakdown: domainStats,\n    checked_at: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "code-calc-rate",
+      "name": "Calculate Rate",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [500, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-needs-alert",
+              "leftValue": "={{ $json.severity }}",
+              "rightValue": "OK",
+              "operator": {
+                "type": "string",
+                "operation": "notEquals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-needs-alert",
+      "name": "Needs Alert?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [720, 300]
+    },
+    {
+      "parameters": {
+        "operation": "insert",
+        "collection": "intent_alerts",
+        "fields": "alert_type,severity,clarification_rate,total_requests,clarification_count,domain_breakdown,created_at"
+      },
+      "id": "mongodb-insert-alert",
+      "name": "MongoDB Log Alert",
+      "type": "n8n-nodes-base.mongoDb",
+      "typeVersion": 1,
+      "position": [940, 200],
+      "credentials": {
+        "mongoDb": {
+          "id": "mongodb-intent",
+          "name": "MongoDB Intent"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare alert data for MongoDB\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    alert_type: 'clarification_high',\n    severity: data.severity,\n    clarification_rate: data.clarification_rate,\n    total_requests: data.total_requests,\n    clarification_count: data.clarification_count,\n    domain_breakdown: JSON.stringify(data.domain_breakdown),\n    created_at: new Date()\n  }\n}];"
+      },
+      "id": "code-prepare-alert",
+      "name": "Prepare Alert",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [940, 60]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT DISCORD MESSAGE\n// ============================================\n\nconst data = $('Calculate Rate').first().json;\nconst emoji = data.severity === 'CRITICAL' ? '🚨' : '⚠️';\nconst color = data.severity === 'CRITICAL' ? 0xFF0000 : 0xFFA500;\n\n// Build domain breakdown text\nlet domainText = '';\nfor (const [domain, stats] of Object.entries(data.domain_breakdown || {})) {\n  const rate = stats.total > 0 ? ((stats.clarifications / stats.total) * 100).toFixed(1) : 0;\n  domainText += `• **${domain}**: ${rate}% (${stats.clarifications}/${stats.total})\\n`;\n}\n\nreturn [{\n  json: {\n    embeds: [{\n      title: `${emoji} Intent Clarification ${data.severity}`,\n      description: `Le taux de clarification a dépassé le seuil dans la dernière heure.`,\n      color: color,\n      fields: [\n        {\n          name: 'Taux de clarification',\n          value: `${data.clarification_rate}%`,\n          inline: true\n        },\n        {\n          name: 'Seuil',\n          value: `${data.severity === 'CRITICAL' ? '>50%' : '>30%'}`,\n          inline: true\n        },\n        {\n          name: 'Total requêtes',\n          value: `${data.total_requests}`,\n          inline: true\n        },\n        {\n          name: 'Détail par domaine',\n          value: domainText || 'Aucune donnée',\n          inline: false\n        }\n      ],\n      timestamp: new Date().toISOString()\n    }]\n  }\n}];"
+      },
+      "id": "code-format-discord",
+      "name": "Format Discord",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 200]
+    },
+    {
+      "parameters": {
+        "content": "## Discord Notification\n\nConfigurer le webhook Discord:\n1. Créer un webhook dans le channel d'alertes\n2. Ajouter les credentials dans n8n\n3. Activer le node Discord ci-dessous",
+        "height": 140,
+        "width": 280,
+        "color": 4
+      },
+      "id": "note-discord",
+      "name": "Discord Note",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [1380, 60]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.DISCORD_WEBHOOK_ALERTS }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json) }}",
+        "options": {}
+      },
+      "id": "http-discord",
+      "name": "Discord Webhook",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 200],
+      "disabled": true
+    },
+    {
+      "parameters": {},
+      "id": "noop-ok",
+      "name": "All Good",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [940, 400]
+    }
+  ],
+  "connections": {
+    "Every Hour": {
+      "main": [
+        [
+          {
+            "node": "MongoDB Last Hour",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "MongoDB Last Hour": {
+      "main": [
+        [
+          {
+            "node": "Calculate Rate",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Calculate Rate": {
+      "main": [
+        [
+          {
+            "node": "Needs Alert?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Needs Alert?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Alert",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "All Good",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Alert": {
+      "main": [
+        [
+          {
+            "node": "MongoDB Log Alert",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "MongoDB Log Alert": {
+      "main": [
+        [
+          {
+            "node": "Format Discord",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Discord": {
+      "main": [
+        [
+          {
+            "node": "Discord Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds hourly alert workflow monitoring clarification rate
- Triggers alerts when rate exceeds thresholds (>30% WARNING, >50% CRITICAL)
- Logs alerts to MongoDB and optionally notifies Discord

## Workflow Details
- **Trigger:** Every hour (0 * * * *)
- **Source:** MongoDB `intent_history` (last hour aggregation)
- **Alert Output:** MongoDB `intent_alerts`
- **Notification:** Discord webhook (disabled by default)

## Alert Thresholds
| Level | Threshold | Action |
|-------|-----------|--------|
| OK | ≤30% | No action |
| WARNING | >30% | Log + notify |
| CRITICAL | >50% | Log + notify (red alert) |

## Test plan
- [ ] Import workflow in n8n
- [ ] Configure MongoDB credentials
- [ ] Set `DISCORD_WEBHOOK_ALERTS` env var (optional)
- [ ] Enable Discord node if notifications needed
- [ ] Manual trigger test with high clarification data

🤖 Generated with [Claude Code](https://claude.com/claude-code)