### PR TITLE
refactor(n8n): use $env.API_URL instead of direct DB connections

### DIFF
--- a/docs/api/RFC031-INTENT-API-ENDPOINTS.md
+++ b/docs/api/RFC031-INTENT-API-ENDPOINTS.md
@@ -1,0 +1,450 @@
+# RFC-031 Intent API Endpoints
+
+> Documentation des endpoints API requis pour les workflows n8n RFC-031.
+
+| Metadata | |
+|----------|---------|
+| **Équipe destinataire** | api-backend |
+| **Équipe source** | n8n-workflows |
+| **RFC** | RFC-031 - Classification d'Intention Hybride |
+| **PR n8n** | #297 |
+| **Date** | 2026-02-10 |
+
+---
+
+## Contexte
+
+Les workflows n8n RFC-031 nécessitent des endpoints API pour :
+- Stocker l'historique des intent events (MongoDB)
+- Agréger et synchroniser les keywords (MongoDB → Redis)
+- Calculer et stocker les métriques (MongoDB → PostgreSQL)
+- Logger les alertes (MongoDB)
+
+**Redis reste géré en direct par n8n** pour les streams temps réel.
+
+---
+
+## Endpoints Requis
+
+### 1. POST /api/intent/history
+
+**Workflow:** `N8N-Intent-Events-Consumer`
+**Fréquence:** Every 10 seconds (batch up to 50 events)
+
+**Description:** Insère un événement d'intent classification dans MongoDB.
+
+**Request:**
+```json
+{
+  "stream_id": "1234567890-0",
+  "message": "je veux une recette de cookies",
+  "tokens": ["recette", "cookies"],
+  "domain": "recipes",
+  "was_validated": true,
+  "validation_type": "implicit",
+  "confidence_at_prediction": 0.85,
+  "user_id": "user123",
+  "guild_id": "guild456",
+  "tool_used": "recipe_search",
+  "original_timestamp": "2026-02-10T10:30:00Z"
+}
+```
+
+**Response (success):**
+```json
+{
+  "success": true,
+  "id": "mongo_object_id"
+}
+```
+
+**Response (error):**
+```json
+{
+  "error": "Database connection failed",
+  "code": 500
+}
+```
+
+**MongoDB Collection:** `intent_history`
+
+---
+
+### 2. POST /api/intent/keywords/aggregate
+
+**Workflow:** `CRON-Intent-Keywords-Sync`
+**Fréquence:** Daily 03:00 AM
+
+**Description:** Agrège les tokens validés des dernières 24h pour calculer les poids.
+
+**Request:**
+```json
+{
+  "period": "24h",
+  "min_count": 3
+}
+```
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "_id": { "domain": "recipes", "token": "recette" },
+      "count": 150,
+      "avg_confidence": 0.87
+    },
+    {
+      "_id": { "domain": "recipes", "token": "cookies" },
+      "count": 45,
+      "avg_confidence": 0.82
+    },
+    {
+      "_id": { "domain": "books", "token": "livre" },
+      "count": 78,
+      "avg_confidence": 0.91
+    }
+  ]
+}
+```
+
+**MongoDB Aggregation Pipeline:**
+```javascript
+[
+  {
+    $match: {
+      was_validated: true,
+      created_at: { $gte: ISODate("now - 24h") }
+    }
+  },
+  { $unwind: "$tokens" },
+  {
+    $group: {
+      _id: { domain: "$domain", token: "$tokens" },
+      count: { $sum: 1 },
+      avg_confidence: { $avg: "$confidence_at_prediction" }
+    }
+  },
+  { $match: { count: { $gte: 3 } } },
+  { $sort: { count: -1 } }
+]
+```
+
+---
+
+### 3. POST /api/intent/keywords/sync
+
+**Workflow:** `CRON-Intent-Keywords-Sync`
+**Fréquence:** Daily 03:00 AM (après aggregate)
+
+**Description:** Synchronise les keywords calculés vers Redis ZSET.
+
+**Request:**
+```json
+{
+  "keywords_by_domain": {
+    "recipes": [
+      { "token": "recette", "weight": 8.5 },
+      { "token": "cookies", "weight": 4.2 }
+    ],
+    "books": [
+      { "token": "livre", "weight": 7.1 }
+    ]
+  },
+  "total_domains": 2,
+  "total_keywords": 3
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "domains_updated": 2,
+  "keywords_synced": 3,
+  "redis_keys": [
+    "keywords:recipes:triggers",
+    "keywords:books:triggers"
+  ]
+}
+```
+
+**Actions Redis:**
+```
+ZADD keywords:recipes:triggers 8.5 "recette" 4.2 "cookies"
+ZADD keywords:books:triggers 7.1 "livre"
+SET keywords:version "2026-02-10T03:00:00Z"
+```
+
+---
+
+### 4. POST /api/intent/stats/aggregate
+
+**Workflow:** `CRON-Intent-Stats-Daily`
+**Fréquence:** Daily 04:00 AM
+
+**Description:** Agrège les statistiques de la veille.
+
+**Request:**
+```json
+{
+  "date": "2026-02-09"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "total_requests": 1250,
+    "validated_count": 980,
+    "clarification_count": 125,
+    "unique_users": 89,
+    "unique_guilds": 12,
+    "latency_p50": 45,
+    "latency_p95": 120,
+    "latency_p99": 250,
+    "domain_breakdown": {
+      "recipes": { "count": 800, "validated": 720 },
+      "books": { "count": 450, "validated": 260 }
+    }
+  }
+}
+```
+
+**MongoDB Aggregation:** Voir workflow pour le pipeline complet avec `$facet`.
+
+---
+
+### 5. POST /api/intent/stats/hourly
+
+**Workflow:** `ALERT-Intent-Clarification-High`
+**Fréquence:** Every hour
+
+**Description:** Statistiques de la dernière heure pour monitoring.
+
+**Request:**
+```json
+{
+  "period": "1h"
+}
+```
+
+**Response:**
+```json
+{
+  "data": {
+    "total": 85,
+    "clarification_count": 12,
+    "domain_breakdown": {
+      "recipes": { "total": 60, "clarifications": 8 },
+      "books": { "total": 25, "clarifications": 4 }
+    }
+  }
+}
+```
+
+---
+
+### 6. POST /api/intent/metrics
+
+**Workflow:** `CRON-Intent-Stats-Daily`
+**Fréquence:** Daily 04:00 AM
+
+**Description:** Sauvegarde les métriques quotidiennes (PostgreSQL).
+
+**Request:**
+```json
+{
+  "stats_date": "2026-02-09",
+  "total_requests": 1250,
+  "unique_users": 89,
+  "unique_guilds": 12,
+  "clarification_rate": 10.0,
+  "accuracy": 78.4,
+  "latency_p50": 45,
+  "latency_p95": 120,
+  "latency_p99": 250,
+  "domain_breakdown": {
+    "recipes": { "count": 800, "accuracy": 90.0 },
+    "books": { "count": 450, "accuracy": 57.8 }
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "action": "upsert",
+  "stats_date": "2026-02-09"
+}
+```
+
+**PostgreSQL Table:** `intent_metrics`
+```sql
+CREATE TABLE intent_metrics (
+  stats_date DATE PRIMARY KEY,
+  total_requests INTEGER,
+  unique_users INTEGER,
+  unique_guilds INTEGER,
+  clarification_rate NUMERIC(5,2),
+  accuracy NUMERIC(5,2),
+  latency_p50 INTEGER,
+  latency_p95 INTEGER,
+  latency_p99 INTEGER,
+  domain_breakdown JSONB,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+**SQL:** `INSERT ... ON CONFLICT (stats_date) DO UPDATE`
+
+---
+
+### 7. POST /api/intent/alerts
+
+**Workflows:** `ALERT-Intent-Clarification-High`, `ALERT-Intent-DLQ-Monitor`
+**Fréquence:** Hourly / Every 15 min
+
+**Description:** Log une alerte dans MongoDB.
+
+**Request (clarification_high):**
+```json
+{
+  "alert_type": "clarification_high",
+  "severity": "WARNING",
+  "clarification_rate": 35.5,
+  "total_requests": 85,
+  "clarification_count": 30,
+  "domain_breakdown": {
+    "recipes": { "total": 60, "clarifications": 25 }
+  }
+}
+```
+
+**Request (dlq_messages):**
+```json
+{
+  "alert_type": "dlq_messages",
+  "severity": "CRITICAL",
+  "dlq_count": 15,
+  "sample_errors": [
+    {
+      "stream_id": "1234567890-0",
+      "message": "test message",
+      "error": "MongoDB connection timeout",
+      "failed_at": "2026-02-10T10:30:00Z"
+    }
+  ]
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "id": "mongo_alert_id"
+}
+```
+
+**MongoDB Collection:** `intent_alerts`
+
+---
+
+## Résumé des endpoints
+
+| Endpoint | Method | Workflow | Fréquence | DB |
+|----------|--------|----------|-----------|-----|
+| `/api/intent/history` | POST | Events Consumer | 10s | MongoDB |
+| `/api/intent/keywords/aggregate` | POST | Keywords Sync | Daily 03:00 | MongoDB |
+| `/api/intent/keywords/sync` | POST | Keywords Sync | Daily 03:00 | Redis |
+| `/api/intent/stats/aggregate` | POST | Stats Daily | Daily 04:00 | MongoDB |
+| `/api/intent/stats/hourly` | POST | Clarification Alert | Hourly | MongoDB |
+| `/api/intent/metrics` | POST | Stats Daily | Daily 04:00 | PostgreSQL |
+| `/api/intent/alerts` | POST | Alerts | Variable | MongoDB |
+
+---
+
+## Schémas de base de données
+
+### MongoDB Collections
+
+```javascript
+// intent_history
+{
+  stream_id: String,
+  message: String,
+  tokens: [String],
+  domain: String,
+  was_validated: Boolean,
+  validation_type: String,  // "implicit" | "explicit" | "clarification"
+  confidence_at_prediction: Number,
+  user_id: String,
+  guild_id: String,
+  tool_used: String,
+  original_timestamp: String,
+  created_at: Date
+}
+
+// intent_alerts
+{
+  alert_type: String,       // "clarification_high" | "dlq_messages"
+  severity: String,         // "OK" | "WARNING" | "CRITICAL"
+  clarification_rate: Number,
+  dlq_count: Number,
+  total_requests: Number,
+  domain_breakdown: Object,
+  sample_errors: Array,
+  created_at: Date
+}
+```
+
+### PostgreSQL Table
+
+```sql
+CREATE TABLE intent_metrics (
+  stats_date DATE PRIMARY KEY,
+  total_requests INTEGER,
+  unique_users INTEGER,
+  unique_guilds INTEGER,
+  clarification_rate NUMERIC(5,2),
+  accuracy NUMERIC(5,2),
+  latency_p50 INTEGER,
+  latency_p95 INTEGER,
+  latency_p99 INTEGER,
+  domain_breakdown JSONB,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+```
+
+### Redis Keys
+
+```
+keywords:{domain}:triggers  → ZSET (token → weight)
+keywords:version            → STRING (ISO timestamp)
+intent:events               → STREAM (géré par chatbot-core)
+intent:dlq                  → STREAM (géré par n8n)
+```
+
+---
+
+## Notes d'implémentation
+
+1. **Authentification:** Les endpoints sont internes (n8n → API). Pas besoin d'auth externe, mais valider l'origine si nécessaire.
+
+2. **Timeout:** Les workflows ont des timeouts configurés (10-60s). L'API doit répondre rapidement.
+
+3. **Idempotence:**
+   - `/api/intent/history` : Utiliser `stream_id` comme clé unique
+   - `/api/intent/metrics` : UPSERT sur `stats_date`
+
+4. **Error handling:** Retourner un objet `{ error: "message" }` en cas d'erreur. Le workflow Consumer redirigera vers la DLQ.
+
+5. **Batch processing:** `/api/intent/history` reçoit 1 event à la fois, mais peut être appelé ~5 fois/seconde en pic.
+
+---
+
+## Contact
+
+Questions → équipe n8n-workflows

--- a/workflows/ALERT-Intent-Clarification-High.json
+++ b/workflows/ALERT-Intent-Clarification-High.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## ALERT - Intent Clarification High\n\n**Issue:** #288\n**RFC:** RFC-031 (Section 13.4)\n\n**Description:**\nSurveille le taux de clarification et alerte si au-dessus du seuil (>30%).\n\n**Fréquence:** Hourly\n\n**Seuils:**\n- WARNING: >30% clarification rate\n- CRITICAL: >50% clarification rate\n\n**Actions:**\n- Log dans MongoDB `intent_alerts`\n- Notification Discord (optionnel)",
+        "content": "## ALERT - Intent Clarification High\n\n**Issue:** #288\n**RFC:** RFC-031 (Section 13.4)\n\n**Description:**\nSurveille le taux de clarification via API et alerte si >30%.\n\n**Fréquence:** Hourly\n\n**Seuils:**\n- WARNING: >30% clarification rate\n- CRITICAL: >50% clarification rate\n\n**Actions:**\n- Log via API /api/intent/alerts\n- Notification Discord (optionnel)",
         "height": 300,
         "width": 360,
         "color": 3
@@ -33,25 +33,24 @@
     },
     {
       "parameters": {
-        "operation": "aggregate",
-        "collection": "intent_history",
-        "query": "=[\n  {\n    \"$match\": {\n      \"created_at\": {\n        \"$gte\": { \"$date\": \"{{ $now.minus({hours: 1}).toISO() }}\" }\n      }\n    }\n  },\n  {\n    \"$group\": {\n      \"_id\": null,\n      \"total\": { \"$sum\": 1 },\n      \"clarification_count\": {\n        \"$sum\": {\n          \"$cond\": [\n            { \"$eq\": [\"$validation_type\", \"clarification\"] },\n            1,\n            0\n          ]\n        }\n      },\n      \"by_domain\": {\n        \"$push\": {\n          \"domain\": \"$domain\",\n          \"needed_clarification\": {\n            \"$cond\": [\n              { \"$eq\": [\"$validation_type\", \"clarification\"] },\n              true,\n              false\n            ]\n          }\n        }\n      }\n    }\n  }\n]"
-      },
-      "id": "mongodb-aggregate",
-      "name": "MongoDB Last Hour",
-      "type": "n8n-nodes-base.mongoDb",
-      "typeVersion": 1,
-      "position": [280, 300],
-      "credentials": {
-        "mongoDb": {
-          "id": "mongodb-intent",
-          "name": "MongoDB Intent"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/stats/hourly",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"period\": \"1h\"\n}",
+        "options": {
+          "timeout": 30000
         }
-      }
+      },
+      "id": "http-api-stats",
+      "name": "API Last Hour Stats",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [280, 300]
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// CALCULATE CLARIFICATION RATE\n// ============================================\n\nconst data = $input.first().json;\n\n// Handle empty results\nif (!data || !data.total || data.total === 0) {\n  return [{\n    json: {\n      status: 'no_data',\n      message: 'No intent data in the last hour',\n      checked_at: new Date().toISOString()\n    }\n  }];\n}\n\n// Calculate rate\nconst total = data.total;\nconst clarificationCount = data.clarification_count || 0;\nconst clarificationRate = (clarificationCount / total) * 100;\n\n// Determine severity\nlet severity = 'OK';\nif (clarificationRate > 50) {\n  severity = 'CRITICAL';\n} else if (clarificationRate > 30) {\n  severity = 'WARNING';\n}\n\n// Calculate per-domain breakdown\nconst domainStats = {};\nif (data.by_domain) {\n  for (const item of data.by_domain) {\n    const domain = item.domain || 'unknown';\n    if (!domainStats[domain]) {\n      domainStats[domain] = { total: 0, clarifications: 0 };\n    }\n    domainStats[domain].total++;\n    if (item.needed_clarification) {\n      domainStats[domain].clarifications++;\n    }\n  }\n}\n\nreturn [{\n  json: {\n    total_requests: total,\n    clarification_count: clarificationCount,\n    clarification_rate: Math.round(clarificationRate * 100) / 100,\n    severity: severity,\n    threshold_warning: 30,\n    threshold_critical: 50,\n    domain_breakdown: domainStats,\n    checked_at: new Date().toISOString()\n  }\n}];"
+        "jsCode": "// ============================================\n// CALCULATE CLARIFICATION RATE\n// ============================================\n\nconst data = $input.first().json.data || {};\n\n// Handle empty results\nif (!data.total || data.total === 0) {\n  return [{\n    json: {\n      status: 'no_data',\n      message: 'No intent data in the last hour',\n      checked_at: new Date().toISOString()\n    }\n  }];\n}\n\n// Calculate rate\nconst total = data.total;\nconst clarificationCount = data.clarification_count || 0;\nconst clarificationRate = (clarificationCount / total) * 100;\n\n// Determine severity\nlet severity = 'OK';\nif (clarificationRate > 50) {\n  severity = 'CRITICAL';\n} else if (clarificationRate > 30) {\n  severity = 'WARNING';\n}\n\nreturn [{\n  json: {\n    total_requests: total,\n    clarification_count: clarificationCount,\n    clarification_rate: Math.round(clarificationRate * 100) / 100,\n    severity: severity,\n    threshold_warning: 30,\n    threshold_critical: 50,\n    domain_breakdown: data.domain_breakdown || {},\n    checked_at: new Date().toISOString()\n  }\n}];"
       },
       "id": "code-calc-rate",
       "name": "Calculate Rate",
@@ -90,31 +89,30 @@
     },
     {
       "parameters": {
-        "operation": "insert",
-        "collection": "intent_alerts",
-        "fields": "alert_type,severity,clarification_rate,total_requests,clarification_count,domain_breakdown,created_at"
-      },
-      "id": "mongodb-insert-alert",
-      "name": "MongoDB Log Alert",
-      "type": "n8n-nodes-base.mongoDb",
-      "typeVersion": 1,
-      "position": [940, 200],
-      "credentials": {
-        "mongoDb": {
-          "id": "mongodb-intent",
-          "name": "MongoDB Intent"
-        }
-      }
-    },
-    {
-      "parameters": {
-        "jsCode": "// Prepare alert data for MongoDB\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    alert_type: 'clarification_high',\n    severity: data.severity,\n    clarification_rate: data.clarification_rate,\n    total_requests: data.total_requests,\n    clarification_count: data.clarification_count,\n    domain_breakdown: JSON.stringify(data.domain_breakdown),\n    created_at: new Date()\n  }\n}];"
+        "jsCode": "// Prepare alert data for API\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    alert_type: 'clarification_high',\n    severity: data.severity,\n    clarification_rate: data.clarification_rate,\n    total_requests: data.total_requests,\n    clarification_count: data.clarification_count,\n    domain_breakdown: data.domain_breakdown\n  }\n}];"
       },
       "id": "code-prepare-alert",
       "name": "Prepare Alert",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [940, 60]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/alerts",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "http-api-alert",
+      "name": "API Log Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200]
     },
     {
       "parameters": {
@@ -128,7 +126,7 @@
     },
     {
       "parameters": {
-        "content": "## Discord Notification\n\nConfigurer le webhook Discord:\n1. Créer un webhook dans le channel d'alertes\n2. Ajouter les credentials dans n8n\n3. Activer le node Discord ci-dessous",
+        "content": "## Discord Notification\n\nConfigurer le webhook Discord:\n1. Créer un webhook dans le channel d'alertes\n2. Configurer DISCORD_WEBHOOK_ALERTS\n3. Activer le node Discord ci-dessous",
         "height": 140,
         "width": 280,
         "color": 4
@@ -169,14 +167,14 @@
       "main": [
         [
           {
-            "node": "MongoDB Last Hour",
+            "node": "API Last Hour Stats",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "MongoDB Last Hour": {
+    "API Last Hour Stats": {
       "main": [
         [
           {
@@ -220,14 +218,14 @@
       "main": [
         [
           {
-            "node": "MongoDB Log Alert",
+            "node": "API Log Alert",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "MongoDB Log Alert": {
+    "API Log Alert": {
       "main": [
         [
           {

--- a/workflows/ALERT-Intent-DLQ-Monitor.json
+++ b/workflows/ALERT-Intent-DLQ-Monitor.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## ALERT - Intent DLQ Monitor\n\n**Issue:** #289\n**RFC:** RFC-031 (Section 13.4, 17.4)\n\n**Description:**\nSurveille la Dead Letter Queue (DLQ) Redis `intent:dlq` et alerte si des messages échouent.\n\n**Fréquence:** Every 15 minutes\n\n**Seuils:**\n- WARNING: >0 messages in DLQ\n- CRITICAL: >10 messages in DLQ\n\n**Actions:**\n- Log dans MongoDB `intent_alerts`\n- Notification Discord\n- Optionnel: Retry automatique",
+        "content": "## ALERT - Intent DLQ Monitor\n\n**Issue:** #289\n**RFC:** RFC-031 (Section 13.4, 17.4)\n\n**Description:**\nSurveille la Dead Letter Queue (DLQ) Redis `intent:dlq` et alerte si des messages échouent.\n\n**Fréquence:** Every 15 minutes\n\n**Seuils:**\n- WARNING: >0 messages in DLQ\n- CRITICAL: >10 messages in DLQ\n\n**Actions:**\n- Log via API /api/intent/alerts\n- Notification Discord\n- Optionnel: Retry automatique",
         "height": 340,
         "width": 360,
         "color": 3
@@ -119,21 +119,20 @@
     },
     {
       "parameters": {
-        "operation": "insert",
-        "collection": "intent_alerts",
-        "fields": "alert_type,severity,dlq_count,sample_errors_json,created_at"
-      },
-      "id": "mongodb-insert-alert",
-      "name": "MongoDB Log Alert",
-      "type": "n8n-nodes-base.mongoDb",
-      "typeVersion": 1,
-      "position": [1380, 200],
-      "credentials": {
-        "mongoDb": {
-          "id": "mongodb-intent",
-          "name": "MongoDB Intent"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/alerts",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ alert_type: $json.alert_type, severity: $json.severity, dlq_count: $json.dlq_count, sample_errors: $json.sample_errors }) }}",
+        "options": {
+          "timeout": 10000
         }
-      }
+      },
+      "id": "http-api-alert",
+      "name": "API Log Alert",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 200]
     },
     {
       "parameters": {
@@ -250,14 +249,14 @@
       "main": [
         [
           {
-            "node": "MongoDB Log Alert",
+            "node": "API Log Alert",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "MongoDB Log Alert": {
+    "API Log Alert": {
       "main": [
         [
           {

--- a/workflows/CRON-Intent-Keywords-Sync.json
+++ b/workflows/CRON-Intent-Keywords-Sync.json
@@ -3,8 +3,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## CRON - Intent Keywords Sync\n\n**Issue:** #286\n**RFC:** RFC-031 (Section 6.3, 13.4)\n\n**Description:**\nAgrège les tokens validés depuis MongoDB et met à jour les poids des keywords dans Redis ZSET.\n\n**Fréquence:** Daily à 03:00 AM\n\n**Flux:**\n1. Aggregate MongoDB (dernières 24h)\n2. Calcul des poids\n3. ZADD Redis keywords:{domain}:triggers\n4. Bump version\n5. Prune si > 500 keywords/domaine",
-        "height": 320,
+        "content": "## CRON - Intent Keywords Sync\n\n**Issue:** #286\n**RFC:** RFC-031 (Section 6.2, 13.4)\n\n**Description:**\nAgrège les tokens validés et met à jour les poids des keywords via API.\n\n**Fréquence:** Daily à 03:00 AM\n\n**Calcul du poids:**\n`weight = min(10, count * avg_confidence)`\n\n**Output:** API sync keywords",
+        "height": 280,
         "width": 360,
         "color": 5
       },
@@ -33,21 +33,20 @@
     },
     {
       "parameters": {
-        "operation": "aggregate",
-        "collection": "intent_history",
-        "query": "=[\n  {\n    \"$match\": {\n      \"was_validated\": true,\n      \"created_at\": { \"$gte\": { \"$date\": \"{{ $now.minus({days: 1}).toISO() }}\" } }\n    }\n  },\n  { \"$unwind\": \"$tokens\" },\n  {\n    \"$group\": {\n      \"_id\": { \"domain\": \"$domain\", \"token\": \"$tokens\" },\n      \"count\": { \"$sum\": 1 },\n      \"avg_confidence\": { \"$avg\": \"$confidence_at_prediction\" }\n    }\n  },\n  { \"$match\": { \"count\": { \"$gte\": 3 } } },\n  { \"$sort\": { \"count\": -1 } }\n]"
-      },
-      "id": "mongodb-aggregate",
-      "name": "MongoDB Aggregate",
-      "type": "n8n-nodes-base.mongoDb",
-      "typeVersion": 1,
-      "position": [280, 300],
-      "credentials": {
-        "mongoDb": {
-          "id": "mongodb-intent",
-          "name": "MongoDB Intent"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/keywords/aggregate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"period\": \"24h\",\n  \"min_count\": 3\n}",
+        "options": {
+          "timeout": 30000
         }
-      }
+      },
+      "id": "http-api-aggregate",
+      "name": "API Aggregate Keywords",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [280, 300]
     },
     {
       "parameters": {
@@ -59,8 +58,8 @@
           },
           "conditions": [
             {
-              "id": "check-has-data",
-              "leftValue": "={{ $json.length }}",
+              "id": "check-has-results",
+              "leftValue": "={{ $json.data?.length }}",
               "rightValue": 0,
               "operator": {
                 "type": "number",
@@ -80,7 +79,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// CALCULATE KEYWORD WEIGHTS\n// ============================================\n// Transform MongoDB aggregation results into Redis ZADD commands\n\nconst items = $input.all();\nconst domainWeights = {};\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Extract domain and token from _id\n  const domain = data._id?.domain;\n  const token = data._id?.token;\n  \n  if (!domain || !token) continue;\n  \n  // Calculate weight: min(10, count * avg_confidence)\n  // This caps weights at 10 to prevent runaway values\n  const weight = Math.min(10, data.count * (data.avg_confidence || 0.5));\n  \n  // Group by domain\n  if (!domainWeights[domain]) {\n    domainWeights[domain] = [];\n  }\n  \n  domainWeights[domain].push({\n    token: token,\n    weight: Math.round(weight * 100) / 100,  // Round to 2 decimals\n    count: data.count,\n    avg_confidence: data.avg_confidence\n  });\n}\n\n// Convert to array for output\nconst results = [];\nfor (const [domain, keywords] of Object.entries(domainWeights)) {\n  results.push({\n    json: {\n      domain: domain,\n      keywords: keywords,\n      total_keywords: keywords.length\n    }\n  });\n}\n\nreturn results.length > 0 ? results : [{ json: { domain: 'none', keywords: [], total_keywords: 0 } }];"
+        "jsCode": "// ============================================\n// CALCULATE KEYWORD WEIGHTS\n// ============================================\n\nconst data = $input.first().json.data || [];\nconst keywordsByDomain = {};\n\nfor (const item of data) {\n  const domain = item._id?.domain || item.domain || 'general';\n  const token = item._id?.token || item.token;\n  const count = item.count || 0;\n  const avgConfidence = item.avg_confidence || 0.5;\n  \n  // Calculate weight: min(10, count * avg_confidence)\n  const weight = Math.min(10, count * avgConfidence);\n  \n  if (!keywordsByDomain[domain]) {\n    keywordsByDomain[domain] = [];\n  }\n  \n  keywordsByDomain[domain].push({\n    token: token,\n    weight: Math.round(weight * 100) / 100\n  });\n}\n\nreturn [{\n  json: {\n    keywords_by_domain: keywordsByDomain,\n    total_domains: Object.keys(keywordsByDomain).length,\n    total_keywords: data.length\n  }\n}];"
       },
       "id": "code-calc-weights",
       "name": "Calculate Weights",
@@ -90,67 +89,39 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// UPDATE REDIS ZSET FOR EACH DOMAIN\n// ============================================\n\nconst domain = $json.domain;\nconst keywords = $json.keywords || [];\n\nif (domain === 'none' || keywords.length === 0) {\n  return [{ json: { status: 'skipped', domain: domain, reason: 'no keywords' } }];\n}\n\n// Build ZADD arguments: [score1, member1, score2, member2, ...]\nconst zaddArgs = [];\nfor (const kw of keywords) {\n  zaddArgs.push(kw.weight);\n  zaddArgs.push(kw.token);\n}\n\nreturn [{\n  json: {\n    domain: domain,\n    redis_key: `keywords:${domain}:triggers`,\n    zadd_args: zaddArgs,\n    total_keywords: keywords.length\n  }\n}];"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/keywords/sync",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "timeout": 30000
+        }
       },
-      "id": "code-prepare-redis",
-      "name": "Prepare Redis ZADD",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
+      "id": "http-api-sync",
+      "name": "API Sync Keywords",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
       "position": [940, 200]
     },
     {
       "parameters": {
-        "operation": "zAdd",
-        "key": "={{ $json.redis_key }}",
-        "value": "={{ $json.zadd_args }}"
-      },
-      "id": "redis-zadd",
-      "name": "Redis ZADD",
-      "type": "n8n-nodes-base.redis",
-      "typeVersion": 1,
-      "position": [1160, 200],
-      "credentials": {
-        "redis": {
-          "id": "redis-intent",
-          "name": "Redis Intent"
-        }
-      }
-    },
-    {
-      "parameters": {
-        "operation": "set",
-        "key": "keywords:version",
-        "value": "={{ $now.toISO() }}",
-        "expire": false
-      },
-      "id": "redis-version",
-      "name": "Bump Version",
-      "type": "n8n-nodes-base.redis",
-      "typeVersion": 1,
-      "position": [1380, 200],
-      "credentials": {
-        "redis": {
-          "id": "redis-intent",
-          "name": "Redis Intent"
-        }
-      }
-    },
-    {
-      "parameters": {
-        "jsCode": "// ============================================\n// SUMMARY LOG\n// ============================================\n\nconst items = $input.all();\nlet totalDomains = 0;\nlet totalKeywords = 0;\n\nfor (const item of items) {\n  if (item.json.total_keywords) {\n    totalDomains++;\n    totalKeywords += item.json.total_keywords;\n  }\n}\n\nreturn [{\n  json: {\n    status: 'completed',\n    timestamp: new Date().toISOString(),\n    domains_updated: totalDomains,\n    total_keywords_synced: totalKeywords\n  }\n}];"
+        "jsCode": "// ============================================\n// LOG SUMMARY\n// ============================================\n\nconst input = $('Calculate Weights').first().json;\nconst apiResponse = $input.first().json;\n\nreturn [{\n  json: {\n    status: 'completed',\n    domains_updated: input.total_domains,\n    keywords_synced: input.total_keywords,\n    api_response: apiResponse,\n    processed_at: new Date().toISOString()\n  }\n}];"
       },
       "id": "code-summary",
       "name": "Summary",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1600, 200]
+      "position": [1160, 200]
     },
     {
-      "parameters": {},
-      "id": "noop-end",
-      "name": "No Data",
-      "type": "n8n-nodes-base.noOp",
-      "typeVersion": 1,
+      "parameters": {
+        "jsCode": "// No validated keywords found\nreturn [{\n  json: {\n    status: 'no_data',\n    message: 'No validated keywords found for sync',\n    processed_at: new Date().toISOString()\n  }\n}];"
+      },
+      "id": "code-no-data",
+      "name": "No Data Log",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [720, 400]
     }
   ],
@@ -159,14 +130,14 @@
       "main": [
         [
           {
-            "node": "MongoDB Aggregate",
+            "node": "API Aggregate Keywords",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "MongoDB Aggregate": {
+    "API Aggregate Keywords": {
       "main": [
         [
           {
@@ -188,7 +159,7 @@
         ],
         [
           {
-            "node": "No Data",
+            "node": "No Data Log",
             "type": "main",
             "index": 0
           }
@@ -199,36 +170,14 @@
       "main": [
         [
           {
-            "node": "Prepare Redis ZADD",
+            "node": "API Sync Keywords",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Prepare Redis ZADD": {
-      "main": [
-        [
-          {
-            "node": "Redis ZADD",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Redis ZADD": {
-      "main": [
-        [
-          {
-            "node": "Bump Version",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Bump Version": {
+    "API Sync Keywords": {
       "main": [
         [
           {

--- a/workflows/CRON-Intent-Stats-Daily.json
+++ b/workflows/CRON-Intent-Stats-Daily.json
@@ -3,8 +3,8 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## CRON - Intent Stats Daily\n\n**Issue:** #287\n**RFC:** RFC-031 (Section 6.3, 13.4)\n\n**Description:**\nCalcule les métriques quotidiennes du système d'intent classification et les stocke dans PostgreSQL.\n\n**Fréquence:** Daily à 04:00 AM\n\n**Métriques calculées:**\n- clarification_rate: % demandes nécessitant clarification\n- accuracy: % predictions validées\n- latency_p50, latency_p95, latency_p99\n- total_requests, unique_users\n\n**Output:** PostgreSQL `intent_metrics`",
-        "height": 380,
+        "content": "## CRON - Intent Stats Daily\n\n**Issue:** #287\n**RFC:** RFC-031 (Section 6.3, 13.4)\n\n**Description:**\nCalcule les métriques quotidiennes via API.\n\n**Fréquence:** Daily à 04:00 AM\n\n**Métriques calculées:**\n- clarification_rate, accuracy\n- latency_p50, latency_p95, latency_p99\n- total_requests, unique_users\n\n**Output:** API /api/intent/metrics",
+        "height": 340,
         "width": 360,
         "color": 5
       },
@@ -33,21 +33,20 @@
     },
     {
       "parameters": {
-        "operation": "aggregate",
-        "collection": "intent_history",
-        "query": "=[\n  {\n    \"$match\": {\n      \"created_at\": {\n        \"$gte\": { \"$date\": \"{{ $now.minus({days: 1}).startOf('day').toISO() }}\" },\n        \"$lt\": { \"$date\": \"{{ $now.startOf('day').toISO() }}\" }\n      }\n    }\n  },\n  {\n    \"$facet\": {\n      \"totals\": [\n        {\n          \"$group\": {\n            \"_id\": null,\n            \"total_requests\": { \"$sum\": 1 },\n            \"validated_count\": {\n              \"$sum\": { \"$cond\": [\"$was_validated\", 1, 0] }\n            },\n            \"clarification_count\": {\n              \"$sum\": {\n                \"$cond\": [\n                  { \"$eq\": [\"$validation_type\", \"clarification\"] },\n                  1,\n                  0\n                ]\n              }\n            },\n            \"unique_users\": { \"$addToSet\": \"$user_id\" },\n            \"unique_guilds\": { \"$addToSet\": \"$guild_id\" }\n          }\n        },\n        {\n          \"$project\": {\n            \"_id\": 0,\n            \"total_requests\": 1,\n            \"validated_count\": 1,\n            \"clarification_count\": 1,\n            \"unique_users\": { \"$size\": \"$unique_users\" },\n            \"unique_guilds\": { \"$size\": \"$unique_guilds\" }\n          }\n        }\n      ],\n      \"by_domain\": [\n        {\n          \"$group\": {\n            \"_id\": \"$domain\",\n            \"count\": { \"$sum\": 1 },\n            \"validated\": {\n              \"$sum\": { \"$cond\": [\"$was_validated\", 1, 0] }\n            }\n          }\n        }\n      ],\n      \"latencies\": [\n        { \"$match\": { \"latency_ms\": { \"$exists\": true } } },\n        { \"$sort\": { \"latency_ms\": 1 } },\n        {\n          \"$group\": {\n            \"_id\": null,\n            \"latencies\": { \"$push\": \"$latency_ms\" },\n            \"count\": { \"$sum\": 1 }\n          }\n        }\n      ]\n    }\n  }\n]"
-      },
-      "id": "mongodb-aggregate",
-      "name": "MongoDB Aggregate Stats",
-      "type": "n8n-nodes-base.mongoDb",
-      "typeVersion": 1,
-      "position": [280, 300],
-      "credentials": {
-        "mongoDb": {
-          "id": "mongodb-intent",
-          "name": "MongoDB Intent"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/stats/aggregate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\n  \"date\": \"{{ $now.minus({days: 1}).toFormat('yyyy-MM-dd') }}\"\n}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "id": "http-api-aggregate",
+      "name": "API Aggregate Stats",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [280, 300]
     },
     {
       "parameters": {
@@ -60,7 +59,7 @@
           "conditions": [
             {
               "id": "check-has-data",
-              "leftValue": "={{ $json.totals?.[0]?.total_requests }}",
+              "leftValue": "={{ $json.data?.total_requests }}",
               "rightValue": 0,
               "operator": {
                 "type": "number",
@@ -80,7 +79,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// CALCULATE METRICS\n// ============================================\n// Process MongoDB aggregation and compute final metrics\n\nconst data = $input.first().json;\nconst totals = data.totals?.[0] || {};\nconst latencies = data.latencies?.[0] || {};\nconst byDomain = data.by_domain || [];\n\n// Calculate rates\nconst totalRequests = totals.total_requests || 0;\nconst clarificationRate = totalRequests > 0 \n  ? (totals.clarification_count / totalRequests) * 100 \n  : 0;\nconst accuracy = totalRequests > 0 \n  ? (totals.validated_count / totalRequests) * 100 \n  : 0;\n\n// Calculate latency percentiles\nfunction percentile(arr, p) {\n  if (!arr || arr.length === 0) return 0;\n  const idx = Math.ceil(arr.length * p / 100) - 1;\n  return arr[Math.max(0, idx)];\n}\n\nconst latencyArray = latencies.latencies || [];\nconst p50 = percentile(latencyArray, 50);\nconst p95 = percentile(latencyArray, 95);\nconst p99 = percentile(latencyArray, 99);\n\n// Build domain breakdown\nconst domainBreakdown = {};\nfor (const d of byDomain) {\n  domainBreakdown[d._id] = {\n    count: d.count,\n    validated: d.validated,\n    accuracy: d.count > 0 ? (d.validated / d.count) * 100 : 0\n  };\n}\n\n// Calculate date for the stats (yesterday)\nconst statsDate = $now.minus({days: 1}).toFormat('yyyy-MM-dd');\n\nreturn [{\n  json: {\n    stats_date: statsDate,\n    total_requests: totalRequests,\n    unique_users: totals.unique_users || 0,\n    unique_guilds: totals.unique_guilds || 0,\n    clarification_rate: Math.round(clarificationRate * 100) / 100,\n    accuracy: Math.round(accuracy * 100) / 100,\n    latency_p50: p50,\n    latency_p95: p95,\n    latency_p99: p99,\n    domain_breakdown: JSON.stringify(domainBreakdown),\n    created_at: new Date().toISOString()\n  }\n}];"
+        "jsCode": "// ============================================\n// CALCULATE METRICS\n// ============================================\n\nconst data = $input.first().json.data || {};\n\nconst totalRequests = data.total_requests || 0;\nconst clarificationRate = totalRequests > 0 \n  ? (data.clarification_count / totalRequests) * 100 \n  : 0;\nconst accuracy = totalRequests > 0 \n  ? (data.validated_count / totalRequests) * 100 \n  : 0;\n\n// Latency percentiles from API\nconst p50 = data.latency_p50 || 0;\nconst p95 = data.latency_p95 || 0;\nconst p99 = data.latency_p99 || 0;\n\nconst statsDate = $now.minus({days: 1}).toFormat('yyyy-MM-dd');\n\nreturn [{\n  json: {\n    stats_date: statsDate,\n    total_requests: totalRequests,\n    unique_users: data.unique_users || 0,\n    unique_guilds: data.unique_guilds || 0,\n    clarification_rate: Math.round(clarificationRate * 100) / 100,\n    accuracy: Math.round(accuracy * 100) / 100,\n    latency_p50: p50,\n    latency_p95: p95,\n    latency_p99: p99,\n    domain_breakdown: data.domain_breakdown || {}\n  }\n}];"
       },
       "id": "code-calc-metrics",
       "name": "Calculate Metrics",
@@ -90,25 +89,24 @@
     },
     {
       "parameters": {
-        "operation": "executeQuery",
-        "query": "INSERT INTO intent_metrics (\n  stats_date,\n  total_requests,\n  unique_users,\n  unique_guilds,\n  clarification_rate,\n  accuracy,\n  latency_p50,\n  latency_p95,\n  latency_p99,\n  domain_breakdown,\n  created_at\n) VALUES (\n  '{{ $json.stats_date }}',\n  {{ $json.total_requests }},\n  {{ $json.unique_users }},\n  {{ $json.unique_guilds }},\n  {{ $json.clarification_rate }},\n  {{ $json.accuracy }},\n  {{ $json.latency_p50 }},\n  {{ $json.latency_p95 }},\n  {{ $json.latency_p99 }},\n  '{{ $json.domain_breakdown }}',\n  '{{ $json.created_at }}'\n)\nON CONFLICT (stats_date) DO UPDATE SET\n  total_requests = EXCLUDED.total_requests,\n  unique_users = EXCLUDED.unique_users,\n  unique_guilds = EXCLUDED.unique_guilds,\n  clarification_rate = EXCLUDED.clarification_rate,\n  accuracy = EXCLUDED.accuracy,\n  latency_p50 = EXCLUDED.latency_p50,\n  latency_p95 = EXCLUDED.latency_p95,\n  latency_p99 = EXCLUDED.latency_p99,\n  domain_breakdown = EXCLUDED.domain_breakdown,\n  created_at = EXCLUDED.created_at",
-        "options": {}
-      },
-      "id": "postgres-insert",
-      "name": "PostgreSQL Insert",
-      "type": "n8n-nodes-base.postgres",
-      "typeVersion": 2.5,
-      "position": [940, 200],
-      "credentials": {
-        "postgres": {
-          "id": "postgres-metrics",
-          "name": "PostgreSQL Metrics"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/metrics",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "timeout": 10000
         }
-      }
+      },
+      "id": "http-api-metrics",
+      "name": "API Save Metrics",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200]
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// LOG SUMMARY\n// ============================================\n\nconst input = $('Calculate Metrics').first().json;\n\nreturn [{\n  json: {\n    status: 'completed',\n    stats_date: input.stats_date,\n    metrics: {\n      total_requests: input.total_requests,\n      unique_users: input.unique_users,\n      clarification_rate: input.clarification_rate + '%',\n      accuracy: input.accuracy + '%',\n      latency_p50: input.latency_p50 + 'ms',\n      latency_p95: input.latency_p95 + 'ms',\n      latency_p99: input.latency_p99 + 'ms'\n    },\n    stored_in: 'PostgreSQL intent_metrics',\n    processed_at: new Date().toISOString()\n  }\n}];"
+        "jsCode": "// ============================================\n// LOG SUMMARY\n// ============================================\n\nconst input = $('Calculate Metrics').first().json;\n\nreturn [{\n  json: {\n    status: 'completed',\n    stats_date: input.stats_date,\n    metrics: {\n      total_requests: input.total_requests,\n      unique_users: input.unique_users,\n      clarification_rate: input.clarification_rate + '%',\n      accuracy: input.accuracy + '%',\n      latency_p50: input.latency_p50 + 'ms',\n      latency_p95: input.latency_p95 + 'ms',\n      latency_p99: input.latency_p99 + 'ms'\n    },\n    processed_at: new Date().toISOString()\n  }\n}];"
       },
       "id": "code-summary",
       "name": "Summary",
@@ -118,7 +116,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// No data for yesterday - log and exit\nreturn [{\n  json: {\n    status: 'no_data',\n    stats_date: $now.minus({days: 1}).toFormat('yyyy-MM-dd'),\n    message: 'No intent history data found for yesterday',\n    processed_at: new Date().toISOString()\n  }\n}];"
+        "jsCode": "// No data for yesterday\nreturn [{\n  json: {\n    status: 'no_data',\n    stats_date: $now.minus({days: 1}).toFormat('yyyy-MM-dd'),\n    message: 'No intent history data found for yesterday',\n    processed_at: new Date().toISOString()\n  }\n}];"
       },
       "id": "code-no-data",
       "name": "No Data Log",
@@ -132,14 +130,14 @@
       "main": [
         [
           {
-            "node": "MongoDB Aggregate Stats",
+            "node": "API Aggregate Stats",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "MongoDB Aggregate Stats": {
+    "API Aggregate Stats": {
       "main": [
         [
           {
@@ -172,14 +170,14 @@
       "main": [
         [
           {
-            "node": "PostgreSQL Insert",
+            "node": "API Save Metrics",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "PostgreSQL Insert": {
+    "API Save Metrics": {
       "main": [
         [
           {

--- a/workflows/N8N-Intent-Events-Consumer.json
+++ b/workflows/N8N-Intent-Events-Consumer.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Intent Events Consumer\n\n**Issue:** #285\n**RFC:** RFC-031 (Section 17.4)\n\n**Description:**\nConsomme le Redis Stream `intent:events` et insère dans MongoDB `intent_history` pour les agrégations batch.\n\n**Architecture:** Option C (Hybride)\n- chatbot-core écrit dans Qdrant (sync) + Redis Stream (async)\n- n8n consomme le stream et écrit dans MongoDB\n\n**Flux:**\n1. XREAD intent:events (polling)\n2. Transform JSON\n3. INSERT MongoDB (continueOnFail)\n4. Check Insert Success\n5. SUCCESS → XACK | FAIL → DLQ",
+        "content": "## Intent Events Consumer\n\n**Issue:** #285\n**RFC:** RFC-031 (Section 17.4)\n\n**Description:**\nConsomme le Redis Stream `intent:events` et insère via API.\n\n**Architecture:** Option C (Hybride)\n- chatbot-core écrit dans Qdrant (sync) + Redis Stream (async)\n- n8n consomme le stream et appelle l'API\n\n**Flux:**\n1. XREAD intent:events (polling)\n2. Transform JSON\n3. POST API /api/intent/history\n4. Check Success\n5. SUCCESS → XACK | FAIL → DLQ",
         "height": 360,
         "width": 360,
         "color": 5
@@ -83,7 +83,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// TRANSFORM INTENT EVENTS\n// ============================================\n// Parse Redis Stream data for MongoDB insert\n\nconst items = $input.all();\nconst transformed = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Redis Stream returns array of [id, fields]\n  // Or object with id and data\n  const streamId = data.id || data[0];\n  const fields = data.data || data.fields || data[1] || data;\n  \n  if (!fields || !fields.message) {\n    continue;\n  }\n  \n  // Parse tokens from JSON string\n  let tokens = [];\n  try {\n    tokens = JSON.parse(fields.tokens || '[]');\n  } catch (e) {\n    tokens = [];\n  }\n  \n  // Transform for MongoDB\n  transformed.push({\n    json: {\n      stream_id: streamId,\n      message: fields.message,\n      tokens: tokens,\n      domain: fields.domain,\n      was_validated: fields.was_validated === 'true' || fields.was_validated === true,\n      validation_type: fields.validation_type || 'implicit',\n      confidence_at_prediction: parseFloat(fields.confidence_at_prediction) || 0,\n      user_id: fields.user_id || '',\n      guild_id: fields.guild_id || '',\n      tool_used: fields.tool_used || '',\n      original_timestamp: fields.timestamp,\n      created_at: new Date()\n    }\n  });\n}\n\nreturn transformed;"
+        "jsCode": "// ============================================\n// TRANSFORM INTENT EVENTS\n// ============================================\n// Parse Redis Stream data for API insert\n\nconst items = $input.all();\nconst transformed = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Redis Stream returns array of [id, fields]\n  // Or object with id and data\n  const streamId = data.id || data[0];\n  const fields = data.data || data.fields || data[1] || data;\n  \n  if (!fields || !fields.message) {\n    continue;\n  }\n  \n  // Parse tokens from JSON string\n  let tokens = [];\n  try {\n    tokens = JSON.parse(fields.tokens || '[]');\n  } catch (e) {\n    tokens = [];\n  }\n  \n  // Transform for API\n  transformed.push({\n    json: {\n      stream_id: streamId,\n      message: fields.message,\n      tokens: tokens,\n      domain: fields.domain,\n      was_validated: fields.was_validated === 'true' || fields.was_validated === true,\n      validation_type: fields.validation_type || 'implicit',\n      confidence_at_prediction: parseFloat(fields.confidence_at_prediction) || 0,\n      user_id: fields.user_id || '',\n      guild_id: fields.guild_id || '',\n      tool_used: fields.tool_used || '',\n      original_timestamp: fields.timestamp\n    }\n  });\n}\n\nreturn transformed;"
       },
       "id": "code-transform",
       "name": "Transform Events",
@@ -93,21 +93,20 @@
     },
     {
       "parameters": {
-        "operation": "insert",
-        "collection": "intent_history",
-        "fields": "stream_id,message,tokens,domain,was_validated,validation_type,confidence_at_prediction,user_id,guild_id,tool_used,original_timestamp,created_at"
-      },
-      "id": "mongodb-insert",
-      "name": "MongoDB Insert",
-      "type": "n8n-nodes-base.mongoDb",
-      "typeVersion": 1,
-      "position": [940, 200],
-      "credentials": {
-        "mongoDb": {
-          "id": "mongodb-intent",
-          "name": "MongoDB Intent"
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/intent/history",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "timeout": 10000
         }
       },
+      "id": "http-api-insert",
+      "name": "API Insert History",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200],
       "onError": "continueRegularOutput"
     },
     {
@@ -120,7 +119,7 @@
           },
           "conditions": [
             {
-              "id": "check-no-error",
+              "id": "check-success",
               "leftValue": "={{ $json.error }}",
               "rightValue": "",
               "operator": {
@@ -160,7 +159,7 @@
     },
     {
       "parameters": {
-        "content": "## Error Handling\n\nMongoDB Insert avec `onError: continueRegularOutput`\n→ Si erreur, le flux continue avec $json.error\n→ IF check success/fail\n→ FAIL: XADD vers `intent:dlq`\n\nLe workflow ALERT-DLQ-Monitor surveille cette queue.",
+        "content": "## Error Handling\n\nAPI Insert avec `onError: continueRegularOutput`\n→ Si erreur, le flux continue avec $json.error\n→ IF check success/fail\n→ FAIL: XADD vers `intent:dlq`\n\nLe workflow ALERT-DLQ-Monitor surveille cette queue.",
         "height": 180,
         "width": 300,
         "color": 3
@@ -187,7 +186,7 @@
             },
             {
               "field": "error",
-              "value": "={{ $json.error || 'MongoDB insert failed' }}"
+              "value": "={{ $json.error || 'API insert failed' }}"
             },
             {
               "field": "retry_count",
@@ -266,14 +265,14 @@
       "main": [
         [
           {
-            "node": "MongoDB Insert",
+            "node": "API Insert History",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "MongoDB Insert": {
+    "API Insert History": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary
- Migre tous les workflows RFC-031 vers des appels API via `$env.API_URL`
- Supprime les connexions directes MongoDB/PostgreSQL
- Redis reste en direct pour les streams (XREAD, XACK, XADD, XLEN, XRANGE)

## Workflows modifiés

| Workflow | Avant | Après |
|----------|-------|-------|
| Intent Events Consumer | MongoDB Insert | POST /api/intent/history |
| Keywords Sync | MongoDB Aggregate + Redis ZADD | POST /api/intent/keywords/* |
| Stats Daily | MongoDB Aggregate + PostgreSQL | POST /api/intent/stats/* |
| Clarification High | MongoDB Aggregate + Insert | POST /api/intent/stats/hourly + alerts |
| DLQ Monitor | MongoDB Insert | POST /api/intent/alerts |

## API Endpoints requis

```
POST /api/intent/history          # Insert intent event
POST /api/intent/keywords/aggregate # Aggregate validated tokens
POST /api/intent/keywords/sync    # Sync to Redis ZSET
POST /api/intent/stats/aggregate  # Daily stats aggregation
POST /api/intent/stats/hourly     # Last hour stats
POST /api/intent/metrics          # Save daily metrics
POST /api/intent/alerts           # Log alert
```

## Variable d'environnement

```env
API_URL=http://localhost:8000
```

## Test plan
- [ ] Configurer API_URL dans n8n
- [ ] Implémenter les endpoints API côté backend
- [ ] Ré-importer les workflows
- [ ] Tester chaque workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)