### PR TITLE
fix(n8n): Update RFC-031 workflows per api-backend contract

### DIFF
--- a/docs/issues/RFC031-RESPONSE-API-BACKEND.md
+++ b/docs/issues/RFC031-RESPONSE-API-BACKEND.md
@@ -1,0 +1,463 @@
+# RFC-031 — Reponse equipe api-backend
+
+> Reponse a `RFC031-INTENT-API-ENDPOINTS.md` (equipe n8n-workflows)
+
+| Metadata | |
+|----------|---------|
+| **Equipe source** | api-backend |
+| **Equipe destinataire** | n8n-workflows |
+| **RFC** | RFC-031 - Classification d'Intention Hybride |
+| **Date** | 2026-02-10 |
+| **Statut** | Proposition — en attente validation n8n |
+
+---
+
+## 1. Perimetre accepte
+
+api-backend prend en charge :
+
+- **Stockage** des events bruts dans MongoDB (`chatbot_analytics`)
+- **Agregation** des keywords et statistiques (logique metier cote API, pas cote n8n)
+- **Sync Redis** des keywords agreges vers ZSET
+- **UPSERT metriques** daily dans PostgreSQL
+- **Stockage alertes** dans MongoDB
+
+n8n se limite a :
+
+- Consommer le Redis Stream `intent:events`
+- Appeler les endpoints api-backend (ecriture + lecture)
+- Declencher les CRONs (sync keywords, stats daily, alertes)
+
+---
+
+## 2. Corrections sur les endpoints proposes
+
+### 2.1 Verbes HTTP — 3 endpoints doivent passer en GET
+
+Les endpoints `keywords/aggregate`, `stats/aggregate` et `stats/hourly` sont des **lectures**.
+Un POST implique la creation ou modification d'une ressource. Lire des donnees agregees = GET.
+
+| # | Proposition n8n (POST) | Correction api-backend (GET) | Raison |
+|---|------------------------|------------------------------|--------|
+| 2 | `POST /api/intent/keywords/aggregate` | `GET /api/intent/keywords` | Lecture de donnees agregees, pas de side-effect |
+| 4 | `POST /api/intent/stats/aggregate` | `GET /api/intent/stats/daily` | Lecture de stats journalieres |
+| 5 | `POST /api/intent/stats/hourly` | `GET /api/intent/stats/hourly` | Lecture de stats horaires |
+
+Les parametres passent du body vers les **query parameters** (convention REST standard).
+
+### 2.2 Nommage
+
+| Proposition n8n | Correction | Raison |
+|-----------------|------------|--------|
+| `/api/intent/history` | `/api/intent/events` | On ecrit un **event**, on lit l'**historique**. Le POST cree un event. |
+| `/api/intent/keywords/aggregate` | `/api/intent/keywords` | L'agregation est un detail d'implementation, pas une ressource |
+| `/api/intent/stats/aggregate` | `/api/intent/stats/daily` | Coherence avec `stats/hourly` |
+
+### 2.3 Endpoint batch recommande
+
+Le doc mentionne "batch up to 50 events" toutes les 10 secondes, mais l'endpoint recoit 1 event a la fois.
+Envoyer 50 requetes HTTP en 10 secondes est inefficace. Ajout d'un endpoint batch :
+
+```
+POST /api/intent/events        → 1 event (conserve pour compatibilite)
+POST /api/intent/events/batch  → jusqu'a 50 events en un appel
+```
+
+---
+
+## 3. Contrat d'API revise
+
+### 3.1 Ecritures (POST) — 4 endpoints
+
+#### `POST /api/intent/events`
+
+Insere un event d'intent classification dans MongoDB.
+
+**Workflow :** `N8N-Intent-Events-Consumer`
+**Frequence :** ~5/s en pic
+**Collection MongoDB :** `intent_events` (base `chatbot_analytics`)
+
+```
+POST /api/intent/events
+Content-Type: application/json
+```
+
+```json
+{
+  "stream_id": "1234567890-0",
+  "message": "je veux une recette de cookies",
+  "tokens": ["recette", "cookies"],
+  "domain": "recipes",
+  "was_validated": true,
+  "validation_type": "implicit",
+  "confidence_at_prediction": 0.85,
+  "user_id": "user123",
+  "guild_id": "guild456",
+  "tool_used": "recipe_search",
+  "original_timestamp": "2026-02-10T10:30:00Z"
+}
+```
+
+**Reponse (201) :**
+
+```json
+{
+  "success": true,
+  "id": "65f1a2b3c4d5e6f7a8b9c0d1"
+}
+```
+
+**Idempotence :** Index unique sur `stream_id`. Un doublon retourne 200 avec l'id existant.
+
+---
+
+#### `POST /api/intent/events/batch`
+
+Insere un batch d'events en un seul appel (recommande).
+
+**Workflow :** `N8N-Intent-Events-Consumer`
+**Frequence :** toutes les 10 secondes (batch de 1 a 50)
+
+```
+POST /api/intent/events/batch
+Content-Type: application/json
+```
+
+```json
+{
+  "events": [
+    {
+      "stream_id": "1234567890-0",
+      "message": "je veux une recette de cookies",
+      "tokens": ["recette", "cookies"],
+      "domain": "recipes",
+      "was_validated": true,
+      "validation_type": "implicit",
+      "confidence_at_prediction": 0.85,
+      "user_id": "user123",
+      "guild_id": "guild456",
+      "tool_used": "recipe_search",
+      "original_timestamp": "2026-02-10T10:30:00Z"
+    }
+  ]
+}
+```
+
+**Reponse (201) :**
+
+```json
+{
+  "success": true,
+  "inserted": 48,
+  "duplicates": 2
+}
+```
+
+**Implementation :** `insert_many(ordered=False)` avec gestion des doublons `stream_id`.
+
+---
+
+#### `POST /api/intent/metrics`
+
+UPSERT des metriques quotidiennes dans PostgreSQL.
+
+**Workflow :** `CRON-Intent-Stats-Daily`
+**Frequence :** Daily 04:00 AM
+**Table PostgreSQL :** `intent_metrics` (schema public)
+
+```
+POST /api/intent/metrics
+Content-Type: application/json
+```
+
+```json
+{
+  "stats_date": "2026-02-09",
+  "total_requests": 1250,
+  "unique_users": 89,
+  "unique_guilds": 12,
+  "clarification_rate": 10.0,
+  "accuracy": 78.4,
+  "latency_p50": 45,
+  "latency_p95": 120,
+  "latency_p99": 250,
+  "domain_breakdown": {
+    "recipes": { "count": 800, "accuracy": 90.0 },
+    "books": { "count": 450, "accuracy": 57.8 }
+  }
+}
+```
+
+**Reponse (200) :**
+
+```json
+{
+  "success": true,
+  "action": "upsert",
+  "stats_date": "2026-02-09"
+}
+```
+
+**Idempotence :** `INSERT ... ON CONFLICT (stats_date) DO UPDATE`.
+
+---
+
+#### `POST /api/intent/alerts`
+
+Log une alerte dans MongoDB.
+
+**Workflows :** `ALERT-Intent-Clarification-High`, `ALERT-Intent-DLQ-Monitor`
+**Frequence :** Horaire / toutes les 15 min
+**Collection MongoDB :** `intent_alerts` (base `chatbot_analytics`)
+
+```
+POST /api/intent/alerts
+Content-Type: application/json
+```
+
+```json
+{
+  "alert_type": "clarification_high",
+  "severity": "WARNING",
+  "payload": {
+    "clarification_rate": 35.5,
+    "total_requests": 85,
+    "clarification_count": 30,
+    "domain_breakdown": {
+      "recipes": { "total": 60, "clarifications": 25 }
+    }
+  }
+}
+```
+
+**Reponse (201) :**
+
+```json
+{
+  "success": true,
+  "id": "65f1a2b3c4d5e6f7a8b9c0d2"
+}
+```
+
+**Note :** Le payload est un champ JSONB flexible — les champs varient selon `alert_type`
+(`clarification_high` vs `dlq_messages`). Pas de schema rigide sur le payload.
+
+---
+
+### 3.2 Lectures (GET) — 3 endpoints
+
+#### `GET /api/intent/keywords`
+
+Retourne les tokens agreges par domaine (agregation MongoDB cote api-backend).
+
+**Workflow :** `CRON-Intent-Keywords-Sync`
+**Frequence :** Daily 03:00 AM
+
+```
+GET /api/intent/keywords?period=24h&min_count=3
+```
+
+| Parametre | Type | Defaut | Description |
+|-----------|------|--------|-------------|
+| `period` | string | `24h` | Fenetre d'agregation (`1h`, `6h`, `12h`, `24h`, `7d`) |
+| `min_count` | int | `3` | Seuil minimum d'occurrences |
+
+**Reponse (200) :**
+
+```json
+{
+  "data": [
+    {
+      "domain": "recipes",
+      "token": "recette",
+      "count": 150,
+      "avg_confidence": 0.87
+    },
+    {
+      "domain": "recipes",
+      "token": "cookies",
+      "count": 45,
+      "avg_confidence": 0.82
+    },
+    {
+      "domain": "books",
+      "token": "livre",
+      "count": 78,
+      "avg_confidence": 0.91
+    }
+  ]
+}
+```
+
+**Note :** L'agregation (pipeline `$unwind` + `$group`) est executee cote api-backend.
+Le format de reponse est aplati (`domain` + `token`) au lieu du `_id: { domain, token }` MongoDB
+pour faciliter le parsing cote n8n.
+
+---
+
+#### `GET /api/intent/stats/daily`
+
+Retourne les statistiques agregees d'une journee (agregation MongoDB cote api-backend).
+
+**Workflow :** `CRON-Intent-Stats-Daily`
+**Frequence :** Daily 04:00 AM
+
+```
+GET /api/intent/stats/daily?date=2026-02-09
+```
+
+| Parametre | Type | Defaut | Description |
+|-----------|------|--------|-------------|
+| `date` | string (YYYY-MM-DD) | **requis** | Journee a agreger |
+
+**Reponse (200) :**
+
+```json
+{
+  "data": {
+    "total_requests": 1250,
+    "validated_count": 980,
+    "clarification_count": 125,
+    "unique_users": 89,
+    "unique_guilds": 12,
+    "latency_p50": 45,
+    "latency_p95": 120,
+    "latency_p99": 250,
+    "domain_breakdown": {
+      "recipes": { "count": 800, "validated": 720 },
+      "books": { "count": 450, "validated": 260 }
+    }
+  }
+}
+```
+
+---
+
+#### `GET /api/intent/stats/hourly`
+
+Retourne les statistiques de la derniere periode pour le monitoring.
+
+**Workflow :** `ALERT-Intent-Clarification-High`
+**Frequence :** Toutes les heures
+
+```
+GET /api/intent/stats/hourly?period=1h
+```
+
+| Parametre | Type | Defaut | Description |
+|-----------|------|--------|-------------|
+| `period` | string | `1h` | Fenetre de lookback (`1h`, `3h`, `6h`) |
+
+**Reponse (200) :**
+
+```json
+{
+  "data": {
+    "total": 85,
+    "clarification_count": 12,
+    "domain_breakdown": {
+      "recipes": { "total": 60, "clarifications": 8 },
+      "books": { "total": 25, "clarifications": 4 }
+    }
+  }
+}
+```
+
+---
+
+### 3.3 Action (POST) — 1 endpoint
+
+#### `POST /api/intent/keywords/sync`
+
+Synchronise les keywords calcules vers Redis ZSET.
+
+**Workflow :** `CRON-Intent-Keywords-Sync`
+**Frequence :** Daily 03:00 AM (apres GET /keywords)
+
+```
+POST /api/intent/keywords/sync
+Content-Type: application/json
+```
+
+```json
+{
+  "keywords_by_domain": {
+    "recipes": [
+      { "token": "recette", "weight": 8.5 },
+      { "token": "cookies", "weight": 4.2 }
+    ],
+    "books": [
+      { "token": "livre", "weight": 7.1 }
+    ]
+  },
+  "total_domains": 2,
+  "total_keywords": 3
+}
+```
+
+**Reponse (200) :**
+
+```json
+{
+  "success": true,
+  "domains_updated": 2,
+  "keywords_synced": 3,
+  "redis_keys": [
+    "keywords:recipes:triggers",
+    "keywords:books:triggers"
+  ]
+}
+```
+
+---
+
+## 4. Resume des changements vs proposition n8n
+
+| Changement | Detail |
+|------------|--------|
+| **3 POST → GET** | `keywords/aggregate`, `stats/aggregate`, `stats/hourly` deviennent des GET avec query params |
+| **Nommage** | `history` → `events`, `keywords/aggregate` → `keywords`, `stats/aggregate` → `stats/daily` |
+| **Endpoint batch** | Ajout `POST /events/batch` (recommande pour le consumer, 1 appel / 10s au lieu de 50) |
+| **Reponse keywords aplatie** | `{ domain, token, count }` au lieu de `{ _id: { domain, token } }` |
+| **Alertes payload flexible** | Champ `payload` JSONB unique au lieu de champs a plat variables selon `alert_type` |
+| **Agregation** | Executee cote api-backend (pipelines MongoDB), n8n consomme les resultats via GET |
+
+## 5. Stockage
+
+| Donnee | Stockage | Base / Schema |
+|--------|----------|---------------|
+| Events bruts (historique) | MongoDB | `chatbot_analytics.intent_events` |
+| Alertes | MongoDB | `chatbot_analytics.intent_alerts` |
+| Metriques daily | PostgreSQL | `public.intent_metrics` |
+| Domaines (config) | PostgreSQL | `public.intent_domains` |
+| Keywords (cache) | Redis | ZSET `keywords:{domain}:triggers` |
+| Domaines actifs (cache) | Redis | SET `config:intent:domains` |
+
+## 6. Pre-requis api-backend
+
+| Pre-requis | Statut |
+|------------|--------|
+| Ajouter `motor` dans `requirements.txt` | A faire |
+| Client Motor async (singleton, pattern Redis) | A faire |
+| Variable `MONGODB_URI` + `MONGODB_DATABASE` | Disponible (`.env.local`) |
+
+## 7. Tableau recapitulatif des endpoints
+
+| # | Methode | Endpoint | Workflow n8n | Frequence | Stockage |
+|---|---------|----------|-------------|-----------|----------|
+| 1 | POST | `/api/intent/events` | Events Consumer | ~5/s pic | MongoDB |
+| 2 | POST | `/api/intent/events/batch` | Events Consumer | /10s | MongoDB |
+| 3 | GET | `/api/intent/keywords` | Keywords Sync | Daily 03:00 | MongoDB (read) |
+| 4 | POST | `/api/intent/keywords/sync` | Keywords Sync | Daily 03:00 | Redis (write) |
+| 5 | GET | `/api/intent/stats/daily` | Stats Daily | Daily 04:00 | MongoDB (read) |
+| 6 | GET | `/api/intent/stats/hourly` | Clarification Alert | Horaire | MongoDB (read) |
+| 7 | POST | `/api/intent/metrics` | Stats Daily | Daily 04:00 | PostgreSQL |
+| 8 | POST | `/api/intent/alerts` | Alerts | Variable | MongoDB |
+
+**Total : 8 endpoints** (5 POST, 3 GET)
+
+---
+
+## Contact
+
+Questions → equipe api-backend

--- a/workflows/ALERT-Intent-Clarification-High.json
+++ b/workflows/ALERT-Intent-Clarification-High.json
@@ -33,17 +33,14 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.API_URL }}/api/intent/stats/hourly",
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "{\n  \"period\": \"1h\"\n}",
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/intent/stats/hourly?period=1h",
         "options": {
           "timeout": 30000
         }
       },
       "id": "http-api-stats",
-      "name": "API Last Hour Stats",
+      "name": "API Get Hourly Stats",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [280, 300]
@@ -89,7 +86,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Prepare alert data for API\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    alert_type: 'clarification_high',\n    severity: data.severity,\n    clarification_rate: data.clarification_rate,\n    total_requests: data.total_requests,\n    clarification_count: data.clarification_count,\n    domain_breakdown: data.domain_breakdown\n  }\n}];"
+        "jsCode": "// Prepare alert data for API (payload wrapper per api-backend spec)\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    alert_type: 'clarification_high',\n    severity: data.severity,\n    payload: {\n      clarification_rate: data.clarification_rate,\n      total_requests: data.total_requests,\n      clarification_count: data.clarification_count,\n      domain_breakdown: data.domain_breakdown\n    }\n  }\n}];"
       },
       "id": "code-prepare-alert",
       "name": "Prepare Alert",
@@ -167,14 +164,14 @@
       "main": [
         [
           {
-            "node": "API Last Hour Stats",
+            "node": "API Get Hourly Stats",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "API Last Hour Stats": {
+    "API Get Hourly Stats": {
       "main": [
         [
           {

--- a/workflows/ALERT-Intent-DLQ-Monitor.json
+++ b/workflows/ALERT-Intent-DLQ-Monitor.json
@@ -123,7 +123,7 @@
         "url": "={{ $env.API_URL }}/api/intent/alerts",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ alert_type: $json.alert_type, severity: $json.severity, dlq_count: $json.dlq_count, sample_errors: $json.sample_errors }) }}",
+        "jsonBody": "={{ JSON.stringify({ alert_type: $json.alert_type, severity: $json.severity, payload: { dlq_count: $json.dlq_count, sample_errors: $json.sample_errors } }) }}",
         "options": {
           "timeout": 10000
         }

--- a/workflows/CRON-Intent-Keywords-Sync.json
+++ b/workflows/CRON-Intent-Keywords-Sync.json
@@ -33,17 +33,14 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.API_URL }}/api/intent/keywords/aggregate",
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "{\n  \"period\": \"24h\",\n  \"min_count\": 3\n}",
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/intent/keywords?period=24h&min_count=3",
         "options": {
           "timeout": 30000
         }
       },
       "id": "http-api-aggregate",
-      "name": "API Aggregate Keywords",
+      "name": "API Get Keywords",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [280, 300]
@@ -130,14 +127,14 @@
       "main": [
         [
           {
-            "node": "API Aggregate Keywords",
+            "node": "API Get Keywords",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "API Aggregate Keywords": {
+    "API Get Keywords": {
       "main": [
         [
           {

--- a/workflows/CRON-Intent-Stats-Daily.json
+++ b/workflows/CRON-Intent-Stats-Daily.json
@@ -33,17 +33,14 @@
     },
     {
       "parameters": {
-        "method": "POST",
-        "url": "={{ $env.API_URL }}/api/intent/stats/aggregate",
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "{\n  \"date\": \"{{ $now.minus({days: 1}).toFormat('yyyy-MM-dd') }}\"\n}",
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/intent/stats/daily?date={{ $now.minus({days: 1}).toFormat('yyyy-MM-dd') }}",
         "options": {
           "timeout": 60000
         }
       },
       "id": "http-api-aggregate",
-      "name": "API Aggregate Stats",
+      "name": "API Get Daily Stats",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [280, 300]
@@ -130,14 +127,14 @@
       "main": [
         [
           {
-            "node": "API Aggregate Stats",
+            "node": "API Get Daily Stats",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "API Aggregate Stats": {
+    "API Get Daily Stats": {
       "main": [
         [
           {

--- a/workflows/N8N-Intent-Events-Consumer.json
+++ b/workflows/N8N-Intent-Events-Consumer.json
@@ -3,7 +3,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Intent Events Consumer\n\n**Issue:** #285\n**RFC:** RFC-031 (Section 17.4)\n\n**Description:**\nConsomme le Redis Stream `intent:events` et insère via API.\n\n**Architecture:** Option C (Hybride)\n- chatbot-core écrit dans Qdrant (sync) + Redis Stream (async)\n- n8n consomme le stream et appelle l'API\n\n**Flux:**\n1. XREAD intent:events (polling)\n2. Transform JSON\n3. POST API /api/intent/history\n4. Check Success\n5. SUCCESS → XACK | FAIL → DLQ",
+        "content": "## Intent Events Consumer\n\n**Issue:** #285\n**RFC:** RFC-031 (Section 17.4)\n\n**Description:**\nConsomme le Redis Stream `intent:events` et insère via API batch.\n\n**Architecture:** Option C (Hybride)\n- chatbot-core écrit dans Qdrant (sync) + Redis Stream (async)\n- n8n consomme le stream et appelle l'API batch\n\n**Flux:**\n1. XREAD intent:events (polling, max 50)\n2. Transform to batch\n3. POST /api/intent/events/batch\n4. SUCCESS → XACK all | FAIL → DLQ",
         "height": 360,
         "width": 360,
         "color": 5
@@ -83,10 +83,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// TRANSFORM INTENT EVENTS\n// ============================================\n// Parse Redis Stream data for API insert\n\nconst items = $input.all();\nconst transformed = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  // Redis Stream returns array of [id, fields]\n  // Or object with id and data\n  const streamId = data.id || data[0];\n  const fields = data.data || data.fields || data[1] || data;\n  \n  if (!fields || !fields.message) {\n    continue;\n  }\n  \n  // Parse tokens from JSON string\n  let tokens = [];\n  try {\n    tokens = JSON.parse(fields.tokens || '[]');\n  } catch (e) {\n    tokens = [];\n  }\n  \n  // Transform for API\n  transformed.push({\n    json: {\n      stream_id: streamId,\n      message: fields.message,\n      tokens: tokens,\n      domain: fields.domain,\n      was_validated: fields.was_validated === 'true' || fields.was_validated === true,\n      validation_type: fields.validation_type || 'implicit',\n      confidence_at_prediction: parseFloat(fields.confidence_at_prediction) || 0,\n      user_id: fields.user_id || '',\n      guild_id: fields.guild_id || '',\n      tool_used: fields.tool_used || '',\n      original_timestamp: fields.timestamp\n    }\n  });\n}\n\nreturn transformed;"
+        "jsCode": "// ============================================\n// TRANSFORM TO BATCH\n// ============================================\n// Collect all events for batch insert\n\nconst items = $input.all();\nconst events = [];\nconst streamIds = [];\n\nfor (const item of items) {\n  const data = item.json;\n  \n  const streamId = data.id || data[0];\n  const fields = data.data || data.fields || data[1] || data;\n  \n  if (!fields || !fields.message) {\n    continue;\n  }\n  \n  let tokens = [];\n  try {\n    tokens = JSON.parse(fields.tokens || '[]');\n  } catch (e) {\n    tokens = [];\n  }\n  \n  streamIds.push(streamId);\n  events.push({\n    stream_id: streamId,\n    message: fields.message,\n    tokens: tokens,\n    domain: fields.domain,\n    was_validated: fields.was_validated === 'true' || fields.was_validated === true,\n    validation_type: fields.validation_type || 'implicit',\n    confidence_at_prediction: parseFloat(fields.confidence_at_prediction) || 0,\n    user_id: fields.user_id || '',\n    guild_id: fields.guild_id || '',\n    tool_used: fields.tool_used || '',\n    original_timestamp: fields.timestamp\n  });\n}\n\nreturn [{\n  json: {\n    events: events,\n    stream_ids: streamIds,\n    count: events.length\n  }\n}];"
       },
       "id": "code-transform",
-      "name": "Transform Events",
+      "name": "Transform to Batch",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [720, 200]
@@ -94,16 +94,16 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.API_URL }}/api/intent/history",
+        "url": "={{ $env.API_URL }}/api/intent/events/batch",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify($json) }}",
+        "jsonBody": "={{ JSON.stringify({ events: $json.events }) }}",
         "options": {
-          "timeout": 10000
+          "timeout": 30000
         }
       },
-      "id": "http-api-insert",
-      "name": "API Insert History",
+      "id": "http-api-batch",
+      "name": "API Batch Insert",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [940, 200],
@@ -120,10 +120,10 @@
           "conditions": [
             {
               "id": "check-success",
-              "leftValue": "={{ $json.error }}",
-              "rightValue": "",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
+                "type": "boolean",
                 "operation": "equals"
               }
             }
@@ -132,24 +132,34 @@
         },
         "options": {}
       },
-      "id": "if-insert-success",
-      "name": "Insert Success?",
+      "id": "if-batch-success",
+      "name": "Batch Success?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [1160, 200]
     },
     {
       "parameters": {
+        "jsCode": "// ============================================\n// XACK ALL STREAM IDS\n// ============================================\n\nconst batchData = $('Transform to Batch').first().json;\nconst streamIds = batchData.stream_ids || [];\n\n// Return each stream_id for XACK\nreturn streamIds.map(id => ({ json: { stream_id: id } }));"
+      },
+      "id": "code-prepare-ack",
+      "name": "Prepare XACK",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 100]
+    },
+    {
+      "parameters": {
         "operation": "xAck",
         "key": "intent:events",
         "group": "n8n-intent-consumer",
-        "messageId": "={{ $('Transform Events').item.json.stream_id }}"
+        "messageId": "={{ $json.stream_id }}"
       },
       "id": "redis-xack",
       "name": "Redis XACK",
       "type": "n8n-nodes-base.redis",
       "typeVersion": 1,
-      "position": [1380, 100],
+      "position": [1600, 100],
       "credentials": {
         "redis": {
           "id": "redis-intent",
@@ -159,7 +169,7 @@
     },
     {
       "parameters": {
-        "content": "## Error Handling\n\nAPI Insert avec `onError: continueRegularOutput`\n→ Si erreur, le flux continue avec $json.error\n→ IF check success/fail\n→ FAIL: XADD vers `intent:dlq`\n\nLe workflow ALERT-DLQ-Monitor surveille cette queue.",
+        "content": "## Error Handling\n\nSi le batch échoue:\n→ Tous les events vont dans la DLQ\n→ ALERT-DLQ-Monitor surveille cette queue\n\nNote: En cas de succès partiel (duplicates),\nle batch retourne quand même success=true.",
         "height": 180,
         "width": 300,
         "color": 3
@@ -168,7 +178,17 @@
       "name": "Error Note",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [1380, 220]
+      "position": [1380, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE DLQ ENTRIES\n// ============================================\n\nconst batchData = $('Transform to Batch').first().json;\nconst apiResponse = $('API Batch Insert').first().json;\nconst events = batchData.events || [];\n\n// Send all events to DLQ on batch failure\nreturn events.map(evt => ({\n  json: {\n    stream_id: evt.stream_id,\n    message: evt.message,\n    error: apiResponse.error || 'Batch insert failed'\n  }\n}));"
+      },
+      "id": "code-prepare-dlq",
+      "name": "Prepare DLQ",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 480]
     },
     {
       "parameters": {
@@ -178,15 +198,15 @@
           "fieldValue": [
             {
               "field": "original_stream_id",
-              "value": "={{ $('Transform Events').item.json.stream_id }}"
+              "value": "={{ $json.stream_id }}"
             },
             {
               "field": "message",
-              "value": "={{ $('Transform Events').item.json.message }}"
+              "value": "={{ $json.message }}"
             },
             {
               "field": "error",
-              "value": "={{ $json.error || 'API insert failed' }}"
+              "value": "={{ $json.error }}"
             },
             {
               "field": "retry_count",
@@ -203,7 +223,7 @@
       "name": "Redis DLQ",
       "type": "n8n-nodes-base.redis",
       "typeVersion": 1,
-      "position": [1380, 400],
+      "position": [1600, 480],
       "credentials": {
         "redis": {
           "id": "redis-intent",
@@ -247,7 +267,7 @@
       "main": [
         [
           {
-            "node": "Transform Events",
+            "node": "Transform to Batch",
             "type": "main",
             "index": 0
           }
@@ -261,29 +281,47 @@
         ]
       ]
     },
-    "Transform Events": {
+    "Transform to Batch": {
       "main": [
         [
           {
-            "node": "API Insert History",
+            "node": "API Batch Insert",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "API Insert History": {
+    "API Batch Insert": {
       "main": [
         [
           {
-            "node": "Insert Success?",
+            "node": "Batch Success?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Insert Success?": {
+    "Batch Success?": {
+      "main": [
+        [
+          {
+            "node": "Prepare XACK",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Prepare DLQ",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare XACK": {
       "main": [
         [
           {
@@ -291,7 +329,11 @@
             "type": "main",
             "index": 0
           }
-        ],
+        ]
+      ]
+    },
+    "Prepare DLQ": {
+      "main": [
         [
           {
             "node": "Redis DLQ",


### PR DESCRIPTION
## Summary

- **N8N-Intent-Events-Consumer**: Use batch endpoint `POST /api/intent/events/batch` for efficiency (1 call/10s instead of 50)
- **CRON-Intent-Keywords-Sync**: Change `POST→GET /api/intent/keywords?period=24h&min_count=3`
- **CRON-Intent-Stats-Daily**: Change `POST→GET /api/intent/stats/daily?date=...`
- **ALERT-Intent-Clarification-High**: Change `POST→GET /api/intent/stats/hourly?period=1h`
- **All alerts**: Wrap data in `payload` field per api-backend spec
- Rename nodes to match new endpoint semantics

## Context

Applies corrections from api-backend team response (`docs/issues/RFC031-RESPONSE-API-BACKEND.md`):

| Change | Detail |
|--------|--------|
| **3 POST → GET** | `keywords/aggregate`, `stats/aggregate`, `stats/hourly` become GET with query params |
| **Naming** | `history` → `events`, `keywords/aggregate` → `keywords`, `stats/aggregate` → `stats/daily` |
| **Batch endpoint** | Add `POST /events/batch` (recommended for consumer) |
| **Alerts payload** | Use flexible `payload` JSONB field instead of flat fields |

## Final Endpoint Summary (8 endpoints)

| # | Method | Endpoint | Workflow |
|---|--------|----------|----------|
| 1 | POST | `/api/intent/events` | Events Consumer (single) |
| 2 | POST | `/api/intent/events/batch` | Events Consumer (batch - used) |
| 3 | GET | `/api/intent/keywords` | Keywords Sync |
| 4 | POST | `/api/intent/keywords/sync` | Keywords Sync |
| 5 | GET | `/api/intent/stats/daily` | Stats Daily |
| 6 | GET | `/api/intent/stats/hourly` | Clarification Alert |
| 7 | POST | `/api/intent/metrics` | Stats Daily |
| 8 | POST | `/api/intent/alerts` | Alerts |

## Test plan

- [ ] Verify all 5 workflows import correctly in n8n
- [ ] Test each endpoint with api-backend team
- [ ] Validate batch insert works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)