### PR TITLE
fix(torah-pdf): update to correct API endpoints

### DIFF
--- a/workflows/Torah-PDF-Generation.json
+++ b/workflows/Torah-PDF-Generation.json
@@ -95,7 +95,7 @@
     },
     {
       "parameters": {
-        "url": "={{ $env.API_URL }}/api/translations?book={{ $('Validate PDF Parameters').first().json.params.book }}&status=approved&limit=100",
+        "url": "={{ $env.API_URL }}/api/translations/search?book={{ $('Validate PDF Parameters').first().json.params.book }}&status=approved&limit=100",
         "options": {
           "timeout": 30000
         }
@@ -158,7 +158,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "{{ $env.API_URL }}/api/pdf/generate",
+        "url": "={{ $env.API_URL }}/api/pdf/generate/complete",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\n  \"translation_ids\": {{ JSON.stringify($json.translation_ids) }},\n  \"format\": \"{{ $json.config.format }}\",\n  \"options\": {\n    \"page_size\": \"{{ $json.config.page_size }}\",\n    \"include_source\": {{ $json.config.include_source }},\n    \"include_translation\": {{ $json.config.include_translation }},\n    \"include_commentaries\": {{ $json.config.include_commentaries }},\n    \"font_size\": {{ $json.config.font_size }},\n    \"rtl_support\": {{ $json.config.rtl_support }},\n    \"max_commentaries_per_page\": {{ $json.config.max_commentaries_per_page }}\n  },\n  \"metadata\": {\n    \"title\": \"{{ $json.book || 'Torah' }} - Traduction Bilingue\",\n    \"author\": \"Torah Translation Project\",\n    \"job_id\": \"{{ $json.job_id }}\"\n  }\n}",
@@ -178,7 +178,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Traiter le resultat de generation PDF\nconst input = $input.first().json;\nconst pdfData = $('Prepare PDF Data').first().json;\nconst webhook = $env.N8N_BASE_URL;\nconst webhookBase = $env.N8N_WEBHOOK_BASE_URL;\nconst apiUrl = $env.API_URL;\n\nconst result = {\n  success: !input.error && !input.detail && (input.pdf_url || input.file_path),\n  job_id: pdfData.job_id,\n  pdf_url: input.pdf_url || null,\n  file_path: input.file_path || null,\n  file_size: input.file_size || null,\n  pages: input.pages || null,\n  translations_included: pdfData.translations_count,\n  error: input.error || input.detail || null,\n  generated_at: new Date().toISOString()\n};\n\n// Construire l'URL de telechargement\nif (result.file_path && !result.pdf_url) {\n  result.pdf_url = apiUrl+`/api/pdf/download/${pdfData.job_id}`;\n}\n\nreturn [{ json: result }];"
+        "jsCode": "// Traiter le resultat de generation PDF (retour direct)\nconst input = $input.first().json;\nconst pdfData = $('Prepare PDF Data').first().json;\n\n// L'API retourne directement le PDF ou une erreur\nconst hasError = input.error || input.detail || input.status >= 400;\n\nconst result = {\n  success: !hasError && (input.pdf_url || input.download_url || input.file_url),\n  job_id: pdfData.job_id,\n  pdf_url: input.pdf_url || input.download_url || input.file_url || null,\n  file_size: input.file_size || input.size || null,\n  pages: input.pages || input.page_count || null,\n  translations_included: pdfData.translations_count,\n  error: input.error || input.detail || input.message || null,\n  generated_at: new Date().toISOString()\n};\n\nreturn [{ json: result }];"
       },
       "id": "process-pdf-result",
       "name": "Process PDF Result",
@@ -679,7 +679,7 @@
       },
       {
         "parameters": {
-          "url": "={{ $env.API_URL }}/api/translations?book={{ $('Validate PDF Parameters').first().json.params.book }}&status=approved&limit=100",
+          "url": "={{ $env.API_URL }}/api/translations/search?book={{ $('Validate PDF Parameters').first().json.params.book }}&status=approved&limit=100",
           "options": {
             "timeout": 30000
           }
@@ -742,7 +742,7 @@
       {
         "parameters": {
           "method": "POST",
-          "url": "{{ $env.API_URL }}/api/pdf/generate",
+          "url": "={{ $env.API_URL }}/api/pdf/generate/complete",
           "sendBody": true,
           "specifyBody": "json",
           "jsonBody": "={\n  \"translation_ids\": {{ JSON.stringify($json.translation_ids) }},\n  \"format\": \"{{ $json.config.format }}\",\n  \"options\": {\n    \"page_size\": \"{{ $json.config.page_size }}\",\n    \"include_source\": {{ $json.config.include_source }},\n    \"include_translation\": {{ $json.config.include_translation }},\n    \"include_commentaries\": {{ $json.config.include_commentaries }},\n    \"font_size\": {{ $json.config.font_size }},\n    \"rtl_support\": {{ $json.config.rtl_support }},\n    \"max_commentaries_per_page\": {{ $json.config.max_commentaries_per_page }}\n  },\n  \"metadata\": {\n    \"title\": \"{{ $json.book || 'Torah' }} - Traduction Bilingue\",\n    \"author\": \"Torah Translation Project\",\n    \"job_id\": \"{{ $json.job_id }}\"\n  }\n}",
@@ -762,7 +762,7 @@
       },
       {
         "parameters": {
-          "jsCode": "// Traiter le resultat de generation PDF\nconst input = $input.first().json;\nconst pdfData = $('Prepare PDF Data').first().json;\nconst webhook = $env.N8N_BASE_URL;\nconst webhookBase = $env.N8N_WEBHOOK_BASE_URL;\nconst apiUrl = $env.API_URL;\n\nconst result = {\n  success: !input.error && !input.detail && (input.pdf_url || input.file_path),\n  job_id: pdfData.job_id,\n  pdf_url: input.pdf_url || null,\n  file_path: input.file_path || null,\n  file_size: input.file_size || null,\n  pages: input.pages || null,\n  translations_included: pdfData.translations_count,\n  error: input.error || input.detail || null,\n  generated_at: new Date().toISOString()\n};\n\n// Construire l'URL de telechargement\nif (result.file_path && !result.pdf_url) {\n  result.pdf_url = apiUrl+`/api/pdf/download/${pdfData.job_id}`;\n}\n\nreturn [{ json: result }];"
+          "jsCode": "// Traiter le resultat de generation PDF (retour direct)\nconst input = $input.first().json;\nconst pdfData = $('Prepare PDF Data').first().json;\n\n// L'API retourne directement le PDF ou une erreur\nconst hasError = input.error || input.detail || input.status >= 400;\n\nconst result = {\n  success: !hasError && (input.pdf_url || input.download_url || input.file_url),\n  job_id: pdfData.job_id,\n  pdf_url: input.pdf_url || input.download_url || input.file_url || null,\n  file_size: input.file_size || input.size || null,\n  pages: input.pages || input.page_count || null,\n  translations_included: pdfData.translations_count,\n  error: input.error || input.detail || input.message || null,\n  generated_at: new Date().toISOString()\n};\n\nreturn [{ json: result }];"
         },
         "id": "process-pdf-result",
         "name": "Process PDF Result",


### PR DESCRIPTION
- GET /api/translations → GET /api/translations/search
- POST /api/pdf/generate → POST /api/pdf/generate/complete
- Remove job_id async logic (PDF returned directly)