### PR TITLE
feat(torah): add Torah sources and chapter webhooks (RFC-037)

### DIFF
--- a/docs/issues/WEBHOOK-TORAH-SOURCES.md
+++ b/docs/issues/WEBHOOK-TORAH-SOURCES.md
@@ -1,0 +1,234 @@
+# Webhook: torah-sources
+
+Documentation pour l'équipe n8n - RFC-037 Dynamic Sources Registry
+
+## Résumé
+
+Le plugin Discord doit charger dynamiquement la liste des sources textuelles (Talmud, Kabbale, etc.) depuis n8n au lieu d'avoir une liste codée en dur.
+
+## Endpoint
+
+```
+GET {N8N_BASE_URL}/webhook/torah-sources
+```
+
+## Comportement attendu
+
+1. Lire la liste des sources depuis la base de données (Qdrant/PostgreSQL)
+2. Retourner un JSON avec toutes les sources disponibles
+3. Inclure les métadonnées (type, structure, endpoints)
+
+## Format de réponse
+
+```json
+{
+  "success": true,
+  "sources": [
+    {
+      "name": "Sukkah",
+      "aliases": ["souccah", "sukka", "soucca", "soukkah", "soukka"],
+      "type": "talmud",
+      "structure": "pages",
+      "pages": 56,
+      "fetch_endpoint": "torah-get-page-translations",
+      "translate_endpoint": "torah-translate-page"
+    },
+    {
+      "name": "Berakhot",
+      "aliases": ["berachot", "brachot", "brakhot"],
+      "type": "talmud",
+      "structure": "pages",
+      "pages": 64,
+      "fetch_endpoint": "torah-get-page-translations",
+      "translate_endpoint": "torah-translate-page"
+    },
+    {
+      "name": "Sha'ar HaHakdamot",
+      "aliases": ["shaar hahakdamot", "shaar hakdamot", "porte des introductions"],
+      "type": "kabbale",
+      "structure": "chapters",
+      "chapters": 12,
+      "fetch_endpoint": "torah-get-chapter",
+      "translate_endpoint": "torah-translate-chapter"
+    }
+  ],
+  "updated_at": "2026-02-16T10:30:00Z"
+}
+```
+
+## Champs obligatoires
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `name` | string | Nom canonique de la source (ex: "Sukkah") |
+| `aliases` | string[] | Variantes du nom en lowercase (ex: ["souccah", "sukka"]) |
+| `type` | string | Type de texte : "talmud", "kabbale", "midrash", "tanakh" |
+| `structure` | string | **"pages"** ou **"chapters"** |
+
+## Champs conditionnels (selon structure)
+
+### Si `structure: "pages"` (Talmud)
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `pages` | int | Nombre total de pages |
+| `fetch_endpoint` | string | `"torah-get-page-translations"` |
+| `translate_endpoint` | string | `"torah-translate-page"` |
+
+### Si `structure: "chapters"` (Kabbale, etc.)
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `chapters` | int | Nombre total de chapitres |
+| `fetch_endpoint` | string | `"torah-get-chapter"` |
+| `translate_endpoint` | string | `"torah-translate-chapter"` |
+
+## Structures supportées
+
+### Pages (Talmud)
+
+```
+Structure: pages
+Référencement: {source} {numéro}{côté}
+Exemple: Berakhot 2a, Sukkah 28b
+Côtés: a (recto), b (verso)
+```
+
+### Chapters (Kabbale, autres)
+
+```
+Structure: chapters
+Référencement: {source} chapitre {numéro}
+Exemple: Sha'ar HaHakdamot chapitre 3
+```
+
+## Webhooks associés à créer
+
+### Pour structure "chapters"
+
+| Webhook | Méthode | Description |
+|---------|---------|-------------|
+| `torah-get-chapter` | POST | Récupère le contenu d'un chapitre |
+| `torah-translate-chapter` | POST | Traduit un chapitre |
+
+#### Payload `torah-get-chapter`
+
+```json
+{
+  "source": "Sha'ar HaHakdamot",
+  "chapter": 3
+}
+```
+
+#### Réponse `torah-get-chapter`
+
+```json
+{
+  "success": true,
+  "source": "Sha'ar HaHakdamot",
+  "chapter": 3,
+  "title": "Hakdama Gimel",
+  "segments": [
+    {
+      "index": 0,
+      "text": "דע כי טרם שנאצלו הנאצלים...",
+      "translation": null
+    },
+    {
+      "index": 1,
+      "text": "והנה בתחילה היה אור...",
+      "translation": "Et voici, au commencement il y avait une lumière..."
+    }
+  ],
+  "total_segments": 45
+}
+```
+
+#### Payload `torah-translate-chapter`
+
+```json
+{
+  "source": "Sha'ar HaHakdamot",
+  "chapter": 3,
+  "language": "fr",
+  "force": false
+}
+```
+
+## Fréquence d'appel
+
+- Le plugin appelle ce webhook **toutes les heures** (configurable)
+- Le premier appel est au **démarrage du bot**
+- En cas d'échec : **3 tentatives** avec backoff exponentiel
+
+## Gestion des erreurs
+
+### Erreur standard
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 500,
+    "message": "Database connection failed",
+    "status": "INTERNAL_ERROR"
+  }
+}
+```
+
+### Comportement du plugin en cas d'erreur
+
+1. Retry 3 fois avec backoff (1s, 2s, 4s)
+2. Si échec total : **conserver l'ancienne liste en cache**
+3. Si premier appel échoue : utiliser une **liste de fallback minimale**
+
+## Source des données
+
+### Option A : Table PostgreSQL
+
+```sql
+CREATE TABLE torah_sources (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL UNIQUE,
+    aliases TEXT[], -- Array de variantes
+    type VARCHAR(50) NOT NULL,
+    structure VARCHAR(20) NOT NULL CHECK (structure IN ('pages', 'chapters')),
+    pages INTEGER,
+    chapters INTEGER,
+    fetch_endpoint VARCHAR(255),
+    translate_endpoint VARCHAR(255),
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Exemple d'insertion
+INSERT INTO torah_sources (name, aliases, type, structure, pages, fetch_endpoint, translate_endpoint)
+VALUES (
+    'Sukkah',
+    ARRAY['souccah', 'sukka', 'soucca'],
+    'talmud',
+    'pages',
+    56,
+    'torah-get-page-translations',
+    'torah-translate-page'
+);
+```
+
+### Option B : Collection Qdrant metadata
+
+Extraire les sources uniques depuis les métadonnées des documents vectorisés.
+
+## Workflow n8n suggéré
+
+```
+┌─────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  Webhook    │ ──► │  Query DB/Qdrant │ ──► │  Format JSON    │
+│  Trigger    │     │  pour sources    │     │  Response       │
+└─────────────┘     └──────────────────┘     └─────────────────┘
+```
+
+## Contact
+
+Pour questions : équipe plugin-torah-bot
+
+RFC associée : `docs/rfc/RFC-037-DYNAMIC-SOURCES-REGISTRY.md`

--- a/workflows/TORAH-Get-Chapter.json
+++ b/workflows/TORAH-Get-Chapter.json
@@ -2,6 +2,19 @@
   "name": "TORAH - Get Chapter",
   "nodes": [
     {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 350,
+        "height": 200,
+        "content": "## TORAH - Get Chapter\n\n**Endpoint:** `POST /webhook/torah-get-chapter`\n\n**Payload:**\n```json\n{\"source\": \"Sha'ar HaHakdamot\", \"chapter\": 3}\n```\n\n**API Backend:** `GET /api/torah/chapters/{source}/{chapter}`"
+      }
+    },
+    {
       "id": "webhook",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",

--- a/workflows/TORAH-Get-Chapter.json
+++ b/workflows/TORAH-Get-Chapter.json
@@ -1,0 +1,237 @@
+{
+  "name": "TORAH - Get Chapter",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "torah-get-chapter",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-get-chapter",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst required = ['source', 'chapter'];\nconst missing = required.filter(field => body[field] === undefined || body[field] === null);\n\nif (missing.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (typeof body.chapter !== 'number' || body.chapter < 1) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'chapter must be a positive integer',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    source: body.source,\n    chapter: body.chapter,\n    language: body.language || 'fr'\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "get-chapter",
+      "name": "Get Chapter from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/chapters/{{ encodeURIComponent($json.source) }}/{{ $json.chapter }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.segments }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 100],
+      "parameters": {
+        "jsCode": "const data = $input.first().json;\nconst validData = $('Validate Input').first().json;\n\nreturn {\n  json: {\n    success: true,\n    source: data.source || validData.source,\n    chapter: data.chapter || validData.chapter,\n    title: data.title || null,\n    segments: (data.segments || []).map(s => ({\n      index: s.index,\n      text: s.text_hebrew || s.text,\n      translation: s.text_translated || s.translation || null\n    })),\n    total_segments: data.total_segments || (data.segments || []).length\n  }\n};"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 404, message: 'Chapter not found or API error', status: 'NOT_FOUND' } } }}",
+        "options": {
+          "responseCode": 404
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Chapter from API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Chapter from API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/TORAH-Get-Page.json
+++ b/workflows/TORAH-Get-Page.json
@@ -2,6 +2,19 @@
   "name": "TORAH - Get Page",
   "nodes": [
     {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 350,
+        "height": 200,
+        "content": "## TORAH - Get Page\n\n**Endpoint:** `POST /webhook/torah-get-page`\n\n**Payload:**\n```json\n{\"source\": \"Sukkah\", \"page\": \"28b\"}\n```\n\n**API Backend:** `GET /api/torah/pages/{source}/{page}`\n\n**Note:** Format page = nombre + a/b (ex: 2a, 28b)"
+      }
+    },
+    {
       "id": "webhook",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",

--- a/workflows/TORAH-Get-Page.json
+++ b/workflows/TORAH-Get-Page.json
@@ -1,0 +1,237 @@
+{
+  "name": "TORAH - Get Page",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "torah-get-page",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-get-page",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst required = ['source', 'page'];\nconst missing = required.filter(field => body[field] === undefined || body[field] === null);\n\nif (missing.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// Validate page format (e.g., \"2a\", \"28b\")\nconst pagePattern = /^\\d+[ab]$/;\nif (!pagePattern.test(body.page)) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'page must be in format: number + a or b (e.g., \"2a\", \"28b\")',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    source: body.source,\n    page: body.page,\n    language: body.language || 'fr'\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "get-page",
+      "name": "Get Page from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/pages/{{ encodeURIComponent($json.source) }}/{{ $json.page }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.segments }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 100],
+      "parameters": {
+        "jsCode": "const data = $input.first().json;\nconst validData = $('Validate Input').first().json;\n\nreturn {\n  json: {\n    success: true,\n    source: data.source || validData.source,\n    page: data.page || validData.page,\n    segments: (data.segments || []).map(s => ({\n      index: s.index,\n      text: s.text_hebrew || s.text,\n      translation: s.text_translated || s.translation || null\n    })),\n    total_segments: data.total_segments || (data.segments || []).length\n  }\n};"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 404, message: 'Page not found or API error', status: 'NOT_FOUND' } } }}",
+        "options": {
+          "responseCode": 404
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Page from API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Page from API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/TORAH-Index.json
+++ b/workflows/TORAH-Index.json
@@ -2,6 +2,19 @@
   "name": "TORAH - Index",
   "nodes": [
     {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 240,
+        "content": "## TORAH - Index (Qdrant)\n\n**Endpoint:** `POST /webhook/torah-index`\n\n**Payload:**\n```json\n{\"source\": \"...\", \"chapter\": 3, \"segments\": [{index, text_hebrew, text_translated}]}\n```\n\n**API Backend:** `POST /api/torah/index`\n\n**Model:** `multilingual-e5-large` (par défaut)"
+      }
+    },
+    {
       "id": "webhook",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",

--- a/workflows/TORAH-Index.json
+++ b/workflows/TORAH-Index.json
@@ -1,0 +1,219 @@
+{
+  "name": "TORAH - Index",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "torah-index",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-index",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst required = ['source', 'segments'];\nconst missing = required.filter(field => body[field] === undefined || body[field] === null);\n\nif (missing.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (!Array.isArray(body.segments) || body.segments.length === 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'segments must be a non-empty array',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// Must have either chapter or page\nif (!body.chapter && !body.page) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Either chapter or page is required',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    source: body.source,\n    chapter: body.chapter || null,\n    page: body.page || null,\n    segments: body.segments,\n    embedding_model: body.embedding_model || 'multilingual-e5-large'\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "index-api",
+      "name": "Index to Qdrant via API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/index",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source: $json.source, chapter: $json.chapter, page: $json.page, segments: $json.segments, embedding_model: $json.embedding_model }) }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-success",
+      "name": "Index Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, source: $('Validate Input').first().json.source, chapter: $('Validate Input').first().json.chapter, page: $('Validate Input').first().json.page, indexed_count: $json.indexed_count || $('Validate Input').first().json.segments.length, collection: $json.collection } }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-index-error",
+      "name": "Respond Index Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 500, message: $json.error || 'Failed to index segments', status: 'INTERNAL_ERROR' } } }}",
+        "options": {
+          "responseCode": 500
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Index to Qdrant via API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Index to Qdrant via API": {
+      "main": [
+        [
+          {
+            "node": "Index Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Index Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Index Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/TORAH-Search.json
+++ b/workflows/TORAH-Search.json
@@ -1,0 +1,238 @@
+{
+  "name": "TORAH - Search",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "torah-search",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-search",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nif (!body.query || typeof body.query !== 'string' || body.query.trim().length === 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing or empty required parameter: query',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    query: body.query.trim(),\n    sources: body.sources || [],  // Optional filter by sources\n    limit: Math.min(body.limit || 5, 20),\n    language: body.language || 'fr',\n    include_hebrew: body.include_hebrew !== false\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "search-api",
+      "name": "Search in Qdrant via API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/search",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ query: $json.query, sources: $json.sources, limit: $json.limit, language: $json.language }) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-results",
+      "name": "Has Results?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.results }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "format-results",
+      "name": "Format Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 100],
+      "parameters": {
+        "jsCode": "const validData = $('Validate Input').first().json;\nconst searchResults = $input.first().json;\n\nconst formattedResults = (searchResults.results || []).map(r => {\n  const result = {\n    source: r.source,\n    reference: r.structure === 'pages' \n      ? `${r.source} ${r.page}` \n      : `${r.source} chapitre ${r.chapter}`,\n    segment_index: r.segment_index,\n    score: Math.round(r.score * 100) / 100\n  };\n  \n  if (validData.include_hebrew) {\n    result.text_hebrew = r.text_hebrew || r.text;\n  }\n  result.translation = r.text_translated || r.translation || null;\n  \n  return result;\n});\n\nreturn {\n  json: {\n    success: true,\n    query: validData.query,\n    results: formattedResults,\n    count: formattedResults.length,\n    language: validData.language\n  }\n};"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-no-results",
+      "name": "Respond No Results",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, query: $('Validate Input').first().json.query, results: [], count: 0, message: 'No matching segments found' } }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Search in Qdrant via API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search in Qdrant via API": {
+      "main": [
+        [
+          {
+            "node": "Has Results?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Results?": {
+      "main": [
+        [
+          {
+            "node": "Format Results",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond No Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Results": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/TORAH-Search.json
+++ b/workflows/TORAH-Search.json
@@ -2,6 +2,19 @@
   "name": "TORAH - Search",
   "nodes": [
     {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 220,
+        "content": "## TORAH - Search (RAG)\n\n**Endpoint:** `POST /webhook/torah-search`\n\n**Payload:**\n```json\n{\"query\": \"contraction lumière\", \"sources\": [], \"limit\": 5}\n```\n\n**API Backend:** `POST /api/torah/search` (Qdrant)\n\n**Response:** `{success, query, results[], count}`"
+      }
+    },
+    {
       "id": "webhook",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",

--- a/workflows/TORAH-Sources.json
+++ b/workflows/TORAH-Sources.json
@@ -1,0 +1,156 @@
+{
+  "name": "TORAH - Sources",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "torah-sources",
+      "parameters": {
+        "httpMethod": "GET",
+        "path": "torah-sources",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "get-sources",
+      "name": "Get Sources from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [460, 300],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/sources",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-success",
+      "name": "Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.sources }}",
+              "rightValue": "",
+              "operator": {
+                "type": "array",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 200],
+      "parameters": {
+        "jsCode": "const sources = $input.first().json.sources || [];\n\n// Format sources for plugin consumption\nconst formattedSources = sources.map(s => ({\n  name: s.name,\n  aliases: s.aliases || [],\n  type: s.type,\n  structure: s.structure,\n  pages: s.pages || null,\n  chapters: s.chapters || null,\n  fetch_endpoint: s.structure === 'pages' ? 'torah-get-page-translations' : 'torah-get-chapter',\n  translate_endpoint: s.structure === 'pages' ? 'torah-translate-page' : 'torah-translate-chapter',\n  qdrant_collection: s.qdrant_collection || null\n}));\n\nreturn {\n  json: {\n    success: true,\n    sources: formattedSources,\n    count: formattedSources.length,\n    updated_at: new Date().toISOString()\n  }\n};"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 200],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 500, message: 'Failed to fetch sources from API', status: 'INTERNAL_ERROR' } } }}",
+        "options": {
+          "responseCode": 500
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Get Sources from API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Sources from API": {
+      "main": [
+        [
+          {
+            "node": "Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Success?": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/TORAH-Sources.json
+++ b/workflows/TORAH-Sources.json
@@ -2,6 +2,19 @@
   "name": "TORAH - Sources",
   "nodes": [
     {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 350,
+        "height": 180,
+        "content": "## TORAH - Sources\n\n**Endpoint:** `GET /webhook/torah-sources`\n\n**Description:** Retourne la liste dynamique des sources Torah\n\n**API Backend:** `GET /api/torah/sources`\n\n**Response:** `{success, sources[], count, updated_at}`"
+      }
+    },
+    {
       "id": "webhook",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",

--- a/workflows/TORAH-Translate-Chapter.json
+++ b/workflows/TORAH-Translate-Chapter.json
@@ -160,7 +160,7 @@
       "position": [2000, 100],
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/translations/batch",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/translations",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ source: $json.source, chapter: $json.chapter, language: $json.language, segments: $json.segments.filter(s => s.translation).map(s => ({ index: s.index, translation: s.translation })), discord_user_id: $json.discord_user_id }) }}",

--- a/workflows/TORAH-Translate-Chapter.json
+++ b/workflows/TORAH-Translate-Chapter.json
@@ -2,6 +2,19 @@
   "name": "TORAH - Translate Chapter",
   "nodes": [
     {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 220,
+        "content": "## TORAH - Translate Chapter\n\n**Endpoint:** `POST /webhook/torah-translate-chapter`\n\n**Payload:**\n```json\n{\"source\": \"...\", \"chapter\": 3, \"anthropic_api_key\": \"sk-...\"}\n```\n\n**Optionnel:** `force: true` pour retraduire\n\n**API Backend:** `POST /api/torah/translations`"
+      }
+    },
+    {
       "id": "webhook",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",

--- a/workflows/TORAH-Translate-Chapter.json
+++ b/workflows/TORAH-Translate-Chapter.json
@@ -1,0 +1,332 @@
+{
+  "name": "TORAH - Translate Chapter",
+  "nodes": [
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "torah-translate-chapter",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-translate-chapter",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst required = ['source', 'chapter'];\nconst missing = required.filter(field => body[field] === undefined || body[field] === null);\n\nif (missing.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (typeof body.chapter !== 'number' || body.chapter < 1) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'chapter must be a positive integer',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    source: body.source,\n    chapter: body.chapter,\n    language: body.language || 'fr',\n    force: body.force || false,\n    anthropic_api_key: body.anthropic_api_key,\n    model: body.model || 'claude-3-5-sonnet-20241022',\n    discord_user_id: body.discord_user_id || body.user_id\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "get-chapter",
+      "name": "Get Chapter Content",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/chapters/{{ encodeURIComponent($json.source) }}/{{ $json.chapter }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "filter-untranslated",
+      "name": "Filter Untranslated Segments",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 200],
+      "parameters": {
+        "jsCode": "const validData = $('Validate Input').first().json;\nconst chapterData = $input.first().json;\n\nif (!chapterData.segments || chapterData.segments.length === 0) {\n  return {\n    json: {\n      error: true,\n      message: 'No segments found'\n    }\n  };\n}\n\n// Filter segments that need translation\nconst toTranslate = validData.force \n  ? chapterData.segments \n  : chapterData.segments.filter(s => !s.text_translated && !s.translation);\n\nif (toTranslate.length === 0) {\n  return {\n    json: {\n      already_translated: true,\n      source: validData.source,\n      chapter: validData.chapter,\n      segments: chapterData.segments\n    }\n  };\n}\n\nreturn {\n  json: {\n    already_translated: false,\n    source: validData.source,\n    chapter: validData.chapter,\n    title: chapterData.title,\n    to_translate: toTranslate,\n    all_segments: chapterData.segments,\n    language: validData.language,\n    anthropic_api_key: validData.anthropic_api_key,\n    model: validData.model,\n    discord_user_id: validData.discord_user_id\n  }\n};"
+      }
+    },
+    {
+      "id": "check-needs-translation",
+      "name": "Needs Translation?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.already_translated }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "call-claude",
+      "name": "Call Claude for Translation",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1560, 100],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropic_api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: $json.model, max_tokens: 8192, system: 'Tu es un traducteur expert en textes hébraïques classiques (Kabbale, Talmud). Traduis fidèlement en français en préservant le sens mystique et les termes techniques. Réponds UNIQUEMENT en JSON: {\"translations\": [{\"index\": number, \"translation\": \"string\"}]}. Ne mets PAS de ```json```.', messages: [{ role: 'user', content: 'Traduis ces segments de ' + $json.source + ' (chapitre ' + $json.chapter + ') en français:\\n\\n' + $json.to_translate.map(s => 'Segment ' + s.index + ':\\n' + (s.text_hebrew || s.text)).join('\\n\\n') }] }) }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "parse-translations",
+      "name": "Parse Translations",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1780, 100],
+      "parameters": {
+        "jsCode": "const filterData = $('Filter Untranslated Segments').first().json;\nconst llmResponse = $input.first().json;\n\ntry {\n  if (llmResponse.error) {\n    throw new Error(llmResponse.error.message || 'Claude API error');\n  }\n\n  const content = llmResponse.content?.[0]?.text || '';\n  let jsonStr = content;\n  const jsonMatch = content.match(/```json\\n?([\\s\\S]*?)\\n?```/);\n  if (jsonMatch) {\n    jsonStr = jsonMatch[1];\n  }\n  \n  const parsed = JSON.parse(jsonStr);\n  const translationsMap = {};\n  parsed.translations.forEach(t => {\n    translationsMap[t.index] = t.translation;\n  });\n\n  // Merge translations with all segments\n  const mergedSegments = filterData.all_segments.map(s => ({\n    index: s.index,\n    text: s.text_hebrew || s.text,\n    translation: translationsMap[s.index] || s.text_translated || s.translation || null\n  }));\n\n  return {\n    json: {\n      success: true,\n      source: filterData.source,\n      chapter: filterData.chapter,\n      title: filterData.title,\n      segments: mergedSegments,\n      translated_count: parsed.translations.length,\n      language: filterData.language,\n      discord_user_id: filterData.discord_user_id\n    }\n  };\n} catch (e) {\n  return {\n    json: {\n      success: false,\n      error: e.message,\n      source: filterData.source,\n      chapter: filterData.chapter\n    }\n  };\n}"
+      }
+    },
+    {
+      "id": "save-translations",
+      "name": "Save Translations to API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2000, 100],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.TORAH_API_URL }}/api/torah/translations/batch",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ source: $json.source, chapter: $json.chapter, language: $json.language, segments: $json.segments.filter(s => s.translation).map(s => ({ index: s.index, translation: s.translation })), discord_user_id: $json.discord_user_id }) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2220, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, source: $('Parse Translations').first().json.source, chapter: $('Parse Translations').first().json.chapter, title: $('Parse Translations').first().json.title, segments: $('Parse Translations').first().json.segments, translated_count: $('Parse Translations').first().json.translated_count, total_segments: $('Parse Translations').first().json.segments.length } }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-already-translated",
+      "name": "Respond Already Translated",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, source: $json.source, chapter: $json.chapter, message: 'All segments already translated', segments: $json.segments.map(s => ({ index: s.index, text: s.text_hebrew || s.text, translation: s.text_translated || s.translation })) } }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Chapter Content",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Chapter Content": {
+      "main": [
+        [
+          {
+            "node": "Filter Untranslated Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter Untranslated Segments": {
+      "main": [
+        [
+          {
+            "node": "Needs Translation?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Needs Translation?": {
+      "main": [
+        [
+          {
+            "node": "Call Claude for Translation",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Already Translated",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call Claude for Translation": {
+      "main": [
+        [
+          {
+            "node": "Parse Translations",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Translations": {
+      "main": [
+        [
+          {
+            "node": "Save Translations to API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Save Translations to API": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}


### PR DESCRIPTION
## Summary

Implements dynamic Torah sources registry webhooks for RFC-037.

### New Workflows (6)

| Workflow | Method | Path | Description |
|----------|--------|------|-------------|
| `TORAH-Sources` | GET | `/torah-sources` | Liste dynamique des sources |
| `TORAH-Get-Chapter` | POST | `/torah-get-chapter` | Récupère contenu chapitre (Kabbale) |
| `TORAH-Get-Page` | POST | `/torah-get-page` | Récupère contenu page (Talmud) |
| `TORAH-Translate-Chapter` | POST | `/torah-translate-chapter` | Traduit via Claude API |
| `TORAH-Search` | POST | `/torah-search` | Recherche sémantique RAG (Qdrant) |
| `TORAH-Index` | POST | `/torah-index` | Indexe segments dans Qdrant |

### API Backend Endpoints Required

| n8n calls | API Backend |
|-----------|-------------|
| `TORAH_API_URL/api/torah/sources` | GET |
| `TORAH_API_URL/api/torah/chapters/{source}/{chapter}` | GET |
| `TORAH_API_URL/api/torah/pages/{source}/{page}` | GET |
| `TORAH_API_URL/api/torah/translations` | POST |
| `TORAH_API_URL/api/torah/search` | POST |
| `TORAH_API_URL/api/torah/index` | POST |

### Configuration

Uses `TORAH_API_URL` environment variable.

### Best Practices

All workflows follow `docs/n8n/WORKFLOW_BEST_PRACTICES.md`:
- Sticky Notes documentation (violet)
- Validation des entrées
- Réponses erreur standardisées `{code, message, status}`
- `onError: continueRegularOutput` sur HTTP Request
- `responseMode: responseNode` sur webhooks

## Test plan

- [ ] Configure `TORAH_API_URL` in n8n environment
- [ ] Import and activate all 6 workflows
- [ ] Test `GET /torah-sources` returns sources list
- [ ] Test `POST /torah-get-chapter` with valid source/chapter
- [ ] Test `POST /torah-get-page` with valid source/page (e.g., "28b")
- [ ] Test `POST /torah-search` with query
- [ ] Test `POST /torah-translate-chapter` with anthropic_api_key
- [ ] Test `POST /torah-index` with segments array

🤖 Generated with [Claude Code](https://claude.com/claude-code)