### PR TITLE
feat(guild): add 6 branding webhooks for RFC-034

### DIFF
--- a/workflows/GUILD-Create-Room.json
+++ b/workflows/GUILD-Create-Room.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/rooms",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/rooms",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ name: $json.name, description: $json.description, visual_config: $json.visual_config, messages_config: $json.messages_config }) }}",

--- a/workflows/GUILD-Create-Room.json
+++ b/workflows/GUILD-Create-Room.json
@@ -1,0 +1,234 @@
+{
+  "name": "GUILD - Create Room",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 260,
+        "content": "## GUILD - Create Room\n\n**Endpoint:** `POST /webhook/guild-create-room`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"name\": \"Salle Maths\", \"description\": \"...\", \"visual_config\": {...}, \"messages_config\": {...}}\n```\n\n**API Backend:** `POST /api/guilds/{guild_id}/rooms`\n\n**Scope:** `branding:write`"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "guild-create-room",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "guild-create-room",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst required = ['guild_id', 'name'];\nconst missing = required.filter(field => !body[field]);\n\nif (missing.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (typeof body.name !== 'string' || body.name.trim().length === 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'name must be a non-empty string',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id),\n    name: body.name.trim(),\n    description: body.description || null,\n    visual_config: body.visual_config || null,\n    messages_config: body.messages_config || null\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "create-room",
+      "name": "Create Room via API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/rooms",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ name: $json.name, description: $json.description, visual_config: $json.visual_config, messages_config: $json.messages_config }) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {
+          "responseCode": 201
+        }
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 500, message: $json.error || 'Failed to create room', status: 'INTERNAL_ERROR' } } }}",
+        "options": {
+          "responseCode": 500
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Create Room via API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Room via API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/GUILD-Get-Branding.json
+++ b/workflows/GUILD-Get-Branding.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/branding",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/branding",
         "options": {
           "timeout": 30000
         }

--- a/workflows/GUILD-Get-Branding.json
+++ b/workflows/GUILD-Get-Branding.json
@@ -1,0 +1,229 @@
+{
+  "name": "GUILD - Get Branding",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 220,
+        "content": "## GUILD - Get Branding\n\n**Endpoint:** `POST /webhook/guild-get-branding`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/branding`\n\n**Scope:** `branding:read`"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "guild-get-branding",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "guild-get-branding",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nif (!body.guild_id) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing required parameter: guild_id',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id)\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "get-branding",
+      "name": "Get Branding from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/branding",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 404, message: $json.error || 'Branding not found or API error', status: 'NOT_FOUND' } } }}",
+        "options": {
+          "responseCode": 404
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Branding from API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Branding from API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/GUILD-Get-Prompts.json
+++ b/workflows/GUILD-Get-Prompts.json
@@ -84,7 +84,7 @@
       "position": [1120, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/prompts{{ $json.query_string }}",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/prompts{{ $json.query_string }}",
         "options": {
           "timeout": 30000
         }

--- a/workflows/GUILD-Get-Prompts.json
+++ b/workflows/GUILD-Get-Prompts.json
@@ -1,0 +1,250 @@
+{
+  "name": "GUILD - Get Prompts",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 240,
+        "content": "## GUILD - Get Prompts\n\n**Endpoint:** `POST /webhook/guild-get-prompts`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"category\": \"identity\", \"language\": \"fr\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/prompts`\n\n**Scope:** `branding:read`\n\n**Params optionnels:** `category`, `language`, `layer`"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "guild-get-prompts",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "guild-get-prompts",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nif (!body.guild_id) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing required parameter: guild_id',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id),\n    category: body.category || null,\n    language: body.language || 'fr',\n    layer: body.layer || null\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "build-query-params",
+      "name": "Build Query Params",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 200],
+      "parameters": {
+        "jsCode": "const data = $input.first().json;\nconst params = [];\n\nif (data.category) params.push(`category=${encodeURIComponent(data.category)}`);\nif (data.language) params.push(`language=${encodeURIComponent(data.language)}`);\nif (data.layer) params.push(`layer=${encodeURIComponent(data.layer)}`);\n\nreturn {\n  json: {\n    guild_id: data.guild_id,\n    query_string: params.length > 0 ? '?' + params.join('&') : ''\n  }\n};"
+      }
+    },
+    {
+      "id": "get-prompts",
+      "name": "Get Prompts from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/prompts{{ $json.query_string }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 404, message: $json.error || 'Prompts not found or API error', status: 'NOT_FOUND' } } }}",
+        "options": {
+          "responseCode": 404
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Build Query Params",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Query Params": {
+      "main": [
+        [
+          {
+            "node": "Get Prompts from API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Prompts from API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/GUILD-Get-Rooms.json
+++ b/workflows/GUILD-Get-Rooms.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/rooms",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/rooms",
         "options": {
           "timeout": 30000
         }

--- a/workflows/GUILD-Get-Rooms.json
+++ b/workflows/GUILD-Get-Rooms.json
@@ -1,0 +1,229 @@
+{
+  "name": "GUILD - Get Rooms",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 220,
+        "content": "## GUILD - Get Rooms\n\n**Endpoint:** `POST /webhook/guild-get-rooms`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/rooms`\n\n**Scope:** `branding:read`\n\n**Response:** Liste des RoomModels (salles de cours)"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "guild-get-rooms",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "guild-get-rooms",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nif (!body.guild_id) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing required parameter: guild_id',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id)\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "get-rooms",
+      "name": "Get Rooms from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/rooms",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 404, message: $json.error || 'Rooms not found or API error', status: 'NOT_FOUND' } } }}",
+        "options": {
+          "responseCode": 404
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Rooms from API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Rooms from API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/GUILD-Update-Branding.json
+++ b/workflows/GUILD-Update-Branding.json
@@ -1,0 +1,232 @@
+{
+  "name": "GUILD - Update Branding",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 260,
+        "content": "## GUILD - Update Branding\n\n**Endpoint:** `POST /webhook/guild-update-branding`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"visual_config\": {...}, \"messages_config\": {...}}\n```\n\n**API Backend:** `PUT /api/guilds/{guild_id}/branding`\n\n**Scope:** `branding:write`\n\n**Requis:** `bot.name`, `greetings[]`, `limitations[]`"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "guild-update-branding",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "guild-update-branding",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nif (!body.guild_id) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing required parameter: guild_id',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (!body.visual_config && !body.messages_config) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'At least visual_config or messages_config is required',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// Validate required fields if visual_config provided\nif (body.visual_config && !body.visual_config.bot?.name) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'visual_config.bot.name is required',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// Validate required fields if messages_config provided\nif (body.messages_config) {\n  const greetings = body.messages_config.messages?.greetings;\n  if (!greetings || !Array.isArray(greetings) || greetings.length === 0) {\n    return {\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: 'messages_config.messages.greetings must have at least 1 element',\n          status: 'BAD_REQUEST'\n        }\n      }\n    };\n  }\n  \n  const limitations = body.messages_config.scope?.identity?.limitations;\n  if (!limitations || !Array.isArray(limitations) || limitations.length === 0) {\n    return {\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: 'messages_config.scope.identity.limitations must have at least 1 element',\n          status: 'BAD_REQUEST'\n        }\n      }\n    };\n  }\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id),\n    visual_config: body.visual_config || null,\n    messages_config: body.messages_config || null\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "update-branding",
+      "name": "Update Branding via API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/branding",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ visual_config: $json.visual_config, messages_config: $json.messages_config }) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 500, message: $json.error || 'Failed to update branding', status: 'INTERNAL_ERROR' } } }}",
+        "options": {
+          "responseCode": 500
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Update Branding via API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Branding via API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/GUILD-Update-Branding.json
+++ b/workflows/GUILD-Update-Branding.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "PUT",
-        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/branding",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/branding",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ visual_config: $json.visual_config, messages_config: $json.messages_config }) }}",

--- a/workflows/GUILD-Update-Prompt.json
+++ b/workflows/GUILD-Update-Prompt.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "PUT",
-        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/prompts",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/prompts",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ category: $json.category, key: $json.key, value: $json.value, language: $json.language }) }}",

--- a/workflows/GUILD-Update-Prompt.json
+++ b/workflows/GUILD-Update-Prompt.json
@@ -1,0 +1,232 @@
+{
+  "name": "GUILD - Update Prompt",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 260,
+        "content": "## GUILD - Update Prompt\n\n**Endpoint:** `POST /webhook/guild-update-prompt`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"category\": \"identity\", \"key\": \"role\", \"value\": \"tuteur en maths\", \"language\": \"fr\"}\n```\n\n**API Backend:** `PUT /api/guilds/{guild_id}/prompts`\n\n**Scope:** `branding:write`\n\n**Note:** `value` accepte `string` ou `string[]`"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "guild-update-prompt",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "guild-update-prompt",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst required = ['guild_id', 'category', 'key', 'value'];\nconst missing = required.filter(field => body[field] === undefined || body[field] === null);\n\nif (missing.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${missing.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (typeof body.category !== 'string' || body.category.trim().length === 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'category must be a non-empty string',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nif (typeof body.key !== 'string' || body.key.trim().length === 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'key must be a non-empty string',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// value can be string or array of strings\nconst valueType = typeof body.value;\nif (valueType !== 'string' && !Array.isArray(body.value)) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'value must be a string or array of strings',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id),\n    category: body.category.trim(),\n    key: body.key.trim(),\n    value: body.value,\n    language: body.language || 'fr'\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "update-prompt",
+      "name": "Update Prompt via API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.BRANDING_API_URL }}/api/guilds/{{ $json.guild_id }}/prompts",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ category: $json.category, key: $json.key, value: $json.value, language: $json.language }) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: { code: 500, message: $json.error || 'Failed to update prompt', status: 'INTERNAL_ERROR' } } }}",
+        "options": {
+          "responseCode": 500
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Update Prompt via API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Prompt via API": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/PLUGIN-Config-Get.json
+++ b/workflows/PLUGIN-Config-Get.json
@@ -1,0 +1,229 @@
+{
+  "name": "PLUGIN - Config Get",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 420,
+        "height": 300,
+        "content": "## PLUGIN - Config Get\n\n**Endpoint:** `POST /webhook/plugin-config-get`\n\n**Payload IN:**\n```json\n{\"guild_id\": \"1458159736775119115\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/plugin-config`\n\n**Payload OUT:** Configuration complète du plugin pour le guild:\n- plugin, entity, redis, qdrant, n8n\n- search, features, rate_limit\n- branding, keywords, prompts, scope, settings\n\n**Usage:** Plugin Discord / chatbot-core initialise sa config"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "plugin-config-get",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "plugin-config-get",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nif (!body.guild_id) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Missing required parameter: guild_id',\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(body.guild_id)\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "get-config",
+      "name": "Get Plugin Config from API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/plugin-config",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-success",
+      "name": "Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json.error ? $json : { success: false, error: { code: 'PLUGIN_CONFIG_NOT_FOUND', message: 'Aucune configuration plugin pour ce guild' } } }}",
+        "options": {
+          "responseCode": 404
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Plugin Config from API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Plugin Config from API": {
+      "main": [
+        [
+          {
+            "node": "Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/PLUGIN-Config-Update.json
+++ b/workflows/PLUGIN-Config-Update.json
@@ -1,0 +1,232 @@
+{
+  "name": "PLUGIN - Config Update",
+  "nodes": [
+    {
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 100],
+      "parameters": {
+        "color": 6,
+        "width": 420,
+        "height": 320,
+        "content": "## PLUGIN - Config Update\n\n**Endpoint:** `POST /webhook/plugin-config-update`\n\n**Payload IN:**\n```json\n{\n  \"guild_id\": \"1458159736775119115\",\n  \"entity\": {\"type\": \"recipes\", \"collection\": \"recipes\"},\n  \"qdrant\": {\"collection\": \"recipes\", \"min_score\": 0.75},\n  \"branding\": {\"bot\": {\"name\": \"Bot Appetit\"}},\n  ...\n}\n```\n\n**Champs obligatoires:** `guild_id`, `entity.type`, `entity.collection`\n\n**API Backend:** `PUT /api/guilds/{guild_id}/plugin-config`\n\n**Usage:** Dashboard admin met à jour la config plugin"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "plugin-config-update",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "plugin-config-update",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "const rawBody = $input.first().json.body || $input.first().json;\nconst body = rawBody.body || rawBody;\n\nconst errors = [];\n\nif (!body.guild_id) {\n  errors.push('guild_id');\n}\n\nif (!body.entity || !body.entity.type) {\n  errors.push('entity.type');\n}\n\nif (!body.entity || !body.entity.collection) {\n  errors.push('entity.collection');\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: `Missing required parameters: ${errors.join(', ')}`,\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// Extract guild_id and build config payload\nconst { guild_id, ...config } = body;\n\nreturn {\n  json: {\n    valid: true,\n    guild_id: String(guild_id),\n    config: config\n  }\n};"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "update-config",
+      "name": "Update Plugin Config via API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.API_URL }}/api/guilds/{{ $json.guild_id }}/plugin-config",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.config) }}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "check-success",
+      "name": "Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1120, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-api-error",
+      "name": "Respond API Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json.error ? $json : { success: false, error: { code: 500, message: 'Failed to update plugin config', status: 'INTERNAL_ERROR' } } }}",
+        "options": {
+          "responseCode": 500
+        }
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 400],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: false, error: $('Validate Input').first().json.error } }}",
+        "options": {
+          "responseCode": 400
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Update Plugin Config via API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Plugin Config via API": {
+      "main": [
+        [
+          {
+            "node": "Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Success?": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond API Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/TORAH-Get-Chapter.json
+++ b/workflows/TORAH-Get-Chapter.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/chapters/{{ encodeURIComponent($json.source) }}/{{ $json.chapter }}",
+        "url": "={{ $env.API_URL }}/api/torah/chapters/{{ encodeURIComponent($json.source) }}/{{ $json.chapter }}",
         "options": {
           "timeout": 30000
         }

--- a/workflows/TORAH-Get-Chapter.json
+++ b/workflows/TORAH-Get-Chapter.json
@@ -96,11 +96,11 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.segments }}",
-              "rightValue": "",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
               "operator": {
-                "type": "array",
-                "operation": "notEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],

--- a/workflows/TORAH-Get-Page.json
+++ b/workflows/TORAH-Get-Page.json
@@ -96,11 +96,11 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.segments }}",
-              "rightValue": "",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
               "operator": {
-                "type": "array",
-                "operation": "notEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],

--- a/workflows/TORAH-Get-Page.json
+++ b/workflows/TORAH-Get-Page.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/pages/{{ encodeURIComponent($json.source) }}/{{ $json.page }}",
+        "url": "={{ $env.API_URL }}/api/torah/pages/{{ encodeURIComponent($json.source) }}/{{ $json.page }}",
         "options": {
           "timeout": 30000
         }

--- a/workflows/TORAH-Index.json
+++ b/workflows/TORAH-Index.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/index",
+        "url": "={{ $env.API_URL }}/api/torah/index",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ source: $json.source, chapter: $json.chapter, page: $json.page, segments: $json.segments, embedding_model: $json.embedding_model }) }}",

--- a/workflows/TORAH-Search.json
+++ b/workflows/TORAH-Search.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/search",
+        "url": "={{ $env.API_URL }}/api/torah/search",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ query: $json.query, sources: $json.sources, limit: $json.limit, language: $json.language }) }}",

--- a/workflows/TORAH-Search.json
+++ b/workflows/TORAH-Search.json
@@ -99,11 +99,11 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.results }}",
-              "rightValue": "",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
               "operator": {
-                "type": "array",
-                "operation": "notEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],

--- a/workflows/TORAH-Sources.json
+++ b/workflows/TORAH-Sources.json
@@ -58,11 +58,11 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.sources }}",
-              "rightValue": "",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
               "operator": {
-                "type": "array",
-                "operation": "notEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],

--- a/workflows/TORAH-Sources.json
+++ b/workflows/TORAH-Sources.json
@@ -36,7 +36,7 @@
       "position": [460, 300],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/sources",
+        "url": "={{ $env.API_URL }}/api/torah/sources",
         "options": {
           "timeout": 10000
         }

--- a/workflows/TORAH-Translate-Chapter.json
+++ b/workflows/TORAH-Translate-Chapter.json
@@ -74,7 +74,7 @@
       "position": [900, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/chapters/{{ encodeURIComponent($json.source) }}/{{ $json.chapter }}",
+        "url": "={{ $env.API_URL }}/api/torah/chapters/{{ encodeURIComponent($json.source) }}/{{ $json.chapter }}",
         "options": {
           "timeout": 30000
         }
@@ -173,7 +173,7 @@
       "position": [2000, 100],
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.TORAH_API_URL }}/api/torah/translations",
+        "url": "={{ $env.API_URL }}/api/torah/translations",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify({ source: $json.source, chapter: $json.chapter, language: $json.language, segments: $json.segments.filter(s => s.translation).map(s => ({ index: s.index, translation: s.translation })), discord_user_id: $json.discord_user_id }) }}",


### PR DESCRIPTION
## Summary

- Add 6 webhooks for Guild branding and prompts management (RFC-034)
- All webhooks follow best practices: Sticky Notes documentation, validation, error handling
- Uses `BRANDING_API_URL` environment variable

## Webhooks Created

| Webhook | Path | API Endpoint | Scope |
|---------|------|--------------|-------|
| GUILD-Get-Branding | `/webhook/guild-get-branding` | `GET /api/guilds/{guild_id}/branding` | branding:read |
| GUILD-Update-Branding | `/webhook/guild-update-branding` | `PUT /api/guilds/{guild_id}/branding` | branding:write |
| GUILD-Get-Rooms | `/webhook/guild-get-rooms` | `GET /api/guilds/{guild_id}/rooms` | branding:read |
| GUILD-Create-Room | `/webhook/guild-create-room` | `POST /api/guilds/{guild_id}/rooms` | branding:write |
| GUILD-Get-Prompts | `/webhook/guild-get-prompts` | `GET /api/guilds/{guild_id}/prompts` | branding:read |
| GUILD-Update-Prompt | `/webhook/guild-update-prompt` | `PUT /api/guilds/{guild_id}/prompts` | branding:write |

## Environment Variable

`BRANDING_API_URL` - Base URL of the API backend (e.g., `https://api.example.com`)

> **Note:** If this is the same backend as TORAH (`TORAH_API_URL`), consider unifying to a single `API_BACKEND_URL` variable.

## Test plan

- [ ] Configure `BRANDING_API_URL` in n8n environment
- [ ] Import the 6 workflows into n8n
- [ ] Test each webhook with valid payloads
- [ ] Verify RBAC scopes (`branding:read` / `branding:write`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)