### PR TITLE
feat(torah): RFC-031 unified translation pipeline

### DIFF
--- a/docs/issues/RFC-031-torah-translation-pipeline.md
+++ b/docs/issues/RFC-031-torah-translation-pipeline.md
@@ -1,0 +1,330 @@
+# RFC-031: Refactoring Torah Translation Pipeline
+
+## Contexte
+
+Le workflow `Torah-Translate-Worker-v2` souffre de problèmes architecturaux avec ses boucles imbriquées (Loop Segments + Loop Chunks). Le `splitInBatches` accumule les items entre les itérations, causant :
+- Mélange de données entre segments
+- `originalSegmentIndex` incorrect
+- Progress qui ne se met pas à jour (toujours 1/N)
+- Status "processing" jamais passé à "completed"
+
+## Problème identifié
+
+Quand Loop Chunks termine et retourne à Loop Segments pour le segment suivant, il garde les items accumulés du segment précédent. Cela cause :
+1. Recombine Chunks reçoit des items mélangés
+2. `isLastSegment` n'est jamais `true`
+3. Le job reste en "processing"
+
+## Solution : Architecture Pipeline
+
+Séparer les responsabilités en workers indépendants orchestrés par un Router.
+
+### Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                            APPELANTS                                  │
+│              (Discord, PDF, API, MCP, etc.)                          │
+└─────────────────────────────┬────────────────────────────────────────┘
+                              │
+                              ▼
+┌──────────────────────────────────────────────────────────────────────┐
+│                     TORAH ROUTER                                      │
+│  Endpoint: POST /webhook/torah-router                                 │
+│                                                                       │
+│  - Analyse le payload                                                 │
+│  - Répond immédiatement avec {received: true, job_id}                │
+│  - Orchestre les workers en background                                │
+│  - Met à jour le progress après chaque segment                        │
+│  - Collecte les erreurs via Error Handler                            │
+│  - Marque le job "completed" ou "completed_with_errors"              │
+└──────────────────────────────────────────────────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          ▼                   ▼                   ▼
+┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐
+│  CHUNK WORKER   │  │TRANSLATE WORKER │  │  SAVE WORKER    │
+│  /torah-chunk   │  │ /torah-translate│  │  /torah-save    │
+│                 │  │                 │  │                 │
+│ Découpe texte   │  │ Traduit segment │  │ Sauvegarde en   │
+│ long en chunks  │  │ (pivot/direct)  │  │ DB via API      │
+│                 │  │ Sans sauvegarde │  │                 │
+└─────────────────┘  └─────────────────┘  └─────────────────┘
+                              │
+                              ▼
+                    ┌─────────────────┐
+                    │ ERROR HANDLER   │
+                    │ /torah-error    │
+                    │                 │
+                    │ Collecte les    │
+                    │ erreurs par job │
+                    └─────────────────┘
+```
+
+### Workflows
+
+| Workflow | Endpoint | Responsabilité |
+|----------|----------|----------------|
+| **Torah Router** | `/webhook/torah-router` | Dispatcher + Orchestrateur |
+| **Torah Chunk Worker** | `/webhook/torah-chunk` | Découpe texte > 10K chars |
+| **Torah Translate Worker** | `/webhook/torah-translate` | Traduit (sans save) |
+| **Torah Save Worker** | `/webhook/torah-save` | Sauvegarde en DB |
+| **Torah Error Handler** | `/webhook/torah-error` | Collecte erreurs |
+
+## Cas d'usage
+
+### Cas 1 : Texte long (document 15 pages)
+
+```
+Router reçoit {text: "...", source_text_id: "doc-123", job_id: "xxx"}
+  │
+  ├─ Détecte : texte > 10K chars
+  │
+  ├─ Chunk Worker : découpe en 5 segments
+  │   └─ Retourne segments[]
+  │
+  ├─ Pour chaque segment (i = 1 à 5) :
+  │   ├─ Translate Worker : traduit segment[i]
+  │   │   └─ Retourne {translation: "..."}
+  │   └─ Update Progress {current: i, total: 5}
+  │
+  ├─ Combine les traductions
+  │
+  ├─ Save Worker : sauvegarde 1 enregistrement
+  │   └─ {source_text_id: "doc-123", translation: combiné}
+  │
+  └─ Update Job {status: "completed"}
+```
+
+### Cas 2 : Batch de commentaires
+
+```
+Router reçoit {segments: [{commentary_id: "c1", text: "..."}, ...], job_id: "xxx"}
+  │
+  ├─ Détecte : batch de commentaires
+  │
+  ├─ Vérifie : aucun segment > 10K (sinon erreur)
+  │
+  ├─ Pour chaque segment (i = 1 à N) :
+  │   ├─ Translate Worker : traduit segment[i]
+  │   │   └─ Retourne {translation: "..."} ou ERREUR
+  │   │
+  │   ├─ Si ERREUR :
+  │   │   └─ Error Handler : enregistre l'erreur
+  │   │
+  │   ├─ Si OK :
+  │   │   └─ Save Worker : sauvegarde
+  │   │       └─ {commentary_id: segment.commentary_id, translation}
+  │   │
+  │   └─ Update Progress {current: i, total: N}
+  │
+  └─ Update Job {status: "completed" ou "completed_with_errors"}
+```
+
+### Cas 3 : Texte court unique
+
+```
+Router reçoit {text: "...", source_text_id: "st-456", job_id: "xxx"}
+  │
+  ├─ Détecte : texte court < 10K
+  │
+  ├─ Translate Worker : traduit
+  │   └─ Retourne {translation: "..."}
+  │
+  ├─ Save Worker : sauvegarde
+  │   └─ {source_text_id: "st-456", translation}
+  │
+  └─ Update Job {status: "completed"}
+```
+
+## Flux de communication
+
+```
+┌─────────┐      ┌──────────────────┐      ┌─────────────┐
+│ Discord │      │ Torah-Discord    │      │ Torah Router│
+│ (user)  │      │ (workflow n8n)   │      │ (workflow)  │
+└────┬────┘      └────────┬─────────┘      └──────┬──────┘
+     │                    │                       │
+     │ !translate ...     │                       │
+     │───────────────────>│                       │
+     │                    │                       │
+     │                    │ POST /api/v2/jobs     │
+     │                    │──────────────────────>│ (API backend)
+     │                    │<── {job_id: "xxx"}    │
+     │                    │                       │
+     │                    │ POST /webhook/torah-router
+     │                    │──────────────────────>│
+     │                    │<── {received: true}   │ ← Réponse immédiate
+     │                    │                       │
+     │<── "Job créé,      │                       │
+     │    ID: xxx"        │                       │
+     │                    │                       │
+     │                    │         ┌─────────────┴─────────────┐
+     │                    │         │ Router orchestre          │
+     │                    │         │ (Chunk → Translate → Save)│
+     │                    │         │ Update progress...        │
+     │                    │         └───────────────────────────┘
+     │                    │                       │
+     │ (poll job status)  │                       │
+     │───────────────────>│ GET /api/v2/jobs/xxx  │
+     │<── "En cours 2/5"  │                       │
+     │                    │                       │
+     │ (poll job status)  │                       │
+     │───────────────────>│ GET /api/v2/jobs/xxx  │
+     │<── "Terminé ✓"     │                       │
+```
+
+## Gestion des erreurs
+
+### Error Handler
+
+**Endpoint :** `POST /webhook/torah-error`
+
+**Payload :**
+```json
+{
+  "job_id": "xxx",
+  "segment_index": 3,
+  "worker": "translate",
+  "error": {
+    "code": "CLAUDE_TIMEOUT",
+    "message": "Request timeout after 180s"
+  },
+  "context": {
+    "text_preview": "הראשונים...",
+    "char_count": 5000
+  }
+}
+```
+
+### Stratégie
+
+- Si un segment échoue : **continuer** avec les autres
+- Enregistrer l'erreur via Error Handler
+- À la fin, marquer le job avec le status approprié :
+  - `completed` : tous les segments OK
+  - `completed_with_errors` : certains segments en erreur
+  - `failed` : erreur critique (ex: tous les segments échoués)
+
+### Résultat final avec erreurs
+
+```json
+{
+  "job_id": "xxx",
+  "status": "completed_with_errors",
+  "progress": {"current": 5, "total": 5, "percentage": 100},
+  "errors": [
+    {"segment_index": 3, "worker": "translate", "error": "CLAUDE_TIMEOUT"}
+  ],
+  "successful_segments": [0, 1, 2, 4]
+}
+```
+
+## Payload du Router
+
+### Input
+
+```json
+{
+  "job_id": "uuid",
+  "job_type": "batch_commentaries | unit_translation | document_translation",
+  "text": "...",                    // Pour texte unique
+  "segments": [                     // Pour batch
+    {"commentary_id": "uuid", "text": "..."},
+    {"source_text_id": "uuid", "text": "..."}
+  ],
+  "traite": "Pesachim",
+  "page": "2b",
+  "section": "Introduction",        // Optionnel
+  "commentator": "Rashi",           // Optionnel
+  "source_language": "he",
+  "target_language": "fr",
+  "api_key": "sk-ant-...",
+  "openai_api_key": "sk-proj-...",  // Optionnel
+  "context": {},
+  "metadata": {},
+  "request_id": "req_xxx"
+}
+```
+
+### Output immédiat
+
+```json
+{
+  "received": true,
+  "job_id": "xxx",
+  "segments_count": 5,
+  "pipeline": "chunk -> translate -> save"
+}
+```
+
+## Plan d'implémentation
+
+### Phase 1 : Router + Translate Worker simplifié
+
+1. [ ] Créer `Torah-Router.json`
+   - Webhook `/webhook/torah-router`
+   - Analyse payload et décide du pipeline
+   - Répond immédiatement
+   - Orchestre les workers
+
+2. [ ] Simplifier `Torah-Translate-Worker-v2.json` → `Torah-Translate-Worker.json`
+   - Retirer Loop Chunks, Recombine Chunks
+   - Retirer Save Translation
+   - Garder uniquement la traduction (pivot ou direct)
+   - Input : 1 segment
+   - Output : 1 traduction
+
+### Phase 2 : Save Worker + Error Handler
+
+3. [ ] Créer `Torah-Save-Worker.json`
+   - Webhook `/webhook/torah-save`
+   - Appelle `/api/translations/save`
+   - Gère les différents types d'ID (commentary_id, source_text_id)
+
+4. [ ] Créer `Torah-Error-Handler.json`
+   - Webhook `/webhook/torah-error`
+   - Stocke les erreurs (Redis ou API)
+
+### Phase 3 : Chunk Worker
+
+5. [ ] Créer `Torah-Chunk-Worker.json`
+   - Webhook `/webhook/torah-chunk`
+   - Utilise Claude Smart Split
+   - Input : 1 texte long
+   - Output : N segments
+
+### Phase 4 : Migration
+
+6. [ ] Modifier `Torah-Discord-Translation-v2-Unified.json`
+   - Appeler `/webhook/torah-router` au lieu de `/webhook/torah-translate-worker`
+
+7. [ ] Modifier `MCP-PDF-Layout-Translator.json`
+   - Appeler `/webhook/torah-router`
+
+8. [ ] Archiver l'ancien workflow
+   - Renommer `Torah-Translate-Worker-v2.json` → `Torah-Translate-Worker-v2-deprecated.json`
+
+## Tests
+
+- [ ] Test batch 3 commentaires courts
+- [ ] Test texte unique court
+- [ ] Test texte unique long (> 10K chars)
+- [ ] Test avec erreur sur 1 segment
+- [ ] Test timeout Claude
+- [ ] Test progress updates
+
+## Rollback
+
+En cas de problème :
+1. Réactiver `Torah-Translate-Worker-v2.json`
+2. Modifier les appelants pour pointer vers l'ancien endpoint
+3. Désactiver le Router
+
+## Références
+
+- Exécution problématique : http://host2.local:5678/workflow/DxfUNwlrIU4XyTAq/executions/63248
+- Workflow actuel : `workflows/Torah-Translate-Worker-v2.json`
+- Workflows appelants :
+  - `workflows/Torah-Discord-Translation-v2-Unified.json`
+  - `workflows/MCP-PDF-Layout-Translator.json`

--- a/workflows/LEARNING-Generate-Worker.json
+++ b/workflows/LEARNING-Generate-Worker.json
@@ -51,7 +51,7 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json }}",
+              "leftValue": "={{ $json.propertyName }}",
               "rightValue": "",
               "operator": {
                 "type": "string",
@@ -72,7 +72,7 @@
       "position": [900, 200],
       "parameters": {
         "operation": "get",
-        "key": "=job:learning:{{ $json }}"
+        "key": "=job:learning:{{ $json.propertyName }}"
       },
       "credentials": {
         "redis": {

--- a/workflows/TORAH-Get-Section.json
+++ b/workflows/TORAH-Get-Section.json
@@ -126,7 +126,7 @@
       "typeVersion": 2,
       "position": [1560, 100],
       "parameters": {
-        "jsCode": "const data = $input.first().json;\nconst validData = $('Validate Input').first().json;\n\nreturn {\n  json: {\n    success: true,\n    source: data.source || validData.source,\n    section: data.section || validData.section,\n    structure_type: 'complex',\n    title: data.title || null,\n    segments: (data.segments || data.entries || []).map((s, idx) => ({\n      index: s.index !== undefined ? s.index : idx + 1,\n      text: s.text_hebrew || s.text,\n      translation: s.text_translated || s.translation || null\n    })),\n    total_segments: data.total_segments || data.count || (data.segments || data.entries || []).length\n  }\n};"
+        "jsCode": "const data = $input.first().json;\nconst validData = $('Validate Input').first().json;\n\nreturn {\n  json: {\n    success: true,\n    source: data.source || validData.source,\n    section: data.section || validData.section,\n    structure_type: 'complex',\n    title: data.title || null,\n    segments: (data.segments || data.entries || []).map((s, idx) => ({\n      source_text_id: s.source_text_id || null,\n      index: s.index !== undefined ? s.index : idx + 1,\n      text_hebrew: s.text_hebrew || s.text,\n      text_translated: s.text_translated || s.translation || null\n    })),\n    total_segments: data.total_segments || data.count || (data.segments || data.entries || []).length\n  }\n};"
       }
     },
     {

--- a/workflows/Torah-Chunk-Worker.json
+++ b/workflows/Torah-Chunk-Worker.json
@@ -1,0 +1,135 @@
+{
+  "name": "Torah Chunk Worker",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Chunk Worker\n\n**Endpoint:** `POST /webhook/torah-chunk`\n\n**Responsabilite:** Decouper un texte long en segments\n\n**Input:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"text\": \"...\",\n  \"threshold\": 10000,\n  \"api_key\": \"sk-ant-...\",\n  \"context\": { \"traite\": \"...\" }\n}\n```\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"segments\": [\n    { \"index\": 0, \"text\": \"...\", \"char_count\": 8000 },\n    { \"index\": 1, \"text\": \"...\", \"char_count\": 7500 }\n  ],\n  \"total_segments\": 2\n}\n```",
+        "height": 380,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-chunk",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "torah-chunk"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.text) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_TEXT', message: 'text is required' }\n    }\n  }];\n}\n\nif (!body.api_key) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_API_KEY', message: 'api_key is required' }\n    }\n  }];\n}\n\nconst threshold = body.threshold || 10000;\nconst textLength = body.text.length;\n\n// If text is short enough, no chunking needed\nif (textLength <= threshold) {\n  return [{\n    json: {\n      success: true,\n      needsChunking: false,\n      segments: [{ index: 0, text: body.text, char_count: textLength }],\n      total_segments: 1\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    text: body.text,\n    textLength: textLength,\n    threshold: threshold,\n    apiKey: body.api_key,\n    context: body.context || {},\n    needsChunking: true\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.needsChunking }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "needs-chunking",
+      "name": "Needs Chunking?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "x-api-key", "value": "={{ $json.apiKey }}" },
+            { "name": "anthropic-version", "value": "2023-06-01" },
+            { "name": "content-type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: 'claude-3-5-haiku-20241022', max_tokens: 8192, messages: [{ role: 'user', content: 'Tu es expert en textes hébraïques rabbiniques (Talmud, Kabbale, Zohar).\\n\\nDécoupe ce texte en sections de maximum 8000 caractères.\\nRespecte les frontières sémantiques :\\n- Fin de citation (וכו\\', ע\\\"כ)\\n- Changement de sujet/commentateur\\n- Marqueurs structurels (<b>, titres)\\n- Ne coupe JAMAIS au milieu d\\'une phrase\\n\\nIgnore les balises <img> - elles seront traitées séparément.\\n\\nRetourne UNIQUEMENT un JSON valide (pas de ```json), format:\\n{\"chunks\": [{\"index\": 0, \"text\": \"...\", \"char_count\": 7500}, {\"index\": 1, \"text\": \"...\", \"char_count\": 6200}], \"total_chunks\": 2}\\n\\nTEXTE À DÉCOUPER:\\n' + $json.text.substring(0, 50000) }] }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 300000
+        }
+      },
+      "id": "claude-smart-split",
+      "name": "Claude Smart Split",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse Claude's chunking response\nconst input = $input.first().json;\nconst prevData = $('Parse Input').first().json;\n\ntry {\n  const body = input.body || input;\n  \n  // Check for API error\n  if (body.error) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 'CLAUDE_ERROR',\n          message: body.error.message || 'Smart Split API error'\n        }\n      }\n    }];\n  }\n  \n  const content = body.content?.[0]?.text || '';\n  \n  if (!content) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 'EMPTY_RESPONSE',\n          message: 'Smart Split returned empty response'\n        }\n      }\n    }];\n  }\n  \n  // Try to parse JSON from response\n  let jsonStr = content;\n  const jsonMatch = content.match(/```json\\n?([\\s\\S]*?)\\n?```/);\n  if (jsonMatch) {\n    jsonStr = jsonMatch[1];\n  }\n  \n  const parsed = JSON.parse(jsonStr);\n  const chunks = parsed.chunks || [];\n  \n  if (chunks.length === 0) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 'NO_CHUNKS',\n          message: 'Smart Split returned no chunks'\n        }\n      }\n    }];\n  }\n  \n  // Format segments\n  const segments = chunks.map((chunk, idx) => ({\n    index: chunk.index !== undefined ? chunk.index : idx,\n    text: chunk.text,\n    char_count: chunk.char_count || chunk.text.length\n  }));\n  \n  return [{\n    json: {\n      success: true,\n      segments: segments,\n      total_segments: segments.length,\n      method: 'claude_semantic'\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 'PARSE_ERROR',\n        message: 'Failed to parse Smart Split response: ' + e.message\n      }\n    }\n  }];\n}"
+      },
+      "id": "parse-chunks",
+      "name": "Parse Chunks",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "mode": "chooseBranch"
+      },
+      "id": "merge-result",
+      "name": "Merge Result",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1540, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [[{ "node": "Parse Input", "type": "main", "index": 0 }]]
+    },
+    "Parse Input": {
+      "main": [[{ "node": "Needs Chunking?", "type": "main", "index": 0 }]]
+    },
+    "Needs Chunking?": {
+      "main": [
+        [{ "node": "Claude Smart Split", "type": "main", "index": 0 }],
+        [{ "node": "Merge Result", "type": "main", "index": 1 }]
+      ]
+    },
+    "Claude Smart Split": {
+      "main": [[{ "node": "Parse Chunks", "type": "main", "index": 0 }]]
+    },
+    "Parse Chunks": {
+      "main": [[{ "node": "Merge Result", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah-Error-Handler.json
+++ b/workflows/Torah-Error-Handler.json
@@ -1,0 +1,89 @@
+{
+  "name": "Torah Error Handler",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Error Handler\n\n**Endpoint:** `POST /webhook/torah-error`\n\n**Responsabilite:** Collecter et stocker les erreurs par job\n\n**Input:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"segment_index\": 3,\n  \"worker\": \"translate\",\n  \"error\": {\n    \"code\": \"CLAUDE_TIMEOUT\",\n    \"message\": \"Request timeout\"\n  },\n  \"context\": {\n    \"text_preview\": \"...\",\n    \"char_count\": 5000\n  }\n}\n```\n\n**Stockage:** Redis (clé: `job_errors:{job_id}`)",
+        "height": 340,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-error",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "torah-error"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse error data\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst errorEntry = {\n  job_id: body.job_id,\n  segment_index: body.segment_index,\n  worker: body.worker || 'unknown',\n  error_code: body.error?.code || 'UNKNOWN_ERROR',\n  error_message: body.error?.message || 'Unknown error',\n  context: body.context || {},\n  timestamp: new Date().toISOString()\n};\n\nreturn [{\n  json: {\n    redisKey: `job_errors:${body.job_id}`,\n    errorEntry: errorEntry,\n    jobId: body.job_id\n  }\n}];"
+      },
+      "id": "parse-error",
+      "name": "Parse Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "operation": "push",
+        "keyName": "={{ $json.redisKey }}",
+        "value": "={{ JSON.stringify($json.errorEntry) }}",
+        "expire": true,
+        "ttl": 86400
+      },
+      "id": "redis-push",
+      "name": "Redis Push Error",
+      "type": "n8n-nodes-base.redis",
+      "typeVersion": 1,
+      "position": [880, 300],
+      "credentials": {
+        "redis": {
+          "id": "redis-credentials",
+          "name": "Redis"
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Return success response\nconst input = $('Parse Error').first().json;\n\nreturn [{\n  json: {\n    success: true,\n    job_id: input.jobId,\n    error_logged: true,\n    redis_key: input.redisKey\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [[{ "node": "Parse Error", "type": "main", "index": 0 }]]
+    },
+    "Parse Error": {
+      "main": [[{ "node": "Redis Push Error", "type": "main", "index": 0 }]]
+    },
+    "Redis Push Error": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah-Router.json
+++ b/workflows/Torah-Router.json
@@ -30,7 +30,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst CHUNK_THRESHOLD = 10000;\n\n// Validate required fields\nif (!body.job_id) {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'job_id is required' }\n    }\n  }];\n}\n\n// Determine pipeline type\nlet pipelineType = 'unknown';\nlet segments = [];\nlet needsChunking = false;\nlet totalSegments = 0;\n\nif (body.segments && Array.isArray(body.segments) && body.segments.length > 0) {\n  // Batch mode: multiple segments (commentaries)\n  pipelineType = 'batch';\n  segments = body.segments.map((s, idx) => ({\n    index: idx,\n    text: typeof s === 'string' ? s : (s.text || s.text_hebrew),\n    commentary_id: s.commentary_id || null,\n    source_text_id: s.source_text_id || null,\n    char_count: (typeof s === 'string' ? s : (s.text || s.text_hebrew || '')).length\n  }));\n  \n  // Check if any segment is too long\n  const tooLongSegment = segments.find(s => s.char_count > CHUNK_THRESHOLD);\n  if (tooLongSegment) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: `Segment ${tooLongSegment.index} is too long (${tooLongSegment.char_count} chars). Max: ${CHUNK_THRESHOLD}. Use chunking for long texts.`\n        }\n      }\n    }];\n  }\n  \n  totalSegments = segments.length;\n  \n} else if (body.text) {\n  // Single text mode\n  const textLength = body.text.length;\n  \n  if (textLength > CHUNK_THRESHOLD) {\n    pipelineType = 'chunk_then_translate';\n    needsChunking = true;\n    // Segments will be created by Chunk Worker\n    segments = [{ index: 0, text: body.text, char_count: textLength }];\n    totalSegments = 1; // Will be updated after chunking\n  } else {\n    pipelineType = 'translate_single';\n    segments = [{\n      index: 0,\n      text: body.text,\n      source_text_id: body.source_text_id || null,\n      char_count: textLength\n    }];\n    totalSegments = 1;\n  }\n} else {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'Either segments[] or text is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: body.job_id,\n    jobType: body.job_type || 'translation',\n    pipelineType: pipelineType,\n    needsChunking: needsChunking,\n    segments: segments,\n    totalSegments: totalSegments,\n    traite: body.traite,\n    page: body.page,\n    section: body.section,\n    commentator: body.commentator,\n    sourceLanguage: body.source_language || 'he',\n    targetLanguage: body.target_language || 'fr',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    context: body.context || {},\n    metadata: body.metadata || {},\n    requestId: body.request_id,\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\nconst CHUNK_THRESHOLD = 10000;\n\n// Generate job_id if not provided\nconst jobIdProvided = !!body.job_id;\nconst jobId = body.job_id || 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\nconst projectId = headers['x-project-id'] || body.project_id || 'default';\n\n// Determine pipeline type\nlet pipelineType = 'unknown';\nlet segments = [];\nlet needsChunking = false;\nlet totalSegments = 0;\n\nif (body.segments && Array.isArray(body.segments) && body.segments.length > 0) {\n  // Batch mode: multiple segments (commentaries)\n  pipelineType = 'batch';\n  segments = body.segments.map((s, idx) => ({\n    index: idx,\n    text: typeof s === 'string' ? s : (s.text || s.text_hebrew),\n    commentary_id: s.commentary_id || null,\n    source_text_id: s.source_text_id || null,\n    char_count: (typeof s === 'string' ? s : (s.text || s.text_hebrew || '')).length\n  }));\n  \n  // Check if any segment is too long\n  const tooLongSegment = segments.find(s => s.char_count > CHUNK_THRESHOLD);\n  if (tooLongSegment) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: `Segment ${tooLongSegment.index} is too long (${tooLongSegment.char_count} chars). Max: ${CHUNK_THRESHOLD}. Use chunking for long texts.`\n        }\n      }\n    }];\n  }\n  \n  totalSegments = segments.length;\n  \n} else if (body.text) {\n  // Single text mode\n  const textLength = body.text.length;\n  \n  if (textLength > CHUNK_THRESHOLD) {\n    pipelineType = 'chunk_then_translate';\n    needsChunking = true;\n    // Segments will be created by Chunk Worker\n    segments = [{ index: 0, text: body.text, char_count: textLength }];\n    totalSegments = 1; // Will be updated after chunking\n  } else {\n    pipelineType = 'translate_single';\n    segments = [{\n      index: 0,\n      text: body.text,\n      source_text_id: body.source_text_id || null,\n      char_count: textLength\n    }];\n    totalSegments = 1;\n  }\n} else {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'Either segments[] or text is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId,\n    jobIdProvided: jobIdProvided,\n    needsJobCreation: !jobIdProvided,\n    projectId: projectId,\n    jobType: body.job_type || 'translation',\n    pipelineType: pipelineType,\n    needsChunking: needsChunking,\n    segments: segments,\n    totalSegments: totalSegments,\n    traite: body.traite,\n    page: body.page,\n    section: body.section,\n    commentator: body.commentator,\n    sourceLanguage: body.source_language || 'he',\n    targetLanguage: body.target_language || 'fr',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    context: body.context || {},\n    metadata: body.metadata || {},\n    requestId: body.request_id,\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
       },
       "id": "parse-input",
       "name": "Parse Input",
@@ -89,18 +89,61 @@
     },
     {
       "parameters": {
-        "method": "PATCH",
-        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $('Parse Input').first().json.needsJobCreation }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "needs-job-creation",
+      "name": "Needs Job Creation?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/v2/jobs",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "X-Project-ID", "value": "={{ $('Parse Input').first().json.projectId }}" }
+          ]
+        },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ status: 'processing', progress: { current: 0, total: $json.totalSegments, percentage: 0 } }) }}",
+        "jsonBody": "={{ JSON.stringify({ job_id: $('Parse Input').first().json.jobId, job_type: $('Parse Input').first().json.jobType, status: 'pending', input: { traite: $('Parse Input').first().json.traite, page: $('Parse Input').first().json.page, target_language: $('Parse Input').first().json.targetLanguage, segments_count: $('Parse Input').first().json.totalSegments, commentator: $('Parse Input').first().json.commentator } }) }}",
+        "options": { "timeout": 10000 }
+      },
+      "id": "create-job",
+      "name": "Create Job",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1540, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $('Parse Input').first().json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'processing', progress: { current: 0, total: $('Parse Input').first().json.totalSegments, percentage: 0 } }) }}",
         "options": { "timeout": 5000 }
       },
       "id": "set-processing",
       "name": "Set Processing",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1320, 200],
+      "position": [1760, 200],
       "onError": "continueRegularOutput"
     },
     {
@@ -109,7 +152,7 @@
           "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
           "conditions": [
             {
-              "leftValue": "={{ $json.needsChunking }}",
+              "leftValue": "={{ $('Parse Input').first().json.needsChunking }}",
               "rightValue": true,
               "operator": { "type": "boolean", "operation": "equals" }
             }
@@ -231,7 +274,7 @@
         "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-save",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, translation: $json.translation, commentary_id: $json.commentary_id, source_text_id: $json.source_text_id, target_language: $json.targetLanguage, metadata: $json.metadata }) }}",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, translation: $json.translation, commentary_id: $json.commentary_id, source_text_id: $json.source_text_id, segment_index: $json.segmentIndex, target_language: $json.targetLanguage, metadata: $json.metadata }) }}",
         "options": { "timeout": 30000 }
       },
       "id": "call-save-worker",
@@ -343,6 +386,15 @@
       ]
     },
     "Respond Accepted": {
+      "main": [[{ "node": "Needs Job Creation?", "type": "main", "index": 0 }]]
+    },
+    "Needs Job Creation?": {
+      "main": [
+        [{ "node": "Create Job", "type": "main", "index": 0 }],
+        [{ "node": "Set Processing", "type": "main", "index": 0 }]
+      ]
+    },
+    "Create Job": {
       "main": [[{ "node": "Set Processing", "type": "main", "index": 0 }]]
     },
     "Set Processing": {

--- a/workflows/Torah-Router.json
+++ b/workflows/Torah-Router.json
@@ -1,0 +1,414 @@
+{
+  "name": "Torah Router",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Router\n\n**Endpoint:** `POST /webhook/torah-router`\n\n**Responsabilite:**\n- Analyse le payload\n- Decide du pipeline (chunk/translate/save)\n- Orchestre les workers\n- Met a jour le progress\n- Gere les erreurs\n\n**Pipelines:**\n- Batch commentaires: Translate -> Save (pour chaque)\n- Texte long: Chunk -> Translate -> Save (combine)\n- Texte court: Translate -> Save",
+        "height": 340,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-router",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "torah-router"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst CHUNK_THRESHOLD = 10000;\n\n// Validate required fields\nif (!body.job_id) {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'job_id is required' }\n    }\n  }];\n}\n\n// Determine pipeline type\nlet pipelineType = 'unknown';\nlet segments = [];\nlet needsChunking = false;\nlet totalSegments = 0;\n\nif (body.segments && Array.isArray(body.segments) && body.segments.length > 0) {\n  // Batch mode: multiple segments (commentaries)\n  pipelineType = 'batch';\n  segments = body.segments.map((s, idx) => ({\n    index: idx,\n    text: typeof s === 'string' ? s : (s.text || s.text_hebrew),\n    commentary_id: s.commentary_id || null,\n    source_text_id: s.source_text_id || null,\n    char_count: (typeof s === 'string' ? s : (s.text || s.text_hebrew || '')).length\n  }));\n  \n  // Check if any segment is too long\n  const tooLongSegment = segments.find(s => s.char_count > CHUNK_THRESHOLD);\n  if (tooLongSegment) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: `Segment ${tooLongSegment.index} is too long (${tooLongSegment.char_count} chars). Max: ${CHUNK_THRESHOLD}. Use chunking for long texts.`\n        }\n      }\n    }];\n  }\n  \n  totalSegments = segments.length;\n  \n} else if (body.text) {\n  // Single text mode\n  const textLength = body.text.length;\n  \n  if (textLength > CHUNK_THRESHOLD) {\n    pipelineType = 'chunk_then_translate';\n    needsChunking = true;\n    // Segments will be created by Chunk Worker\n    segments = [{ index: 0, text: body.text, char_count: textLength }];\n    totalSegments = 1; // Will be updated after chunking\n  } else {\n    pipelineType = 'translate_single';\n    segments = [{\n      index: 0,\n      text: body.text,\n      source_text_id: body.source_text_id || null,\n      char_count: textLength\n    }];\n    totalSegments = 1;\n  }\n} else {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'Either segments[] or text is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: body.job_id,\n    jobType: body.job_type || 'translation',\n    pipelineType: pipelineType,\n    needsChunking: needsChunking,\n    segments: segments,\n    totalSegments: totalSegments,\n    traite: body.traite,\n    page: body.page,\n    section: body.section,\n    commentator: body.commentator,\n    sourceLanguage: body.source_language || 'he',\n    targetLanguage: body.target_language || 'fr',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    context: body.context || {},\n    metadata: body.metadata || {},\n    requestId: body.request_id,\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}"
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 500]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ received: true, job_id: $json.jobId, pipeline: $json.pipelineType, segments_count: $json.totalSegments }) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "respond-accepted",
+      "name": "Respond Accepted",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1100, 200]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'processing', progress: { current: 0, total: $json.totalSegments, percentage: 0 } }) }}",
+        "options": { "timeout": 5000 }
+      },
+      "id": "set-processing",
+      "name": "Set Processing",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1320, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.needsChunking }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "needs-chunking",
+      "name": "Needs Chunking?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-chunk",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $('Parse Input').first().json.jobId, text: $('Parse Input').first().json.segments[0].text, source_text_id: $('Parse Input').first().json.segments[0].source_text_id, threshold: $('Parse Input').first().json.chunkThreshold, api_key: $('Parse Input').first().json.apiKey, context: { traite: $('Parse Input').first().json.traite, page: $('Parse Input').first().json.page, section: $('Parse Input').first().json.section } }) }}",
+        "options": { "timeout": 300000 }
+      },
+      "id": "call-chunk-worker",
+      "name": "Call Chunk Worker",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1760, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare segments for translation loop\nconst input = $('Parse Input').first().json;\nconst chunkResult = $input.first().json;\n\nlet segments = [];\n\n// Check if chunking was done\nif (chunkResult.segments && Array.isArray(chunkResult.segments)) {\n  // Chunked segments from Chunk Worker\n  segments = chunkResult.segments.map((s, idx) => ({\n    index: idx,\n    text: s.text,\n    source_text_id: input.segments[0]?.source_text_id,\n    char_count: s.text?.length || 0,\n    isChunk: true,\n    totalChunks: chunkResult.segments.length\n  }));\n} else {\n  // Use original segments (no chunking needed or chunking failed)\n  segments = input.segments;\n}\n\nconst items = segments.map(segment => ({\n  json: {\n    ...segment,\n    jobId: input.jobId,\n    totalSegments: segments.length,\n    traite: input.traite,\n    page: input.page,\n    section: input.section,\n    commentator: input.commentator,\n    sourceLanguage: input.sourceLanguage,\n    targetLanguage: input.targetLanguage,\n    apiKey: input.apiKey,\n    openaiApiKey: input.openaiApiKey,\n    context: input.context,\n    metadata: input.metadata,\n    pipelineType: input.pipelineType\n  }\n}));\n\nreturn items;"
+      },
+      "id": "prepare-segments",
+      "name": "Prepare Segments",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Use original segments directly (no chunking)\nconst input = $('Parse Input').first().json;\n\nconst items = input.segments.map(segment => ({\n  json: {\n    ...segment,\n    jobId: input.jobId,\n    totalSegments: input.totalSegments,\n    traite: input.traite,\n    page: input.page,\n    section: input.section,\n    commentator: input.commentator,\n    sourceLanguage: input.sourceLanguage,\n    targetLanguage: input.targetLanguage,\n    apiKey: input.apiKey,\n    openaiApiKey: input.openaiApiKey,\n    context: input.context,\n    metadata: input.metadata,\n    pipelineType: input.pipelineType\n  }\n}));\n\nreturn items;"
+      },
+      "id": "prepare-segments-direct",
+      "name": "Prepare Segments Direct",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1760, 300]
+    },
+    {
+      "parameters": {
+        "mode": "chooseBranch"
+      },
+      "id": "merge-segments",
+      "name": "Merge Segments",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [2200, 200]
+    },
+    {
+      "parameters": { "options": {} },
+      "id": "loop-segments",
+      "name": "Loop Segments",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [2420, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-translate",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, text: $json.text, source_language: $json.sourceLanguage, target_language: $json.targetLanguage, api_key: $json.apiKey, context: { traite: $json.traite, page: $json.page, section: $json.section, commentator: $json.commentator }, metadata: $json.metadata }) }}",
+        "options": { "timeout": 300000 }
+      },
+      "id": "call-translate-worker",
+      "name": "Call Translate Worker",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2640, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "loose" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "translate-success",
+      "name": "Translate Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2860, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Prepare save payload\nconst loopItem = $('Loop Segments').first().json;\nconst translateResult = $input.first().json;\n\nreturn [{\n  json: {\n    jobId: loopItem.jobId,\n    segmentIndex: loopItem.index,\n    totalSegments: loopItem.totalSegments,\n    translation: translateResult.translation,\n    commentary_id: loopItem.commentary_id,\n    source_text_id: loopItem.source_text_id,\n    targetLanguage: loopItem.targetLanguage,\n    metadata: loopItem.metadata,\n    isChunk: loopItem.isChunk || false,\n    pipelineType: loopItem.pipelineType\n  }\n}];"
+      },
+      "id": "prepare-save",
+      "name": "Prepare Save",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3080, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-save",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, translation: $json.translation, commentary_id: $json.commentary_id, source_text_id: $json.source_text_id, target_language: $json.targetLanguage, metadata: $json.metadata }) }}",
+        "options": { "timeout": 30000 }
+      },
+      "id": "call-save-worker",
+      "name": "Call Save Worker",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3300, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-error",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $('Loop Segments').first().json.jobId, segment_index: $('Loop Segments').first().json.index, worker: 'translate', error: { code: $json.error?.code || 'TRANSLATE_ERROR', message: $json.error?.message || 'Translation failed' }, context: { text_preview: $('Loop Segments').first().json.text?.substring(0, 100), char_count: $('Loop Segments').first().json.char_count } }) }}",
+        "options": { "timeout": 10000 }
+      },
+      "id": "call-error-handler",
+      "name": "Call Error Handler",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3080, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Update progress after each segment\nconst loopItem = $('Loop Segments').first().json;\nconst current = loopItem.index + 1;\nconst total = loopItem.totalSegments;\nconst percentage = Math.round((current / total) * 100);\n\nreturn [{\n  json: {\n    jobId: loopItem.jobId,\n    current: current,\n    total: total,\n    percentage: percentage,\n    isLast: current >= total\n  }\n}];"
+      },
+      "id": "calc-progress",
+      "name": "Calc Progress",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3520, 300]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'processing', progress: { current: $json.current, total: $json.total, percentage: $json.percentage } }) }}",
+        "options": { "timeout": 5000 }
+      },
+      "id": "update-progress",
+      "name": "Update Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3740, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $('Calc Progress').first().json.isLast }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "is-last",
+      "name": "Is Last?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [3960, 300]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $('Calc Progress').first().json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'completed', progress: { current: $('Calc Progress').first().json.total, total: $('Calc Progress').first().json.total, percentage: 100 } }) }}",
+        "options": { "timeout": 10000 }
+      },
+      "id": "set-completed",
+      "name": "Set Completed",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [4180, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {},
+      "id": "done",
+      "name": "Done",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [4400, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [[{ "node": "Parse Input", "type": "main", "index": 0 }]]
+    },
+    "Parse Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "Respond Accepted", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "Respond Accepted": {
+      "main": [[{ "node": "Set Processing", "type": "main", "index": 0 }]]
+    },
+    "Set Processing": {
+      "main": [[{ "node": "Needs Chunking?", "type": "main", "index": 0 }]]
+    },
+    "Needs Chunking?": {
+      "main": [
+        [{ "node": "Call Chunk Worker", "type": "main", "index": 0 }],
+        [{ "node": "Prepare Segments Direct", "type": "main", "index": 0 }]
+      ]
+    },
+    "Call Chunk Worker": {
+      "main": [[{ "node": "Prepare Segments", "type": "main", "index": 0 }]]
+    },
+    "Prepare Segments": {
+      "main": [[{ "node": "Merge Segments", "type": "main", "index": 0 }]]
+    },
+    "Prepare Segments Direct": {
+      "main": [[{ "node": "Merge Segments", "type": "main", "index": 1 }]]
+    },
+    "Merge Segments": {
+      "main": [[{ "node": "Loop Segments", "type": "main", "index": 0 }]]
+    },
+    "Loop Segments": {
+      "main": [
+        [{ "node": "Done", "type": "main", "index": 0 }],
+        [{ "node": "Call Translate Worker", "type": "main", "index": 0 }]
+      ]
+    },
+    "Call Translate Worker": {
+      "main": [[{ "node": "Translate Success?", "type": "main", "index": 0 }]]
+    },
+    "Translate Success?": {
+      "main": [
+        [{ "node": "Prepare Save", "type": "main", "index": 0 }],
+        [{ "node": "Call Error Handler", "type": "main", "index": 0 }]
+      ]
+    },
+    "Prepare Save": {
+      "main": [[{ "node": "Call Save Worker", "type": "main", "index": 0 }]]
+    },
+    "Call Save Worker": {
+      "main": [[{ "node": "Calc Progress", "type": "main", "index": 0 }]]
+    },
+    "Call Error Handler": {
+      "main": [[{ "node": "Calc Progress", "type": "main", "index": 0 }]]
+    },
+    "Calc Progress": {
+      "main": [[{ "node": "Update Progress", "type": "main", "index": 0 }]]
+    },
+    "Update Progress": {
+      "main": [[{ "node": "Is Last?", "type": "main", "index": 0 }]]
+    },
+    "Is Last?": {
+      "main": [
+        [{ "node": "Set Completed", "type": "main", "index": 0 }],
+        [{ "node": "Loop Segments", "type": "main", "index": 0 }]
+      ]
+    },
+    "Set Completed": {
+      "main": [[{ "node": "Done", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah-Save-Worker.json
+++ b/workflows/Torah-Save-Worker.json
@@ -30,7 +30,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.translation) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_TRANSLATION', message: 'translation is required' }\n    }\n  }];\n}\n\nif (!body.commentary_id && !body.source_text_id) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_ID', message: 'Either commentary_id or source_text_id is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    translation: body.translation,\n    commentaryId: body.commentary_id || null,\n    sourceTextId: body.source_text_id || null,\n    targetLanguage: body.target_language || 'fr',\n    provider: body.provider || 'anthropic',\n    model: body.model || 'claude-sonnet-4-20250514',\n    tokens: body.tokens || null,\n    metadata: body.metadata || {}\n  }\n}];"
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.translation) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_TRANSLATION', message: 'translation is required' }\n    }\n  }];\n}\n\nif (!body.commentary_id && !body.source_text_id) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_ID', message: 'Either commentary_id or source_text_id is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    translation: body.translation,\n    commentaryId: body.commentary_id || null,\n    sourceTextId: body.source_text_id || null,\n    segmentIndex: body.segment_index !== undefined ? body.segment_index : null,\n    targetLanguage: body.target_language || 'fr',\n    provider: body.provider || 'anthropic',\n    model: body.model || 'claude-sonnet-4-20250514',\n    tokens: body.tokens || null,\n    metadata: body.metadata || {}\n  }\n}];"
       },
       "id": "parse-input",
       "name": "Parse Input",
@@ -44,7 +44,7 @@
         "url": "={{ $env.API_URL }}/api/translations/save",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, source_text_id: $json.sourceTextId, commentary_id: $json.commentaryId, translated_text: $json.translation, target_language: $json.targetLanguage, provider: $json.provider, model: $json.model, tokens: $json.tokens, metadata: $json.metadata }) }}",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, source_text_id: $json.sourceTextId, commentary_id: $json.commentaryId, segment_index: $json.segmentIndex, translated_text: $json.translation, target_language: $json.targetLanguage, provider: $json.provider, model: $json.model, tokens: $json.tokens, metadata: $json.metadata }) }}",
         "options": { "timeout": 30000 }
       },
       "id": "save-to-api",

--- a/workflows/Torah-Save-Worker.json
+++ b/workflows/Torah-Save-Worker.json
@@ -1,0 +1,84 @@
+{
+  "name": "Torah Save Worker",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Save Worker\n\n**Endpoint:** `POST /webhook/torah-save`\n\n**Responsabilite:** Sauvegarder UNE traduction en DB\n\n**Input:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"translation\": \"...\",\n  \"commentary_id\": \"uuid\",  // OU\n  \"source_text_id\": \"uuid\",\n  \"target_language\": \"fr\",\n  \"metadata\": {}\n}\n```\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"saved_id\": \"uuid\"\n}\n```",
+        "height": 320,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-save",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "torah-save"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nif (!body.translation) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_TRANSLATION', message: 'translation is required' }\n    }\n  }];\n}\n\nif (!body.commentary_id && !body.source_text_id) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_ID', message: 'Either commentary_id or source_text_id is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    translation: body.translation,\n    commentaryId: body.commentary_id || null,\n    sourceTextId: body.source_text_id || null,\n    targetLanguage: body.target_language || 'fr',\n    provider: body.provider || 'anthropic',\n    model: body.model || 'claude-sonnet-4-20250514',\n    tokens: body.tokens || null,\n    metadata: body.metadata || {}\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/translations/save",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, source_text_id: $json.sourceTextId, commentary_id: $json.commentaryId, translated_text: $json.translation, target_language: $json.targetLanguage, provider: $json.provider, model: $json.model, tokens: $json.tokens, metadata: $json.metadata }) }}",
+        "options": { "timeout": 30000 }
+      },
+      "id": "save-to-api",
+      "name": "Save to API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [880, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format response\nconst input = $input.first().json;\n\nif (input.error) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 'SAVE_ERROR',\n        message: input.error.message || 'Failed to save translation'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    success: input.success !== false,\n    saved_id: input.translation_id || input.commentary_id || input.source_text_id,\n    message: input.message || 'Translation saved'\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1100, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [[{ "node": "Parse Input", "type": "main", "index": 0 }]]
+    },
+    "Parse Input": {
+      "main": [[{ "node": "Save to API", "type": "main", "index": 0 }]]
+    },
+    "Save to API": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah-Translate-Page.json
+++ b/workflows/Torah-Translate-Page.json
@@ -4,7 +4,7 @@
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\",\n  \"force\": false\n}\n```\n\n**Parameters:**\n- `force`: Si true, force la retraduction même si existante\n\n**Response (already translated):**\n```json\n{\n  \"success\": true,\n  \"status\": \"already_translated\",\n  \"segments_count\": 14,\n  \"translated_count\": 14,\n  \"segments\": [...]\n}\n```\n\n**Response (started):**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Check existing translations\n3. If translated & !force → return existing\n4. Else → Create job, launch worker",
+        "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\",\n  \"force\": false,\n  \"job_type\": \"page_translation\"\n}\n```\n\n**Parameters:**\n- `force`: Si true, force la retraduction même si existante\n\n**Response (already translated):**\n```json\n{\n  \"success\": true,\n  \"status\": \"already_translated\",\n  \"segments_count\": 14,\n  \"translated_count\": 14,\n  \"segments\": [...]\n}\n```\n\n**Response (started):**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Check existing translations\n3. If translated & !force → return existing\n4. Else → Create job, launch Torah Router\n\n**RFC-031:** Utilise le pipeline unifie Torah Router",
         "height": 420,
         "width": 320,
         "color": 6
@@ -305,7 +305,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Préparer le payload pour le worker\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    workerPayload: {\n      job_id: data.jobId,\n      traite: data.traite,\n      page: data.page,\n      mode: data.mode,\n      target_language: data.targetLanguage,\n      api_key: data.apiKey,\n      openai_api_key: data.openaiApiKey,\n      source_text_id: data.sourceTextId,\n      reference: data.reference,\n      segments: data.segments,\n      request_id: data.requestId\n    },\n    // Garder les autres données pour Format Response\n    jobId: data.jobId,\n    traite: data.traite,\n    page: data.page,\n    segmentsCount: data.segmentsCount,\n    estimatedSeconds: data.estimatedSeconds\n  }\n}];"
+        "jsCode": "// Préparer le payload pour le Torah Router\nconst data = $input.first().json;\n\n// Formater les segments pour le Router\n// Chaque segment doit avoir: text, source_text_id (optionnel)\nconst formattedSegments = data.segments.map((text, index) => ({\n  text: text,\n  source_text_id: data.sourceTextId,\n  index: index\n}));\n\nreturn [{\n  json: {\n    routerPayload: {\n      job_id: data.jobId,\n      job_type: data.jobType || 'page_translation',\n      segments: formattedSegments,\n      source_language: 'he',\n      target_language: data.targetLanguage,\n      api_key: data.apiKey,\n      openai_api_key: data.openaiApiKey,\n      traite: data.traite,\n      page: data.page,\n      context: {\n        traite: data.traite,\n        page: data.page,\n        reference: data.reference,\n        mode: data.mode\n      },\n      metadata: {\n        source_text_id: data.sourceTextId,\n        reference: data.reference,\n        request_id: data.requestId\n      }\n    },\n    // Garder les autres données pour Format Response\n    jobId: data.jobId,\n    traite: data.traite,\n    page: data.page,\n    segmentsCount: data.segmentsCount,\n    estimatedSeconds: data.estimatedSeconds\n  }\n}];"
       },
       "id": "prepare-worker-payload",
       "name": "Prepare Worker Payload",
@@ -319,16 +319,16 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-translate-page-worker",
+        "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-router",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify($json.workerPayload) }}",
+        "jsonBody": "={{ JSON.stringify($json.routerPayload) }}",
         "options": {
           "timeout": 5000
         }
       },
-      "id": "launch-worker",
-      "name": "Launch Worker (async)",
+      "id": "launch-router",
+      "name": "Launch Router (async)",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
@@ -597,14 +597,14 @@
       "main": [
         [
           {
-            "node": "Launch Worker (async)",
+            "node": "Launch Router (async)",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Launch Worker (async)": {
+    "Launch Router (async)": {
       "main": [
         [
           {
@@ -652,7 +652,7 @@
     "nodes": [
       {
         "parameters": {
-          "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\",\n  \"force\": false\n}\n```\n\n**Parameters:**\n- `force`: Si true, force la retraduction même si existante\n\n**Response (already translated):**\n```json\n{\n  \"success\": true,\n  \"status\": \"already_translated\",\n  \"segments_count\": 14,\n  \"translated_count\": 14,\n  \"segments\": [...]\n}\n```\n\n**Response (started):**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Check existing translations\n3. If translated & !force → return existing\n4. Else → Create job, launch worker",
+          "content": "## Torah Page Translation - Start Job\n\n**Endpoint:** POST /webhook/torah-translate-page\n\n**Request:**\n```json\n{\n  \"traite\": \"Berakhot\",\n  \"page\": \"2a\",\n  \"mode\": \"premium\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"...\",\n  \"openai_api_key\": \"...\",\n  \"force\": false,\n  \"job_type\": \"page_translation\"\n}\n```\n\n**Parameters:**\n- `force`: Si true, force la retraduction même si existante\n\n**Response (already translated):**\n```json\n{\n  \"success\": true,\n  \"status\": \"already_translated\",\n  \"segments_count\": 14,\n  \"translated_count\": 14,\n  \"segments\": [...]\n}\n```\n\n**Response (started):**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"segments_count\": 14,\n  \"estimated_seconds\": 100\n}\n```\n\n**Flow:**\n1. Validate input\n2. Check existing translations\n3. If translated & !force → return existing\n4. Else → Create job, launch Torah Router\n\n**RFC-031:** Utilise le pipeline unifie Torah Router",
           "height": 420,
           "width": 320,
           "color": 6
@@ -953,7 +953,7 @@
       },
       {
         "parameters": {
-          "jsCode": "// Préparer le payload pour le worker\nconst data = $input.first().json;\n\nreturn [{\n  json: {\n    workerPayload: {\n      job_id: data.jobId,\n      traite: data.traite,\n      page: data.page,\n      mode: data.mode,\n      target_language: data.targetLanguage,\n      api_key: data.apiKey,\n      openai_api_key: data.openaiApiKey,\n      source_text_id: data.sourceTextId,\n      reference: data.reference,\n      segments: data.segments,\n      request_id: data.requestId\n    },\n    // Garder les autres données pour Format Response\n    jobId: data.jobId,\n    traite: data.traite,\n    page: data.page,\n    segmentsCount: data.segmentsCount,\n    estimatedSeconds: data.estimatedSeconds\n  }\n}];"
+          "jsCode": "// Préparer le payload pour le Torah Router\nconst data = $input.first().json;\n\n// Formater les segments pour le Router\n// Chaque segment doit avoir: text, source_text_id (optionnel)\nconst formattedSegments = data.segments.map((text, index) => ({\n  text: text,\n  source_text_id: data.sourceTextId,\n  index: index\n}));\n\nreturn [{\n  json: {\n    routerPayload: {\n      job_id: data.jobId,\n      job_type: data.jobType || 'page_translation',\n      segments: formattedSegments,\n      source_language: 'he',\n      target_language: data.targetLanguage,\n      api_key: data.apiKey,\n      openai_api_key: data.openaiApiKey,\n      traite: data.traite,\n      page: data.page,\n      context: {\n        traite: data.traite,\n        page: data.page,\n        reference: data.reference,\n        mode: data.mode\n      },\n      metadata: {\n        source_text_id: data.sourceTextId,\n        reference: data.reference,\n        request_id: data.requestId\n      }\n    },\n    // Garder les autres données pour Format Response\n    jobId: data.jobId,\n    traite: data.traite,\n    page: data.page,\n    segmentsCount: data.segmentsCount,\n    estimatedSeconds: data.estimatedSeconds\n  }\n}];"
         },
         "id": "prepare-worker-payload",
         "name": "Prepare Worker Payload",
@@ -967,16 +967,16 @@
       {
         "parameters": {
           "method": "POST",
-          "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-translate-page-worker",
+          "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-router",
           "sendBody": true,
           "specifyBody": "json",
-          "jsonBody": "={{ JSON.stringify($json.workerPayload) }}",
+          "jsonBody": "={{ JSON.stringify($json.routerPayload) }}",
           "options": {
             "timeout": 5000
           }
         },
-        "id": "launch-worker",
-        "name": "Launch Worker (async)",
+        "id": "launch-router",
+        "name": "Launch Router (async)",
         "type": "n8n-nodes-base.httpRequest",
         "typeVersion": 4.2,
         "position": [
@@ -1245,14 +1245,14 @@
         "main": [
           [
             {
-              "node": "Launch Worker (async)",
+              "node": "Launch Router (async)",
               "type": "main",
               "index": 0
             }
           ]
         ]
       },
-      "Launch Worker (async)": {
+      "Launch Router (async)": {
         "main": [
           [
             {

--- a/workflows/Torah-Translate-Simple.json
+++ b/workflows/Torah-Translate-Simple.json
@@ -1,0 +1,248 @@
+{
+  "name": "Torah Translate Simple",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Translate Simple\n\n**Endpoint:** `POST /webhook/torah-translate`\n\n**Responsabilite:** Traduire UN segment (sans sauvegarder)\n\n**Input:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"text\": \"...\",\n  \"source_language\": \"he\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"sk-ant-...\",\n  \"context\": { \"traite\": \"...\", \"page\": \"...\" }\n}\n```\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"translation\": \"...\",\n  \"tokens\": { \"input\": 100, \"output\": 150 }\n}\n```",
+        "height": 380,
+        "width": 340,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "torah-translate",
+        "responseMode": "lastNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [440, 300],
+      "webhookId": "torah-translate"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst languageNames = {\n  'fr': 'français',\n  'en': 'English',\n  'es': 'español',\n  'he': 'hébreu',\n  'ar': 'araméen',\n  'de': 'allemand',\n  'it': 'italien'\n};\n\nif (!body.text) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_TEXT', message: 'text is required' }\n    }\n  }];\n}\n\nif (!body.api_key) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'MISSING_API_KEY', message: 'api_key is required' }\n    }\n  }];\n}\n\nconst sourceLanguage = body.source_language || 'he';\nconst targetLanguage = body.target_language || 'fr';\nconst needsPivot = sourceLanguage !== 'en' && targetLanguage !== 'en';\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    text: body.text,\n    sourceLanguage: sourceLanguage,\n    sourceLangName: languageNames[sourceLanguage] || sourceLanguage,\n    targetLanguage: targetLanguage,\n    targetLangName: languageNames[targetLanguage] || targetLanguage,\n    needsPivot: needsPivot,\n    apiKey: body.api_key,\n    model: body.model || 'claude-sonnet-4-20250514',\n    context: body.context || {},\n    metadata: body.metadata || {}\n  }\n}];"
+      },
+      "id": "parse-input",
+      "name": "Parse Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.needsPivot }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "needs-pivot",
+      "name": "Needs Pivot?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [880, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "x-api-key", "value": "={{ $json.apiKey }}" },
+            { "name": "anthropic-version", "value": "2023-06-01" },
+            { "name": "content-type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: $json.model, max_tokens: 8192, messages: [{ role: 'user', content: 'Tu es un expert en textes talmudiques et kabbalistiques. Le texte source est en ' + $json.sourceLangName + '. Traduis en English (anglais).\\n\\nContexte: ' + ($json.context.traite || '') + ' ' + ($json.context.page || '') + ($json.context.commentator ? ' - ' + $json.context.commentator : '') + '\\n\\nTexte à traduire:\\n' + $json.text + '\\n\\nRéponds UNIQUEMENT avec la traduction anglaise.' }] }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 180000
+        }
+      },
+      "id": "claude-pivot-step1",
+      "name": "Claude Pivot Step 1",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract English translation from pivot step 1\nconst input = $input.first().json;\nconst prevData = $('Parse Input').first().json;\n\ntry {\n  const body = input.body || input;\n  \n  if (body.error) {\n    return [{\n      json: {\n        success: false,\n        error: { code: 'CLAUDE_ERROR', message: body.error.message || 'Claude API error' }\n      }\n    }];\n  }\n  \n  const content = body.content?.[0]?.text || '';\n  const usage = body.usage || {};\n  \n  if (!content) {\n    return [{\n      json: {\n        success: false,\n        error: { code: 'EMPTY_RESPONSE', message: 'Claude returned empty response' }\n      }\n    }];\n  }\n  \n  return [{\n    json: {\n      ...prevData,\n      intermediateTranslation: content,\n      pivotTokens: {\n        input_tokens: usage.input_tokens || 0,\n        output_tokens: usage.output_tokens || 0\n      }\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'PARSE_ERROR', message: e.message }\n    }\n  }];\n}"
+      },
+      "id": "extract-step1",
+      "name": "Extract Step 1",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "loose" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.success }}",
+              "rightValue": false,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "step1-failed",
+      "name": "Step 1 Failed?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1540, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "x-api-key", "value": "={{ $json.apiKey }}" },
+            { "name": "anthropic-version", "value": "2023-06-01" },
+            { "name": "content-type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: $json.model, max_tokens: 8192, messages: [{ role: 'user', content: 'Tu es un expert traducteur. Le texte est en English. Traduis en ' + $json.targetLangName + '.\\n\\nContexte: ' + ($json.context.traite || '') + ' ' + ($json.context.page || '') + ($json.context.commentator ? ' - ' + $json.context.commentator : '') + '\\n\\nTexte à traduire:\\n' + $json.intermediateTranslation + '\\n\\nRéponds UNIQUEMENT avec la traduction.' }] }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 180000
+        }
+      },
+      "id": "claude-pivot-step2",
+      "name": "Claude Pivot Step 2",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1760, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract final translation from pivot step 2\nconst input = $input.first().json;\nconst prevData = $('Extract Step 1').first().json;\n\ntry {\n  const body = input.body || input;\n  \n  if (body.error) {\n    return [{\n      json: {\n        success: false,\n        error: { code: 'CLAUDE_ERROR', message: body.error.message || 'Claude API error in step 2' }\n      }\n    }];\n  }\n  \n  const content = body.content?.[0]?.text || '';\n  const usage = body.usage || {};\n  \n  if (!content) {\n    return [{\n      json: {\n        success: false,\n        error: { code: 'EMPTY_RESPONSE', message: 'Claude returned empty response in step 2' }\n      }\n    }];\n  }\n  \n  return [{\n    json: {\n      success: true,\n      translation: content,\n      method: 'pivot',\n      tokens: {\n        input_tokens: (prevData.pivotTokens?.input_tokens || 0) + (usage.input_tokens || 0),\n        output_tokens: (prevData.pivotTokens?.output_tokens || 0) + (usage.output_tokens || 0)\n      }\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'PARSE_ERROR', message: e.message }\n    }\n  }];\n}"
+      },
+      "id": "extract-step2",
+      "name": "Extract Step 2",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1980, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "x-api-key", "value": "={{ $json.apiKey }}" },
+            { "name": "anthropic-version", "value": "2023-06-01" },
+            { "name": "content-type", "value": "application/json" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: $json.model, max_tokens: 8192, messages: [{ role: 'user', content: 'Tu es un expert en textes talmudiques et kabbalistiques. Le texte source est en ' + $json.sourceLangName + '. Traduis directement en ' + $json.targetLangName + '.\\n\\nContexte: ' + ($json.context.traite || '') + ' ' + ($json.context.page || '') + ($json.context.commentator ? ' - ' + $json.context.commentator : '') + '\\n\\nTexte à traduire:\\n' + $json.text + '\\n\\nRéponds UNIQUEMENT avec la traduction.' }] }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 180000
+        }
+      },
+      "id": "claude-direct",
+      "name": "Claude Direct",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1100, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Extract direct translation\nconst input = $input.first().json;\n\ntry {\n  const body = input.body || input;\n  \n  if (body.error) {\n    return [{\n      json: {\n        success: false,\n        error: { code: 'CLAUDE_ERROR', message: body.error.message || 'Claude API error' }\n      }\n    }];\n  }\n  \n  const content = body.content?.[0]?.text || '';\n  const usage = body.usage || {};\n  \n  if (!content) {\n    return [{\n      json: {\n        success: false,\n        error: { code: 'EMPTY_RESPONSE', message: 'Claude returned empty response' }\n      }\n    }];\n  }\n  \n  return [{\n    json: {\n      success: true,\n      translation: content,\n      method: 'direct',\n      tokens: {\n        input_tokens: usage.input_tokens || 0,\n        output_tokens: usage.output_tokens || 0\n      }\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: { code: 'PARSE_ERROR', message: e.message }\n    }\n  }];\n}"
+      },
+      "id": "extract-direct",
+      "name": "Extract Direct",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1320, 400]
+    },
+    {
+      "parameters": {
+        "mode": "chooseBranch"
+      },
+      "id": "merge-result",
+      "name": "Merge Result",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [2200, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [[{ "node": "Parse Input", "type": "main", "index": 0 }]]
+    },
+    "Parse Input": {
+      "main": [[{ "node": "Needs Pivot?", "type": "main", "index": 0 }]]
+    },
+    "Needs Pivot?": {
+      "main": [
+        [{ "node": "Claude Pivot Step 1", "type": "main", "index": 0 }],
+        [{ "node": "Claude Direct", "type": "main", "index": 0 }]
+      ]
+    },
+    "Claude Pivot Step 1": {
+      "main": [[{ "node": "Extract Step 1", "type": "main", "index": 0 }]]
+    },
+    "Extract Step 1": {
+      "main": [[{ "node": "Step 1 Failed?", "type": "main", "index": 0 }]]
+    },
+    "Step 1 Failed?": {
+      "main": [
+        [{ "node": "Merge Result", "type": "main", "index": 0 }],
+        [{ "node": "Claude Pivot Step 2", "type": "main", "index": 0 }]
+      ]
+    },
+    "Claude Pivot Step 2": {
+      "main": [[{ "node": "Extract Step 2", "type": "main", "index": 0 }]]
+    },
+    "Extract Step 2": {
+      "main": [[{ "node": "Merge Result", "type": "main", "index": 0 }]]
+    },
+    "Claude Direct": {
+      "main": [[{ "node": "Extract Direct", "type": "main", "index": 0 }]]
+    },
+    "Extract Direct": {
+      "main": [[{ "node": "Merge Result", "type": "main", "index": 1 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah-Translate-Worker-v2.json
+++ b/workflows/Torah-Translate-Worker-v2.json
@@ -1,10 +1,10 @@
 {
   "name": "Torah Translate Worker v2",
-  "active": false,
+  "active": true,
   "nodes": [
     {
       "parameters": {
-        "content": "## Torah Translate Worker v2\n\n**Endpoint:** POST /webhook/torah-translate-worker-v2\n\n**Améliorations v2:**\n- Support `section` pour sources complexes (section || page)\n- Découpage intelligent des segments longs (> 10K chars)\n- Claude utilisé pour split sémantique\n- Extraction OCR des images\n- max_tokens: 8192, timeout: 180s\n\n**Payload:**\n```json\n{ \"traite\": \"Sha'ar HaHakdamot\", \"section\": \"Introductions\", ... }\n```",
+        "content": "## Torah Translate Worker v2\n\n**Endpoint:** POST /webhook/torah-translate-worker\n\n**Améliorations v2:**\n- Support `section` pour sources complexes (section || page)\n- Découpage intelligent des segments longs (> 10K chars)\n- Claude utilisé pour split sémantique\n- Extraction OCR des images\n- max_tokens: 8192, timeout: 180s\n\n**Payload:**\n```json\n{ \"traite\": \"Sha'ar HaHakdamot\", \"section\": \"Introductions\", ... }\n```",
         "height": 380,
         "width": 340,
         "color": 5
@@ -18,7 +18,7 @@
     {
       "parameters": {
         "httpMethod": "POST",
-        "path": "torah-translate-worker-v2",
+        "path": "torah-translate-worker",
         "responseMode": "responseNode",
         "options": {}
       },
@@ -27,11 +27,11 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [400, 300],
-      "webhookId": "torah-translate-worker-v2"
+      "webhookId": "torah-translate-worker"
     },
     {
       "parameters": {
-        "jsCode": "// Parse input data - v2 avec support preprocessing + section\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst CHUNK_THRESHOLD = 10000; // 10K chars\n\nconst languageNames = {\n  'fr': 'français',\n  'en': 'English',\n  'es': 'español',\n  'he': 'hébreu',\n  'ar': 'araméen',\n  'de': 'allemand',\n  'it': 'italien'\n};\n\nconst sourceLanguage = body.source_language || 'he';\nconst targetLanguage = body.target_language || 'fr';\nconst needsPivot = sourceLanguage !== 'en' && targetLanguage !== 'en';\n\n// Support section || page for complex sources\nconst section = body.section || body.page || null;\nconst page = body.page || body.section || null;\n\n// Handle segments\nlet segments = [];\nif (Array.isArray(body.segments)) {\n  segments = body.segments;\n} else if (body.text) {\n  segments = [body.text];\n}\n\n// Analyze each segment for preprocessing needs\nconst analyzedSegments = segments.map((segment, idx) => {\n  const isObject = typeof segment === 'object' && segment !== null;\n  const segmentText = isObject ? segment.text : segment;\n  const charCount = segmentText.length;\n  \n  // Detect images\n  const imageRegex = /<img[^>]+src=[\"']([^\"']+)[\"'][^>]*>/gi;\n  const imageMatches = [...segmentText.matchAll(imageRegex)];\n  const imageUrls = imageMatches.map(m => m[1]);\n  \n  return {\n    index: idx,\n    text: segmentText,\n    commentary_id: isObject ? segment.commentary_id : null,\n    source_text_id: isObject ? segment.source_text_id : null,\n    char_count: charCount,\n    needs_chunking: charCount > CHUNK_THRESHOLD,\n    has_images: imageUrls.length > 0,\n    image_urls: imageUrls\n  };\n});\n\nconst metadata = {\n  ...(body.metadata || {}),\n  commentator: body.commentator || body.metadata?.commentator\n};\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    traite: body.traite,\n    section: section,\n    page: page,\n    locationLabel: section || page || '',\n    jobType: body.job_type || 'unit_translation',\n    mode: body.mode || 'standard',\n    sourceLanguage: sourceLanguage,\n    sourceLangName: languageNames[sourceLanguage] || sourceLanguage,\n    targetLanguage: targetLanguage,\n    targetLangName: languageNames[targetLanguage] || targetLanguage,\n    needsPivot: needsPivot,\n    llmProvider: body.llm_provider || 'anthropic',\n    modelAnthropic: body.model_anthropic || 'claude-sonnet-4-20250514',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    mistralApiKey: body.mistral_api_key,\n    segments: analyzedSegments,\n    segmentsCount: segments.length,\n    needsPreprocessing: analyzedSegments.some(s => s.needs_chunking || s.has_images),\n    context: body.context || {},\n    metadata: metadata,\n    requestId: body.request_id,\n    startTime: Date.now(),\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
+        "jsCode": "// Parse input data - v2 avec support preprocessing + section + source_text_id\nconst input = $input.first().json;\nconst body = input.body || input;\n\nconst CHUNK_THRESHOLD = 10000; // 10K chars\n\nconst languageNames = {\n  'fr': 'français',\n  'en': 'English',\n  'es': 'español',\n  'he': 'hébreu',\n  'ar': 'araméen',\n  'de': 'allemand',\n  'it': 'italien'\n};\n\nconst sourceLanguage = body.source_language || 'he';\nconst targetLanguage = body.target_language || 'fr';\nconst needsPivot = sourceLanguage !== 'en' && targetLanguage !== 'en';\n\n// Support section || page for complex sources\nconst section = body.section || body.page || null;\nconst page = body.page || body.section || null;\n\n// Handle segments\nlet segments = [];\nif (Array.isArray(body.segments)) {\n  segments = body.segments;\n} else if (body.text) {\n  segments = [body.text];\n}\n\n// Analyze each segment for preprocessing needs\n// Skip segments that are already translated (text_translated != null)\nlet skippedCount = 0;\nconst analyzedSegments = segments.map((segment, idx) => {\n  const isObject = typeof segment === 'object' && segment !== null;\n  const segmentText = isObject ? (segment.text || segment.text_hebrew) : segment;\n  const alreadyTranslated = isObject && segment.text_translated != null && segment.text_translated !== '';\n  const charCount = segmentText ? segmentText.length : 0;\n  \n  if (alreadyTranslated) {\n    skippedCount++;\n  }\n  \n  // Detect images\n  const imageRegex = /<img[^>]+src=[\"']([^\"']+)[\"'][^>]*>/gi;\n  const imageMatches = segmentText ? [...segmentText.matchAll(imageRegex)] : [];\n  const imageUrls = imageMatches.map(m => m[1]);\n  \n  return {\n    index: idx,\n    text: segmentText,\n    commentary_id: isObject ? segment.commentary_id : null,\n    source_text_id: isObject ? segment.source_text_id : null,\n    already_translated: alreadyTranslated,\n    existing_translation: isObject ? segment.text_translated : null,\n    char_count: charCount,\n    needs_chunking: charCount > CHUNK_THRESHOLD,\n    has_images: imageUrls.length > 0,\n    image_urls: imageUrls\n  };\n}).filter(s => !s.already_translated); // Filter out already translated\n\nconst metadata = {\n  ...(body.metadata || {}),\n  commentator: body.commentator || body.metadata?.commentator\n};\n\nreturn [{\n  json: {\n    jobId: body.job_id,\n    traite: body.traite,\n    section: section,\n    page: page,\n    locationLabel: section || page || '',\n    jobType: body.job_type || 'unit_translation',\n    mode: body.mode || 'standard',\n    sourceLanguage: sourceLanguage,\n    sourceLangName: languageNames[sourceLanguage] || sourceLanguage,\n    targetLanguage: targetLanguage,\n    targetLangName: languageNames[targetLanguage] || targetLanguage,\n    needsPivot: needsPivot,\n    llmProvider: body.llm_provider || 'anthropic',\n    modelAnthropic: body.model_anthropic || 'claude-sonnet-4-20250514',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    mistralApiKey: body.mistral_api_key,\n    segments: analyzedSegments,\n    segmentsCount: analyzedSegments.length,\n    skippedCount: skippedCount,\n    totalInputSegments: segments.length,\n    needsPreprocessing: analyzedSegments.some(s => s.needs_chunking || s.has_images),\n    context: body.context || {},\n    metadata: metadata,\n    requestId: body.request_id,\n    startTime: Date.now(),\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
       },
       "id": "parse-input",
       "name": "Parse Input",
@@ -140,7 +140,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Parse Claude's chunking response\nconst input = $input.first().json;\nconst originalData = $('Needs Chunking?').first().json;\n\ntry {\n  const body = input.body || input;\n  const content = body.content?.[0]?.text || '';\n  \n  // Try to parse JSON from response\n  let jsonStr = content;\n  const jsonMatch = content.match(/```json\\n?([\\s\\S]*?)\\n?```/);\n  if (jsonMatch) {\n    jsonStr = jsonMatch[1];\n  }\n  \n  const parsed = JSON.parse(jsonStr);\n  const chunks = parsed.chunks || [];\n  \n  if (chunks.length === 0) {\n    // Fallback: return original as single chunk\n    return [{\n      json: {\n        ...originalData,\n        chunks: [{ index: 0, text: originalData.text, char_count: originalData.char_count }],\n        total_chunks: 1,\n        split_method: 'fallback_single'\n      }\n    }];\n  }\n  \n  return [{\n    json: {\n      ...originalData,\n      chunks: chunks,\n      total_chunks: chunks.length,\n      split_method: 'claude_semantic'\n    }\n  }];\n} catch (e) {\n  // Error parsing: return original as single chunk\n  return [{\n    json: {\n      ...originalData,\n      chunks: [{ index: 0, text: originalData.text, char_count: originalData.char_count }],\n      total_chunks: 1,\n      split_method: 'fallback_error',\n      split_error: e.message\n    }\n  }];\n}"
+        "jsCode": "// Parse Claude's chunking response\nconst input = $input.first().json;\nconst originalData = $('Needs Chunking?').first().json;\n\ntry {\n  const body = input.body || input;\n  const content = body.content?.[0]?.text || '';\n  \n  // Check for API error\n  if (body.error || !content) {\n    return [{\n      json: {\n        ...originalData,\n        chunks: [],\n        total_chunks: 0,\n        split_method: 'error',\n        split_error: body.error?.message || 'Smart Split API returned empty response',\n        hasError: true\n      }\n    }];\n  }\n  \n  // Try to parse JSON from response\n  let jsonStr = content;\n  const jsonMatch = content.match(/```json\\n?([\\s\\S]*?)\\n?```/);\n  if (jsonMatch) {\n    jsonStr = jsonMatch[1];\n  }\n  \n  const parsed = JSON.parse(jsonStr);\n  const chunks = parsed.chunks || [];\n  \n  if (chunks.length === 0) {\n    return [{\n      json: {\n        ...originalData,\n        chunks: [],\n        total_chunks: 0,\n        split_method: 'error',\n        split_error: 'Smart Split returned no chunks - text too long or complex (' + originalData.char_count + ' chars)',\n        hasError: true\n      }\n    }];\n  }\n  \n  return [{\n    json: {\n      ...originalData,\n      chunks: chunks,\n      total_chunks: chunks.length,\n      split_method: 'claude_semantic',\n      hasError: false\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      ...originalData,\n      chunks: [],\n      total_chunks: 0,\n      split_method: 'error',\n      split_error: 'Failed to parse Smart Split response: ' + e.message,\n      hasError: true\n    }\n  }];\n}"
       },
       "id": "parse-chunks",
       "name": "Parse Chunks",
@@ -160,14 +160,50 @@
     },
     {
       "parameters": {
-        "mode": "chooseBranch",
-        "output": "input1"
+        "mode": "chooseBranch"
       },
       "id": "merge-after-chunk",
       "name": "Merge After Chunk",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
       "position": [2380, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.hasError }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-split-error",
+      "name": "Split Error?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2600, 400]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'failed', error: { code: 'SMART_SPLIT_FAILED', message: $json.split_error, segment_index: $json.index, char_count: $json.char_count } }) }}",
+        "options": { "timeout": 10000 }
+      },
+      "id": "update-job-split-error",
+      "name": "Update Job Split Error",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2820, 300],
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
@@ -188,7 +224,7 @@
       "name": "Has Images?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [2600, 400]
+      "position": [2820, 500]
     },
     {
       "parameters": {
@@ -198,7 +234,7 @@
       "name": "Process Images",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2820, 300]
+      "position": [3040, 400]
     },
     {
       "parameters": {
@@ -208,18 +244,17 @@
       "name": "No Images",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2820, 500]
+      "position": [3040, 600]
     },
     {
       "parameters": {
-        "mode": "chooseBranch",
-        "output": "input1"
+        "mode": "chooseBranch"
       },
       "id": "merge-after-images",
       "name": "Merge After Images",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [3040, 400]
+      "position": [3260, 500]
     },
     {
       "parameters": {
@@ -232,7 +267,7 @@
       "position": [3260, 400]
     },
     {
-      "parameters": { "options": {} },
+      "parameters": { "batchSize": 3, "options": {} },
       "id": "loop-chunks",
       "name": "Loop Chunks",
       "type": "n8n-nodes-base.splitInBatches",
@@ -373,8 +408,7 @@
     },
     {
       "parameters": {
-        "mode": "chooseBranch",
-        "output": "input1"
+        "mode": "chooseBranch"
       },
       "id": "merge-translations",
       "name": "Merge Translations",
@@ -384,7 +418,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Accumulate chunk translation for recombination\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    chunkIndex: input.chunkIndex,\n    originalSegmentIndex: input.originalSegmentIndex,\n    originalText: input.chunkText,\n    translation: input.finalTranslation,\n    totalChunks: input.totalChunks,\n    claudeTokens: input.claudeTokens || { input_tokens: 0, output_tokens: 0 },\n    commentary_id: input.commentary_id,\n    metadata: input.metadata,\n    jobId: input.jobId,\n    traite: input.traite,\n    section: input.section,\n    page: input.page,\n    targetLanguage: input.targetLanguage\n  }\n}];"
+        "jsCode": "// Accumulate chunk translation for recombination\nconst input = $input.first().json;\n\nreturn [{\n  json: {\n    chunkIndex: input.chunkIndex,\n    originalSegmentIndex: input.originalSegmentIndex,\n    originalText: input.chunkText,\n    translation: input.finalTranslation,\n    totalChunks: input.totalChunks,\n    totalSegments: input.totalSegments,\n    claudeTokens: input.claudeTokens || { input_tokens: 0, output_tokens: 0 },\n    source_text_id: input.source_text_id,\n    commentary_id: input.commentary_id,\n    modelAnthropic: input.modelAnthropic,\n    metadata: input.metadata,\n    jobId: input.jobId,\n    traite: input.traite,\n    section: input.section,\n    page: input.page,\n    targetLanguage: input.targetLanguage\n  }\n}];"
       },
       "id": "accumulate-chunk",
       "name": "Accumulate Chunk",
@@ -394,7 +428,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Recombine chunks when segment is complete\n// This runs after all chunks of a segment are processed\nconst allItems = $input.all();\n\n// Group by originalSegmentIndex\nconst grouped = {};\nfor (const item of allItems) {\n  const segIdx = item.json.originalSegmentIndex;\n  if (!grouped[segIdx]) {\n    grouped[segIdx] = [];\n  }\n  grouped[segIdx].push(item.json);\n}\n\n// Sort and recombine\nconst results = [];\nfor (const segIdx of Object.keys(grouped).sort((a, b) => parseInt(a) - parseInt(b))) {\n  const chunks = grouped[segIdx].sort((a, b) => a.chunkIndex - b.chunkIndex);\n  const combinedTranslation = chunks.map(c => c.translation).join('\\n\\n');\n  const combinedOriginal = chunks.map(c => c.originalText).join('\\n\\n');\n  const totalTokens = chunks.reduce((acc, c) => ({\n    input_tokens: acc.input_tokens + (c.claudeTokens?.input_tokens || 0),\n    output_tokens: acc.output_tokens + (c.claudeTokens?.output_tokens || 0)\n  }), { input_tokens: 0, output_tokens: 0 });\n  \n  results.push({\n    json: {\n      segmentIndex: parseInt(segIdx),\n      originalText: combinedOriginal,\n      translation: combinedTranslation,\n      chunks_count: chunks.length,\n      claudeTokens: totalTokens,\n      commentary_id: chunks[0].commentary_id,\n      metadata: chunks[0].metadata,\n      jobId: chunks[0].jobId,\n      traite: chunks[0].traite,\n      section: chunks[0].section,\n      page: chunks[0].page,\n      targetLanguage: chunks[0].targetLanguage\n    }\n  });\n}\n\nreturn results;"
+        "jsCode": "// Recombine chunks for the CURRENT segment only\n// Now runs after each segment's chunks are processed (not at the end of all segments)\nconst allItems = $input.all();\n\nif (allItems.length === 0) {\n  return [];\n}\n\n// All chunks should be from the same segment\nconst firstItem = allItems[0].json;\nconst originalSegmentIndex = firstItem.originalSegmentIndex;\nconst totalSegments = firstItem.totalSegments;\n\n// Sort chunks by index\nconst chunks = allItems.map(item => item.json).sort((a, b) => a.chunkIndex - b.chunkIndex);\n\nconst combinedTranslation = chunks.map(c => c.translation).filter(t => t).join('\\n\\n');\nconst combinedOriginal = chunks.map(c => c.originalText).filter(t => t).join('\\n\\n');\nconst totalTokens = chunks.reduce((acc, c) => ({\n  input_tokens: acc.input_tokens + (c.claudeTokens?.input_tokens || 0),\n  output_tokens: acc.output_tokens + (c.claudeTokens?.output_tokens || 0)\n}), { input_tokens: 0, output_tokens: 0 });\n\nreturn [{\n  json: {\n    segmentIndex: originalSegmentIndex,\n    currentSegment: originalSegmentIndex + 1,\n    totalSegments: totalSegments,\n    isLastSegment: (originalSegmentIndex + 1) >= totalSegments,\n    originalText: combinedOriginal,\n    translation: combinedTranslation,\n    chunks_count: chunks.length,\n    claudeTokens: totalTokens,\n    source_text_id: firstItem.source_text_id,\n    commentary_id: firstItem.commentary_id,\n    modelAnthropic: firstItem.modelAnthropic,\n    metadata: firstItem.metadata,\n    jobId: firstItem.jobId,\n    traite: firstItem.traite,\n    section: firstItem.section,\n    page: firstItem.page,\n    targetLanguage: firstItem.targetLanguage\n  }\n}];"
       },
       "id": "recombine-chunks",
       "name": "Recombine Chunks",
@@ -404,34 +438,92 @@
     },
     {
       "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.translation }}",
+              "rightValue": "",
+              "operator": { "type": "string", "operation": "notEquals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "has-translation",
+      "name": "Check Translation",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [5570, 400]
+    },
+    {
+      "parameters": {
         "method": "POST",
         "url": "={{ $env.API_URL }}/api/translations/save",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, traite: $json.traite, section: $json.section, page: $json.page, original_text: $json.originalText, translated_text: $json.translation, target_language: $json.targetLanguage, commentary_id: $json.commentary_id, metadata: $json.metadata, tokens: $json.claudeTokens }) }}",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.jobId, source_text_id: $json.source_text_id, translated_text: $json.translation, target_language: $json.targetLanguage, provider: 'anthropic', model: $json.modelAnthropic || 'claude-sonnet-4-20250514', commentary_id: $json.commentary_id, metadata: $json.metadata, tokens: $json.claudeTokens }) }}",
         "options": { "timeout": 30000 }
       },
       "id": "save-translation",
       "name": "Save Translation",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [5680, 400],
+      "position": [5780, 300],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
         "method": "PATCH",
-        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $('Recombine Chunks').first().json.jobId }}",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $('Check Translation').first().json.jobId }}",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ status: 'completed', output: { translations_count: $input.all().length, total_tokens: $input.all().reduce((acc, item) => ({ input_tokens: acc.input_tokens + (item.json.claudeTokens?.input_tokens || 0), output_tokens: acc.output_tokens + (item.json.claudeTokens?.output_tokens || 0) }), { input_tokens: 0, output_tokens: 0 }) } }) }}",
+        "jsonBody": "={{ JSON.stringify({ status: 'processing', progress: { current: $('Check Translation').first().json.currentSegment, total: $('Check Translation').first().json.totalSegments, percent: Math.round(($('Check Translation').first().json.currentSegment / $('Check Translation').first().json.totalSegments) * 100) } }) }}",
+        "options": { "timeout": 5000 }
+      },
+      "id": "update-progress",
+      "name": "Update Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [5900, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "leftValue": "={{ $('Check Translation').first().json.isLastSegment }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "is-last-segment",
+      "name": "Last Segment?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [6120, 400]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.API_URL }}/api/v2/jobs/{{ $('Check Translation').first().json.jobId }}",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ status: 'completed', progress: { current: $('Check Translation').first().json.totalSegments, total: $('Check Translation').first().json.totalSegments, percent: 100 }, output: { translations_count: $('Check Translation').first().json.totalSegments, final_segment: $('Check Translation').first().json.segmentIndex } }) }}",
         "options": { "timeout": 10000 }
       },
       "id": "update-job-complete",
       "name": "Update Job Complete",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [5900, 400],
+      "position": [6340, 300],
       "onError": "continueRegularOutput"
     },
     {
@@ -440,7 +532,7 @@
       "name": "Done",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [6120, 400]
+      "position": [6560, 400]
     }
   ],
   "connections": {
@@ -461,7 +553,7 @@
     },
     "Loop Segments": {
       "main": [
-        [{ "node": "Recombine Chunks", "type": "main", "index": 0 }],
+        [{ "node": "Done", "type": "main", "index": 0 }],
         [{ "node": "Needs Chunking?", "type": "main", "index": 0 }]
       ]
     },
@@ -475,13 +567,19 @@
       "main": [[{ "node": "Parse Chunks", "type": "main", "index": 0 }]]
     },
     "Parse Chunks": {
-      "main": [[{ "node": "Merge After Chunk", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Split Error?", "type": "main", "index": 0 }]]
     },
     "No Chunking": {
-      "main": [[{ "node": "Merge After Chunk", "type": "main", "index": 1 }]]
+      "main": [[{ "node": "Split Error?", "type": "main", "index": 0 }]]
     },
-    "Merge After Chunk": {
-      "main": [[{ "node": "Has Images?", "type": "main", "index": 0 }]]
+    "Split Error?": {
+      "main": [
+        [{ "node": "Update Job Split Error", "type": "main", "index": 0 }],
+        [{ "node": "Has Images?", "type": "main", "index": 0 }]
+      ]
+    },
+    "Update Job Split Error": {
+      "main": [[{ "node": "Loop Segments", "type": "main", "index": 0 }]]
     },
     "Has Images?": {
       "main": [
@@ -490,12 +588,9 @@
       ]
     },
     "Process Images": {
-      "main": [[{ "node": "Merge After Images", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Expand Chunks", "type": "main", "index": 0 }]]
     },
     "No Images": {
-      "main": [[{ "node": "Merge After Images", "type": "main", "index": 1 }]]
-    },
-    "Merge After Images": {
       "main": [[{ "node": "Expand Chunks", "type": "main", "index": 0 }]]
     },
     "Expand Chunks": {
@@ -503,7 +598,7 @@
     },
     "Loop Chunks": {
       "main": [
-        [{ "node": "Accumulate Chunk", "type": "main", "index": 0 }],
+        [{ "node": "Recombine Chunks", "type": "main", "index": 0 }],
         [{ "node": "Needs Pivot?", "type": "main", "index": 0 }]
       ]
     },
@@ -523,25 +618,37 @@
       "main": [[{ "node": "Extract Step 2", "type": "main", "index": 0 }]]
     },
     "Extract Step 2": {
-      "main": [[{ "node": "Merge Translations", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Accumulate Chunk", "type": "main", "index": 0 }]]
     },
     "Claude Direct": {
       "main": [[{ "node": "Extract Direct", "type": "main", "index": 0 }]]
     },
     "Extract Direct": {
-      "main": [[{ "node": "Merge Translations", "type": "main", "index": 1 }]]
-    },
-    "Merge Translations": {
       "main": [[{ "node": "Accumulate Chunk", "type": "main", "index": 0 }]]
     },
     "Accumulate Chunk": {
       "main": [[{ "node": "Loop Chunks", "type": "main", "index": 0 }]]
     },
     "Recombine Chunks": {
-      "main": [[{ "node": "Save Translation", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Check Translation", "type": "main", "index": 0 }]]
+    },
+    "Check Translation": {
+      "main": [
+        [{ "node": "Save Translation", "type": "main", "index": 0 }],
+        [{ "node": "Update Progress", "type": "main", "index": 0 }]
+      ]
     },
     "Save Translation": {
-      "main": [[{ "node": "Update Job Complete", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Update Progress", "type": "main", "index": 0 }]]
+    },
+    "Update Progress": {
+      "main": [[{ "node": "Last Segment?", "type": "main", "index": 0 }]]
+    },
+    "Last Segment?": {
+      "main": [
+        [{ "node": "Update Job Complete", "type": "main", "index": 0 }],
+        [{ "node": "Loop Segments", "type": "main", "index": 0 }]
+      ]
     },
     "Update Job Complete": {
       "main": [[{ "node": "Done", "type": "main", "index": 0 }]]

--- a/workflows/Torah-Translate-Worker.json
+++ b/workflows/Torah-Translate-Worker.json
@@ -1,6 +1,6 @@
 {
-  "name": "Torah Translate Worker",
-  "active": true,
+  "name": "Torah Translate Worker (v1 - DEPRECATED)",
+  "active": false,
   "nodes": [
     {
       "parameters": {
@@ -21,7 +21,7 @@
     {
       "parameters": {
         "httpMethod": "POST",
-        "path": "torah-translate-worker",
+        "path": "torah-translate-worker-v1-deprecated",
         "responseMode": "responseNode",
         "options": {}
       },
@@ -810,7 +810,7 @@
       {
         "parameters": {
           "httpMethod": "POST",
-          "path": "torah-translate-worker",
+          "path": "torah-translate-worker-v1-deprecated",
           "responseMode": "responseNode",
           "options": {}
         },


### PR DESCRIPTION
## Summary

- Implement RFC-031: unified Torah translation pipeline architecture
- Add Torah Router as central orchestrator for all translation flows
- Create modular workers: Torah-Translate-Simple, Torah-Save-Worker, Torah-Chunk-Worker
- Fix job status tracking throughout the pipeline
- Add segment_index support to prevent translation overwrites

## Changes

### New Workflows
- **Torah Router** - Central orchestrator handling job creation, status updates, and worker coordination
- **Torah Translate Simple** - Stateless translation worker (translate only, no job management)
- **Torah Save Worker** - Handles saving translations with segment_index support
- **Torah Chunk Worker** - Splits long texts semantically

### Fixed Workflows
- **LEARNING-Generate-Worker** - Fixed Redis pop condition (`$json.propertyName`)
- **Torah-Translate-Page** - Now calls Torah Router instead of direct worker
- **Torah-Translate-Worker v1** - Deprecated (webhook renamed)
- **TORAH-Get-Section** - Fixed segment mapping

### Architecture
```
Plugin/Discord → Torah Router → [Chunk Worker] → Translate Simple → Save Worker
                     ↓
              Job Status Updates (processing → progress → completed)
```

## Test plan

- [x] Test page translation via Torah Router
- [x] Test commentary translation via Torah Router  
- [x] Verify job status updates (processing, progress, completed)
- [x] Verify segment_index prevents overwrites
- [x] Test /translate-text command through plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)