### PR TITLE
feat(chess): add Chess API integration workflows (RFC-039)

### DIFF
--- a/docs/guides/chess-plugin-integration-guide.md
+++ b/docs/guides/chess-plugin-integration-guide.md
@@ -1,0 +1,779 @@
+# Guide d'integration - Chess Plugin Discord
+
+## Authentification
+
+Chaque requete doit inclure ces headers:
+
+```
+Content-Type: application/json
+```
+
+Dans le body JSON, inclure systematiquement:
+- `tenant_id`: identifiant du plugin (valeur fixe: `"chess_plugin"`)
+- `user_id`: identifiant Discord de l'utilisateur (ex: `"user_987654321"`)
+
+### Flux du tenant_id
+
+```
+Plugin Chess                    n8n Workflow                     Backend API
+     |                               |                               |
+     |  POST /webhook/progress-get   |                               |
+     |  Body: {                      |                               |
+     |    "tenant_id": "chess_plugin"|                               |
+     |    "user_id": "discord_123"   |                               |
+     |  }                            |                               |
+     |------------------------------>|                               |
+     |                               |                               |
+     |                    Valide tenant_id                           |
+     |                    (erreur 400 si absent)                     |
+     |                               |                               |
+     |                               |  POST /api/n8n/progress       |
+     |                               |  Headers:                     |
+     |                               |    X-Tenant-ID: chess_plugin  |
+     |                               |    X-API-Key: $env.N8N_API_KEY|
+     |                               |  Body: { "user_id": "..." }   |
+     |                               |------------------------------>|
+```
+
+**Resume:**
+1. Le plugin envoie `tenant_id` dans le body JSON
+2. n8n valide sa presence (erreur 400 si manquant)
+3. n8n le transmet au backend comme header `X-Tenant-ID`
+
+---
+
+## Base URL
+
+```
+POST https://pi6.local:5678/webhook/<endpoint>
+```
+
+---
+
+## Workflows disponibles
+
+### 1. Progress
+
+#### GET Progress - Lire la progression
+```
+POST /webhook/progress-get
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "domain": "chess",
+  "include": ["stats", "lessons", "badges", "lichess_elo"]
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "user_id": "user_987654321",
+  "stats": { "total_sessions": 5, "last_active": "..." },
+  "lessons": [...],
+  "badges": [...],
+  "lichess": {
+    "connected": true,
+    "username": "DrNykterstein",
+    "profile": {...},
+    "elo_history": [...]
+  }
+}
+```
+
+---
+
+#### UPDATE Progress - Mises a jour
+```
+POST /webhook/progress-update
+```
+
+**Operations disponibles:**
+
+##### session - Incrementer sessions
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "operation": "session",
+  "data": {}
+}
+```
+
+##### add_lesson - Ajouter une lecon
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "operation": "add_lesson",
+  "data": {
+    "lesson_id": "opening-sicilian-01",
+    "domain": "openings",
+    "score": 85,
+    "duration_minutes": 12
+  }
+}
+```
+
+##### award_badge - Attribuer un badge
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "operation": "award_badge",
+  "data": {
+    "badge_id": "first-win",
+    "domain": "games",
+    "metadata": { "opponent": "bot_easy" }
+  }
+}
+```
+
+##### preferences - Mettre a jour preferences
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "operation": "preferences",
+  "data": {
+    "difficulty": "intermediate",
+    "daily_goal": 3,
+    "language": "fr"
+  }
+}
+```
+
+##### link_lichess - Lier compte Lichess
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "operation": "link_lichess",
+  "data": {
+    "lichess_username": "DrNykterstein"
+  }
+}
+```
+
+---
+
+#### DELETE Progress - Suppression GDPR
+```
+POST /webhook/progress-delete
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "confirm": true
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "message": "Toutes les donnees utilisateur ont ete supprimees",
+  "deleted": {
+    "user_progress": { "deleted": true },
+    "user_games": 5,
+    "user_oauth_tokens": 1
+  }
+}
+```
+
+---
+
+### 2. Games
+
+#### LIST Games - Lister les parties
+```
+POST /webhook/games-list
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "limit": 20,
+  "offset": 0,
+  "filters": {
+    "result": "win",
+    "source": "lichess",
+    "has_analysis": true
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "games": [
+    {
+      "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+      "white": "user",
+      "black": "opponent",
+      "result": "win",
+      "pgn": "1. e4 e5..."
+    }
+  ],
+  "total": 42,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+---
+
+#### ADD Game - Ajouter une partie
+```
+POST /webhook/games-add
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "game": {
+    "white": "user",
+    "black": "opponent_name",
+    "result": "win",
+    "pgn": "1. e4 e5 2. Nf3 ...",
+    "source": "manual",
+    "time_control": "10+0",
+    "opening": "Sicilian Defense"
+  }
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "created": true
+}
+```
+
+---
+
+#### UPDATE Analysis - Mettre a jour l'analyse
+```
+POST /webhook/games-analysis
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "analysis": {
+    "done": true,
+    "accuracy": { "white": 85.5, "black": 72.3 },
+    "mistakes": { "blunders": 2, "mistakes": 3, "inaccuracies": 5 },
+    "key_moments": [
+      {
+        "move_number": 15,
+        "description": "Blunder - perte de la dame",
+        "evaluation_before": 1.5,
+        "evaluation_after": -3.2
+      }
+    ],
+    "summary": "Bonne ouverture mais erreurs en milieu de partie"
+  }
+}
+```
+
+---
+
+#### LINK Lichess - Marquer import Lichess
+```
+POST /webhook/games-lichess
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "lichess_game_id": "AbCdEfGh",
+  "lichess_url": "https://lichess.org/AbCdEfGh"
+}
+```
+
+---
+
+### 3. OAuth (Lichess)
+
+#### START Auth - Demarrer OAuth Lichess
+```
+POST /webhook/lichess-auth-start
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "redirect_uri": "https://your-app.com/callback"
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "auth_url": "https://lichess.org/oauth?...",
+  "state": "base64_encoded_state",
+  "code_verifier": "pkce_verifier_to_store",
+  "message": "Redirigez l'utilisateur vers auth_url"
+}
+```
+
+**Important:** Stocker `code_verifier` cote client pour le callback.
+
+---
+
+#### CALLBACK Auth - Finaliser OAuth Lichess
+```
+POST /webhook/lichess-auth-callback
+```
+
+**Input:**
+```json
+{
+  "code": "authorization_code_from_lichess",
+  "state": "base64_encoded_state",
+  "code_verifier": "stored_pkce_verifier"
+}
+```
+
+**Output:**
+```json
+{
+  "success": true,
+  "message": "Compte Lichess 'DrNykterstein' connecte",
+  "lichess_username": "DrNykterstein",
+  "scope": "challenge:read challenge:write board:play"
+}
+```
+
+---
+
+#### GET OAuth Token - Recuperer token
+```
+POST /webhook/oauth-get
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "provider": "lichess"
+}
+```
+
+**Output (token existe):**
+```json
+{
+  "success": true,
+  "has_token": true,
+  "provider": "lichess",
+  "access_token": "lip_xxxx",
+  "expires_at": "2026-04-12T14:00:00+00:00",
+  "is_expired": false,
+  "provider_user_id": "DrNykterstein"
+}
+```
+
+**Output (pas de token):**
+```json
+{
+  "success": true,
+  "has_token": false,
+  "provider": "lichess"
+}
+```
+
+---
+
+#### DELETE OAuth Token - Supprimer token
+```
+POST /webhook/oauth-delete
+```
+
+**Input:**
+```json
+{
+  "tenant_id": "guild_123456789",
+  "user_id": "user_987654321",
+  "provider": "lichess"
+}
+```
+
+---
+
+## Resume des endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/webhook/progress-get` | Lire progression utilisateur |
+| `/webhook/progress-update` | Mises a jour (session, lesson, badge, prefs, lichess) |
+| `/webhook/progress-delete` | Suppression GDPR |
+| `/webhook/games-list` | Lister parties avec filtres |
+| `/webhook/games-add` | Ajouter une partie |
+| `/webhook/games-analysis` | Mettre a jour analyse |
+| `/webhook/games-lichess` | Marquer import Lichess |
+| `/webhook/lichess-auth-start` | Demarrer OAuth Lichess |
+| `/webhook/lichess-auth-callback` | Finaliser OAuth Lichess |
+| `/webhook/oauth-get` | Recuperer token OAuth |
+| `/webhook/oauth-delete` | Supprimer token OAuth |
+
+---
+
+## Codes d'erreur
+
+| Code | Description |
+|------|-------------|
+| 200 | Succes |
+| 400 | Requete invalide (champs manquants) |
+| 404 | Ressource non trouvee (game_id invalide) |
+| 500 | Erreur serveur |
+
+**Format erreur:**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 400,
+    "message": "tenant_id requis, user_id requis",
+    "status": "BAD_REQUEST"
+  }
+}
+```
+
+---
+
+## Exemple d'implementation (Python)
+
+```python
+import requests
+
+BASE_URL = "https://pi6.local:5678/webhook"
+TENANT_ID = "guild_123456789"
+
+def get_progress(user_id: str) -> dict:
+    response = requests.post(
+        f"{BASE_URL}/progress-get",
+        json={
+            "tenant_id": TENANT_ID,
+            "user_id": user_id,
+            "include": ["stats", "lessons", "badges"]
+        }
+    )
+    return response.json()
+
+def add_lesson(user_id: str, lesson_id: str, score: int) -> dict:
+    response = requests.post(
+        f"{BASE_URL}/progress-update",
+        json={
+            "tenant_id": TENANT_ID,
+            "user_id": user_id,
+            "operation": "add_lesson",
+            "data": {
+                "lesson_id": lesson_id,
+                "domain": "chess",
+                "score": score
+            }
+        }
+    )
+    return response.json()
+```
+
+---
+
+## Questions en attente de reponse
+
+### Questions pour l'equipe chatbot-core
+
+> **[CHATBOT-CORE-001]** Client MCP pour n8n
+>
+> Existe-t-il deja un client MCP dans chatbot-core pour appeler les webhooks n8n ?
+> Ou doit-on utiliser `N8nClient` directement ?
+>
+> **Contexte:** Le plugin-chess doit appeler les endpoints n8n (`progress-*`, `games-*`, `oauth-*`).
+> On veut savoir si on doit creer un wrapper ou utiliser un composant existant.
+>
+> **Statut:** [ ] En attente [ ] Repondu
+>
+> **Reponse:**
+> ```
+> (a completer par l'equipe chatbot-core)
+> ```
+
+---
+
+> **[CHATBOT-CORE-002]** OAuth Flow dans Discord
+>
+> Comment gerer le redirect OAuth Lichess dans Discord ?
+>
+> **Options envisagees:**
+> 1. Bouton avec lien externe → callback sur une API web
+> 2. Modal avec code a copier-coller
+> 3. Bot DM avec lien personnalise
+>
+> **Contexte:** L'utilisateur doit autoriser le bot a acceder a son compte Lichess.
+> Discord ne permet pas de rediriger directement vers une URL depuis un bouton.
+>
+> **Statut:** [ ] En attente [ ] Repondu
+>
+> **Reponse:**
+> ```
+> (a completer par l'equipe chatbot-core)
+> ```
+
+---
+
+> **[CHATBOT-CORE-003]** Service OAuth generique
+>
+> Faut-il creer un service OAuth reutilisable dans chatbot-core ?
+>
+> **Besoins identifies:**
+> - Support PKCE (requis par Lichess)
+> - Stockage tokens dans Redis
+> - Refresh automatique des tokens expires
+> - Multi-provider (Lichess, chess.com futur)
+>
+> **Statut:** [ ] En attente [ ] Repondu
+>
+> **Reponse:**
+> ```
+> (a completer par l'equipe chatbot-core)
+> ```
+
+---
+
+### Questions pour l'equipe n8n
+
+> **[N8N-001]** Callback OAuth - Destination
+>
+> Le `redirect_uri` dans `lichess-auth-start` doit pointer vers quoi ?
+>
+> **Options:**
+> 1. Un endpoint n8n (`/webhook/lichess-auth-callback-redirect`)
+> 2. Une API FastAPI externe
+> 3. Une page web statique qui appelle le callback
+>
+> **Contexte:** Apres autorisation sur Lichess, l'utilisateur est redirige vers `redirect_uri`.
+> On doit capturer le `code` et appeler `lichess-auth-callback`.
+>
+> **Statut:** [x] Repondu
+>
+> **Reponse:**
+> ```
+> Option recommandee: Page web statique (option 3)
+>
+> Flow complet:
+> 1. Plugin appelle /webhook/lichess-auth-start
+>    - Recoit: auth_url, state, code_verifier
+>    - Plugin stocke code_verifier en memoire/Redis (cle: state)
+>
+> 2. Plugin envoie auth_url a l'utilisateur (bouton Discord)
+>    - redirect_uri = https://votre-domaine.com/oauth/lichess/callback
+>
+> 3. Utilisateur autorise sur Lichess
+>    - Lichess redirige vers: redirect_uri?code=XXX&state=YYY
+>
+> 4. Page web statique:
+>    - Affiche "Autorisation reussie!"
+>    - Affiche le code a copier OU
+>    - Envoie message au plugin via webhook/websocket
+>
+> 5. Plugin appelle /webhook/lichess-auth-callback
+>    - Envoie: code, state, code_verifier (recupere via state)
+>
+> Alternative Discord-friendly:
+> - La page web peut afficher: "Retournez sur Discord et tapez: /lichess verify CODE"
+> - Le plugin recoit le code via commande et finalise le flow
+>
+> Note: Un endpoint n8n GET pourrait aussi fonctionner mais necessite
+> de stocker le code_verifier cote serveur (voir N8N-002).
+> ```
+
+---
+
+> **[N8N-002]** Stockage code_verifier PKCE
+>
+> Ou stocker le `code_verifier` entre `auth-start` et `callback` ?
+>
+> **Le flow PKCE necessite:**
+> 1. `auth-start` genere `code_verifier` + `code_challenge`
+> 2. L'utilisateur autorise sur Lichess (peut prendre plusieurs minutes)
+> 3. `callback` a besoin du `code_verifier` original
+>
+> **Options:**
+> - Redis avec TTL (5-10 min)
+> - Base de donnees
+> - Encode dans le `state` (risque securite)
+>
+> **Statut:** [x] Repondu
+>
+> **Reponse:**
+> ```
+> Design actuel: Le plugin stocke le code_verifier (recommande)
+>
+> C'est le design PKCE standard - le CLIENT qui initie le flow
+> est responsable de conserver le code_verifier.
+>
+> Implementation plugin-chess:
+> 1. Appeler /webhook/lichess-auth-start
+> 2. Recevoir { auth_url, state, code_verifier }
+> 3. Stocker en Redis: oauth:lichess:{state} -> { code_verifier, user_id, timestamp }
+>    TTL: 10 minutes (l'utilisateur a 10 min pour autoriser)
+> 4. Quand callback recoit le code:
+>    - Recuperer code_verifier via state
+>    - Appeler /webhook/lichess-auth-callback avec les 3 valeurs
+>    - Supprimer la cle Redis
+>
+> Code exemple (plugin):
+> ```python
+> # auth-start
+> response = await n8n_client.lichess_auth_start(user_id, redirect_uri)
+> await redis.setex(
+>     f"oauth:lichess:{response['state']}",
+>     600,  # 10 minutes TTL
+>     json.dumps({
+>         "code_verifier": response["code_verifier"],
+>         "user_id": user_id
+>     })
+> )
+>
+> # callback (apres redirect)
+> data = json.loads(await redis.get(f"oauth:lichess:{state}"))
+> await n8n_client.lichess_auth_callback(code, state, data["code_verifier"])
+> await redis.delete(f"oauth:lichess:{state}")
+> ```
+>
+> Pourquoi pas cote n8n/backend ?
+> - PKCE est concu pour que le client garde le secret
+> - Evite de stocker des secrets temporaires cote serveur
+> - Le state permet de retrouver le bon code_verifier
+> ```
+
+---
+
+> **[N8N-003]** Sync automatique Lichess
+>
+> Y a-t-il un workflow pour importer automatiquement les parties recentes depuis Lichess ?
+>
+> **Scenario souhaite:**
+> 1. L'utilisateur connecte son compte Lichess
+> 2. Periodiquement (ou on-demand), on importe ses nouvelles parties
+> 3. Option: lancer l'analyse Stockfish automatiquement
+>
+> **Questions:**
+> - Workflow existant ou a creer ?
+> - Frequence de sync recommandee ?
+> - Limites API Lichess a respecter ?
+>
+> **Statut:** [x] Repondu
+>
+> **Reponse:**
+> ```
+> Workflow existant: NON - A creer si besoin
+>
+> Proposition de workflow: MCP-Lichess-Sync
+>
+> Option A - Sync on-demand (recommande pour commencer):
+> POST /webhook/lichess-sync
+> Input:
+> {
+>   "tenant_id": "chess_plugin",
+>   "user_id": "discord_123",
+>   "since": "2024-01-01T00:00:00Z",  // optionnel
+>   "max_games": 50,                   // optionnel, defaut 20
+>   "with_analysis": false             // lancer analyse auto?
+> }
+>
+> Flow interne:
+> 1. Recuperer token OAuth via /api/n8n/oauth/get
+> 2. Appeler Lichess API: GET /api/games/user/{username}
+> 3. Filtrer parties deja importees (via lichess_game_id)
+> 4. Pour chaque nouvelle partie:
+>    - Appeler /api/n8n/games/add
+>    - Marquer liaison via /api/n8n/games/lichess
+> 5. Optionnel: Declencher analyse Stockfish
+>
+> Option B - Sync periodique (cron):
+> - Workflow cron toutes les heures
+> - Parcourt tous les utilisateurs avec token Lichess valide
+> - Importe les parties des dernieres 24h
+> - Attention aux rate limits!
+>
+> Limites API Lichess:
+> - Authentifie: ~20 req/sec (avec token OAuth)
+> - Non-authentifie: ~1 req/sec
+> - Endpoint games: max 300 parties par requete
+> - Recommandation: espacer les requetes de 100ms minimum
+>
+> Frequence recommandee:
+> - On-demand: A chaque /lichess import (utilisateur decide)
+> - Periodique: 1x par heure max, batch de 10 users max par run
+>
+> Estimation effort: 1-2 jours pour creer le workflow
+> Dependance: Token OAuth stocke (workflow existant OK)
+>
+> Voulez-vous qu'on cree ce workflow? Ouvrir une RFC?
+> ```
+
+---
+
+## Plan de developpement
+
+### Phase 1 : Integration n8n de base
+**Priorite: Haute | Effort: 2-3 jours | Equipe: plugin-chess**
+
+- [ ] Creer `src/services/n8n_chess_client.py` (wrapper webhooks)
+- [ ] Migrer stockage analyses vers `games-add` + `games-analysis`
+- [ ] `/analyses` utilise `games-list` au lieu de Redis
+- [ ] Tracking sessions via `progress-update(operation="session")`
+
+### Phase 2 : Commandes de progression
+**Priorite: Moyenne | Effort: 2 jours | Equipe: plugin-chess**
+
+- [ ] `/progress` - Voir ma progression (stats, badges, ELO)
+- [ ] `/leaderboard` - Classement serveur
+- [ ] `/badges` - Liste des badges
+
+### Phase 3 : Integration Lichess
+**Priorite: Moyenne | Effort: 3-4 jours | Equipe: chatbot-core + plugin-chess**
+**Bloquee par:** [CHATBOT-CORE-002], [CHATBOT-CORE-003] ~~[N8N-001]~~, ~~[N8N-002]~~
+
+- [ ] [chatbot-core] Service OAuth generique avec PKCE
+- [ ] [plugin-chess] `/lichess connect` - Lier compte
+- [ ] [plugin-chess] `/lichess import` - Importer parties
+- [ ] [plugin-chess] `/lichess profile` - Afficher profil
+
+### Phase 4 : Systeme de lecons
+**Priorite: Basse | Effort: 3-5 jours | Equipe: plugin-chess**
+
+- [ ] `/learn <topic>` - Ouvertures, tactiques, finales
+- [ ] Quiz interactifs avec tracking progression
+
+### Phase 5 : GDPR & Admin
+**Priorite: Basse | Effort: 1 jour | Equipe: plugin-chess**
+
+- [ ] `/chess-delete-data` - Suppression donnees utilisateur

--- a/docs/guides/n8n-chess-api-guide.md
+++ b/docs/guides/n8n-chess-api-guide.md
@@ -1,0 +1,395 @@
+# N8N Chess API — Guide d'intégration
+
+## Authentification
+
+Chaque requête doit inclure deux headers :
+
+```
+X-API-Key: <clé partagée, fournie par l'équipe backend>
+X-Tenant-ID: <identifiant du tenant, envoyé par le plugin bot Discord>
+```
+
+- **`X-API-Key`** : secret partagé entre n8n et l'API backend. Identique pour tous les tenants.
+- **`X-Tenant-ID`** : identifiant du tenant (organisation/serveur Discord). Fourni dynamiquement par le plugin bot à chaque appel.
+
+### Erreurs d'authentification
+
+| Code | Cause |
+|------|-------|
+| 401 | `X-API-Key` manquant ou invalide |
+| 403 | `X-Tenant-ID` manquant |
+| 503 | Base de données Chess indisponible |
+
+---
+
+## Base URL
+
+```
+POST https://<api-host>/api/n8n/<endpoint>
+```
+
+Tous les endpoints sont en **POST** (compatibilité HTTP Request node n8n).
+
+La documentation Swagger interactive est disponible sur `https://<api-host>/docs` (filtrer par tag **n8n-chess**).
+
+---
+
+## Format de réponse
+
+**Succès :**
+```json
+{
+  "success": true,
+  "data": { ... }
+}
+```
+
+**Erreur :**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 404,
+    "message": "Game not found"
+  }
+}
+```
+
+---
+
+## Identité des joueurs
+
+- `user_id` = identifiant Discord du joueur (ex: `"123456789012345678"`)
+- **Pas de création de compte nécessaire** : les documents utilisateur sont auto-créés au premier appel (upsert)
+- Toutes les données sont isolées par `tenant_id` : un même `user_id` sur deux tenants différents = deux joueurs distincts
+
+---
+
+## Endpoints
+
+### Progress (7 endpoints)
+
+#### `POST /api/n8n/progress` — Lire la progression
+
+```json
+{
+  "user_id": "123456789",
+  "domain": "openings"       // optionnel — filtre par domaine
+}
+```
+
+Réponse : le document complet de progression (lessons, badges, stats, preferences).
+
+---
+
+#### `POST /api/n8n/progress/sessions` — Incrémenter le compteur de sessions
+
+```json
+{
+  "user_id": "123456789"
+}
+```
+
+Réponse :
+```json
+{
+  "total_sessions": 5,
+  "last_active": "2026-03-12T14:30:00+00:00"
+}
+```
+
+---
+
+#### `POST /api/n8n/progress/lessons` — Ajouter ou MAJ une leçon
+
+```json
+{
+  "user_id": "123456789",
+  "lesson": {
+    "lesson_id": "opening-sicilian-01",
+    "domain": "openings",
+    "title": "La défense sicilienne",
+    "score": 85,
+    "completed_at": "2026-03-12T14:00:00Z"
+  }
+}
+```
+
+Réponse :
+```json
+{
+  "added": true,
+  "total_lessons": 12
+}
+```
+
+---
+
+#### `POST /api/n8n/progress/badges` — Attribuer un badge (idempotent)
+
+```json
+{
+  "user_id": "123456789",
+  "badge": {
+    "id": "first-win",
+    "domain": "games",
+    "name": "Première victoire",
+    "earned_at": "2026-03-12T14:00:00Z"
+  }
+}
+```
+
+Réponse :
+```json
+{
+  "awarded": true,
+  "already_had": false,
+  "total_badges": 3
+}
+```
+
+Si le badge existe déjà : `awarded: false, already_had: true`.
+
+---
+
+#### `POST /api/n8n/progress/preferences` — MAJ des préférences
+
+```json
+{
+  "user_id": "123456789",
+  "preferences": {
+    "difficulty": "intermediate",
+    "daily_goal": 3,
+    "preferred_color": "white",
+    "language": "fr",
+    "notifications_enabled": true
+  }
+}
+```
+
+Tous les champs de `preferences` sont optionnels (merge partiel).
+
+---
+
+#### `POST /api/n8n/progress/lichess` — Lier/délier un compte Lichess
+
+```json
+{
+  "user_id": "123456789",
+  "lichess_username": "DrNykterstein"    // null pour délier
+}
+```
+
+---
+
+#### `POST /api/n8n/progress/delete` — Supprimer toutes les données (GDPR)
+
+```json
+{
+  "user_id": "123456789"
+}
+```
+
+Réponse :
+```json
+{
+  "deleted": {
+    "user_progress": { "deleted": true },
+    "user_games": 5,
+    "user_oauth_tokens": 1
+  }
+}
+```
+
+Suppression en cascade dans les 3 collections (progress, games, oauth tokens).
+
+---
+
+### Games (4 endpoints)
+
+#### `POST /api/n8n/games` — Lister les parties
+
+```json
+{
+  "user_id": "123456789",
+  "limit": 20,               // optionnel, défaut 20, max 100
+  "offset": 0,               // optionnel, défaut 0
+  "filters": {                // optionnel
+    "result": "win",          // "win", "loss", "draw"
+    "source": "lichess",      // "manual", "lichess", "pgn_import"
+    "has_analysis": true      // true/false
+  }
+}
+```
+
+Réponse :
+```json
+{
+  "games": [ { "game_id": "...", "user_id": "...", ... } ],
+  "total": 42,
+  "limit": 20,
+  "offset": 0
+}
+```
+
+---
+
+#### `POST /api/n8n/games/add` — Ajouter une partie
+
+```json
+{
+  "user_id": "123456789",
+  "game": {
+    "white": "user",
+    "black": "opponent_name",
+    "result": "win",
+    "pgn": "1. e4 e5 2. Nf3 ...",
+    "source": "manual",
+    "time_control": "10+0",
+    "opening": "Sicilian Defense"
+  }
+}
+```
+
+Réponse :
+```json
+{
+  "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "created": true
+}
+```
+
+---
+
+#### `POST /api/n8n/games/analysis` — MAJ de l'analyse d'une partie
+
+```json
+{
+  "user_id": "123456789",
+  "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "analysis": {
+    "done": true,
+    "accuracy": {
+      "white": 85.5,
+      "black": 72.3
+    },
+    "mistakes": {
+      "blunders": 2,
+      "mistakes": 3,
+      "inaccuracies": 5
+    },
+    "key_moments": [
+      {
+        "move_number": 15,
+        "description": "Blunder — perte de la dame",
+        "evaluation_before": 1.5,
+        "evaluation_after": -3.2
+      }
+    ],
+    "summary": "Bonne ouverture mais erreurs en milieu de partie"
+  }
+}
+```
+
+Retourne `404` si `game_id` introuvable.
+
+---
+
+#### `POST /api/n8n/games/lichess` — Marquer une partie comme importée sur Lichess
+
+```json
+{
+  "user_id": "123456789",
+  "game_id": "665f1a2b3c4d5e6f7a8b9c0d",
+  "lichess_game_id": "AbCdEfGh",
+  "lichess_url": "https://lichess.org/AbCdEfGh"
+}
+```
+
+---
+
+### OAuth (3 endpoints)
+
+#### `POST /api/n8n/oauth/store` — Stocker un token OAuth
+
+```json
+{
+  "user_id": "123456789",
+  "provider": "lichess",
+  "access_token": "lip_xxxxxxxxxxxx",
+  "refresh_token": "lrt_xxxxxxxxxxxx",
+  "expires_at": "2026-04-12T14:00:00Z",
+  "scope": "challenge:read challenge:write",
+  "provider_user_id": "DrNykterstein"
+}
+```
+
+Les tokens sont **chiffrés (AES-256-GCM)** avant stockage en base. Le `refresh_token` est optionnel.
+
+---
+
+#### `POST /api/n8n/oauth` — Récupérer un token
+
+```json
+{
+  "user_id": "123456789",
+  "provider": "lichess"
+}
+```
+
+Réponse :
+```json
+{
+  "access_token": "lip_xxxxxxxxxxxx",
+  "refresh_token": "lrt_xxxxxxxxxxxx",
+  "expires_at": "2026-04-12T14:00:00+00:00",
+  "is_expired": false,
+  "scope": "challenge:read challenge:write",
+  "provider_user_id": "DrNykterstein"
+}
+```
+
+Les tokens sont déchiffrés à la volée. Si `data` est `null`, aucun token n'existe pour ce couple user/provider.
+
+---
+
+#### `POST /api/n8n/oauth/delete` — Supprimer un token
+
+```json
+{
+  "user_id": "123456789",
+  "provider": "lichess"
+}
+```
+
+---
+
+## Exemple n8n — HTTP Request node
+
+Configuration type pour un node HTTP Request :
+
+- **Method** : POST
+- **URL** : `https://<api-host>/api/n8n/progress/sessions`
+- **Authentication** : None (géré par headers)
+- **Headers** :
+  - `X-API-Key` : `{{ $credentials.n8nChessApiKey }}`
+  - `X-Tenant-ID` : `{{ $json.tenant_id }}`
+  - `Content-Type` : `application/json`
+- **Body (JSON)** :
+  ```json
+  {
+    "user_id": "{{ $json.discord_user_id }}"
+  }
+  ```
+
+---
+
+## Collections MongoDB
+
+Pour référence, les 3 collections dans la base `chess` :
+
+| Collection | Clé unique | Description |
+|---|---|---|
+| `user_progress` | `(tenant_id, user_id)` | Progression, leçons, badges, préférences |
+| `user_games` | `_id` (ObjectId) | Parties jouées, analyses |
+| `user_oauth_tokens` | `(tenant_id, user_id, provider)` | Tokens OAuth chiffrés |

--- a/docs/rfc/RFC-039-BACKEND-API-ENDPOINTS.md
+++ b/docs/rfc/RFC-039-BACKEND-API-ENDPOINTS.md
@@ -1,0 +1,972 @@
+# RFC-039: Backend API Endpoints pour Progress Tracker & Chess Tools
+
+| Metadata | |
+|----------|---------|
+| **Auteur** | Équipe n8n-workflows |
+| **Révisé par** | Équipe Backend |
+| **Date** | 2026-03-11 |
+| **Révision** | 2026-03-12 — Intégration recommandations Backend |
+| **Status** | Validé |
+| **Dépendances** | RFC-038 (Feature Tools Missing), MongoDB |
+| **Impacte** | API Backend, n8n workflows, Bot Échecs, Bot Cuisine |
+
+---
+
+## 1. Contexte
+
+La RFC-038 identifie plusieurs outils à créer/compléter pour les bots Échecs et Cuisine. Ces outils nécessitent un stockage persistant en MongoDB, accessible via des endpoints REST.
+
+**Principes clés:**
+- n8n n'accède jamais directement à MongoDB. Toutes les opérations passent par l'API backend.
+- L'API est **multi-tenant** : chaque requête est scopée par `tenant_id`.
+- Les endpoints sont préfixés `/api/n8n/` pour isoler les routes service-to-service.
+- Pas d'opérateurs MongoDB bruts exposés — chaque opération est un endpoint métier explicite.
+
+---
+
+## 2. Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                                                                       │
+│  n8n Workflows                                                        │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐      │
+│  │ MCP-Progress-Get│  │ MCP-Progress-   │  │ MCP-Lichess-    │      │
+│  │                 │  │ Update          │  │ Auth            │      │
+│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘      │
+│           │                    │                    │                │
+│           └────────────────────┼────────────────────┘                │
+│                                │                                     │
+│                    X-API-Key + X-Tenant-ID                           │
+│                                │                                     │
+│                                ▼                                     │
+│  ┌───────────────────────────────────────────────────────────────┐   │
+│  │                    API Backend                                │   │
+│  │                    /api/n8n/...                                │   │
+│  │                                                               │   │
+│  │  POST /api/n8n/progress            POST /api/n8n/games        │   │
+│  │  POST /api/n8n/progress/sessions   POST /api/n8n/games/add    │   │
+│  │  POST /api/n8n/progress/lessons    POST /api/n8n/games/analysis│  │
+│  │  POST /api/n8n/progress/badges     POST /api/n8n/games/lichess│   │
+│  │  POST /api/n8n/progress/preferences                           │   │
+│  │  POST /api/n8n/progress/lichess    POST /api/n8n/oauth/store  │   │
+│  │                                    POST /api/n8n/oauth         │   │
+│  │                                    POST /api/n8n/oauth/delete  │   │
+│  └───────────────────────────────┬───────────────────────────────┘   │
+│                                  │                                    │
+│                                  ▼                                    │
+│  ┌───────────────────────────────────────────────────────────────┐   │
+│  │                    MongoDB — Base: chess                       │   │
+│  │  URI: mongodb://chatbot_user:***@host1.local:27017/chess      │   │
+│  │       ?authSource=chatbot_analytics                           │   │
+│  │                                                               │   │
+│  │  Collections:                                                 │   │
+│  │  - user_progress                                              │   │
+│  │  - user_games                                                 │   │
+│  │  - user_oauth_tokens                                          │   │
+│  └───────────────────────────────────────────────────────────────┘   │
+│                                                                       │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. MongoDB — Base `chess`
+
+### 3.1 Connexion
+
+Réutilise le client Motor existant (`app.config.mongodb._mongo_client`), même pattern que `mcp_activity`.
+
+```python
+# app/config/mongodb_chess.py
+CHESS_DATABASE = get_env("CHESS_DATABASE", "chess")
+_chess_db = _mongo_client[CHESS_DATABASE]
+```
+
+**Pré-requis** : accorder les droits à `chatbot_user` :
+
+```js
+use chatbot_analytics
+db.grantRolesToUser("chatbot_user", [
+  { role: "readWrite", db: "chess" }
+])
+```
+
+### 3.2 Variables d'environnement (Backend)
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `CHESS_DATABASE` | Nom de la base MongoDB | `chess` |
+| `N8N_API_KEY` | Clé d'auth pour les endpoints n8n | (requis) |
+| `OAUTH_ENCRYPTION_KEY` | Clé AES-256 pour chiffrement tokens | (requis, 32 bytes base64) |
+
+---
+
+## 4. Authentification API
+
+Tous les endpoints `/api/n8n/` requièrent :
+
+```
+X-API-Key: {N8N_API_KEY}
+X-Tenant-ID: {tenant_id}
+Content-Type: application/json
+```
+
+| Header | Description | Requis |
+|--------|-------------|--------|
+| `X-API-Key` | Clé statique service-to-service, vérifiée par un middleware dédié | Oui |
+| `X-Tenant-ID` | Identifiant du tenant (isolation multi-tenant) | Oui |
+
+> **Note** : ces endpoints ne sont PAS accessibles par le Frontend. Le Frontend utilise les endpoints JWT/RBAC classiques.
+
+---
+
+## 5. Collections MongoDB
+
+### 5.1 Collection: `user_progress`
+
+Stocke la progression utilisateur (leçons, badges, préférences).
+
+**Schema:**
+```javascript
+{
+  _id: ObjectId,
+  tenant_id: String,            // Isolation multi-tenant
+  user_id: String,              // "discord_636639897767378954"
+
+  // Liens externes
+  lichess_username: String,     // null si non connecté
+
+  // Stats globales
+  stats: {
+    total_sessions: Number,
+    last_active: ISODate
+  },
+
+  // Leçons complétées
+  lessons: [{
+    lesson_id: String,
+    completed_at: ISODate,
+    score: Number,              // 0-100
+    domain: String,             // "chess" | "cooking"
+    duration_minutes: Number
+  }],
+
+  // Badges gagnés
+  badges: [{
+    id: String,
+    earned_at: ISODate,
+    domain: String,
+    metadata: Object            // Données additionnelles
+  }],
+
+  // Préférences utilisateur
+  preferences: {
+    difficulty_level: String,   // "beginner" | "intermediate" | "advanced"
+    favorite_openings: [String],
+    notifications: Boolean
+  },
+
+  // Données spécifiques Cuisine
+  cooking: {
+    recipes_completed: Number,
+    techniques_learned: [String]
+  },
+
+  created_at: ISODate,
+  updated_at: ISODate
+}
+```
+
+**Index:**
+```javascript
+{ tenant_id: 1, user_id: 1 }           // Unique compound
+{ tenant_id: 1, "lessons.domain": 1 }
+{ tenant_id: 1, "badges.domain": 1 }
+{ tenant_id: 1, lichess_username: 1 }
+```
+
+---
+
+### 5.2 Collection: `user_games`
+
+Stocke les parties non-Lichess (scoresheets, imports manuels).
+
+**Schema:**
+```javascript
+{
+  _id: ObjectId,
+  tenant_id: String,
+  user_id: String,
+
+  // Source de la partie
+  source: String,               // "scoresheet_photo" | "manual_input" | "pgn_import"
+
+  // Métadonnées partie
+  white_player: String,
+  black_player: String,
+  user_color: String,           // "white" | "black"
+  date: String,                 // "2026-03-10"
+  event: String,                // "Club Tournament Round 3"
+  result: String,               // "1-0" | "0-1" | "1/2-1/2" | "*"
+
+  // Contenu
+  pgn: String,                  // "1. e4 e5 2. Nf3 Nc6..."
+
+  // Analyse (null si pas encore analysée)
+  analysis: {
+    done: Boolean,
+    done_at: ISODate,
+    engine: String,             // "stockfish_16"
+    depth: Number,
+    accuracy: {
+      white: Number,            // 0-100
+      black: Number
+    },
+    mistakes: {
+      white: Number,
+      black: Number
+    },
+    blunders: {
+      white: Number,
+      black: Number
+    },
+    key_moments: [{
+      move: Number,
+      eval_before: Number,      // Centipawns / 100
+      eval_after: Number,
+      type: String,             // "blunder" | "mistake" | "brilliant"
+      best_move: String         // "Nxe5"
+    }]
+  },
+
+  // Synchro Lichess (si importée)
+  lichess_imported: Boolean,
+  lichess_game_id: String,
+  lichess_url: String,
+
+  created_at: ISODate,
+  updated_at: ISODate
+}
+```
+
+**Index:**
+```javascript
+{ tenant_id: 1, user_id: 1, created_at: -1 }
+{ tenant_id: 1, user_id: 1, "analysis.done": 1 }
+{ lichess_game_id: 1 }
+```
+
+---
+
+### 5.3 Collection: `user_oauth_tokens`
+
+Stocke les tokens OAuth (Lichess, etc.).
+
+**Schema:**
+```javascript
+{
+  _id: ObjectId,
+  tenant_id: String,
+  user_id: String,
+  provider: String,             // "lichess"
+
+  access_token: String,         // Chiffré AES-256-GCM
+  refresh_token: String,        // Chiffré AES-256-GCM
+  expires_at: ISODate,
+  scope: String,                // "preference:read game:read game:write"
+
+  // Données provider
+  provider_user_id: String,     // "player123" (Lichess username)
+
+  created_at: ISODate,
+  updated_at: ISODate
+}
+```
+
+**Index:**
+```javascript
+{ tenant_id: 1, user_id: 1, provider: 1 }  // Unique compound
+```
+
+**Chiffrement :**
+- Algorithme : AES-256-GCM (authentifié)
+- Clé : `OAUTH_ENCRYPTION_KEY` (variable d'env, 32 bytes base64)
+- Champs chiffrés : `access_token`, `refresh_token`
+- Le chiffrement/déchiffrement est effectué côté Backend. n8n envoie les tokens en clair, le Backend chiffre avant stockage et déchiffre avant réponse.
+
+---
+
+## 6. Endpoints API
+
+### 6.1 Progress Endpoints
+
+Préfixe : `/api/n8n/progress`
+
+---
+
+#### `POST /api/n8n/progress`
+
+Récupère la progression d'un utilisateur.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "domain": "chess"
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `domain` | string | Non | Filtrer par domaine (`chess`, `cooking`, `null` = tous) |
+
+> `tenant_id` est fourni via le header `X-Tenant-ID`, pas dans le body.
+
+**Response 200 (trouvé):**
+```json
+{
+  "success": true,
+  "data": {
+    "user_id": "discord_636639897767378954",
+    "lichess_username": "player123",
+    "stats": {
+      "total_sessions": 142,
+      "last_active": "2026-03-11T14:30:00Z"
+    },
+    "lessons": [
+      {
+        "lesson_id": "chess_opening_basics",
+        "completed_at": "2026-03-10T10:00:00Z",
+        "score": 85,
+        "domain": "chess",
+        "duration_minutes": 12
+      }
+    ],
+    "badges": [
+      {
+        "id": "first_lesson",
+        "earned_at": "2026-03-01T12:00:00Z",
+        "domain": "chess",
+        "metadata": {}
+      }
+    ],
+    "preferences": {
+      "difficulty_level": "intermediate",
+      "favorite_openings": ["Sicilian Defense"],
+      "notifications": true
+    },
+    "cooking": null,
+    "created_at": "2026-01-15T08:00:00Z",
+    "updated_at": "2026-03-11T14:30:00Z"
+  }
+}
+```
+
+**Response 200 (non trouvé):**
+```json
+{
+  "success": true,
+  "data": null
+}
+```
+
+---
+
+#### `POST /api/n8n/progress/sessions`
+
+Incrémente le compteur de sessions et met à jour `last_active`.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954"
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "total_sessions": 143,
+    "last_active": "2026-03-12T10:00:00Z"
+  }
+}
+```
+
+**Comportement :** Upsert — crée le document `user_progress` s'il n'existe pas.
+
+---
+
+#### `POST /api/n8n/progress/lessons`
+
+Ajoute ou met à jour une leçon complétée.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "lesson": {
+    "lesson_id": "chess_endgame_101",
+    "completed_at": "2026-03-11T16:00:00Z",
+    "score": 92,
+    "domain": "chess",
+    "duration_minutes": 15
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `lesson.lesson_id` | string | Oui | ID unique de la leçon |
+| `lesson.completed_at` | string | Oui | Date ISO 8601 |
+| `lesson.score` | number | Oui | Score 0-100 |
+| `lesson.domain` | string | Oui | `chess` ou `cooking` |
+| `lesson.duration_minutes` | number | Non | Durée en minutes |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "added": true,
+    "total_lessons": 12
+  }
+}
+```
+
+**Comportement :** Si `lesson_id` existe déjà pour cet utilisateur, met à jour (score, date). Upsert du document parent si inexistant.
+
+---
+
+#### `POST /api/n8n/progress/badges`
+
+Attribue un badge à un utilisateur.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "badge": {
+    "id": "streak_7",
+    "domain": "chess",
+    "earned_at": "2026-03-11T16:30:00Z",
+    "metadata": {
+      "streak_count": 7
+    }
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `badge.id` | string | Oui | ID unique du badge |
+| `badge.domain` | string | Oui | `chess` ou `cooking` |
+| `badge.earned_at` | string | Oui | Date ISO 8601 |
+| `badge.metadata` | object | Non | Données additionnelles |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "awarded": true,
+    "already_had": false,
+    "total_badges": 5
+  }
+}
+```
+
+**Comportement :** Si le badge existe déjà, retourne `already_had: true` sans erreur. Upsert du document parent si inexistant.
+
+---
+
+#### `POST /api/n8n/progress/preferences`
+
+Met à jour les préférences utilisateur.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "preferences": {
+    "difficulty_level": "advanced",
+    "favorite_openings": ["Sicilian Defense", "King's Indian"],
+    "notifications": true
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `preferences.difficulty_level` | string | Non | `beginner`, `intermediate`, `advanced` |
+| `preferences.favorite_openings` | string[] | Non | Liste d'ouvertures |
+| `preferences.notifications` | boolean | Non | Activer les notifications |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "updated": true
+  }
+}
+```
+
+**Comportement :** Merge partiel — seuls les champs fournis sont mis à jour. Upsert du document parent si inexistant.
+
+---
+
+#### `POST /api/n8n/progress/lichess`
+
+Lie ou délie un compte Lichess à l'utilisateur.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "lichess_username": "player123"
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `lichess_username` | string\|null | Oui | Username Lichess (`null` pour délier) |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "updated": true,
+    "lichess_username": "player123"
+  }
+}
+```
+
+---
+
+### 6.2 Games Endpoints
+
+Préfixe : `/api/n8n/games`
+
+---
+
+#### `POST /api/n8n/games`
+
+Récupère les parties d'un utilisateur.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "limit": 10,
+  "offset": 0,
+  "filters": {
+    "result": "1-0",
+    "has_analysis": true,
+    "source": "scoresheet_photo"
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `limit` | number | Non | Nombre max (défaut: 20, max: 100) |
+| `offset` | number | Non | Offset pagination (défaut: 0) |
+| `filters.result` | string | Non | Filtrer par résultat |
+| `filters.has_analysis` | boolean | Non | Seulement parties analysées |
+| `filters.source` | string | Non | Filtrer par source |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "games": [
+      {
+        "game_id": "6412abc123def456",
+        "source": "scoresheet_photo",
+        "white_player": "John Doe",
+        "black_player": "Opponent",
+        "user_color": "white",
+        "result": "1-0",
+        "date": "2026-03-10",
+        "event": "Club Tournament Round 3",
+        "pgn": "1. e4 e5 2. Nf3...",
+        "analysis": {
+          "done": true,
+          "accuracy": { "white": 87.5, "black": 72.3 }
+        },
+        "lichess_imported": false,
+        "created_at": "2026-03-10T18:00:00Z"
+      }
+    ],
+    "total": 15,
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+---
+
+#### `POST /api/n8n/games/add`
+
+Ajoute une partie (scoresheet, import manuel).
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "game": {
+    "source": "scoresheet_photo",
+    "white_player": "John Doe",
+    "black_player": "Opponent Name",
+    "user_color": "white",
+    "date": "2026-03-10",
+    "event": "Club Tournament Round 3",
+    "result": "1-0",
+    "pgn": "1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Be7"
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `game.source` | string | Oui | `scoresheet_photo`, `manual_input`, `pgn_import` |
+| `game.white_player` | string | Oui | Nom joueur blancs |
+| `game.black_player` | string | Oui | Nom joueur noirs |
+| `game.user_color` | string | Oui | `white` ou `black` |
+| `game.date` | string | Non | Date YYYY-MM-DD |
+| `game.event` | string | Non | Nom de l'événement |
+| `game.result` | string | Oui | `1-0`, `0-1`, `1/2-1/2`, `*` |
+| `game.pgn` | string | Oui | Notation PGN |
+
+**Response 201:**
+```json
+{
+  "success": true,
+  "data": {
+    "game_id": "6412abc123def456",
+    "created": true
+  }
+}
+```
+
+---
+
+#### `POST /api/n8n/games/analysis`
+
+Met à jour l'analyse d'une partie.
+
+**Request:**
+```json
+{
+  "game_id": "6412abc123def456",
+  "user_id": "discord_636639897767378954",
+  "analysis": {
+    "done": true,
+    "done_at": "2026-03-11T17:00:00Z",
+    "engine": "stockfish_16",
+    "depth": 20,
+    "accuracy": {
+      "white": 87.5,
+      "black": 72.3
+    },
+    "mistakes": {
+      "white": 2,
+      "black": 5
+    },
+    "blunders": {
+      "white": 0,
+      "black": 2
+    },
+    "key_moments": [
+      {
+        "move": 15,
+        "eval_before": 0.3,
+        "eval_after": 2.1,
+        "type": "blunder",
+        "best_move": "Nxe5"
+      }
+    ]
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `game_id` | string | Oui | ID de la partie (ObjectId) |
+| `user_id` | string | Oui | ID utilisateur (vérifie que la partie lui appartient) |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "updated": true
+  }
+}
+```
+
+**Response 404:**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 404,
+    "message": "Game not found"
+  }
+}
+```
+
+**Sécurité :** Le Backend vérifie que `game.user_id == user_id` ET `game.tenant_id == tenant_id` (header) avant d'autoriser la mise à jour.
+
+---
+
+#### `POST /api/n8n/games/lichess`
+
+Marque une partie comme importée sur Lichess.
+
+**Request:**
+```json
+{
+  "game_id": "6412abc123def456",
+  "user_id": "discord_636639897767378954",
+  "lichess_game_id": "AbCdEfGh",
+  "lichess_url": "https://lichess.org/AbCdEfGh"
+}
+```
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "updated": true
+  }
+}
+```
+
+---
+
+### 6.3 OAuth Endpoints
+
+Préfixe : `/api/n8n/oauth`
+
+---
+
+#### `POST /api/n8n/oauth/store`
+
+Stocke un token OAuth. Le Backend chiffre les tokens avant stockage.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "provider": "lichess",
+  "access_token": "lip_xxxxxxxxxxxxx",
+  "refresh_token": "lir_xxxxxxxxxxxxx",
+  "expires_at": "2026-03-12T15:00:00Z",
+  "scope": "preference:read game:read game:write",
+  "provider_user_id": "player123"
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | Oui | Identifiant utilisateur |
+| `provider` | string | Oui | `lichess` (extensible) |
+| `access_token` | string | Oui | Token d'accès (envoyé en clair, chiffré au stockage) |
+| `refresh_token` | string | Non | Token de refresh (envoyé en clair, chiffré au stockage) |
+| `expires_at` | string | Oui | Date expiration ISO 8601 |
+| `scope` | string | Oui | Scopes autorisés |
+| `provider_user_id` | string | Oui | Username Lichess |
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "stored": true
+  }
+}
+```
+
+**Comportement :** Si un token existe déjà pour ce `tenant_id + user_id + provider`, le remplacer.
+
+---
+
+#### `POST /api/n8n/oauth`
+
+Récupère un token OAuth. Le Backend déchiffre les tokens avant réponse.
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "provider": "lichess"
+}
+```
+
+**Response 200 (trouvé):**
+```json
+{
+  "success": true,
+  "data": {
+    "access_token": "lip_xxxxxxxxxxxxx",
+    "refresh_token": "lir_xxxxxxxxxxxxx",
+    "expires_at": "2026-03-12T15:00:00Z",
+    "is_expired": false,
+    "scope": "preference:read game:read game:write",
+    "provider_user_id": "player123"
+  }
+}
+```
+
+**Response 200 (non trouvé):**
+```json
+{
+  "success": true,
+  "data": null
+}
+```
+
+**Comportement :** `is_expired` est calculé côté Backend (`expires_at < now`).
+
+---
+
+#### `POST /api/n8n/oauth/delete`
+
+Supprime un token OAuth (déconnexion).
+
+**Request:**
+```json
+{
+  "user_id": "discord_636639897767378954",
+  "provider": "lichess"
+}
+```
+
+**Response 200:**
+```json
+{
+  "success": true,
+  "data": {
+    "deleted": true
+  }
+}
+```
+
+---
+
+## 7. Codes d'erreur
+
+| Code | Status HTTP | Description |
+|------|-------------|-------------|
+| 400 | Bad Request | Paramètres manquants ou invalides |
+| 401 | Unauthorized | X-API-Key manquant ou invalide |
+| 403 | Forbidden | X-Tenant-ID manquant |
+| 404 | Not Found | Ressource non trouvée |
+| 429 | Too Many Requests | Rate limit dépassé |
+| 500 | Internal Error | Erreur serveur |
+
+**Format erreur:**
+```json
+{
+  "success": false,
+  "error": {
+    "code": 400,
+    "message": "user_id requis",
+    "details": {}
+  }
+}
+```
+
+---
+
+## 8. Rate Limiting
+
+| Scope | Limite | Fenêtre |
+|-------|--------|---------|
+| Par API Key | 1000 requêtes | 1 minute |
+| Par endpoint + user_id | 60 requêtes | 1 minute |
+
+Implémenté via Redis (même instance que l'app).
+
+---
+
+## 9. Variables d'environnement
+
+### Backend
+
+| Variable | Description | Défaut |
+|----------|-------------|--------|
+| `CHESS_DATABASE` | Nom de la base MongoDB | `chess` |
+| `N8N_API_KEY` | Clé d'auth service-to-service | (requis) |
+| `OAUTH_ENCRYPTION_KEY` | Clé AES-256-GCM (32 bytes base64) | (requis) |
+
+### n8n
+
+| Variable | Description | Exemple |
+|----------|-------------|---------|
+| `BACKEND_API_URL` | URL base de l'API Backend | `https://api.azy.solutions` |
+| `N8N_API_KEY` | Clé d'authentification | `sk-xxxxx` |
+| `LICHESS_CLIENT_ID` | Client ID OAuth Lichess | `azy-chess-bot` |
+| `LICHESS_CLIENT_SECRET` | Client Secret OAuth | `secret` |
+| `LICHESS_REDIRECT_URI` | Callback OAuth | `https://api.azy.solutions/webhook/lichess/callback` |
+
+---
+
+## 10. Récapitulatif des endpoints
+
+| Endpoint | Méthode | Description |
+|----------|---------|-------------|
+| `/api/n8n/progress` | POST | Lire progression utilisateur |
+| `/api/n8n/progress/sessions` | POST | Incrémenter sessions |
+| `/api/n8n/progress/lessons` | POST | Ajouter/màj leçon |
+| `/api/n8n/progress/badges` | POST | Attribuer badge |
+| `/api/n8n/progress/preferences` | POST | Mettre à jour préférences |
+| `/api/n8n/progress/lichess` | POST | Lier compte Lichess |
+| `/api/n8n/games` | POST | Lister parties |
+| `/api/n8n/games/add` | POST | Ajouter partie |
+| `/api/n8n/games/analysis` | POST | Mettre à jour analyse |
+| `/api/n8n/games/lichess` | POST | Marquer import Lichess |
+| `/api/n8n/oauth/store` | POST | Stocker token OAuth |
+| `/api/n8n/oauth` | POST | Récupérer token OAuth |
+| `/api/n8n/oauth/delete` | POST | Supprimer token OAuth |
+
+**Total : 13 endpoints** (tous POST pour compatibilité n8n HTTP Request node)
+
+---
+
+## 11. Décisions Backend (ex-questions ouvertes)
+
+| # | Question originale | Décision |
+|---|-------------------|----------|
+| 1 | URL de base de l'API ? | `https://api.azy.solutions/api/n8n/` |
+| 2 | Mécanisme d'auth ? | `X-API-Key` statique (service-to-service, n8n uniquement) |
+| 3 | Chiffrement tokens OAuth ? | AES-256-GCM, clé dans `OAUTH_ENCRYPTION_KEY` |
+| 4 | Rate limiting ? | Oui — 1000/min par clé, 60/min par user_id |
+| 5 | Multi-tenancy ? | `X-Tenant-ID` header obligatoire, scopé dans toutes les queries |
+| 6 | Opérateurs MongoDB bruts ? | **Non** — remplacés par des endpoints métier explicites |
+| 7 | Préfixe URL ? | `/api/n8n/` pour isoler les routes service-to-service |
+| 8 | MongoDB database ? | Nouvelle base `chess`, droits `chatbot_user` à accorder |
+
+---
+
+*Document généré le 11 mars 2026 — Équipe n8n-workflows / RFC-039*
+*Révisé le 12 mars 2026 — Équipe Backend*

--- a/scripts/n8n/batch_import.sh
+++ b/scripts/n8n/batch_import.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+#
+# Batch import and activate n8n workflows
+# Usage: ./batch_import.sh [--dry-run] [--pattern <pattern>]
+#
+# Options:
+#   --dry-run       Show what would be done without executing
+#   --pattern       Filter workflows by pattern (e.g., "MCP-Games")
+#   --untracked     Only import untracked files (git status ??)
+#   --modified      Only import modified files (git status M)
+#   --all           Import all .json files in workflows/
+#
+
+# Don't use set -e, we handle errors manually
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKFLOWS_DIR="$REPO_ROOT/workflows"
+N8N_API="python3 $SCRIPT_DIR/n8n_api.py"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Options
+DRY_RUN=false
+PATTERN=""
+MODE="untracked"  # default: only untracked files
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --pattern)
+            PATTERN="$2"
+            shift 2
+            ;;
+        --untracked)
+            MODE="untracked"
+            shift
+            ;;
+        --modified)
+            MODE="modified"
+            shift
+            ;;
+        --all)
+            MODE="all"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--dry-run] [--pattern <pattern>] [--untracked|--modified|--all]"
+            echo ""
+            echo "Options:"
+            echo "  --dry-run       Show what would be done without executing"
+            echo "  --pattern       Filter workflows by pattern (e.g., 'MCP-Games')"
+            echo "  --untracked     Only import untracked files (git status ??)"
+            echo "  --modified      Only import modified files (git status M)"
+            echo "  --all           Import all .json files in workflows/"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}  n8n Workflow Batch Import & Activate${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Get list of workflows to import
+cd "$REPO_ROOT"
+
+declare -a WORKFLOWS
+
+if [[ "$MODE" == "untracked" ]]; then
+    echo -e "${YELLOW}Mode: Untracked files only${NC}"
+    while IFS= read -r line; do
+        status="${line:0:2}"
+        file="${line:3}"
+        if [[ "$status" == "??" && "$file" == workflows/*.json ]]; then
+            WORKFLOWS+=("$file")
+        fi
+    done < <(git status --porcelain workflows/)
+elif [[ "$MODE" == "modified" ]]; then
+    echo -e "${YELLOW}Mode: Modified files only${NC}"
+    while IFS= read -r line; do
+        status="${line:0:2}"
+        file="${line:3}"
+        if [[ "$status" == " M" || "$status" == "M " ]] && [[ "$file" == workflows/*.json ]]; then
+            WORKFLOWS+=("$file")
+        fi
+    done < <(git status --porcelain workflows/)
+elif [[ "$MODE" == "all" ]]; then
+    echo -e "${YELLOW}Mode: All workflow files${NC}"
+    for f in "$WORKFLOWS_DIR"/*.json; do
+        [[ -f "$f" ]] && WORKFLOWS+=("workflows/$(basename "$f")")
+    done
+fi
+
+# Apply pattern filter
+if [[ -n "$PATTERN" ]]; then
+    echo -e "${YELLOW}Pattern filter: $PATTERN${NC}"
+    FILTERED=()
+    for w in "${WORKFLOWS[@]}"; do
+        if [[ "$w" == *"$PATTERN"* ]]; then
+            FILTERED+=("$w")
+        fi
+    done
+    WORKFLOWS=("${FILTERED[@]}")
+fi
+
+echo ""
+echo -e "${BLUE}Workflows to import: ${#WORKFLOWS[@]}${NC}"
+echo ""
+
+if [[ ${#WORKFLOWS[@]} -eq 0 ]]; then
+    echo -e "${YELLOW}No workflows to import.${NC}"
+    exit 0
+fi
+
+# List workflows
+for w in "${WORKFLOWS[@]}"; do
+    echo "  - $w"
+done
+echo ""
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo -e "${YELLOW}[DRY RUN] Would import and activate the above workflows${NC}"
+    exit 0
+fi
+
+# Confirm
+read -p "Proceed with import and activation? [y/N] " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborted."
+    exit 0
+fi
+
+echo ""
+
+# Import and activate each workflow
+SUCCESS=0
+FAILED=0
+
+for workflow_file in "${WORKFLOWS[@]}"; do
+    workflow_name=$(basename "$workflow_file" .json)
+    echo -e "${BLUE}----------------------------------------${NC}"
+    echo -e "${BLUE}Importing: $workflow_name${NC}"
+
+    # Import workflow and capture output
+    output=$($N8N_API import "$REPO_ROOT/$workflow_file" 2>&1) || true
+    echo "$output"
+
+    # Extract workflow ID from output using sed (portable)
+    # Looking for pattern: "(ID: <id>)"
+    workflow_id=$(echo "$output" | sed -n 's/.*ID: \([a-zA-Z0-9]*\).*/\1/p' | head -1)
+
+    if [[ -z "$workflow_id" ]]; then
+        echo -e "${RED}Failed to get workflow ID for $workflow_name${NC}"
+        FAILED=$((FAILED + 1))
+        continue
+    fi
+
+    echo -e "${GREEN}Workflow ID: $workflow_id${NC}"
+
+    # Activate workflow
+    echo -e "${BLUE}Activating workflow $workflow_id...${NC}"
+    activate_output=$($N8N_API activate "$workflow_id" 2>&1) || true
+
+    if echo "$activate_output" | grep -q "is now ACTIVE"; then
+        echo -e "${GREEN}Activated: $workflow_name${NC}"
+        SUCCESS=$((SUCCESS + 1))
+    else
+        echo "$activate_output"
+        echo -e "${YELLOW}Warning: Activation may have failed for $workflow_name${NC}"
+        SUCCESS=$((SUCCESS + 1))  # Still count as success since import worked
+    fi
+
+    echo ""
+done
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${GREEN}Success: $SUCCESS${NC}"
+if [[ $FAILED -gt 0 ]]; then
+    echo -e "${RED}Failed: $FAILED${NC}"
+fi
+echo -e "${BLUE}========================================${NC}"

--- a/workflows/MCP-Games-Add.json
+++ b/workflows/MCP-Games-Add.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - Games Add",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "games-add",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "games-add-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst game = body.game || {};\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\n\n// Game validation\nif (!game.white) errors.push('game.white requis');\nif (!game.black) errors.push('game.black requis');\n\nconst validResults = ['win', 'loss', 'draw'];\nif (!game.result) {\n  errors.push('game.result requis');\n} else if (!validResults.includes(game.result)) {\n  errors.push(`game.result invalide: ${game.result}. Valeurs: ${validResults.join(', ')}`);\n}\n\nconst validSources = ['manual', 'lichess', 'pgn_import'];\nif (game.source && !validSources.includes(game.source)) {\n  errors.push(`game.source invalide: ${game.source}. Valeurs: ${validSources.join(', ')}`);\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\n// Set defaults\nif (!game.source) game.source = 'manual';\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    game\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games/add",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, game: $json.game }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 15000
+        }
+      },
+      "id": "api-add-game",
+      "name": "API Add Game",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nconst data = body.data || body;\n\nreturn {\n  json: {\n    success: true,\n    game_id: data.game_id,\n    created: data.created !== false\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Games Add\n\n**Endpoint:** POST /webhook/games-add\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"game\": {\n    \"white\": \"user\",\n    \"black\": \"opponent_name\",\n    \"result\": \"win\",\n    \"pgn\": \"1. e4 e5 2. Nf3 ...\",\n    \"source\": \"manual\",\n    \"time_control\": \"10+0\",\n    \"opening\": \"Sicilian Defense\"\n  }\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"game_id\": \"665f1a2b3c4d5e6f7a8b9c0d\",\n  \"created\": true\n}\n```\n\n### Champs game\n- `white`: requis\n- `black`: requis\n- `result`: requis (win, loss, draw)\n- `source`: optionnel (manual, lichess, pgn_import)\n- `pgn`: optionnel\n- `time_control`: optionnel\n- `opening`: optionnel\n\n### RFC-039 compliant",
+        "height": 480,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 40]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API Add Game", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API Add Game": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Games-Analysis.json
+++ b/workflows/MCP-Games-Analysis.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - Games Analysis",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "games-analysis",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "games-analysis-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst game_id = body.game_id;\nconst analysis = body.analysis || {};\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (!game_id) errors.push('game_id requis');\n\n// Analysis validation\nif (Object.keys(analysis).length === 0) {\n  errors.push('analysis requis (objet non vide)');\n}\n\nif (analysis.accuracy) {\n  if (typeof analysis.accuracy.white !== 'number' && typeof analysis.accuracy.black !== 'number') {\n    errors.push('analysis.accuracy doit contenir white et/ou black (nombres)');\n  }\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    game_id,\n    analysis\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games/analysis",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, game_id: $json.game_id, analysis: $json.analysis }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 15000
+        }
+      },
+      "id": "api-analysis",
+      "name": "API Update Analysis",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode === 404) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: 'Partie non trouvee',\n        game_id: $('Validate Input').first().json.game_id\n      }\n    }\n  };\n}\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    success: true,\n    message: 'Analyse mise a jour',\n    game_id: $('Validate Input').first().json.game_id\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Games Analysis\n\n**Endpoint:** POST /webhook/games-analysis\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"game_id\": \"665f1a2b3c4d5e6f7a8b9c0d\",\n  \"analysis\": {\n    \"done\": true,\n    \"accuracy\": {\n      \"white\": 85.5,\n      \"black\": 72.3\n    },\n    \"mistakes\": {\n      \"blunders\": 2,\n      \"mistakes\": 3,\n      \"inaccuracies\": 5\n    },\n    \"key_moments\": [\n      {\n        \"move_number\": 15,\n        \"description\": \"Blunder\",\n        \"evaluation_before\": 1.5,\n        \"evaluation_after\": -3.2\n      }\n    ],\n    \"summary\": \"Bonne ouverture...\"\n  }\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Analyse mise a jour\",\n  \"game_id\": \"665f1a2b...\"\n}\n```\n\n### Erreurs\n- 404: game_id introuvable\n\n### RFC-039 compliant",
+        "height": 560,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 20]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API Update Analysis", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API Update Analysis": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Games-Lichess.json
+++ b/workflows/MCP-Games-Lichess.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - Games Lichess",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "games-lichess",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "games-lichess-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst game_id = body.game_id;\nconst lichess_game_id = body.lichess_game_id;\nconst lichess_url = body.lichess_url;\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (!game_id) errors.push('game_id requis');\nif (!lichess_game_id) errors.push('lichess_game_id requis');\n\n// Validate lichess_url format if provided\nif (lichess_url && !lichess_url.startsWith('https://lichess.org/')) {\n  errors.push('lichess_url doit commencer par https://lichess.org/');\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    game_id,\n    lichess_game_id,\n    lichess_url: lichess_url || `https://lichess.org/${lichess_game_id}`\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games/lichess",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, game_id: $json.game_id, lichess_game_id: $json.lichess_game_id, lichess_url: $json.lichess_url }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-lichess",
+      "name": "API Mark Lichess",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $('Validate Input').first().json;\nconst response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode === 404) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: 'Partie non trouvee',\n        game_id: input.game_id\n      }\n    }\n  };\n}\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    success: true,\n    message: 'Partie liee a Lichess',\n    game_id: input.game_id,\n    lichess_game_id: input.lichess_game_id,\n    lichess_url: input.lichess_url\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.code || 500) }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Games Lichess\n\n**Endpoint:** POST /webhook/games-lichess\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"game_id\": \"665f1a2b3c4d5e6f7a8b9c0d\",\n  \"lichess_game_id\": \"AbCdEfGh\",\n  \"lichess_url\": \"https://lichess.org/AbCdEfGh\"\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Partie liee a Lichess\",\n  \"game_id\": \"665f1a2b...\",\n  \"lichess_game_id\": \"AbCdEfGh\",\n  \"lichess_url\": \"https://lichess.org/AbCdEfGh\"\n}\n```\n\n### Usage\nMarque une partie locale comme importee\ndepuis Lichess. Permet de retrouver la\npartie originale sur Lichess.\n\n### Erreurs\n- 404: game_id introuvable\n\n### RFC-039 compliant",
+        "height": 420,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API Mark Lichess", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API Mark Lichess": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Games-List.json
+++ b/workflows/MCP-Games-List.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - Games List",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "games-list",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "games-list-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst limit = body.limit || 20;\nconst offset = body.offset || 0;\nconst filters = body.filters || {};\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\n\n// Validate limit\nif (limit < 1 || limit > 100) {\n  errors.push('limit doit etre entre 1 et 100');\n}\n\n// Validate filters\nconst validResults = ['win', 'loss', 'draw'];\nif (filters.result && !validResults.includes(filters.result)) {\n  errors.push(`filters.result invalide: ${filters.result}. Valeurs: ${validResults.join(', ')}`);\n}\n\nconst validSources = ['manual', 'lichess', 'pgn_import'];\nif (filters.source && !validSources.includes(filters.source)) {\n  errors.push(`filters.source invalide: ${filters.source}. Valeurs: ${validSources.join(', ')}`);\n}\n\nif (filters.has_analysis !== undefined && typeof filters.has_analysis !== 'boolean') {\n  errors.push('filters.has_analysis doit etre un booleen');\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    limit,\n    offset,\n    filters\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, limit: $json.limit, offset: $json.offset, filters: Object.keys($json.filters).length > 0 ? $json.filters : undefined }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 15000
+        }
+      },
+      "id": "api-games",
+      "name": "API List Games",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $('Validate Input').first().json;\nconst response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nconst data = body.data || body;\n\nreturn {\n  json: {\n    success: true,\n    games: data.games || [],\n    total: data.total || 0,\n    limit: data.limit || input.limit,\n    offset: data.offset || input.offset\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Games List\n\n**Endpoint:** POST /webhook/games-list\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"limit\": 20,\n  \"offset\": 0,\n  \"filters\": {\n    \"result\": \"win\",\n    \"source\": \"lichess\",\n    \"has_analysis\": true\n  }\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"games\": [\n    {\n      \"game_id\": \"...\",\n      \"white\": \"user\",\n      \"black\": \"opponent\",\n      \"result\": \"win\",\n      \"pgn\": \"1. e4 e5...\"\n    }\n  ],\n  \"total\": 42,\n  \"limit\": 20,\n  \"offset\": 0\n}\n```\n\n### Filtres\n- `result`: win, loss, draw\n- `source`: manual, lichess, pgn_import\n- `has_analysis`: true/false\n\n### Pagination\n- `limit`: 1-100 (defaut 20)\n- `offset`: defaut 0\n\n### RFC-039 compliant",
+        "height": 520,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 40]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API List Games", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API List Games": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Lichess-Auth-Callback.json
+++ b/workflows/MCP-Lichess-Auth-Callback.json
@@ -1,0 +1,303 @@
+{
+  "name": "MCP - Lichess Auth Callback",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lichess-auth-callback",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "lichess-auth-callback-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst code = body.code;\nconst state = body.state;\nconst code_verifier = body.code_verifier;\nconst error = body.error;\nconst error_description = body.error_description;\n\n// Check for OAuth error from Lichess\nif (error) {\n  return {\n    json: {\n      valid: false,\n      error: { \n        code: 400, \n        message: `Lichess OAuth error: ${error}`, \n        description: error_description,\n        status: 'OAUTH_ERROR' \n      }\n    }\n  };\n}\n\n// Validation\nconst errors = [];\nif (!code) errors.push('code manquant');\nif (!state) errors.push('state manquant');\nif (!code_verifier) errors.push('code_verifier manquant');\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\n// Decode state to get tenant_id and user_id\nlet stateData;\ntry {\n  stateData = JSON.parse(Buffer.from(state, 'base64url').toString());\n} catch (e) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: 'state invalide (décodage échoué)', status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nif (!stateData.tenant_id || !stateData.user_id) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: 'state invalide (tenant_id ou user_id manquant)', status: 'BAD_REQUEST' }\n    }\n  };\n}\n\n// Check state freshness (10 min max)\nconst stateAge = Date.now() - stateData.ts;\nif (stateAge > 600000) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: 'state expiré (> 10 minutes)', status: 'STATE_EXPIRED' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    code,\n    state,\n    code_verifier,\n    tenant_id: stateData.tenant_id,\n    user_id: stateData.user_id\n  }\n};"
+      },
+      "id": "validate-callback",
+      "name": "Validate Callback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://lichess.org/api/token",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/x-www-form-urlencoded" }
+          ]
+        },
+        "sendBody": true,
+        "contentType": "form-urlencoded",
+        "bodyParameters": {
+          "parameters": [
+            { "name": "grant_type", "value": "authorization_code" },
+            { "name": "code", "value": "={{ $json.code }}" },
+            { "name": "code_verifier", "value": "={{ $json.code_verifier }}" },
+            { "name": "redirect_uri", "value": "={{ $env.LICHESS_REDIRECT_URI }}" },
+            { "name": "client_id", "value": "={{ $env.LICHESS_CLIENT_ID }}" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 15000
+        }
+      },
+      "id": "exchange-token",
+      "name": "Exchange Token",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const callbackData = $('Validate Callback').first().json;\nconst tokenResult = $input.first().json;\n\nif (tokenResult.statusCode >= 400) {\n  return {\n    json: {\n      valid: false,\n      error: { \n        code: tokenResult.statusCode, \n        message: 'Lichess token exchange failed', \n        details: tokenResult.body \n      }\n    }\n  };\n}\n\nconst tokens = tokenResult.body;\n\n// Calculate expiry\nconst expiresAt = new Date(Date.now() + (tokens.expires_in * 1000)).toISOString();\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id: callbackData.tenant_id,\n    user_id: callbackData.user_id,\n    access_token: tokens.access_token,\n    refresh_token: tokens.refresh_token || null,\n    token_type: tokens.token_type,\n    expires_in: tokens.expires_in,\n    expires_at: expiresAt,\n    scope: tokens.scope\n  }\n};"
+      },
+      "id": "parse-token",
+      "name": "Parse Token",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-token-valid",
+      "name": "Token Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-token-error",
+      "name": "Respond Token Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 460]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "https://lichess.org/api/account",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Authorization", "value": "=Bearer {{ $json.access_token }}" },
+            { "name": "Accept", "value": "application/json" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "get-lichess-account",
+      "name": "Get Lichess Account",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1560, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth/store",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $('Parse Token').first().json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $('Parse Token').first().json.user_id, provider: 'lichess', access_token: $('Parse Token').first().json.access_token, refresh_token: $('Parse Token').first().json.refresh_token, expires_at: $('Parse Token').first().json.expires_at, scope: $('Parse Token').first().json.scope, provider_user_id: $json.body?.username || $json.body?.id }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "store-tokens",
+      "name": "Store Tokens",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1780, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/lichess",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $('Parse Token').first().json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $('Parse Token').first().json.user_id, lichess_username: $('Get Lichess Account').first().json.body?.username || $('Get Lichess Account').first().json.body?.id }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "update-progress",
+      "name": "Link Lichess in Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2000, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const tokenData = $('Parse Token').first().json;\nconst accountData = $('Get Lichess Account').first().json;\n\nconst lichessUsername = accountData.body?.username || accountData.body?.id || 'unknown';\n\nreturn {\n  json: {\n    success: true,\n    message: `Compte Lichess \"${lichessUsername}\" connecté avec succès`,\n    user_id: tokenData.user_id,\n    lichess_username: lichessUsername,\n    scope: tokenData.scope\n  }\n};"
+      },
+      "id": "build-success",
+      "name": "Build Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2220, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2440, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Lichess Auth Callback\n\n**Endpoint:** POST /webhook/lichess-auth-callback\n\n### Input\n```json\n{\n  \"code\": \"lic_abc123...\",\n  \"state\": \"base64...\",\n  \"code_verifier\": \"xyz789...\"\n}\n```\n\nLe caller (chess plugin) doit :\n1. Recevoir le callback de Lichess (?code=...&state=...)\n2. Ajouter le code_verifier (stocké lors de auth-start)\n3. Appeler ce endpoint\n\n### Flow\n1. Valide code, state, code_verifier\n2. Décode state → tenant_id + user_id\n3. Échange code → access_token (Lichess API)\n4. Récupère profil Lichess\n5. Stocke tokens (POST /api/n8n/oauth/store)\n6. Lie lichess_username (POST /api/n8n/progress/lichess)\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Compte Lichess 'player123' connecté\",\n  \"lichess_username\": \"player123\"\n}\n```\n\n### Variables d'environnement\n- `LICHESS_CLIENT_ID`\n- `LICHESS_REDIRECT_URI`\n- `BACKEND_API_URL`\n- `N8N_API_KEY`\n\n### RFC-039 compliant",
+        "height": 580,
+        "width": 420,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 20]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Callback", "type": "main", "index": 0 }]]
+    },
+    "Validate Callback": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "Exchange Token", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "Exchange Token": {
+      "main": [[{ "node": "Parse Token", "type": "main", "index": 0 }]]
+    },
+    "Parse Token": {
+      "main": [[{ "node": "Token Valid?", "type": "main", "index": 0 }]]
+    },
+    "Token Valid?": {
+      "main": [
+        [{ "node": "Get Lichess Account", "type": "main", "index": 0 }],
+        [{ "node": "Respond Token Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "Get Lichess Account": {
+      "main": [[{ "node": "Store Tokens", "type": "main", "index": 0 }]]
+    },
+    "Store Tokens": {
+      "main": [[{ "node": "Link Lichess in Progress", "type": "main", "index": 0 }]]
+    },
+    "Link Lichess in Progress": {
+      "main": [[{ "node": "Build Success Response", "type": "main", "index": 0 }]]
+    },
+    "Build Success Response": {
+      "main": [[{ "node": "Respond Success", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Lichess-Auth-Start.json
+++ b/workflows/MCP-Lichess-Auth-Start.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - Lichess Auth Start",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "lichess-auth-start",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "lichess-auth-start-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst redirect_uri = body.redirect_uri || $env.LICHESS_REDIRECT_URI;\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (!redirect_uri) errors.push('redirect_uri requis (ou configurer LICHESS_REDIRECT_URI)');\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\n// Generate state token (includes user_id + tenant_id for callback)\nconst state = Buffer.from(JSON.stringify({\n  tenant_id,\n  user_id,\n  ts: Date.now(),\n  nonce: Math.random().toString(36).substring(2, 15)\n})).toString('base64url');\n\n// PKCE: Generate code_verifier and code_challenge\nconst crypto = require('crypto');\nconst code_verifier = crypto.randomBytes(32).toString('base64url');\nconst code_challenge = crypto\n  .createHash('sha256')\n  .update(code_verifier)\n  .digest('base64url');\n\n// Lichess OAuth scopes\nconst scopes = [\n  'preference:read',\n  'challenge:read',\n  'challenge:write', \n  'puzzle:read',\n  'team:read',\n  'board:play'\n].join(' ');\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    redirect_uri,\n    state,\n    code_verifier,\n    code_challenge,\n    scopes\n  }\n};"
+      },
+      "id": "validate-and-prepare",
+      "name": "Validate & Prepare",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth/store",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, provider: 'lichess', access_token: '__PENDING__', expires_at: new Date(Date.now() + 600000).toISOString(), scope: 'pending', provider_user_id: '__pending_' + $json.state.substring(0, 8) + '__' }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "store-pending",
+      "name": "Store Pending Auth",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $('Validate & Prepare').first().json;\nconst storeResult = $input.first().json;\n\nif (storeResult.statusCode >= 400) {\n  return {\n    json: {\n      success: false,\n      error: { code: 500, message: 'Erreur stockage state', details: storeResult }\n    }\n  };\n}\n\n// Build Lichess authorization URL\nconst clientId = $env.LICHESS_CLIENT_ID;\nif (!clientId) {\n  return {\n    json: {\n      success: false,\n      error: { code: 500, message: 'LICHESS_CLIENT_ID non configuré' }\n    }\n  };\n}\n\nconst params = new URLSearchParams({\n  response_type: 'code',\n  client_id: clientId,\n  redirect_uri: input.redirect_uri,\n  scope: input.scopes,\n  state: input.state,\n  code_challenge: input.code_challenge,\n  code_challenge_method: 'S256'\n});\n\nconst authUrl = `https://lichess.org/oauth?${params.toString()}`;\n\n// Store code_verifier in memory for callback (via state mapping)\n// Note: In production, store code_verifier in Redis or similar\n// For now, we embed it in state (less secure but functional)\n\nreturn {\n  json: {\n    success: true,\n    auth_url: authUrl,\n    state: input.state,\n    code_verifier: input.code_verifier,\n    message: 'Redirigez l\\'utilisateur vers auth_url pour autorisation Lichess'\n  }\n};"
+      },
+      "id": "build-auth-url",
+      "name": "Build Auth URL",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Lichess Auth Start\n\n**Endpoint:** POST /webhook/lichess-auth-start\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"redirect_uri\": \"https://app.local/callback\" \n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"auth_url\": \"https://lichess.org/oauth?...\",\n  \"state\": \"base64...\",\n  \"code_verifier\": \"abc123...\",\n  \"message\": \"Redirigez l'utilisateur...\"\n}\n```\n\n### Flow\n1. Valide tenant_id + user_id\n2. Génère state (contient tenant_id + user_id) + PKCE\n3. Stocke placeholder en OAuth store\n4. Retourne URL d'autorisation Lichess\n\n### Note\nLe `code_verifier` est retourné au caller qui doit\nle passer au callback (ou le stocker côté client).\n\n### Variables d'environnement\n- `LICHESS_CLIENT_ID`\n- `LICHESS_REDIRECT_URI`\n- `BACKEND_API_URL`\n- `N8N_API_KEY`\n\n### RFC-039 compliant",
+        "height": 500,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 40]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate & Prepare", "type": "main", "index": 0 }]]
+    },
+    "Validate & Prepare": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "Store Pending Auth", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "Store Pending Auth": {
+      "main": [[{ "node": "Build Auth URL", "type": "main", "index": 0 }]]
+    },
+    "Build Auth URL": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-OAuth-Delete.json
+++ b/workflows/MCP-OAuth-Delete.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - OAuth Delete",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "oauth-delete",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "oauth-delete-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst provider = body.provider;\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (!provider) errors.push('provider requis');\n\nconst validProviders = ['lichess'];\nif (provider && !validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider}. Valeurs: ${validProviders.join(', ')}`);\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    provider\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth/delete",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, provider: $json.provider }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-delete",
+      "name": "API Delete OAuth",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $('Validate Input').first().json;\nconst response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    success: true,\n    message: `Token OAuth ${input.provider} supprime`,\n    provider: input.provider,\n    user_id: input.user_id\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - OAuth Delete\n\n**Endpoint:** POST /webhook/oauth-delete\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"provider\": \"lichess\"\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Token OAuth lichess supprime\",\n  \"provider\": \"lichess\",\n  \"user_id\": \"discord_123456\"\n}\n```\n\n### Usage\nSupprime le token OAuth pour un provider\nspecifique. Utilise pour:\n- Deconnexion de Lichess\n- Revocation d'acces\n- Nettoyage de tokens expires\n\n### Providers supportes\n- `lichess`\n\n### RFC-039 compliant",
+        "height": 380,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API Delete OAuth", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API Delete OAuth": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-OAuth-Get.json
+++ b/workflows/MCP-OAuth-Get.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - OAuth Get",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "oauth-get",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "oauth-get-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst provider = body.provider;\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (!provider) errors.push('provider requis');\n\nconst validProviders = ['lichess'];\nif (provider && !validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider}. Valeurs: ${validProviders.join(', ')}`);\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    provider\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, provider: $json.provider }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-oauth",
+      "name": "API Get OAuth",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $('Validate Input').first().json;\nconst response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nconst data = body.data;\n\n// No token found\nif (data === null) {\n  return {\n    json: {\n      success: true,\n      has_token: false,\n      provider: input.provider,\n      message: 'Aucun token OAuth trouve pour ce provider'\n    }\n  };\n}\n\n// Token found\nreturn {\n  json: {\n    success: true,\n    has_token: true,\n    provider: input.provider,\n    access_token: data.access_token,\n    refresh_token: data.refresh_token || null,\n    expires_at: data.expires_at,\n    is_expired: data.is_expired || false,\n    scope: data.scope,\n    provider_user_id: data.provider_user_id\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - OAuth Get\n\n**Endpoint:** POST /webhook/oauth-get\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"provider\": \"lichess\"\n}\n```\n\n### Output (token existe)\n```json\n{\n  \"success\": true,\n  \"has_token\": true,\n  \"provider\": \"lichess\",\n  \"access_token\": \"lip_xxxx\",\n  \"refresh_token\": \"lrt_xxxx\",\n  \"expires_at\": \"2026-04-12T14:00:00+00:00\",\n  \"is_expired\": false,\n  \"scope\": \"challenge:read challenge:write\",\n  \"provider_user_id\": \"DrNykterstein\"\n}\n```\n\n### Output (pas de token)\n```json\n{\n  \"success\": true,\n  \"has_token\": false,\n  \"provider\": \"lichess\",\n  \"message\": \"Aucun token OAuth...\"\n}\n```\n\n### Securite\nLes tokens sont dechiffres a la volee\n(AES-256-GCM cote backend).\n\n### RFC-039 compliant",
+        "height": 480,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 40]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API Get OAuth", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API Get OAuth": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Progress-Delete.json
+++ b/workflows/MCP-Progress-Delete.json
@@ -1,0 +1,155 @@
+{
+  "name": "MCP - Progress Delete",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "progress-delete",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "progress-delete-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst confirm = body.confirm;\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (confirm !== true) errors.push('confirm: true requis pour confirmer la suppression');\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/delete",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 15000
+        }
+      },
+      "id": "api-delete",
+      "name": "API Delete User Data",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur suppression',\n        details: body\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    success: true,\n    message: 'Toutes les donnees utilisateur ont ete supprimees (GDPR)',\n    deleted: body.data?.deleted || body.deleted || body.data\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Progress Delete (GDPR)\n\n**Endpoint:** POST /webhook/progress-delete\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"confirm\": true\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Toutes les donnees...\",\n  \"deleted\": {\n    \"user_progress\": { \"deleted\": true },\n    \"user_games\": 5,\n    \"user_oauth_tokens\": 1\n  }\n}\n```\n\n### Suppression cascade\n- `user_progress` (progression, badges, lecons)\n- `user_games` (parties jouees)\n- `user_oauth_tokens` (tokens Lichess)\n\n### Securite\n- Requiert `confirm: true` explicite\n- Action irreversible\n\n### RFC-039 compliant",
+        "height": 460,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "API Delete User Data", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "API Delete User Data": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Progress-Get.json
+++ b/workflows/MCP-Progress-Get.json
@@ -1,0 +1,262 @@
+{
+  "name": "MCP - Progress Get",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "progress-get",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "progress-get-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst domain = body.domain || null;  // chess, cooking, null = all\nconst include = body.include || ['stats', 'lessons', 'badges'];\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    domain,\n    include,\n    include_lichess: include.includes('lichess_games') || include.includes('lichess_elo')\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, domain: $json.domain }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "get-progress",
+      "name": "Get Progress",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $('Validate Input').first().json;\nconst response = $input.first().json;\n\n// Parse response\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: { code: statusCode, message: body.error?.message || 'Erreur API', details: body }\n    }\n  };\n}\n\nconst progress = body.data;\n\n// User not found\nif (progress === null) {\n  return {\n    json: {\n      success: true,\n      user_id: input.user_id,\n      exists: false,\n      message: 'Utilisateur non trouvé - nouveau profil'\n    }\n  };\n}\n\n// Check if we need Lichess data\nconst lichessUsername = progress.lichess_username;\nconst needsLichess = input.include_lichess && lichessUsername;\n\nreturn {\n  json: {\n    progress,\n    lichess_username: lichessUsername,\n    needs_lichess: needsLichess,\n    include: input.include\n  }\n};"
+      },
+      "id": "parse-progress",
+      "name": "Parse Progress Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-lichess",
+              "leftValue": "={{ $json.needs_lichess }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "needs-lichess",
+      "name": "Needs Lichess?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 300]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://lichess.org/api/user/{{ $json.lichess_username }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/json" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "get-lichess-profile",
+      "name": "Get Lichess Profile",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1560, 220],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=https://lichess.org/api/user/{{ $('Parse Progress Response').first().json.lichess_username }}/rating-history",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Accept", "value": "application/json" }
+          ]
+        },
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "get-lichess-elo",
+      "name": "Get Lichess Elo History",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1560, 380],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const progressData = $('Parse Progress Response').first().json;\nconst lichessProfile = $('Get Lichess Profile').first().json;\nconst lichessElo = $('Get Lichess Elo History').first().json;\n\n// Parse Lichess data\nconst profile = lichessProfile.body || {};\nconst eloHistory = lichessElo.body || [];\n\nconst progress = progressData.progress;\n\n// Build combined response\nconst result = {\n  success: true,\n  user_id: progress.user_id,\n  \n  // App data from MongoDB\n  stats: progress.stats || {},\n  lessons: progress.lessons || [],\n  badges: progress.badges || [],\n  preferences: progress.preferences || {},\n  cooking: progress.cooking || null,\n  \n  // Lichess data (live)\n  lichess: {\n    connected: true,\n    username: progressData.lichess_username,\n    profile: {\n      id: profile.id,\n      username: profile.username,\n      perfs: profile.perfs,\n      count: profile.count,\n      playTime: profile.playTime\n    },\n    elo_history: eloHistory.filter(cat => \n      ['bullet', 'blitz', 'rapid', 'classical', 'puzzle'].includes(cat.name)\n    ).map(cat => ({\n      category: cat.name,\n      points: cat.points.slice(-30)\n    }))\n  }\n};\n\nreturn { json: result };"
+      },
+      "id": "merge-lichess",
+      "name": "Merge Lichess Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1780, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "const progressData = $('Parse Progress Response').first().json;\n\n// Check if user not found\nif (progressData.exists === false) {\n  return { json: progressData };\n}\n\nconst progress = progressData.progress;\n\n// Build response without Lichess\nconst result = {\n  success: true,\n  user_id: progress.user_id,\n  \n  // App data from MongoDB\n  stats: progress.stats || {},\n  lessons: progress.lessons || [],\n  badges: progress.badges || [],\n  preferences: progress.preferences || {},\n  cooking: progress.cooking || null,\n  \n  // Lichess not connected or not requested\n  lichess: progressData.lichess_username ? {\n    connected: true,\n    username: progressData.lichess_username,\n    profile: null,\n    elo_history: null\n  } : {\n    connected: false\n  }\n};\n\nreturn { json: result };"
+      },
+      "id": "build-response-no-lichess",
+      "name": "Build Response (No Lichess)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 460]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2000, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Progress Get\n\n**Endpoint:** POST /webhook/progress-get\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"domain\": \"chess\" | \"cooking\" | null,\n  \"include\": [\"stats\", \"lessons\", \"badges\", \"lichess_elo\"]\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"stats\": {...},\n  \"lessons\": [...],\n  \"badges\": [...],\n  \"lichess\": { \"connected\": true, \"profile\": {...} }\n}\n```\n\n### Sources\n- Backend API: `/api/n8n/progress`\n- Lichess API: profile, elo history (si connecté et demandé)\n\n### RFC-039 compliant",
+        "height": 380,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 80]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "Get Progress", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "Get Progress": {
+      "main": [[{ "node": "Parse Progress Response", "type": "main", "index": 0 }]]
+    },
+    "Parse Progress Response": {
+      "main": [[{ "node": "Needs Lichess?", "type": "main", "index": 0 }]]
+    },
+    "Needs Lichess?": {
+      "main": [
+        [
+          { "node": "Get Lichess Profile", "type": "main", "index": 0 },
+          { "node": "Get Lichess Elo History", "type": "main", "index": 0 }
+        ],
+        [{ "node": "Build Response (No Lichess)", "type": "main", "index": 0 }]
+      ]
+    },
+    "Get Lichess Profile": {
+      "main": [[{ "node": "Merge Lichess Data", "type": "main", "index": 0 }]]
+    },
+    "Get Lichess Elo History": {
+      "main": [[{ "node": "Merge Lichess Data", "type": "main", "index": 0 }]]
+    },
+    "Merge Lichess Data": {
+      "main": [[{ "node": "Respond Success", "type": "main", "index": 0 }]]
+    },
+    "Build Response (No Lichess)": {
+      "main": [[{ "node": "Respond Success", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP-Progress-Update.json
+++ b/workflows/MCP-Progress-Update.json
@@ -1,0 +1,301 @@
+{
+  "name": "MCP - Progress Update",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "progress-update",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "progress-update-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\n\nconst tenant_id = body.tenant_id;\nconst user_id = body.user_id;\nconst operation = body.operation;\nconst data = body.data || {};\n\n// Validation\nconst errors = [];\nif (!tenant_id) errors.push('tenant_id requis');\nif (!user_id) errors.push('user_id requis');\nif (!operation) errors.push('operation requis');\n\nconst validOps = ['session', 'add_lesson', 'award_badge', 'preferences', 'link_lichess'];\nif (operation && !validOps.includes(operation)) {\n  errors.push(`operation invalide: ${operation}. Valeurs: ${validOps.join(', ')}`);\n}\n\n// Operation-specific validation\nif (operation === 'add_lesson') {\n  if (!data.lesson_id) errors.push('data.lesson_id requis pour add_lesson');\n  if (!data.domain) errors.push('data.domain requis pour add_lesson');\n  if (data.score === undefined) errors.push('data.score requis pour add_lesson');\n}\nif (operation === 'award_badge') {\n  if (!data.badge_id) errors.push('data.badge_id requis pour award_badge');\n  if (!data.domain) errors.push('data.domain requis pour award_badge');\n}\nif (operation === 'link_lichess') {\n  if (data.lichess_username === undefined) errors.push('data.lichess_username requis pour link_lichess (null pour délier)');\n}\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: { code: 400, message: errors.join(', '), status: 'BAD_REQUEST' }\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    tenant_id,\n    user_id,\n    operation,\n    data\n  }\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [900, 540]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            { "outputKey": "session", "conditions": { "conditions": [{ "leftValue": "={{ $json.operation }}", "rightValue": "session", "operator": { "type": "string", "operation": "equals" } }] } },
+            { "outputKey": "add_lesson", "conditions": { "conditions": [{ "leftValue": "={{ $json.operation }}", "rightValue": "add_lesson", "operator": { "type": "string", "operation": "equals" } }] } },
+            { "outputKey": "award_badge", "conditions": { "conditions": [{ "leftValue": "={{ $json.operation }}", "rightValue": "award_badge", "operator": { "type": "string", "operation": "equals" } }] } },
+            { "outputKey": "preferences", "conditions": { "conditions": [{ "leftValue": "={{ $json.operation }}", "rightValue": "preferences", "operator": { "type": "string", "operation": "equals" } }] } },
+            { "outputKey": "link_lichess", "conditions": { "conditions": [{ "leftValue": "={{ $json.operation }}", "rightValue": "link_lichess", "operator": { "type": "string", "operation": "equals" } }] } }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-operation",
+      "name": "Switch Operation",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [900, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/sessions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-session",
+      "name": "API Session",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/lessons",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, lesson: { lesson_id: $json.data.lesson_id, completed_at: $json.data.completed_at || new Date().toISOString(), score: $json.data.score, domain: $json.data.domain, duration_minutes: $json.data.duration_minutes || null } }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-lesson",
+      "name": "API Add Lesson",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/badges",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, badge: { id: $json.data.badge_id, domain: $json.data.domain, earned_at: $json.data.earned_at || new Date().toISOString(), metadata: $json.data.metadata || {} } }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-badge",
+      "name": "API Award Badge",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/preferences",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, preferences: $json.data }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-preferences",
+      "name": "API Preferences",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/lichess",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            { "name": "Content-Type", "value": "application/json" },
+            { "name": "X-API-Key", "value": "={{ $env.N8N_API_KEY }}" },
+            { "name": "X-Tenant-ID", "value": "={{ $json.tenant_id }}" }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, lichess_username: $json.data.lichess_username }) }}",
+        "options": {
+          "response": { "response": { "fullResponse": true } },
+          "timeout": 10000
+        }
+      },
+      "id": "api-lichess",
+      "name": "API Link Lichess",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 500],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json;\nconst operation = $('Validate Input').first().json.operation;\n\nconst statusCode = response.statusCode || 200;\nconst body = response.body || response;\n\nif (statusCode >= 400 || body.success === false) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: body.error?.message || 'Erreur API',\n        details: body\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    success: true,\n    operation,\n    message: body.message || 'Mise à jour effectuée',\n    data: body.data || body\n  }\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : 500 }}",
+          "responseHeaders": { "entries": [{ "name": "Content-Type", "value": "application/json" }] }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1600, 300]
+    },
+    {
+      "parameters": {
+        "content": "## MCP - Progress Update\n\n**Endpoint:** POST /webhook/progress-update\n\n### Operations (RFC-039 compliant)\n\n**1. session** - Incrémenter sessions\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"operation\": \"session\",\n  \"data\": {}\n}\n```\n\n**2. add_lesson** - Ajouter leçon\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"operation\": \"add_lesson\",\n  \"data\": {\n    \"lesson_id\": \"endgame_101\",\n    \"domain\": \"chess\",\n    \"score\": 85,\n    \"duration_minutes\": 12\n  }\n}\n```\n\n**3. award_badge**\n```json\n{\n  \"operation\": \"award_badge\",\n  \"data\": {\n    \"badge_id\": \"first_win\",\n    \"domain\": \"chess\",\n    \"metadata\": { \"opponent\": \"bot_easy\" }\n  }\n}\n```\n\n**4. preferences**\n```json\n{\n  \"operation\": \"preferences\",\n  \"data\": {\n    \"difficulty_level\": \"intermediate\",\n    \"notifications\": true\n  }\n}\n```\n\n**5. link_lichess**\n```json\n{\n  \"operation\": \"link_lichess\",\n  \"data\": { \"lichess_username\": \"player123\" }\n}\n```",
+        "height": 620,
+        "width": 400,
+        "color": 6
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 40]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [[{ "node": "Validate Input", "type": "main", "index": 0 }]]
+    },
+    "Validate Input": {
+      "main": [[{ "node": "Valid?", "type": "main", "index": 0 }]]
+    },
+    "Valid?": {
+      "main": [
+        [{ "node": "Switch Operation", "type": "main", "index": 0 }],
+        [{ "node": "Respond Error", "type": "main", "index": 0 }]
+      ]
+    },
+    "Switch Operation": {
+      "session": [[{ "node": "API Session", "type": "main", "index": 0 }]],
+      "add_lesson": [[{ "node": "API Add Lesson", "type": "main", "index": 0 }]],
+      "award_badge": [[{ "node": "API Award Badge", "type": "main", "index": 0 }]],
+      "preferences": [[{ "node": "API Preferences", "type": "main", "index": 0 }]],
+      "link_lichess": [[{ "node": "API Link Lichess", "type": "main", "index": 0 }]]
+    },
+    "API Session": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "API Add Lesson": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "API Award Badge": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "API Preferences": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "API Link Lichess": {
+      "main": [[{ "node": "Format Response", "type": "main", "index": 0 }]]
+    },
+    "Format Response": {
+      "main": [[{ "node": "Respond", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}


### PR DESCRIPTION
## Summary

- Add 11 n8n workflows for Chess Plugin Discord integration (RFC-039)
- Add RFC-039 backend API endpoints specification
- Add integration guide for plugin-chess team with Q&A responses

## Workflows Added

### Progress (3)
- `MCP-Progress-Get.json` - Read user progression
- `MCP-Progress-Update.json` - Update sessions, lessons, badges, preferences
- `MCP-Progress-Delete.json` - GDPR data deletion

### Games (4)
- `MCP-Games-List.json` - List games with filters
- `MCP-Games-Add.json` - Add new game
- `MCP-Games-Analysis.json` - Update game analysis
- `MCP-Games-Lichess.json` - Mark Lichess import

### OAuth (4)
- `MCP-OAuth-Get.json` - Retrieve OAuth token
- `MCP-OAuth-Delete.json` - Delete OAuth token
- `MCP-Lichess-Auth-Start.json` - Start Lichess OAuth PKCE flow
- `MCP-Lichess-Auth-Callback.json` - Complete OAuth callback

## Documentation

- `docs/rfc/RFC-039-BACKEND-API-ENDPOINTS.md` - Backend API specification
- `docs/guides/n8n-chess-api-guide.md` - Backend team API guide
- `docs/guides/chess-plugin-integration-guide.md` - Plugin integration guide with N8N team Q&A responses

## Tools

- `scripts/n8n/batch_import.sh` - Script to import/activate workflows via n8n API

## Test plan

- [ ] Import workflows via batch_import.sh
- [ ] Verify all webhooks respond correctly
- [ ] Test progress-get/update/delete flow
- [ ] Test games-list/add/analysis flow
- [ ] Test OAuth flow with Lichess

🤖 Generated with [Claude Code](https://claude.com/claude-code)