### PR TITLE
feat: RFC-049 Entity Storage Architecture - 5 nouveaux webhooks

### DIFF
--- a/docs/RFC-049-MIGRATION-GUIDE.md
+++ b/docs/RFC-049-MIGRATION-GUIDE.md
@@ -25,6 +25,7 @@ Les nouveaux webhooks remplacent les anciens webhooks Qdrant-only.
 | `MCP Qdrant - Search` | **MCP - Entity - Search** | + Enrichissement depuis MongoDB<br>+ Filtrage tenant_id obligatoire<br>+ Endpoint batch pour performance |
 | *(nouveau)* | **MCP - Entity - Rating** | Notes 1-5 stockées en PostgreSQL |
 | *(nouveau)* | **MCP - Entity - Comment** | Commentaires stockés en PostgreSQL |
+| *(nouveau)* | **MCP - Entity - Favorite** | Sauvegarder/retirer des favoris (PostgreSQL) |
 | *(nouveau)* | **MCP - Tenant - Resolve** | Résout Discord user_id → tenant_id |
 
 ---
@@ -188,6 +189,96 @@ X-Tenant-ID: {tenant_id}
 
 ---
 
+### MCP - Entity - Favorite
+
+**URL:** `POST /webhook/entity-favorite`
+
+**Description:** Permet à un utilisateur de sauvegarder une entité dans ses favoris ou de la retirer.
+
+**Payload (save):**
+```json
+{
+  "action": "save",
+  "entity_id": "5606c365-...",
+  "entity_type": "recipe",
+  "user_id": "636639897767378954",
+  "guild_id": "123456789"
+}
+```
+
+**Payload (unsave):**
+```json
+{
+  "action": "unsave",
+  "entity_id": "5606c365-...",
+  "entity_type": "recipe",
+  "user_id": "636639897767378954",
+  "guild_id": "123456789"
+}
+```
+
+**Payload (list):**
+```json
+{
+  "action": "list",
+  "entity_type": "recipe",
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "limit": 20,
+  "offset": 0
+}
+```
+
+**Réponse (action=save):**
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-...",
+    "saved": true,
+    "saved_at": "2026-03-27T10:30:00Z"
+  },
+  "_trace": {...}
+}
+```
+
+**Réponse (action=unsave):**
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-...",
+    "saved": false
+  },
+  "_trace": {...}
+}
+```
+
+**Réponse (action=list):**
+```json
+{
+  "success": true,
+  "data": {
+    "favorites": [
+      {
+        "entity_id": "5606c365-...",
+        "entity_type": "recipe",
+        "saved_at": "2026-03-27T10:30:00Z"
+      }
+    ],
+    "total": 12
+  },
+  "_trace": {...}
+}
+```
+
+**API Backend appelée:**
+- `POST /api/n8n/entities/{type}/{id}/save` (action=save)
+- `DELETE /api/n8n/entities/{type}/{id}/save?user_id=X&guild_id=Y` (action=unsave)
+- `GET /api/n8n/entities/{type}/saved?user_id=X&guild_id=Y` (action=list)
+
+---
+
 ### MCP - Tenant - Resolve
 
 **URL:** `POST /webhook/tenant-resolve`
@@ -263,12 +354,60 @@ Qdrant est une instance partagée. Le filtrage par `tenant_id` est **automatique
 
 ### 4. Enrichissement batch
 
-Pour éviter N appels séquentiels lors d'un Search, l'API Backend expose un endpoint batch:
+Pour éviter N appels séquentiels lors d'un Search, l'API Backend expose un endpoint batch.
+
+**Comportement interne de MCP - Entity - Search:**
+
+Quand `enrich: true` est passé, le workflow:
+1. Recherche dans Qdrant → obtient N `entity_id`
+2. Appelle l'endpoint batch avec tous les IDs en un seul appel
+3. Fusionne les résultats Qdrant + MongoDB
+
+```
+MCP - Entity - Search (avec enrich: true)
+    │
+    ├── 1. Search Qdrant
+    │   └── Résultat: [{ id: "uuid1", score: 0.9 }, { id: "uuid2", score: 0.8 }, ...]
+    │
+    ├── 2. Batch enrichissement (1 seul appel API)
+    │   POST /api/n8n/entities/{type}/batch
+    │   Body: { "ids": ["uuid1", "uuid2", ...], "fields": ["title", "ingredients"] }
+    │   └── Résultat: [{ id: "uuid1", data: {...} }, { id: "uuid2", data: {...} }]
+    │
+    └── 3. Fusion
+        └── [{ entity_id: "uuid1", score: 0.9, entity: {...} }, ...]
+```
+
+**Endpoint batch (côté API Backend):**
 
 ```
 POST /api/n8n/entities/{type}/batch
-Body: { "ids": ["uuid1", "uuid2", ...], "fields": ["title", "ingredients"] }
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: {tenant_id}
+Body:
+{
+  "ids": ["uuid1", "uuid2", "uuid3"],
+  "fields": ["title", "ingredients", "tags"]  // optionnel, tout si absent
+}
 ```
+
+**Réponse:**
+```json
+{
+  "success": true,
+  "data": [
+    { "id": "uuid1", "data": { "title": "...", "ingredients": [...] } },
+    { "id": "uuid2", "data": { "title": "...", "ingredients": [...] } }
+  ],
+  "found": 2,
+  "not_found": ["uuid3"]
+}
+```
+
+**Limites:**
+- Maximum 50 IDs par appel
+- Les IDs introuvables sont listés dans `not_found` (pas d'erreur 404)
 
 ---
 
@@ -334,6 +473,9 @@ Les nouveaux webhooks appellent l'API Backend. Ces endpoints doivent être dispo
 | `POST /api/n8n/entities/{type}/{id}/rate` | A implémenter |
 | `POST /api/n8n/entities/{type}/{id}/comment` | A implémenter |
 | `GET /api/n8n/entities/{type}/{id}/comments` | A implémenter |
+| `POST /api/n8n/entities/{type}/{id}/save` | A implémenter |
+| `DELETE /api/n8n/entities/{type}/{id}/save` | A implémenter |
+| `GET /api/n8n/entities/{type}/saved` | A implémenter |
 
 Voir [RFC-049](./rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md) pour les spécifications complètes.
 
@@ -351,6 +493,7 @@ Les anciens webhooks `MCP Qdrant - Save` et `MCP Qdrant - Search` restent foncti
 | MCP - Entity - Search | **Actif** |
 | MCP - Entity - Rating | **Actif** |
 | MCP - Entity - Comment | **Actif** |
+| MCP - Entity - Favorite | **Actif** |
 | MCP - Tenant - Resolve | **Actif** |
 
 ---

--- a/docs/RFC-049-MIGRATION-GUIDE.md
+++ b/docs/RFC-049-MIGRATION-GUIDE.md
@@ -1,0 +1,390 @@
+# Guide de Migration RFC-049 : Entity Storage Architecture
+
+**Date:** 2026-03-27
+**Version:** 1.0
+**Audiences:** Equipes chatbot-core, plugin, API Backend
+
+---
+
+## Résumé
+
+RFC-049 introduit une nouvelle architecture de stockage des entités qui unifie:
+- **MongoDB** pour les données structurées (recettes, documents, cours...)
+- **PostgreSQL** pour les données relationnelles (ratings, comments)
+- **Qdrant** pour la recherche vectorielle
+
+Les nouveaux webhooks remplacent les anciens webhooks Qdrant-only.
+
+---
+
+## Tableau de correspondance
+
+| Ancien webhook | Nouveau webhook | Changements |
+|----------------|-----------------|-------------|
+| `MCP Qdrant - Save` | **MCP - Entity - Save** | + Sauvegarde MongoDB via API<br>+ tenant_id obligatoire (header)<br>+ Même UUID pour entity_id et qdrant_point_id |
+| `MCP Qdrant - Search` | **MCP - Entity - Search** | + Enrichissement depuis MongoDB<br>+ Filtrage tenant_id obligatoire<br>+ Endpoint batch pour performance |
+| *(nouveau)* | **MCP - Entity - Rating** | Notes 1-5 stockées en PostgreSQL |
+| *(nouveau)* | **MCP - Entity - Comment** | Commentaires stockés en PostgreSQL |
+| *(nouveau)* | **MCP - Tenant - Resolve** | Résout Discord user_id → tenant_id |
+
+---
+
+## Nouveaux Endpoints
+
+### MCP - Entity - Save
+
+**URL:** `POST /webhook/entity-save`
+
+**Headers requis:**
+```
+X-Tenant-ID: {tenant_id}
+```
+
+**Payload:**
+```json
+{
+  "action": "save|update|delete",
+  "entity_type": "recipe|document|course|quiz|flashcard",
+  "entity_id": "uuid (requis pour update/delete)",
+  "data": {
+    "title": "Fraisier Vegan",
+    "description": "...",
+    "tags": ["vegan", "dessert"],
+    "ingredients": [...],
+    "steps": [...]
+  },
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "qdrant_host": "host3.local",
+  "qdrant_port": 20001,
+  "qdrant_collection": "recipes",
+  "api_key": "xxx",
+  "openai_api_key": "sk-xxx"
+}
+```
+
+**Réponse:**
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "qdrant_point_id": "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "entity_type": "recipe",
+    "saved_in_db": true,
+    "saved_in_qdrant": true
+  },
+  "_trace": {
+    "service_response": { "api": {...}, "qdrant": {...} },
+    "provider": "api+qdrant",
+    "latency_ms": 342
+  }
+}
+```
+
+---
+
+### MCP - Entity - Search
+
+**URL:** `POST /webhook/entity-search`
+
+**Headers requis:**
+```
+X-Tenant-ID: {tenant_id}
+```
+
+**Payload:**
+```json
+{
+  "action": "search|similar",
+  "query": "recette vegan dessert",
+  "entity_id": "uuid (pour action=similar)",
+  "entity_type": "recipe",
+  "limit": 10,
+  "enrich": true,
+  "fields": ["title", "ingredients", "tags"],
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "qdrant_host": "host3.local",
+  "qdrant_port": 20001,
+  "qdrant_collection": "recipes",
+  "api_key": "xxx",
+  "openai_api_key": "sk-xxx"
+}
+```
+
+**Réponse:**
+```json
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "entity_id": "5606c365-...",
+        "score": 0.89,
+        "entity": {
+          "title": "Fraisier Vegan",
+          "ingredients": [...],
+          "tags": ["vegan", "dessert"]
+        }
+      }
+    ],
+    "total": 5
+  },
+  "_trace": {...}
+}
+```
+
+---
+
+### MCP - Entity - Rating
+
+**URL:** `POST /webhook/entity-rating`
+
+**Payload:**
+```json
+{
+  "action": "rate|get|delete",
+  "entity_id": "5606c365-...",
+  "entity_type": "recipe",
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "rating": 4
+}
+```
+
+**Réponse (action=rate):**
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-...",
+    "rating": 4,
+    "new_average": 4.2,
+    "total_ratings": 15
+  }
+}
+```
+
+---
+
+### MCP - Entity - Comment
+
+**URL:** `POST /webhook/entity-comment`
+
+**Payload:**
+```json
+{
+  "action": "comment|list|edit|delete",
+  "entity_id": "5606c365-...",
+  "entity_type": "recipe",
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "content": "Excellente recette !",
+  "comment_id": "uuid (pour edit/delete)",
+  "parent_id": "uuid (pour réponses)"
+}
+```
+
+---
+
+### MCP - Tenant - Resolve
+
+**URL:** `POST /webhook/tenant-resolve`
+
+**Payload:**
+```json
+{
+  "user_id": "636639897767378954",
+  "guild_id": "123456789"
+}
+```
+
+**Réponse:**
+```json
+{
+  "success": true,
+  "data": {
+    "tenant_id": "Z6F3GSWB",
+    "user_id": "636639897767378954",
+    "subscription_status": "active"
+  }
+}
+```
+
+---
+
+## Changements clés
+
+### 1. tenant_id obligatoire
+
+Le `tenant_id` est maintenant **obligatoire** pour toutes les opérations. Il est passé via le header `X-Tenant-ID`.
+
+**Workflow d'obtention du tenant_id:**
+```
+chatbot-core/plugin
+    │
+    ├── Connait le user_id Discord
+    │
+    ▼
+MCP - Tenant - Resolve
+    │
+    ├── Résout user_id → tenant_id
+    │
+    ▼
+MCP - Entity - Save/Search
+    │
+    └── Header X-Tenant-ID: {tenant_id}
+```
+
+### 2. Même UUID partout
+
+L'`entity_id` (MongoDB) et le `qdrant_point_id` (Qdrant) sont **identiques**. Plus besoin de mapping.
+
+```
+MongoDB: { _id: "5606c365-..." }
+                    ↕ même UUID
+Qdrant:  { id: "5606c365-..." }
+```
+
+### 3. Isolation multi-tenant Qdrant
+
+Qdrant est une instance partagée. Le filtrage par `tenant_id` est **automatique** dans les nouveaux webhooks:
+
+```json
+{
+  "filter": {
+    "must": [
+      { "key": "tenant_id", "match": { "value": "Z6F3GSWB" } }
+    ]
+  }
+}
+```
+
+### 4. Enrichissement batch
+
+Pour éviter N appels séquentiels lors d'un Search, l'API Backend expose un endpoint batch:
+
+```
+POST /api/n8n/entities/{type}/batch
+Body: { "ids": ["uuid1", "uuid2", ...], "fields": ["title", "ingredients"] }
+```
+
+---
+
+## Migration depuis chatbot-core
+
+### Avant (MCP Qdrant - Save)
+
+```python
+response = call_webhook("mcp-qdrant-save", {
+    "content": "Fraisier Vegan...",
+    "metadata": {"title": "Fraisier", "tags": ["vegan"]},
+    "qdrant_host": "host3.local",
+    "qdrant_port": 20001,
+    "qdrant_collection": "recipes",
+    "api_key": QDRANT_API_KEY
+})
+```
+
+### Après (MCP - Entity - Save)
+
+```python
+# 1. Résoudre le tenant_id (une fois par session)
+tenant = call_webhook("mcp-tenant-resolve", {
+    "user_id": discord_user_id
+})
+tenant_id = tenant["data"]["tenant_id"]
+
+# 2. Sauvegarder avec le nouveau webhook
+response = call_webhook("mcp-entity-save", {
+    "action": "save",
+    "entity_type": "recipe",
+    "data": {
+        "title": "Fraisier Vegan",
+        "description": "...",
+        "tags": ["vegan", "dessert"],
+        "ingredients": [...],
+        "steps": [...]
+    },
+    "user_id": discord_user_id,
+    "guild_id": guild_id,
+    "qdrant_host": "host3.local",
+    "qdrant_port": 20001,
+    "qdrant_collection": "recipes",
+    "api_key": QDRANT_API_KEY,
+    "openai_api_key": OPENAI_API_KEY
+}, headers={"X-Tenant-ID": tenant_id})
+```
+
+---
+
+## Prérequis API Backend
+
+Les nouveaux webhooks appellent l'API Backend. Ces endpoints doivent être disponibles:
+
+| Endpoint | Status |
+|----------|--------|
+| `GET /api/n8n/tenants/resolve` | A implémenter |
+| `POST /api/n8n/entities/{type}` | A implémenter |
+| `GET /api/n8n/entities/{type}/{id}` | A implémenter |
+| `PUT /api/n8n/entities/{type}/{id}` | A implémenter |
+| `DELETE /api/n8n/entities/{type}/{id}` | A implémenter |
+| `POST /api/n8n/entities/{type}/batch` | A implémenter |
+| `POST /api/n8n/entities/{type}/{id}/rate` | A implémenter |
+| `POST /api/n8n/entities/{type}/{id}/comment` | A implémenter |
+| `GET /api/n8n/entities/{type}/{id}/comments` | A implémenter |
+
+Voir [RFC-049](./rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md) pour les spécifications complètes.
+
+---
+
+## Cohabitation
+
+Les anciens webhooks `MCP Qdrant - Save` et `MCP Qdrant - Search` restent fonctionnels pendant la période de transition. Ils seront dépréciés une fois la migration complète.
+
+| Webhook | Status |
+|---------|--------|
+| MCP Qdrant - Save | **Deprecated** - utiliser MCP - Entity - Save |
+| MCP Qdrant - Search | **Deprecated** - utiliser MCP - Entity - Search |
+| MCP - Entity - Save | **Actif** |
+| MCP - Entity - Search | **Actif** |
+| MCP - Entity - Rating | **Actif** |
+| MCP - Entity - Comment | **Actif** |
+| MCP - Tenant - Resolve | **Actif** |
+
+---
+
+## Questions fréquentes
+
+### Q: Dois-je migrer immédiatement ?
+
+Non. Les anciens webhooks continuent de fonctionner. Migrez quand vous êtes prêts.
+
+### Q: Que se passe-t-il si l'API Backend est down ?
+
+Le webhook retourne `partial: true` avec les détails de ce qui a réussi/échoué:
+```json
+{
+  "success": true,
+  "partial": true,
+  "saved_in_db": false,
+  "saved_in_qdrant": true,
+  "errors": ["API timeout"]
+}
+```
+
+### Q: Comment obtenir le tenant_id ?
+
+Appelez `MCP - Tenant - Resolve` avec le `user_id` Discord. Cachez le résultat par session utilisateur.
+
+### Q: Les embeddings sont-ils recalculés ?
+
+Par défaut oui. Vous pouvez passer un embedding pré-calculé via le champ `embedding` pour éviter l'appel OpenAI.
+
+---
+
+## Contact
+
+- **RFC complète:** [RFC-049-ENTITY-STORAGE-ARCHITECTURE.md](./rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md)
+- **Plan d'implémentation:** [ISSUE-014-RFC049-IMPLEMENTATION-PLAN.md](./issues/ISSUE-014-RFC049-IMPLEMENTATION-PLAN.md)

--- a/docs/issues/ISSUE-013-ITEMS-RATING-COMMENT-WEBHOOKS.md
+++ b/docs/issues/ISSUE-013-ITEMS-RATING-COMMENT-WEBHOOKS.md
@@ -1,0 +1,248 @@
+# ISSUE-013: Webhooks Items Rating & Comment
+
+**Date:** 2026-03-27
+**Status:** SUPERSEDED
+**Priority:** P1
+**Assignee:** Equipe n8n
+
+> ⚠️ **SUPERSEDED BY [RFC-049](../rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md)**
+>
+> Cette issue a été intégrée dans l'architecture complète RFC-049 qui définit:
+> - MCP - Entity - Save (MongoDB + Qdrant)
+> - MCP - Entity - Search (Qdrant + MongoDB)
+> - MCP - Entity - Rating (PostgreSQL)
+> - MCP - Entity - Comment (PostgreSQL)
+> - MCP - Tenant - Resolve (Discord user_id → tenant_id)
+>
+> Voir RFC-049 pour les spécifications complètes et le plan d'implémentation.
+
+---
+
+## Contexte (Archive)
+
+Les composants frontend utilisent deux webhooks pour la notation et les avis qui **n'existent pas encore**.
+
+## Webhooks à créer
+
+### 1. `items-rating` - Noter un item
+
+**Endpoint:** `POST /webhook/items-rating`
+
+**InputSchema:**
+```json
+{
+  "required": ["action", "entity_id", "user_id", "rating"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["rate"],
+      "description": "Action à effectuer"
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "ID de l'entité à noter (recette, document, etc.)"
+    },
+    "entity_type": {
+      "type": "string",
+      "description": "Type d'entité: recipe, document, course, etc."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "ID de l'utilisateur"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "ID du serveur Discord (optionnel)"
+    },
+    "rating": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 5,
+      "description": "Note de 1 à 5 étoiles"
+    }
+  }
+}
+```
+
+**Exemple de payload:**
+```json
+{
+  "action": "rate",
+  "entity_id": "recipe-123",
+  "entity_type": "recipe",
+  "user_id": "user-456",
+  "guild_id": "guild-789",
+  "rating": 4
+}
+```
+
+**Réponse attendue:**
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "recipe-123",
+    "new_average": 4.2,
+    "total_ratings": 15
+  },
+  "_trace": {
+    "service_response": { ... },
+    "provider": "api",
+    "latency_ms": 45,
+    "user_id": "user-456",
+    "guild_id": "guild-789"
+  }
+}
+```
+
+---
+
+### 2. `items-comment` - Commenter un item
+
+**Endpoint:** `POST /webhook/items-comment`
+
+**InputSchema:**
+```json
+{
+  "required": ["action", "entity_id", "user_id", "content"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["comment", "edit", "delete"],
+      "description": "Action: comment (créer), edit (modifier), delete (supprimer)"
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "ID de l'entité à commenter"
+    },
+    "entity_type": {
+      "type": "string",
+      "description": "Type d'entité: recipe, document, course, etc."
+    },
+    "user_id": {
+      "type": "string",
+      "description": "ID de l'utilisateur"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "ID du serveur Discord (optionnel)"
+    },
+    "content": {
+      "type": "string",
+      "description": "Contenu du commentaire (requis pour action=comment/edit)"
+    },
+    "comment_id": {
+      "type": "string",
+      "description": "ID du commentaire (requis pour action=edit/delete)"
+    },
+    "parent_id": {
+      "type": "string",
+      "description": "ID du commentaire parent (pour réponses)"
+    }
+  }
+}
+```
+
+**Exemple de payload (création):**
+```json
+{
+  "action": "comment",
+  "entity_id": "recipe-123",
+  "entity_type": "recipe",
+  "user_id": "user-456",
+  "guild_id": "guild-789",
+  "content": "Excellente recette ! J'ai ajouté un peu de cannelle."
+}
+```
+
+**Réponse attendue:**
+```json
+{
+  "success": true,
+  "data": {
+    "comment_id": "comment-abc",
+    "entity_id": "recipe-123",
+    "content": "Excellente recette ! J'ai ajouté un peu de cannelle.",
+    "created_at": "2026-03-27T10:30:00Z",
+    "user_id": "user-456"
+  },
+  "_trace": {
+    "service_response": { ... },
+    "provider": "api",
+    "latency_ms": 52,
+    "user_id": "user-456",
+    "guild_id": "guild-789"
+  }
+}
+```
+
+---
+
+## Architecture suggérée
+
+### Base de données
+
+```sql
+-- Table ratings
+CREATE TABLE ratings (
+  id UUID PRIMARY KEY,
+  entity_id VARCHAR(255) NOT NULL,
+  entity_type VARCHAR(50) NOT NULL,
+  user_id VARCHAR(255) NOT NULL,
+  guild_id VARCHAR(255),
+  rating INTEGER CHECK (rating >= 1 AND rating <= 5),
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(entity_id, user_id)  -- Un user = une note par entité
+);
+
+-- Table comments
+CREATE TABLE comments (
+  id UUID PRIMARY KEY,
+  entity_id VARCHAR(255) NOT NULL,
+  entity_type VARCHAR(50) NOT NULL,
+  user_id VARCHAR(255) NOT NULL,
+  guild_id VARCHAR(255),
+  content TEXT NOT NULL,
+  parent_id UUID REFERENCES comments(id),
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW(),
+  deleted_at TIMESTAMP  -- Soft delete
+);
+
+-- Index pour recherche rapide
+CREATE INDEX idx_ratings_entity ON ratings(entity_id, entity_type);
+CREATE INDEX idx_comments_entity ON comments(entity_id, entity_type);
+```
+
+### Workflow n8n suggéré
+
+```
+Webhook → Validate Input → Valid?
+                            ├── (true) → Switch Action → [rate/comment/edit/delete]
+                            │                               ├── Rate → Upsert Rating → Calculate Average → Respond
+                            │                               ├── Comment → Insert Comment → Respond
+                            │                               ├── Edit → Update Comment → Respond
+                            │                               └── Delete → Soft Delete → Respond
+                            └── (false) → Build Error → Respond Error
+```
+
+---
+
+## Checklist
+
+- [ ] Créer tables PostgreSQL (ratings, comments)
+- [ ] Créer workflow `MCP - Items Rating`
+- [ ] Créer workflow `MCP - Items Comment`
+- [ ] Ajouter InputSchema standardisé (issue #323)
+- [ ] Ajouter `_trace` aux réponses
+- [ ] Tester avec frontend
+- [ ] Documenter dans le registry MCP
+
+---
+
+## Notes
+
+- Les champs `user_id`, `guild_id` suivent le pattern RFC-014
+- Le `_trace` suit le standard établi dans l'issue #323/#325
+- Considérer l'ajout de modération de contenu pour les commentaires (MCP - Content Analyzer)

--- a/docs/issues/ISSUE-014-RFC049-IMPLEMENTATION-PLAN.md
+++ b/docs/issues/ISSUE-014-RFC049-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,456 @@
+# ISSUE-014: Plan d'Implémentation RFC-049
+
+**Date:** 2026-03-27
+**Status:** IN_PROGRESS
+**Priority:** P0
+**RFC:** [RFC-049-ENTITY-STORAGE-ARCHITECTURE](../rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md)
+**Supersedes:** [ISSUE-013](./ISSUE-013-ITEMS-RATING-COMMENT-WEBHOOKS.md)
+
+---
+
+## Vue d'ensemble
+
+Ce plan décrit l'implémentation des webhooks définis dans RFC-049 pour l'architecture de stockage des entités. L'implémentation est conçue pour être exécutée en parallèle via des subagents.
+
+---
+
+## Phases d'Implémentation
+
+### Phase 0: Prérequis (Séquentiel)
+
+| Task | Description | Équipe | Dépendances |
+|------|-------------|--------|-------------|
+| 0.1 | Créer collections MongoDB (entities) | API Backend | - |
+| 0.2 | Créer tables PostgreSQL (ratings, comments, tenants) | API Backend | - |
+| 0.3 | Configurer Qdrant collection avec tenant_id filtering | API Backend | - |
+| 0.4 | Exposer endpoints API Backend (RFC-049 §4) | API Backend | 0.1, 0.2, 0.3 |
+
+### Phase 1: Webhooks Core (Parallélisable)
+
+Ces webhooks peuvent être implémentés en parallèle par des subagents.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    PARALLEL EXECUTION GROUP 1                    │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌────────────────┐ │
+│  │ Subagent A       │  │ Subagent B       │  │ Subagent C     │ │
+│  │ ──────────────── │  │ ──────────────── │  │ ────────────── │ │
+│  │ MCP - Tenant     │  │ MCP - Entity     │  │ MCP - Entity   │ │
+│  │ Resolve          │  │ Save             │  │ Search         │ │
+│  │                  │  │                  │  │                │ │
+│  │ Dépendances: -   │  │ Dépendances: -   │  │ Dépendances: - │ │
+│  └──────────────────┘  └──────────────────┘  └────────────────┘ │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    PARALLEL EXECUTION GROUP 2                    │
+│              (Après Phase 1 - dépend de Tenant Resolve)          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────────┐  ┌──────────────────┐                     │
+│  │ Subagent D       │  │ Subagent E       │                     │
+│  │ ──────────────── │  │ ──────────────── │                     │
+│  │ MCP - Entity     │  │ MCP - Entity     │                     │
+│  │ Rating           │  │ Comment          │                     │
+│  │                  │  │                  │                     │
+│  │ Dép: 1.1         │  │ Dép: 1.1         │                     │
+│  └──────────────────┘  └──────────────────┘                     │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Spécifications des Webhooks
+
+### 1.1 MCP - Tenant - Resolve
+
+**Priorité:** P0 (bloque 1.4, 1.5)
+**Endpoint:** `POST /webhook/tenant-resolve`
+**Fichier:** `workflows/MCP_-_Tenant_-_Resolve.json`
+
+**InputSchema:**
+```json
+{
+  "type": "object",
+  "required": ["action", "user_id"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["resolve"],
+      "description": "Action à effectuer"
+    },
+    "user_id": {
+      "type": "string",
+      "description": "Discord user ID"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "Discord guild ID (optionnel)"
+    }
+  }
+}
+```
+
+**Workflow Flow:**
+```
+Webhook → Validate Input → Call API Backend /tenants/resolve
+                         → Return tenant_id + metadata
+```
+
+**API Backend Call:**
+```
+GET /api/n8n/tenants/resolve?user_id={user_id}&guild_id={guild_id}
+```
+
+---
+
+### 1.2 MCP - Entity - Save
+
+**Priorité:** P0
+**Endpoint:** `POST /webhook/entity-save`
+**Fichier:** `workflows/MCP_-_Entity_-_Save.json`
+**Remplace:** `MCP Qdrant - Save`
+
+**InputSchema:**
+```json
+{
+  "type": "object",
+  "required": ["action", "entity_type", "content"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["save", "update", "delete"],
+      "description": "Action CRUD"
+    },
+    "entity_type": {
+      "type": "string",
+      "enum": ["recipe", "document", "course", "quiz", "flashcard"],
+      "description": "Type d'entité"
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "UUID existant (requis pour update/delete)"
+    },
+    "content": {
+      "type": "object",
+      "description": "Données de l'entité (structure selon entity_type)"
+    },
+    "embedding": {
+      "type": "array",
+      "items": { "type": "number" },
+      "description": "Vecteur d'embedding (optionnel, calculé si absent)"
+    },
+    "user_id": {
+      "type": "string",
+      "description": "Discord user ID (optionnel, tracing)"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "Discord guild ID (optionnel, tracing)"
+    }
+  }
+}
+```
+
+**Workflow Flow:**
+```
+Webhook → Validate Input → Get tenant_id (header X-Tenant-ID)
+                         → Switch action
+                           ├── save → Generate UUID → Save MongoDB → Save Qdrant → Response
+                           ├── update → Update MongoDB → Update Qdrant → Response
+                           └── delete → Delete MongoDB → Delete Qdrant → Response
+```
+
+**Points clés:**
+- Même UUID pour `entity_id` et `qdrant_point_id`
+- `tenant_id` extrait du header `X-Tenant-ID`
+- Fallback `api_key` pour compatibilité legacy
+
+---
+
+### 1.3 MCP - Entity - Search
+
+**Priorité:** P0
+**Endpoint:** `POST /webhook/entity-search`
+**Fichier:** `workflows/MCP_-_Entity_-_Search.json`
+**Remplace:** `MCP Qdrant - Search`
+
+**InputSchema:**
+```json
+{
+  "type": "object",
+  "required": ["action", "query"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["search", "similar"],
+      "description": "search=par query, similar=par entity_id"
+    },
+    "query": {
+      "type": "string",
+      "description": "Texte de recherche (pour action=search)"
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "UUID pour recherche similaire (pour action=similar)"
+    },
+    "entity_type": {
+      "type": "string",
+      "description": "Filtrer par type d'entité"
+    },
+    "limit": {
+      "type": "integer",
+      "default": 10,
+      "description": "Nombre de résultats max"
+    },
+    "filters": {
+      "type": "object",
+      "description": "Filtres additionnels Qdrant"
+    },
+    "user_id": {
+      "type": "string",
+      "description": "Discord user ID (optionnel, tracing)"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "Discord guild ID (optionnel, tracing)"
+    }
+  }
+}
+```
+
+**Workflow Flow:**
+```
+Webhook → Validate Input → Get tenant_id (header)
+                         → Switch action
+                           ├── search → Embed query → Search Qdrant (+ tenant_id filter)
+                           │          → Fetch entities from MongoDB → Response
+                           └── similar → Get entity vector → Search Qdrant
+                                       → Fetch entities from MongoDB → Response
+```
+
+---
+
+### 1.4 MCP - Entity - Rating
+
+**Priorité:** P1
+**Endpoint:** `POST /webhook/entity-rating`
+**Fichier:** `workflows/MCP_-_Entity_-_Rating.json`
+**Dépend de:** Tenant Resolve (pour validation user)
+
+**InputSchema:**
+```json
+{
+  "type": "object",
+  "required": ["action", "entity_id", "user_id"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["rate", "get", "delete"],
+      "description": "rate=noter, get=obtenir stats, delete=supprimer note"
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "UUID de l'entité"
+    },
+    "user_id": {
+      "type": "string",
+      "description": "Discord user ID"
+    },
+    "rating": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 5,
+      "description": "Note 1-5 (requis pour action=rate)"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "Discord guild ID (optionnel)"
+    }
+  }
+}
+```
+
+**Workflow Flow:**
+```
+Webhook → Validate Input → Resolve tenant_id
+                         → Switch action
+                           ├── rate → Upsert PostgreSQL → Calculate avg → Response
+                           ├── get → Query PostgreSQL → Response
+                           └── delete → Delete PostgreSQL → Recalculate avg → Response
+```
+
+---
+
+### 1.5 MCP - Entity - Comment
+
+**Priorité:** P1
+**Endpoint:** `POST /webhook/entity-comment`
+**Fichier:** `workflows/MCP_-_Entity_-_Comment.json`
+**Dépend de:** Tenant Resolve (pour validation user)
+
+**InputSchema:**
+```json
+{
+  "type": "object",
+  "required": ["action", "entity_id", "user_id"],
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["comment", "list", "edit", "delete"],
+      "description": "Action CRUD"
+    },
+    "entity_id": {
+      "type": "string",
+      "description": "UUID de l'entité"
+    },
+    "user_id": {
+      "type": "string",
+      "description": "Discord user ID"
+    },
+    "content": {
+      "type": "string",
+      "description": "Contenu du commentaire (requis pour comment/edit)"
+    },
+    "comment_id": {
+      "type": "string",
+      "description": "UUID du commentaire (requis pour edit/delete)"
+    },
+    "parent_id": {
+      "type": "string",
+      "description": "UUID du commentaire parent (pour réponses)"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "Discord guild ID (optionnel)"
+    }
+  }
+}
+```
+
+**Workflow Flow:**
+```
+Webhook → Validate Input → Resolve tenant_id
+                         → Switch action
+                           ├── comment → Insert PostgreSQL → Response
+                           ├── list → Query PostgreSQL (with pagination) → Response
+                           ├── edit → Verify owner → Update PostgreSQL → Response
+                           └── delete → Verify owner → Soft delete → Response
+```
+
+---
+
+## Phase 2: Intégration (Séquentiel)
+
+| Task | Description | Dépendances |
+|------|-------------|-------------|
+| 2.1 | Mettre à jour chatbot-core plugin | Phase 1 complète |
+| 2.2 | Migrer appels legacy Qdrant → Entity | 2.1 |
+| 2.3 | Tests end-to-end | 2.2 |
+| 2.4 | Supprimer workflows legacy | 2.3 |
+
+---
+
+## Commandes Subagent
+
+### Lancer Phase 1 Group 1 (Parallèle)
+
+```bash
+# Subagent A: Tenant Resolve
+claude-code task --prompt "Créer workflow MCP - Tenant - Resolve selon ISSUE-014 spec 1.1" &
+
+# Subagent B: Entity Save
+claude-code task --prompt "Créer workflow MCP - Entity - Save selon ISSUE-014 spec 1.2" &
+
+# Subagent C: Entity Search
+claude-code task --prompt "Créer workflow MCP - Entity - Search selon ISSUE-014 spec 1.3" &
+
+wait
+```
+
+### Lancer Phase 1 Group 2 (Après Group 1)
+
+```bash
+# Subagent D: Entity Rating
+claude-code task --prompt "Créer workflow MCP - Entity - Rating selon ISSUE-014 spec 1.4" &
+
+# Subagent E: Entity Comment
+claude-code task --prompt "Créer workflow MCP - Entity - Comment selon ISSUE-014 spec 1.5" &
+
+wait
+```
+
+---
+
+## Structure Standard des Workflows
+
+Chaque workflow doit suivre ce pattern:
+
+```
+Webhook (POST)
+  ├── InputSchema (RFC-014 standard)
+  └── Response Webhook
+
+Validate Input (Code node)
+  ├── Extraire body/query
+  ├── Valider required fields
+  ├── Extraire tenant_id de X-Tenant-ID header
+  └── Fallback api_key pour compatibilité
+
+Switch Action
+  └── [Branches selon action]
+
+Build Response (Code node)
+  ├── success: true/false
+  ├── data: { ... }
+  └── _trace: {
+        service_response: { ... },
+        provider: "api",
+        latency_ms: number,
+        user_id: optional,
+        guild_id: optional
+      }
+
+Respond (Respond to Webhook)
+```
+
+---
+
+## Checklist
+
+### Phase 0
+- [ ] Collections MongoDB créées
+- [ ] Tables PostgreSQL créées
+- [ ] Qdrant configuré avec tenant_id
+- [ ] Endpoints API Backend exposés
+
+### Phase 1 - Group 1
+- [ ] MCP - Tenant - Resolve
+- [ ] MCP - Entity - Save
+- [ ] MCP - Entity - Search
+
+### Phase 1 - Group 2
+- [ ] MCP - Entity - Rating
+- [ ] MCP - Entity - Comment
+
+### Phase 2
+- [ ] chatbot-core mis à jour
+- [ ] Migration legacy complète
+- [ ] Tests E2E passent
+- [ ] Cleanup legacy workflows
+
+---
+
+## Notes
+
+- Tous les webhooks utilisent `_trace` standard (issue #323/#325)
+- `user_id`, `guild_id` sont OPTIONNELS (tracing only)
+- `tenant_id` est REQUIS (via header X-Tenant-ID ou résolution)
+- Même UUID partagé entre MongoDB entity_id et Qdrant point_id
+- Qdrant est multi-tenant, filtrage par tenant_id obligatoire

--- a/docs/rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md
+++ b/docs/rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md
@@ -1,0 +1,1272 @@
+# RFC-049: Architecture de stockage des entités (DB + Vector)
+
+**Date:** 2026-03-27
+**Status:** Draft
+**Auteur:** Équipe n8n
+**Équipes concernées:** API, chatbot-core, plugin, n8n
+
+---
+
+## Résumé
+
+Actuellement, les webhooks `MCP Qdrant - Save` et `MCP Qdrant - Search` ne gèrent que la partie vectorielle (Qdrant). Les données structurées (recettes, documents, etc.) doivent aussi être persistées en base relationnelle (PostgreSQL).
+
+Cette RFC propose de fusionner les responsabilités dans des webhooks unifiés.
+
+---
+
+## Problème actuel
+
+### Flux actuel (incomplet)
+
+```
+Caller (chatbot-core/plugin)
+    │
+    ├── MCP Qdrant - Save
+    │   └── Sauvegarde UNIQUEMENT dans Qdrant
+    │   └── ❌ Pas de sauvegarde en PostgreSQL
+    │
+    └── MCP Qdrant - Search
+        └── Recherche UNIQUEMENT dans Qdrant
+        └── ❌ Pas d'enrichissement depuis PostgreSQL
+```
+
+### Conséquences
+
+1. **Données perdues** : Les entités ne sont pas persistées en DB
+2. **Pas de CRUD complet** : Impossible de lister, modifier, supprimer via API
+3. **Incohérence** : `qdrant_point_id` existe mais pas de lien avec `entity_id` en DB
+
+---
+
+## Solution proposée
+
+### Nouveaux webhooks unifiés
+
+| Ancien nom | Nouveau nom | Responsabilités |
+|------------|-------------|-----------------|
+| MCP Qdrant - Save | **MCP - Entity - Save** | DB + Qdrant |
+| MCP Qdrant - Search | **MCP - Entity - Search** | Qdrant + enrichissement DB |
+
+### Flux proposé : MCP - Entity - Save
+
+```
+Caller
+    │
+    ▼
+MCP - Entity - Save
+    │
+    ├── 1. Validate Input
+    │
+    ├── 2. Save to API (PostgreSQL)  ─────────────────┐
+    │   POST /api/entities/{entity_type}              │
+    │   Body: { data, user_id, guild_id, ... }        │  Parallèle
+    │   Response: { id: entity_id, ... }              │
+    │                                                  │
+    ├── 3. Generate Embedding (OpenAI)  ──────────────┤
+    │   POST /v1/embeddings                           │
+    │   Response: { embedding: [...] }                │
+    │                                                  │
+    └── 4. Store in Qdrant  ──────────────────────────┘
+        PUT /collections/{collection}/points
+        Body: {
+          id: entity_id,  // ← Même ID que PostgreSQL
+          vector: embedding,
+          payload: { title, tags, ... }
+        }
+    │
+    ▼
+Response unifiée
+{
+  "success": true,
+  "data": {
+    "entity_id": "uuid",       // ID PostgreSQL
+    "qdrant_point_id": "uuid", // = entity_id (même ID)
+    "saved_in_db": true,
+    "saved_in_qdrant": true
+  }
+}
+```
+
+### Flux proposé : MCP - Entity - Search
+
+```
+Caller
+    │
+    ▼
+MCP - Entity - Search
+    │
+    ├── 1. Validate Input
+    │
+    ├── 2. Generate Query Embedding (OpenAI)
+    │
+    ├── 3. Search in Qdrant
+    │   Response: [{ id, score, payload }, ...]
+    │
+    ├── 4. Enrich from API (optionnel)
+    │   GET /api/entities/{entity_type}/{id}
+    │   Response: { full entity data }
+    │
+    └── 5. Merge & Format
+    │
+    ▼
+Response
+{
+  "success": true,
+  "data": {
+    "results": [
+      {
+        "entity_id": "uuid",
+        "score": 0.89,
+        "entity": { /* données complètes depuis DB */ }
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Décisions à prendre
+
+### 1. Identifiants
+
+**Option 1A : Même ID partout (recommandé)**
+```
+entity_id = qdrant_point_id = UUID généré par l'API
+```
+- Avantage : Cohérence, pas de mapping à maintenir
+- Inconvénient : Nécessite que l'API génère l'ID en premier
+
+**Option 1B : IDs séparés avec mapping**
+```
+entity_id = UUID API
+qdrant_point_id = UUID Qdrant
+Mapping stocké en DB: entities.qdrant_point_id
+```
+- Avantage : Indépendance des systèmes
+- Inconvénient : Complexité, risque de désynchronisation
+
+**Question pour l'équipe API :** L'API peut-elle générer l'UUID avant insertion et le retourner immédiatement ?
+
+---
+
+### 2. Gestion des échecs partiels
+
+**Scénario : API OK, Qdrant KO**
+```json
+{
+  "success": true,
+  "partial": true,
+  "saved_in_db": true,
+  "saved_in_qdrant": false,
+  "errors": ["Qdrant timeout"],
+  "retry_token": "xxx"  // Pour retry Qdrant plus tard
+}
+```
+
+**Scénario : API KO, Qdrant OK**
+```json
+{
+  "success": false,
+  "saved_in_db": false,
+  "saved_in_qdrant": true,
+  "errors": ["API unavailable"],
+  "orphan_qdrant_id": "uuid"  // À nettoyer
+}
+```
+
+**Question pour les équipes :** Comment gérer les orphelins Qdrant ? Job de nettoyage ?
+
+---
+
+### 3. Enrichissement au Search
+
+**Option 3A : Toujours enrichir depuis DB**
+- Avantage : Données toujours à jour
+- Inconvénient : Latence supplémentaire, N appels API
+
+**Option 3B : Payload Qdrant suffisant**
+- Stocker les champs essentiels dans le payload Qdrant
+- Enrichir uniquement si `enrich: true` dans la requête
+- Avantage : Performance
+- Inconvénient : Données potentiellement stale
+
+**Option 3C : Hybride (recommandé)**
+- Payload Qdrant contient : `title`, `description`, `tags`, `difficulty`, `prep_time`
+- Enrichissement DB pour : `ingredients`, `steps`, `full_content`
+- Paramètre `fields: ["ingredients", "steps"]` pour demander l'enrichissement
+
+**Question pour chatbot-core/plugin :** Quels champs sont nécessaires à l'affichage immédiat vs au détail ?
+
+---
+
+### 4. Impact sur les callers
+
+#### chatbot-core
+
+```python
+# Avant
+response = call_webhook("mcp-qdrant-save", payload)
+
+# Après
+response = call_webhook("mcp-entity-save", payload)
+# Payload identique, response enrichie
+```
+
+#### plugin
+
+```python
+# Avant
+results = call_webhook("mcp-qdrant-search", {"query": "..."})
+
+# Après
+results = call_webhook("mcp-entity-search", {
+    "query": "...",
+    "enrich": True,  # Nouveau paramètre
+    "fields": ["ingredients", "steps"]  # Optionnel
+})
+```
+
+---
+
+## InputSchema proposé
+
+### MCP - Entity - Save
+
+```json
+{
+  "required": ["entity_type", "data"],
+  "properties": {
+    "entity_type": {
+      "type": "string",
+      "enum": ["recipes", "documents", "courses"],
+      "description": "Type d'entité"
+    },
+    "data": {
+      "type": "object",
+      "description": "Données de l'entité"
+    },
+    "user_id": {
+      "type": "string",
+      "description": "ID utilisateur (propriétaire)"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "ID serveur Discord"
+    },
+    "store_embedding": {
+      "type": "boolean",
+      "default": true,
+      "description": "Stocker dans Qdrant"
+    },
+    "qdrant_host": { "type": "string" },
+    "qdrant_port": { "type": "integer" },
+    "qdrant_collection": { "type": "string" },
+    "api_key": { "type": "string", "description": "Clé API Qdrant" },
+    "openai_api_key": { "type": "string" }
+  }
+}
+```
+
+### MCP - Entity - Search
+
+```json
+{
+  "required": ["query", "entity_type"],
+  "properties": {
+    "query": {
+      "type": "string",
+      "description": "Requête de recherche"
+    },
+    "entity_type": {
+      "type": "string",
+      "description": "Type d'entité à rechercher"
+    },
+    "limit": {
+      "type": "integer",
+      "default": 10
+    },
+    "filters": {
+      "type": "object",
+      "description": "Filtres (tags, difficulty, etc.)"
+    },
+    "enrich": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enrichir depuis DB"
+    },
+    "fields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Champs à récupérer depuis DB"
+    },
+    "user_id": { "type": "string" },
+    "guild_id": { "type": "string" },
+    "qdrant_host": { "type": "string" },
+    "qdrant_port": { "type": "integer" },
+    "qdrant_collection": { "type": "string" },
+    "api_key": { "type": "string" },
+    "openai_api_key": { "type": "string" }
+  }
+}
+```
+
+---
+
+## Plan de migration
+
+### Phase 1 : Création (sans breaking change)
+
+1. Créer `MCP - Entity - Save` (nouveau webhook)
+2. Créer `MCP - Entity - Search` (nouveau webhook)
+3. Les anciens webhooks restent fonctionnels
+4. Tests avec chatbot-core/plugin en mode opt-in
+
+### Phase 2 : Migration progressive
+
+1. chatbot-core migre vers les nouveaux webhooks
+2. plugin migre vers les nouveaux webhooks
+3. Période de double-run pour validation
+
+### Phase 3 : Décommissionnement
+
+1. Désactiver `MCP Qdrant - Save` (deprecated)
+2. Désactiver `MCP Qdrant - Search` (deprecated)
+3. Supprimer après 30 jours
+
+---
+
+## Questions ouvertes
+
+| # | Question | Équipe | Réponse |
+|---|----------|--------|---------|
+| 1 | L'API peut-elle générer l'UUID avant insertion ? | API | **Oui.** `uuid4()` côté API, retourné immédiatement. |
+| 2 | Comment gérer les orphelins Qdrant ? | n8n + API | **Celery beat job** côté API (voir section Review Backend). |
+| 3 | Quels champs pour l'affichage immédiat ? | chatbot-core | **Payload Qdrant :** `title`, `description` (tronquée), `tags`, `difficulty`, `prep_time`, `thumbnail_url` |
+| 4 | Quels champs pour le détail ? | chatbot-core | **Enrichissement DB :** `ingredients`, `steps`, `cook_time`, `servings`, `nutrition`, `images` |
+| 5 | Faut-il un job de sync DB ↔ Qdrant ? | API + n8n | **Oui**, job de nettoyage quotidien (voir section Review Backend). |
+| 6 | Timeout acceptable pour enrichissement ? | chatbot-core | **500ms** par défaut, configurable. |
+
+---
+
+## Review de l'équipe API Backend (v2)
+
+> **Date** : 2026-03-27
+> **Auteur** : API Backend Team
+
+### Décisions architecturales
+
+**Option 1A (même ID partout) : validée.** L'API génère le UUID,
+le retourne, n8n l'utilise comme `qdrant_point_id`.
+
+**Option 3C (hybride enrichissement) : validée.**
+
+**Option C (MongoDB multi-tenant) : validée.** Une seule DB `entities`,
+une collection par type (`recipes`, `documents`, `courses`). Chaque
+document contient `tenant_id` + `guild_id` pour l'isolation. Index
+compound pour la performance. Pas de création dynamique de
+collections/DBs par guild.
+
+### Architecture de stockage
+
+```
+MongoDB (DB: entities)                PostgreSQL (tenant schemas)
+┌──────────────────────────┐          ┌──────────────────────────┐
+│ Col: recipes             │          │ Schema: tenant_Z6F3GSWB  │
+│ Col: documents           │          │                          │
+│ Col: courses             │          │ Table: ratings           │
+│ Col: chess_progress      │          │   entity_id → Mongo _id  │
+│ Col: chess_games         │          │   user_id (discord)      │
+│ ...                      │          │   rating (1-5)           │
+│                          │          │                          │
+│ Chaque document :        │          │ Table: comments          │
+│   _id (UUID)             │◄─────────│   entity_id → Mongo _id  │
+│   tenant_id              │          │   content, parent_id     │
+│   guild_id               │          │                          │
+│   user_id (discord)      │          │ Table: saved_entities    │
+│   entity_type            │          │   entity_id → Mongo _id  │
+│   data (flexible)        │          │   entity_type            │
+│   created_at             │          └──────────────────────────┘
+│   updated_at             │
+└──────────────────────────┘                  │
+         │                                    │ même UUID
+         │ même UUID                          ▼
+         ▼                           Qdrant (vecteurs)
+Qdrant                               ┌──────────────────────────┐
+┌──────────────────────────┐         │ point_id = entity _id    │
+│ point_id = entity _id    │         │ payload: {tenant_id,     │
+│ payload (léger)          │         │   guild_id, title, tags} │
+└──────────────────────────┘         └──────────────────────────┘
+```
+
+### Authentification n8n ↔ API
+
+L'authentification est déjà définie dans RFC-039 et implémentée
+dans `app/middleware/n8n_auth.py`. **Tous les endpoints entités
+appelés par n8n utilisent ce mécanisme :**
+
+```
+Headers requis :
+  X-API-Key: {N8N_API_KEY}       ← clé partagée, déjà en .env.local
+  X-Tenant-ID: {tenant_id}      ← identifie le tenant
+  Content-Type: application/json
+```
+
+Le middleware `verify_n8n_auth()` vérifie les deux headers et
+retourne `(tenant_id, api_key)`. Codes d'erreur :
+- `401` — X-API-Key manquante ou invalide
+- `403` — X-Tenant-ID manquant
+- `503` — N8N_API_KEY pas configurée côté API
+
+---
+
+### Endpoints API — Référence pour l'équipe n8n
+
+Prefix : `/api/n8n/entities`
+
+Auth : `X-API-Key` + `X-Tenant-ID` (RFC-039)
+
+---
+
+#### 1. POST /api/n8n/entities/{entity_type} — Créer une entité
+
+Crée un document dans MongoDB et retourne l'UUID pré-généré.
+
+```
+POST /api/n8n/entities/recipes
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+  Content-Type: application/json
+```
+
+**Request body :**
+
+```json
+{
+  "guild_id": "123456789",
+  "user_id": "636639897767378954",
+  "data": {
+    "title": "Fraisier Vegan",
+    "description": "Un délicieux fraisier sans produits laitiers",
+    "ingredients": ["farine", "lait végétal", "fraises"],
+    "steps": ["Préchauffer le four", "Mélanger", "Cuire"],
+    "tags": ["vegan", "dessert"],
+    "difficulty": "Moyen",
+    "prep_time": 60,
+    "cook_time": 25
+  }
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `guild_id` | string | oui | ID serveur Discord |
+| `user_id` | string | oui | ID Discord de l'utilisateur |
+| `data` | object | oui | Contenu de l'entité (structure libre) |
+
+**Response 201 :**
+
+```json
+{
+  "success": true,
+  "entity": {
+    "id": "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "entity_type": "recipes",
+    "tenant_id": "Z6F3GSWB",
+    "guild_id": "123456789",
+    "user_id": "636639897767378954",
+    "created_at": "2026-03-27T10:30:00Z"
+  }
+}
+```
+
+Le `entity.id` est le UUID à utiliser comme `qdrant_point_id`.
+
+---
+
+#### 2. GET /api/n8n/entities/{entity_type}/{entity_id} — Récupérer
+
+Pour l'enrichissement lors du Search.
+
+```
+GET /api/n8n/entities/recipes/5606c365-b2c0-47d2-b8de-436c268e7895
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Query params optionnels :**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `fields` | string | Champs à retourner (comma-separated). Si absent → tout. |
+
+```
+GET /api/n8n/entities/recipes/5606c365...?fields=title,ingredients,steps
+```
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "entity": {
+    "id": "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "entity_type": "recipes",
+    "tenant_id": "Z6F3GSWB",
+    "guild_id": "123456789",
+    "user_id": "636639897767378954",
+    "data": {
+      "title": "Fraisier Vegan",
+      "ingredients": ["farine", "lait végétal", "fraises"],
+      "steps": ["Préchauffer le four", "Mélanger", "Cuire"]
+    },
+    "created_at": "2026-03-27T10:30:00Z",
+    "updated_at": "2026-03-27T10:30:00Z"
+  }
+}
+```
+
+**Response 404 :**
+
+```json
+{
+  "success": false,
+  "error": { "code": "ENTITY_NOT_FOUND", "message": "Entity not found" }
+}
+```
+
+---
+
+#### 3. GET /api/n8n/entities/{entity_type} — Lister
+
+```
+GET /api/n8n/entities/recipes?guild_id=123456789&limit=20&offset=0
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+| Param | Type | Défaut | Description |
+|-------|------|--------|-------------|
+| `guild_id` | string | null | Filtrer par guild |
+| `user_id` | string | null | Filtrer par utilisateur |
+| `tags` | string | null | Filtrer par tags (comma-separated) |
+| `limit` | int | 20 | Max 100 |
+| `offset` | int | 0 | Pagination |
+| `sort` | string | `-created_at` | Tri |
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "5606c365-...",
+      "data": { "title": "Fraisier Vegan", "tags": ["vegan"] },
+      "user_id": "636639897767378954",
+      "created_at": "2026-03-27T10:30:00Z"
+    }
+  ],
+  "pagination": { "total": 42, "limit": 20, "offset": 0 }
+}
+```
+
+---
+
+#### 3b. POST /api/n8n/entities/{entity_type}/batch — Batch enrichissement
+
+> Suite à la question de l'équipe n8n : lors d'un Search Qdrant qui
+> retourne 10 résultats, faire 10 GET séquentiels est coûteux.
+> Cet endpoint retourne plusieurs entités en un seul appel.
+
+```
+POST /api/n8n/entities/recipes/batch
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Request body :**
+
+```json
+{
+  "ids": [
+    "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "99887766-5544-3322-1100-aabbccddeeff"
+  ],
+  "fields": ["title", "ingredients", "tags", "difficulty"]
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `ids` | string[] | oui | UUIDs des entités (max 50) |
+| `fields` | string[] | non | Champs à retourner. Si absent → tout. |
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "id": "5606c365-...",
+      "data": { "title": "Fraisier Vegan", "ingredients": [...], "tags": [...], "difficulty": "Moyen" }
+    },
+    {
+      "id": "a1b2c3d4-...",
+      "data": { "title": "Tiramisu", "ingredients": [...], "tags": [...], "difficulty": "Facile" }
+    }
+  ],
+  "found": 2,
+  "not_found": ["99887766-..."]
+}
+```
+
+Les entités sont retournées dans l'ordre des `ids`. Les IDs
+introuvables sont listés dans `not_found` (pas d'erreur 404).
+
+---
+
+#### 4. PUT /api/n8n/entities/{entity_type}/{entity_id} — Modifier
+
+```
+PUT /api/n8n/entities/recipes/5606c365-...
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Request body :**
+
+```json
+{
+  "data": {
+    "title": "Fraisier Vegan (amélioré)",
+    "tags": ["vegan", "dessert", "amélioré"]
+  }
+}
+```
+
+Merge partiel : seuls les champs dans `data` sont mis à jour.
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "entity": {
+    "id": "5606c365-...",
+    "updated_at": "2026-03-27T11:00:00Z"
+  }
+}
+```
+
+---
+
+#### 5. DELETE /api/n8n/entities/{entity_type}/{entity_id} — Supprimer
+
+```
+DELETE /api/n8n/entities/recipes/5606c365-...
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "deleted": { "id": "5606c365-...", "entity_type": "recipes" }
+}
+```
+
+Soft delete (champ `deleted_at`). Le job de nettoyage Qdrant
+supprimera le vecteur correspondant après 24h.
+
+Pour la suppression définitive (RGPD), un endpoint dédié sera
+ajouté en Phase 2 :
+
+```
+DELETE /api/n8n/entities/{type}/{id}/purge
+```
+
+Ce purge supprimera immédiatement : le document MongoDB + le point
+Qdrant + les ratings/comments/saves associés en PostgreSQL.
+
+---
+
+#### 6. POST /api/n8n/entities/{entity_type}/{entity_id}/rate — Noter
+
+> Ref: ISSUE-013
+
+L'ajout de notes passe par n8n qui appelle l'API. La note est
+stockée en PostgreSQL (schema tenant).
+
+```
+POST /api/n8n/entities/recipes/5606c365-.../rate
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Request body :**
+
+```json
+{
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "rating": 4
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | oui | ID Discord |
+| `guild_id` | string | oui | ID guild |
+| `rating` | int | oui | 1 à 5 |
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-...",
+    "rating": 4,
+    "new_average": 4.2,
+    "total_ratings": 15
+  }
+}
+```
+
+Un user ne peut noter qu'une fois par entité (UPSERT). La
+moyenne est recalculée à chaque notation.
+
+---
+
+#### 7. POST /api/n8n/entities/{entity_type}/{entity_id}/comment — Commenter
+
+> Ref: ISSUE-013
+
+```
+POST /api/n8n/entities/recipes/5606c365-.../comment
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Request body :**
+
+```json
+{
+  "action": "comment",
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "content": "Excellente recette ! J'ai ajouté de la cannelle."
+}
+```
+
+| Champ | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `action` | string | oui | `comment`, `edit`, `delete` |
+| `user_id` | string | oui | ID Discord |
+| `guild_id` | string | oui | ID guild |
+| `content` | string | oui* | Texte (* requis pour comment/edit) |
+| `comment_id` | string | non | Requis pour edit/delete |
+| `parent_id` | string | non | Pour les réponses (thread) |
+
+**Response 200 (action=comment) :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "comment_id": "a1b2c3d4-...",
+    "entity_id": "5606c365-...",
+    "content": "Excellente recette ! J'ai ajouté de la cannelle.",
+    "user_id": "636639897767378954",
+    "created_at": "2026-03-27T10:30:00Z"
+  }
+}
+```
+
+**Response 200 (action=edit) :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "comment_id": "a1b2c3d4-...",
+    "content": "Contenu modifié",
+    "updated_at": "2026-03-27T11:00:00Z"
+  }
+}
+```
+
+**Response 200 (action=delete) :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "comment_id": "a1b2c3d4-...",
+    "deleted": true
+  }
+}
+```
+
+---
+
+#### 8. GET /api/n8n/entities/{entity_type}/{entity_id}/comments — Lister
+
+```
+GET /api/n8n/entities/recipes/5606c365-.../comments?limit=20&offset=0
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "data": [
+    {
+      "comment_id": "a1b2c3d4-...",
+      "user_id": "636639897767378954",
+      "content": "Excellente recette !",
+      "parent_id": null,
+      "created_at": "2026-03-27T10:30:00Z",
+      "replies": [
+        {
+          "comment_id": "e5f6g7h8-...",
+          "user_id": "111222333444555666",
+          "content": "Merci !",
+          "parent_id": "a1b2c3d4-...",
+          "created_at": "2026-03-27T10:35:00Z"
+        }
+      ]
+    }
+  ],
+  "total": 12
+}
+```
+
+---
+
+#### 9. POST /api/n8n/entities/{entity_type}/{entity_id}/save — Sauvegarder
+
+L'utilisateur sauvegarde un document dans ses favoris.
+
+```
+POST /api/n8n/entities/recipes/5606c365-.../save
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+**Request body :**
+
+```json
+{
+  "user_id": "636639897767378954",
+  "guild_id": "123456789"
+}
+```
+
+**Response 200 (sauvegardé) :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-...",
+    "saved": true,
+    "saved_at": "2026-03-27T10:30:00Z"
+  }
+}
+```
+
+**Response 200 (déjà sauvegardé) :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-...",
+    "saved": true,
+    "already_saved": true
+  }
+}
+```
+
+#### 10. DELETE /api/n8n/entities/{entity_type}/{entity_id}/save — Retirer
+
+> Note : pas de body dans DELETE (certains clients HTTP l'ignorent).
+> Les identifiants sont passés en query params.
+
+```
+DELETE /api/n8n/entities/recipes/5606c365-.../save?user_id=636639897767378954&guild_id=123456789
+Headers:
+  X-API-Key: {N8N_API_KEY}
+  X-Tenant-ID: Z6F3GSWB
+```
+
+| Param | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `user_id` | string | oui | ID Discord |
+| `guild_id` | string | oui | ID guild |
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "data": { "entity_id": "5606c365-...", "saved": false }
+}
+```
+
+---
+
+### Codes d'erreur
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `ENTITY_NOT_FOUND` | 404 | Entité introuvable |
+| `COMMENT_NOT_FOUND` | 404 | Commentaire introuvable |
+| `INVALID_RATING` | 400 | Note hors 1-5 |
+| `INVALID_ACTION` | 400 | Action comment invalide |
+| `ALREADY_SAVED` | 200 | Entité déjà sauvegardée (pas une erreur) |
+| `INVALID_ENTITY_TYPE` | 400 | Type non supporté |
+
+---
+
+### Tables PostgreSQL (schemas tenant)
+
+```sql
+-- Table ratings (schema tenant)
+CREATE TABLE ratings (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_id UUID NOT NULL,
+    entity_type VARCHAR(50) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    guild_id VARCHAR(20) NOT NULL,
+    rating INTEGER CHECK (rating >= 1 AND rating <= 5),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(entity_id, user_id)
+);
+CREATE INDEX idx_ratings_entity ON ratings(entity_id, entity_type);
+
+-- Table comments (schema tenant)
+CREATE TABLE comments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_id UUID NOT NULL,
+    entity_type VARCHAR(50) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    guild_id VARCHAR(20) NOT NULL,
+    content TEXT NOT NULL,
+    parent_id UUID REFERENCES comments(id),
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+CREATE INDEX idx_comments_entity ON comments(entity_id, entity_type);
+CREATE INDEX idx_comments_parent ON comments(parent_id);
+
+-- Table saved_entities (schema tenant)
+CREATE TABLE saved_entities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_id UUID NOT NULL,
+    entity_type VARCHAR(50) NOT NULL,
+    user_id VARCHAR(255) NOT NULL,
+    guild_id VARCHAR(20) NOT NULL,
+    saved_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(entity_id, user_id)
+);
+CREATE INDEX idx_saved_entity ON saved_entities(entity_id, entity_type);
+CREATE INDEX idx_saved_user ON saved_entities(user_id, guild_id);
+```
+
+---
+
+### Qdrant multi-tenant — tenant_id dans le payload
+
+**Qdrant est une instance unique partagée** entre tous les tenants
+(`host3.local:200001`, DB `azychat_qdrant_dev`). Il n'y a pas
+d'instance Qdrant par tenant.
+
+Le `tenant_id` est donc **obligatoire** dans le payload Qdrant
+pour isoler les données entre tenants lors du Search :
+
+```json
+{
+  "id": "5606c365-...",
+  "vector": [0.123, -0.456, ...],
+  "payload": {
+    "tenant_id": "Z6F3GSWB",
+    "guild_id": "123456789",
+    "title": "Fraisier Vegan",
+    "tags": ["vegan", "dessert"],
+    "difficulty": "Moyen",
+    "entity_type": "recipes"
+  }
+}
+```
+
+Lors du Search, le workflow n8n **doit** filtrer par `tenant_id` :
+
+```json
+{
+  "vector": [0.123, -0.456, ...],
+  "filter": {
+    "must": [
+      { "key": "tenant_id", "match": { "value": "Z6F3GSWB" } }
+    ]
+  },
+  "limit": 10
+}
+```
+
+Sans ce filtre, un tenant pourrait voir les entités d'un autre
+tenant dans les résultats de recherche sémantique.
+
+---
+
+### Gestion des orphelins Qdrant
+
+Job Celery beat quotidien :
+1. Lister les `point_id` dans Qdrant par collection
+2. Vérifier l'existence en MongoDB (DB `entities`)
+3. Supprimer les points orphelins (> 24h sans document MongoDB)
+4. Supprimer les points des entités soft-deleted (> 24h)
+
+### Gestion des échecs partiels
+
+Si API OK mais Qdrant KO → `partial: true` + `retry_token`
+Si Qdrant OK mais API KO → orphelin nettoyé par le job quotidien
+
+---
+
+### Réponses aux questions de l'équipe n8n (2026-03-27)
+
+| # | Question n8n | Réponse API |
+|---|-------------|-------------|
+| 1 | **DELETE /save — body ignoré par certains clients HTTP** | Corrigé : `user_id` et `guild_id` passent en **query params** (endpoint 10). |
+| 2 | **Batch enrichissement pour Search (10 GET séquentiels = lent)** | Ajouté : **endpoint 3b** `POST .../batch` — retourne N entités en un appel (max 50 IDs). |
+| 3 | **tenant_id dans le payload Qdrant — est-ce nécessaire ?** | **Oui, obligatoire.** Qdrant est une instance unique partagée entre tous les tenants. Le filtre `tenant_id` dans la query Qdrant est nécessaire pour l'isolation (voir section "Qdrant multi-tenant"). |
+| 4 | **Soft delete vs Hard delete (RGPD)** | Le DELETE fait un soft delete. Le job Qdrant supprime les points des entités soft-deleted après 24h. Un endpoint `/purge` pour le hard delete RGPD sera ajouté en Phase 2 (voir endpoint 5). |
+| 5 | **Contradiction tenant_id : header vs payload ?** | **Header seul (`X-Tenant-ID`).** Voir section "Résolution du tenant_id" ci-dessous. |
+
+### Résolution du tenant_id — Header seul, pas de payload
+
+Le `tenant_id` est transmis **uniquement via le header
+`X-Tenant-ID`**, jamais dans le body de la requête. C'est le
+pattern RFC-039 déjà en place (`app/middleware/n8n_auth.py`).
+
+**Flux complet :**
+
+```
+chatbot-core / plugin → webhook n8n
+  Body: {
+    entity_type: "recipes",
+    data: { title: "Fraisier Vegan", ... },
+    user_id: "636639897767378954",
+    guild_id: "123456789"
+  }
+  ⚠ Pas de tenant_id dans le body
+
+n8n (workflow MCP - Entity - Save) :
+  1. Appelle MCP - Tenant - Resolve pour obtenir le tenant_id
+     depuis le user_id Discord
+  2. Forward vers l'API backend avec le tenant_id résolu :
+
+n8n → API backend
+  Headers:
+    X-API-Key: {N8N_API_KEY}
+    X-Tenant-ID: Z6F3GSWB          ← résolu par MCP - Tenant - Resolve
+  Body: {
+    guild_id: "123456789",
+    user_id: "636639897767378954",
+    data: { title: "Fraisier Vegan", ... }
+  }
+```
+
+**Pourquoi pas dans le body ?**
+
+1. **Séparation des responsabilités** — le tenant_id est une
+   donnée d'authentification/routage, pas une donnée métier
+2. **Pas de contradiction possible** — un seul endroit pour le
+   tenant_id, pas de risque de mismatch header ≠ body
+3. **Cohérence** — tous les endpoints `/api/n8n/*` utilisent déjà
+   ce pattern (RFC-039, RFC-040, RFC-042)
+4. **chatbot-core n'a pas besoin de connaître le tenant_id** — c'est
+   n8n qui le résout
+
+---
+
+### Webhook MCP - Tenant - Resolve (nouveau)
+
+Ce webhook résout le `tenant_id` à partir du `user_id` Discord.
+Il est appelé en interne par les autres webhooks MCP qui ont
+besoin du tenant_id pour appeler l'API backend.
+
+**Endpoint :** `POST /webhook/tenant-resolve`
+
+**InputSchema :**
+
+```json
+{
+  "required": ["user_id"],
+  "properties": {
+    "user_id": {
+      "type": "string",
+      "description": "ID Discord de l'utilisateur"
+    },
+    "guild_id": {
+      "type": "string",
+      "description": "ID serveur Discord (optionnel, pour validation)"
+    }
+  }
+}
+```
+
+**Response 200 :**
+
+```json
+{
+  "success": true,
+  "data": {
+    "tenant_id": "Z6F3GSWB",
+    "user_id": "636639897767378954",
+    "subscription_status": "active"
+  }
+}
+```
+
+**Response 404 (user non trouvé) :**
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "USER_NOT_FOUND",
+    "message": "No tenant found for user_id 636639897767378954"
+  }
+}
+```
+
+**Implémentation :**
+
+Le webhook appelle l'API backend :
+```
+GET /api/n8n/tenants/resolve?user_id=636639897767378954
+Headers:
+  X-API-Key: {N8N_API_KEY}
+```
+
+L'API backend cherche dans sa base le tenant associé à cet
+utilisateur Discord (table `tenant_users` ou équivalent).
+
+---
+
+### Lien avec ISSUE-013
+
+L'ISSUE-013 proposait des **webhooks n8n** (`items-rating`,
+`items-comment`) avec leurs propres tables. Cette RFC les remplace
+par des **endpoints API REST** (endpoints 6, 7, 8 ci-dessus) que
+n8n appelle via `X-API-Key` + `X-Tenant-ID`.
+
+L'équipe n8n n'a pas besoin de créer de workflow pour les ratings
+et comments — c'est un simple proxy HTTP vers ces endpoints.
+
+---
+
+### Checklist API Backend
+
+- [ ] Config MongoDB `entities` (connexion Motor, init au startup)
+- [ ] Service `EntityService` (CRUD MongoDB + UUID pré-généré)
+- [ ] Routes `/api/n8n/entities/{type}` (5 endpoints CRUD + batch)
+- [ ] Routes `/api/n8n/entities/{type}/{id}/rate` (ISSUE-013)
+- [ ] Routes `/api/n8n/entities/{type}/{id}/comment` (ISSUE-013)
+- [ ] Routes `/api/n8n/entities/{type}/{id}/save`
+- [ ] Migration Alembic : tables `ratings` + `comments` + `saved_entities`
+- [ ] Job Celery beat : nettoyage orphelins Qdrant + soft-deleted
+- [ ] Phase 2 : endpoint `/purge` (hard delete RGPD)
+- [ ] Tests unitaires
+
+---
+
+## Checklist d'implémentation (toutes équipes)
+
+- [ ] Équipe API : Endpoints CRUD entités (MongoDB) — voir section Review
+- [ ] Équipe API : Endpoints rate + comment + save (PostgreSQL)
+- [ ] Équipe API : Job nettoyage orphelins Qdrant
+- [ ] Équipe n8n : Créer MCP - Entity - Save (appelle POST /api/n8n/entities/{type} + Qdrant)
+- [ ] Équipe n8n : Créer MCP - Entity - Search (Qdrant + GET /api/n8n/entities/{type}/{id})
+- [ ] Équipe n8n : Appeler /rate, /comment, /save depuis les workflows
+- [ ] Équipe chatbot-core : Migrer vers nouveaux webhooks
+- [ ] Équipe plugin : Migrer vers nouveaux webhooks
+- [ ] Tests E2E : Save + Search + Rate + Comment
+- [ ] Documentation : Mettre à jour le registry MCP
+
+---
+
+## Annexes
+
+### A. Exemple de payload Save
+
+```json
+{
+  "entity_type": "recipes",
+  "data": {
+    "title": "Fraisier Vegan",
+    "description": "Un délicieux fraisier sans produits laitiers",
+    "ingredients": ["farine", "lait végétal", "fraises"],
+    "steps": ["Préchauffer le four", "Mélanger", "Cuire"],
+    "tags": ["vegan", "dessert"],
+    "difficulty": "Moyen",
+    "prep_time": 60,
+    "cook_time": 25
+  },
+  "user_id": "636639897767378954",
+  "guild_id": "123456789",
+  "qdrant_host": "host3.local",
+  "qdrant_port": 20001,
+  "qdrant_collection": "recipes",
+  "api_key": "xxx",
+  "openai_api_key": "sk-xxx"
+}
+```
+
+### B. Exemple de response Save
+
+```json
+{
+  "success": true,
+  "data": {
+    "entity_id": "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "qdrant_point_id": "5606c365-b2c0-47d2-b8de-436c268e7895",
+    "entity_type": "recipes",
+    "saved_in_db": true,
+    "saved_in_qdrant": true
+  },
+  "_trace": {
+    "service_response": {
+      "api": { "id": "5606c365-..." },
+      "qdrant": { "status": "ok" }
+    },
+    "provider": "api+qdrant",
+    "latency_ms": 342,
+    "user_id": "636639897767378954"
+  }
+}
+```

--- a/workflows/LLM-Request-Validator.json
+++ b/workflows/LLM-Request-Validator.json
@@ -1,0 +1,271 @@
+{
+  "name": "LLM - Request Validator",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## LLM - Request Validator\n\n**Endpoint:** POST /webhook/llm-request-validator\n\n**Description:** Validates user requests against a domain context using LLM (RFC-044).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_request\", \"domain\"],\n  \"properties\": {\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request to validate\" },\n    \"domain\": {\n      \"type\": \"object\",\n      \"required\": [\"name\", \"description\"],\n      \"properties\": {\n        \"name\": { \"type\": \"string\" },\n        \"description\": { \"type\": \"string\" },\n        \"bot_name\": { \"type\": \"string\" },\n        \"contradiction_examples\": { \"type\": \"array\" },\n        \"constraints_schema\": { \"type\": \"object\" },\n        \"user_level_hints\": { \"type\": \"object\" },\n        \"out_of_scope_examples\": { \"type\": \"array\" }\n      }\n    },\n    \"has_image\": { \"type\": \"boolean\", \"description\": \"Has image attachment\" },\n    \"image_attachments\": { \"type\": \"array\", \"description\": \"Image attachments\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing (optional)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing (optional)\" }\n  }\n}\n```\n\n**Note:** API key from request or env (ANTHROPIC_API_KEY).\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"is_valid\", \"issue_type\", \"user_state\", \"response\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 640,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "llm-request-validator",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "llm-request-validator"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Request Validator (RFC-014)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Context fields for tracing (OPTIONAL - RFC-014) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required field: user_request ---\nif (!userRequest || typeof userRequest !== 'string' || userRequest.trim().length === 0) {\n  errors.push('user_request requis (chaine non vide)');\n}\n\n// --- Required field: domain ---\nconst domain = body.domain || ctx.domain;\nif (!domain || typeof domain !== 'object') {\n  errors.push('domain requis (objet)');\n} else {\n  if (!domain.name) errors.push('domain.name requis');\n  if (!domain.description) errors.push('domain.description requis');\n}\n\n// --- API Key from request or env ---\nconst anthropicApiKey = body.anthropic_api_key || body.plugin_context?.api_keys?.anthropic || $env.ANTHROPIC_API_KEY || '';\nif (!anthropicApiKey) {\n  errors.push('anthropic_api_key requis (via request ou env)');\n}\n\n// --- Optional fields ---\nconst hasImage = body.has_image === true;\nconst imageAttachments = Array.isArray(body.image_attachments) ? body.image_attachments : [];\nconst model = body.model || ctx.model || 'claude-haiku-4-5-20251001';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  user_request: userRequest.trim(),\n  domain: domain,\n  user_id: userId,\n  guild_id: guildId,\n  anthropic_api_key: anthropicApiKey,\n  model: model,\n  has_image: hasImage,\n  image_attachments: imageAttachments,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
+    },
+    {
+      "parameters": {
+        "jsCode": "const data = $input.first().json;\n\n// === HELPERS ===\nconst formatValue = (v) => Array.isArray(v) ? v.join(' | ') : v;\nconst MAX_HINTS = data.domain.max_hints_per_level || 5;\n\n// === SECTION CONTRADICTIONS (dynamique) ===\nconst contradictionSection = data.domain.contradiction_examples?.length > 0\n  ? `Exemples de contradictions pour ${data.domain.name} :\\n${data.domain.contradiction_examples.map(e => `- ${e}`).join('\\n')}`\n  : `Identifie les contradictions logiques dans le contexte \"${data.domain.name}\"`;\n\n// === SECTION OUT OF SCOPE (dynamique) ===\nconst outOfScopeSection = data.domain.out_of_scope_examples?.length > 0\n  ? `\\n\\nExemples de requetes HORS SCOPE (a rejeter) :\\n${data.domain.out_of_scope_examples.map(e => `- \"${e}\"`).join('\\n')}`\n  : '';\n\n// === SECTION CONTRAINTES (dynamique) ===\nlet constraintsSection;\nlet constraintsKeys;\nif (data.domain.constraints_schema && Object.keys(data.domain.constraints_schema).length > 0) {\n  constraintsKeys = Object.keys(data.domain.constraints_schema);\n  constraintsSection = `Contraintes a extraire (UTILISE UNIQUEMENT ces valeurs) :\\n` +\n    Object.entries(data.domain.constraints_schema)\n      .map(([key, values]) => `- ${key} : ${formatValue(values)}`)\n      .join('\\n');\n} else {\n  constraintsKeys = ['time', 'budget'];\n  constraintsSection = `Contraintes a extraire :\\n- time : very_short | short | medium | long | null\\n- budget : low | medium | high | null\\n- Extrais toute autre contrainte pertinente mentionnee`;\n}\n\n// === SECTION NIVEAU UTILISATEUR (dynamique) ===\nlet userLevelSection;\nif (data.domain.user_level_hints && Object.keys(data.domain.user_level_hints).length > 0) {\n  userLevelSection = Object.entries(data.domain.user_level_hints)\n    .map(([level, hints]) => `- ${level} : ${hints.slice(0, MAX_HINTS).map(h => `\"${h}\"`).join(', ')}`)\n    .join('\\n');\n} else {\n  userLevelSection = `- beginner : indices de debutant, demandes d'aide basique\\n- intermediate : requetes standard sans difficulte particuliere\\n- advanced : termes techniques, demandes complexes\\n- unknown : impossible a determiner`;\n}\n\n// === SCHEMA JSON DYNAMIQUE ===\nconst constraintsJsonSchema = constraintsKeys.map(k => `      \"${k}\": \"valeur ou null\"`).join(',\\n');\n\n// === SECTION ATTACHMENTS ===\nlet attachmentContext = '';\nif (data.has_image && data.image_attachments && data.image_attachments.length > 0) {\n  const attachmentList = data.image_attachments.map(a => {\n    const filename = a.filename || 'fichier';\n    const contentType = a.content_type || 'unknown';\n    return `- ${filename} (${contentType})`;\n  }).join('\\n');\n  attachmentContext = `\\n\\n[FICHIERS ATTACHES]\\nL'utilisateur a joint ${data.image_attachments.length} fichier(s) a sa requete :\\n${attachmentList}\\n\\nPRENDS EN COMPTE ces fichiers joints lors de la validation. Une requete demandant de \"scanner\", \"analyser\", \"lire\" ou \"extraire\" un document est VALIDE si un fichier est attache.`;\n}\n\n// === PROMPT SYSTEM ===\nconst systemPrompt = `Tu es un validateur de requetes pour ${data.domain.bot_name || data.domain.name}.\n\nDOMAINE : ${data.domain.name}\n${data.domain.description}${outOfScopeSection}\n\n---\n\n# PARTIE 1 : VALIDATION\n\n## ETAPE 1 - PERTINENCE\nLa requete concerne-t-elle ce domaine ?\n- Juge si la requete a un lien direct avec ${data.domain.name}\n- Ne liste PAS ce qui est hors scope, deduis-le du domaine defini\n- Si l'utilisateur a joint des fichiers, considere que la requete peut concerner ces fichiers\n\n## ETAPE 2 - COHERENCE (uniquement si pertinent au domaine)\nLes contraintes de la requete sont-elles compatibles entre elles ?\n\n${contradictionSection}\n\n---\n\n# PARTIE 2 : ANALYSE DE L'ETAT UTILISATEUR\n\nAnalyse le message pour comprendre l'etat emotionnel et contextuel de l'utilisateur.\n\n## Emotions a detecter\n- stress : pression, anxiete (\"je dois\", \"il faut que\", \"j'ai pas le temps\")\n- fatigue : epuisement (\"creve\", \"fatigue\", \"pas envie\", \"flemme\")\n- frustration : agacement (\"j'en ai marre\", \"rien ne marche\", \"encore\")\n- motivation : enthousiasme (\"j'ai envie de\", \"je veux essayer\", \"ca me tente\")\n- curiosity : decouverte (\"c'est quoi\", \"comment on fait\", \"je me demande\")\n- joy : plaisir (\"j'adore\", \"genial\", \"super\")\n- neutral : pas d'emotion particuliere detectee\n\n## Urgence\n- high : contrainte temps explicite courte (<30min) ou mots d'urgence (\"vite\", \"urgent\", \"tout de suite\")\n- medium : contrainte temps moderee ou implicite\n- low : pas de pression temporelle\n\n## ${constraintsSection}\n\n## Niveau utilisateur\n${userLevelSection}\n\n## Ton recommande\n- reassuring : si stress, fatigue ou frustration -> rassurer, simplifier\n- direct : si urgence high -> aller droit au but\n- enthusiastic : si motivation ou joy -> partager l'enthousiasme\n- pedagogical : si curiosity ou beginner -> expliquer\n- neutral : si aucune emotion forte\n\n---\n\n# REPONSE\n\nReponds UNIQUEMENT en JSON valide, sans texte autour :\n\n{\n  \"is_valid\": true ou false,\n  \"issue_type\": null ou \"out_of_scope\" ou \"contradiction\",\n  \"response\": \"message oriente solution si invalide, sinon null\",\n  \"user_state\": {\n    \"emotions\": [\"liste\", \"des\", \"emotions\"],\n    \"urgency\": \"low\" ou \"medium\" ou \"high\",\n    \"constraints\": {\n${constraintsJsonSchema}\n    },\n    \"user_level\": \"beginner\" ou \"intermediate\" ou \"advanced\" ou \"unknown\",\n    \"tone_preference\": \"reassuring\" ou \"direct\" ou \"enthusiastic\" ou \"pedagogical\" ou \"neutral\"\n  }\n}\n\nIMPORTANT pour la reponse si invalide :\n- Sois poli et bienveillant\n- Explique brievement le probleme\n- Propose des alternatives concretes\n- Pose une question pour guider l'utilisateur`;\n\n// Build user message with attachment context\nlet userMessage = `Requete a valider : \"${data.user_request}\"`;\nif (attachmentContext) {\n  userMessage += attachmentContext;\n}\n\nconst body = {\n  model: data.model,\n  max_tokens: 800,\n  temperature: 0,\n  messages: [\n    { role: 'user', content: userMessage }\n  ],\n  system: systemPrompt\n};\n\nreturn [{\n  json: {\n    ...data,\n    llm_body: JSON.stringify(body)\n  }\n}];"
+      },
+      "id": "prepare-llm",
+      "name": "Prepare LLM Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 200]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropic_api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.llm_body }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "call-claude",
+      "name": "Claude Validate",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1160, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PARSE LLM RESPONSE - LLM Request Validator\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Build dynamic default constraints from domain schema\nconst constraintsSchema = prevData.domain?.constraints_schema || {};\nconst defaultConstraints = {};\nconst schemaKeys = Object.keys(constraintsSchema);\nif (schemaKeys.length > 0) {\n  for (const key of schemaKeys) {\n    defaultConstraints[key] = null;\n  }\n} else {\n  defaultConstraints.time = null;\n  defaultConstraints.budget = null;\n}\n\n// Default user_state for fail-open scenarios\nconst defaultUserState = {\n  emotions: [\"neutral\"],\n  urgency: \"low\",\n  constraints: defaultConstraints,\n  user_level: \"unknown\",\n  tone_preference: \"neutral\"\n};\n\n// Helper to build trace\nconst buildTrace = (llmResponse, serviceResponse, errorStep = null) => ({\n  llm_response: llmResponse,\n  service_response: serviceResponse,\n  provider: 'anthropic',\n  model: prevData.model,\n  tokens: { \n    input: input.usage?.input_tokens || null, \n    output: input.usage?.output_tokens || null \n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  error_step: errorStep\n});\n\ntry {\n  // Handle API error - fail-open with default state\n  if (input.error) {\n    return [{\n      json: {\n        success: true,\n        is_valid: true,\n        issue_type: null,\n        response: null,\n        user_state: defaultUserState,\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _error: input.error.message,\n        _trace: buildTrace(null, input, 'api_call')\n      }\n    }];\n  }\n\n  // Extract text content from Claude response\n  let textContent = '';\n  for (const block of (input.content || [])) {\n    if (block.type === 'text') {\n      textContent += block.text;\n    }\n  }\n\n  // Parse JSON from response\n  let result;\n  try {\n    const cleaned = textContent.replace(/```json\\n?/g, '').replace(/```\\n?/g, '').trim();\n    result = JSON.parse(cleaned);\n  } catch (e) {\n    // If parsing fails, assume valid request with default state (fail-open)\n    return [{\n      json: {\n        success: true,\n        is_valid: true,\n        issue_type: null,\n        response: null,\n        user_state: defaultUserState,\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _parse_error: e.message,\n        _trace: buildTrace(textContent, input, 'json_parse')\n      }\n    }];\n  }\n\n  // Validate and normalize user_state\n  const userState = result.user_state || {};\n  \n  // Build normalized constraints from schema keys\n  const normalizedConstraints = {};\n  const keysToUse = schemaKeys.length > 0 ? schemaKeys : ['time', 'budget'];\n  for (const key of keysToUse) {\n    normalizedConstraints[key] = userState.constraints?.[key] || null;\n  }\n\n  const normalizedUserState = {\n    emotions: Array.isArray(userState.emotions) ? userState.emotions : [\"neutral\"],\n    urgency: [\"low\", \"medium\", \"high\"].includes(userState.urgency) ? userState.urgency : \"low\",\n    constraints: normalizedConstraints,\n    user_level: [\"beginner\", \"intermediate\", \"advanced\", \"unknown\"].includes(userState.user_level) \n      ? userState.user_level : \"unknown\",\n    tone_preference: [\"reassuring\", \"direct\", \"enthusiastic\", \"pedagogical\", \"neutral\"].includes(userState.tone_preference)\n      ? userState.tone_preference : \"neutral\"\n  };\n\n  // Return RFC-044 compliant format with trace\n  return [{\n    json: {\n      success: true,\n      is_valid: result.is_valid ?? true,\n      issue_type: result.issue_type || null,\n      response: result.response || null,\n      user_state: normalizedUserState,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: buildTrace(textContent, input)\n    }\n  }];\n} catch (e) {\n  // Fail-open: accept request with default state if error\n  return [{\n    json: {\n      success: true,\n      is_valid: true,\n      issue_type: null,\n      response: null,\n      user_state: defaultUserState,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _error: e.message,\n      _trace: buildTrace(null, input, 'unexpected_error')\n    }\n  }];\n}"
+      },
+      "id": "parse-response",
+      "name": "Parse Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1400, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1640, 200]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Prepare LLM Request",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare LLM Request": {
+      "main": [
+        [
+          {
+            "node": "Claude Validate",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Validate": {
+      "main": [
+        [
+          {
+            "node": "Parse Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  }
+}

--- a/workflows/LLM_-_Web_Search.json
+++ b/workflows/LLM_-_Web_Search.json
@@ -1,12 +1,19 @@
 {
-  "updatedAt": "2026-01-17T19:44:08.000Z",
-  "createdAt": "2026-01-07T11:15:31.627Z",
-  "id": "Zq5SGUcoFvXndkLO",
   "name": "LLM - Web Search",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "parameters": {
+        "content": "## LLM - Web Search (Multi-Provider)\n\n**Endpoint:** POST /webhook/llm-web-search\n\n**Description:** Performs web search using multiple LLM providers with grounding.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"query\"],\n  \"properties\": {\n    \"query\": { \"type\": \"string\", \"description\": \"Search query (required)\" },\n    \"provider\": { \"type\": \"string\", \"description\": \"LLM provider: openai, openai-mini, claude, claude-haiku, gemini, gemini-pro, mistral, mistral-premium (default: gemini)\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Override model\" },\n    \"options\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"search_depth\": { \"type\": \"string\", \"description\": \"medium or deep\" },\n        \"max_results\": { \"type\": \"integer\", \"description\": \"Max search results\" },\n        \"language\": { \"type\": \"string\", \"description\": \"Output language\" },\n        \"allowed_domains\": { \"type\": \"array\", \"description\": \"Allowed domains (Claude only)\" },\n        \"blocked_domains\": { \"type\": \"array\", \"description\": \"Blocked domains\" },\n        \"include_sources\": { \"type\": \"boolean\", \"description\": \"Include sources\" }\n      }\n    },\n    \"output_schema\": { \"type\": \"object\", \"description\": \"Structured output schema\" },\n    \"messages\": { \"type\": \"array\", \"description\": \"Conversation history\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"OpenAI API key (required for OpenAI)\" },\n    \"anthropic_api_key\": { \"type\": \"string\", \"description\": \"Anthropic API key (required for Claude)\" },\n    \"google_api_key\": { \"type\": \"string\", \"description\": \"Google API key (required for Gemini)\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key (required for Mistral)\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"content\", \"sources\", \"structured_data\"],\n  \"domain\": \"search\"\n}\n```\n\n**Notes:**\n- `allowed_domains` only works with Claude\n- Mistral search is NOT guaranteed (agent decides)\n- Gemini uses Google Search, OpenAI uses Bing, Claude/Mistral use Brave",
+        "height": 820,
+        "width": 500,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-880, -280]
+    },
     {
       "parameters": {
         "httpMethod": "POST",
@@ -18,24 +25,18 @@
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        -768,
-        272
-      ],
+      "position": [-768, 272],
       "webhookId": "recipes-web-search-webhook"
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const body = input.body || input;\n\n  const errors = [];\n\n  // Déclarations AVANT utilisation\n  const validProviders = ['openai', 'openai-mini', 'claude', 'claude-haiku', 'gemini', 'gemini-pro', 'mistral',\n  'mistral-premium'];\n  const defaultModels = {\n    openai: 'gpt-4o-search-preview',\n    'openai-mini': 'gpt-4o-mini-search-preview',\n    claude: 'claude-sonnet-4-20250514',\n    'claude-haiku': 'claude-3-5-haiku-latest',\n    gemini: 'gemini-2.5-flash',\n    'gemini-pro': 'gemini-2.5-pro',\n    mistral: 'mistral-medium-2505',\n    'mistral-premium': 'mistral-medium-2505'\n  };\n\n  if (!body.query) {\n    errors.push('Missing required parameter: query');\n  }\n\n  const provider = body.provider || 'gemini';\n\n  if (!validProviders.includes(provider)) {\n    errors.push(`Invalid provider: '${provider}'. Valid options: ${validProviders.join(', ')}`);\n  }\n\n  // Check required API keys based on provider\n  if (provider.startsWith('openai') && !body.openai_api_key) {\n    errors.push('Missing openai_api_key for OpenAI provider');\n  }\n  if (provider.startsWith('claude') && !body.anthropic_api_key) {\n    errors.push('Missing anthropic_api_key for Claude provider');\n  }\n  if (provider.startsWith('gemini') && !body.google_api_key) {\n    errors.push('Missing google_api_key for Gemini provider');\n  }\n  if (provider.startsWith('mistral') && !body.mistral_api_key) {\n    errors.push('Missing mistral_api_key for Mistral provider');\n  }\n\n  if (errors.length > 0) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: errors.join(', '),\n          status: 'BAD_REQUEST'\n        }\n      }\n    }];\n  }\n\n  const opts = body.options || {};\n\n  return [{\n    json: {\n      valid: true,\n      query: body.query,\n      provider,\n      provider_type: provider.split('-')[0],\n      model: body.model || defaultModels[provider],\n      user_id: body.user_id,\n      openai_api_key: body.openai_api_key,\n      anthropic_api_key: body.anthropic_api_key,\n      google_api_key: body.google_api_key,\n      mistral_api_key: body.mistral_api_key,\n      options: {\n        search_depth: opts.search_depth || 'medium',\n        max_results: opts.max_results || 3,\n        language: opts.language || 'fr',\n        allowed_domains: opts.allowed_domains || [],\n        blocked_domains: opts.blocked_domains || [],\n        include_sources: opts.include_sources !== false\n      },\n      output_schema: body.output_schema || null,\n      allowed_context: body.allowed_context || null,\n      messages: body.messages || null\n    }\n  }];\n"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Web Search\n// RFC-014: Support context.* with fallback to root level\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Provider configuration ---\nconst validProviders = ['openai', 'openai-mini', 'claude', 'claude-haiku', 'gemini', 'gemini-pro', 'mistral', 'mistral-premium'];\nconst defaultModels = {\n  openai: 'gpt-4o-search-preview',\n  'openai-mini': 'gpt-4o-mini-search-preview',\n  claude: 'claude-sonnet-4-20250514',\n  'claude-haiku': 'claude-3-5-haiku-latest',\n  gemini: 'gemini-2.5-flash',\n  'gemini-pro': 'gemini-2.5-pro',\n  mistral: 'mistral-medium-2505',\n  'mistral-premium': 'mistral-medium-2505'\n};\n\n// --- Required field ---\nconst query = body.query || ctx.query;\nif (!query || typeof query !== 'string' || query.trim().length === 0) {\n  errors.push('query requis (chaine non vide)');\n}\n\n// --- Provider validation ---\nconst provider = body.provider || ctx.provider || 'gemini';\nif (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: '${provider}'. Options valides: ${validProviders.join(', ')}`);\n}\n\n// --- API Keys validation based on provider ---\nif (provider.startsWith('openai') && !body.openai_api_key) {\n  errors.push('openai_api_key requis pour le provider OpenAI');\n}\nif (provider.startsWith('claude') && !body.anthropic_api_key) {\n  errors.push('anthropic_api_key requis pour le provider Claude');\n}\nif (provider.startsWith('gemini') && !body.google_api_key) {\n  errors.push('google_api_key requis pour le provider Gemini');\n}\nif (provider.startsWith('mistral') && !body.mistral_api_key) {\n  errors.push('mistral_api_key requis pour le provider Mistral');\n}\n\n// --- OPTIONAL context fields for tracing (NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Options ---\nconst opts = body.options || ctx.options || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  query: (query || '').trim(),\n  provider: provider,\n  provider_type: provider.split('-')[0],\n  model: body.model || ctx.model || defaultModels[provider],\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  openai_api_key: body.openai_api_key,\n  anthropic_api_key: body.anthropic_api_key,\n  google_api_key: body.google_api_key,\n  mistral_api_key: body.mistral_api_key,\n  options: {\n    search_depth: opts.search_depth || 'medium',\n    max_results: opts.max_results || 3,\n    language: opts.language || 'fr',\n    allowed_domains: opts.allowed_domains || [],\n    blocked_domains: opts.blocked_domains || [],\n    include_sources: opts.include_sources !== false\n  },\n  output_schema: body.output_schema || ctx.output_schema || null,\n  allowed_context: body.allowed_context || ctx.allowed_context || null,\n  messages: body.messages || ctx.messages || null,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        -528,
-        272
-      ]
+      "position": [-528, 272]
     },
     {
       "parameters": {
@@ -65,27 +66,39 @@
       "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        -288,
-        272
-      ]
+      "position": [-288, 272]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [-48, 480]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { success: false, error: $json.error, meta: { provider: 'web-search' } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       },
-      "id": "error-validation",
-      "name": "Error: Validation",
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1248,
-        640
-      ]
+      "position": [192, 480]
     },
     {
       "parameters": {
@@ -201,10 +214,7 @@
       "name": "Switch Provider",
       "type": "n8n-nodes-base.switch",
       "typeVersion": 3.2,
-      "position": [
-        672,
-        -96
-      ]
+      "position": [672, -96]
     },
     {
       "parameters": {
@@ -234,10 +244,7 @@
       "name": "OpenAI Web Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1296,
-        -96
-      ],
+      "position": [1296, -96],
       "onError": "continueRegularOutput"
     },
     {
@@ -272,10 +279,7 @@
       "name": "Claude Web Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1296,
-        96
-      ],
+      "position": [1296, 96],
       "onError": "continueRegularOutput"
     },
     {
@@ -302,10 +306,7 @@
       "name": "Gemini Web Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1296,
-        272
-      ],
+      "position": [1296, 272],
       "onError": "continueRegularOutput"
     },
     {
@@ -336,63 +337,48 @@
       "name": "Mistral Web Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1296,
-        448
-      ],
+      "position": [1296, 448],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "const input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst usage = {\n    input_tokens: input.usage?.prompt_tokens || 0,\n    output_tokens: input.usage?.completion_tokens || 0,\n    total_tokens: input.usage?.total_tokens || 0\n  };\n  function getDomain(url) {\n    if (!url) return '';\n    const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n    return match ? match[1] : '';\n  }\n\n  try {\n    let textContent = '';\n    const sources = [];\n    let structuredData = null;\n\n    // Extraire le contenu texte\n    const message = input.choices?.[0]?.message;\n\n    if (message?.content) {\n      textContent = message.content;\n    }\n\n    // Extraire les sources (annotations)\n    const annotations = message?.annotations || [];\n    for (const ann of annotations) {\n      if (ann.type === 'url_citation') {\n        sources.push({\n          title: ann.title || 'Source',\n          url: ann.url,\n          domain: getDomain(ann.url)\n        });\n      }\n    }\n\n    // Extraire les données structurées (tool_calls)\n    const toolCalls = message?.tool_calls || [];\n    if (toolCalls.length > 0) {\n      const call = toolCalls[0];\n      if (call.type === 'function') {\n        structuredData = {\n          tool_name: call.function.name,\n          data: JSON.parse(call.function.arguments)\n        };\n      }\n    }\n\n    return [{\n      json: {\n        normalized: true,\n        provider: prevData.provider,\n        query: prevData.query,\n        content: textContent,\n        sources,\n        structured_data: structuredData,\n        search_performed: sources.length > 0,\n        has_structured_output: structuredData !== null,\n        usage\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        normalized: false,\n        provider: prevData.provider,\n        error: e.message\n      }\n    }];\n  }"
+        "jsCode": "// ============================================\n// NORMALIZE OPENAI - With _trace support\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst usage = {\n  input_tokens: input.usage?.prompt_tokens || 0,\n  output_tokens: input.usage?.completion_tokens || 0,\n  total_tokens: input.usage?.total_tokens || 0\n};\n\nfunction getDomain(url) {\n  if (!url) return '';\n  const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n  return match ? match[1] : '';\n}\n\ntry {\n  let textContent = '';\n  const sources = [];\n  let structuredData = null;\n\n  // Extract text content\n  const message = input.choices?.[0]?.message;\n\n  if (message?.content) {\n    textContent = message.content;\n  }\n\n  // Extract sources (annotations)\n  const annotations = message?.annotations || [];\n  for (const ann of annotations) {\n    if (ann.type === 'url_citation') {\n      sources.push({\n        title: ann.title || 'Source',\n        url: ann.url,\n        domain: getDomain(ann.url)\n      });\n    }\n  }\n\n  // Extract structured data (tool_calls)\n  const toolCalls = message?.tool_calls || [];\n  if (toolCalls.length > 0) {\n    const call = toolCalls[0];\n    if (call.type === 'function') {\n      structuredData = {\n        tool_name: call.function.name,\n        data: JSON.parse(call.function.arguments)\n      };\n    }\n  }\n\n  return [{\n    json: {\n      normalized: true,\n      provider: prevData.provider,\n      query: prevData.query,\n      content: textContent,\n      sources,\n      structured_data: structuredData,\n      search_performed: sources.length > 0,\n      has_structured_output: structuredData !== null,\n      usage,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      normalized: false,\n      provider: prevData.provider,\n      error: e.message,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n}"
       },
       "id": "normalize-openai",
       "name": "Normalize OpenAI",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1536,
-        -176
-      ]
+      "position": [1536, -176]
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validate Input').first().json;\n  const usage = {\n    input_tokens: input.usage?.input_tokens || 0,\n    output_tokens: input.usage?.output_tokens || 0,\n    total_tokens: (input.usage?.input_tokens || 0) + (input.usage?.output_tokens || 0)\n  };\n\n  function getDomain(url) {\n    if (!url) return '';\n    const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n    return match ? match[1] : '';\n  }\n\n  try {\n    let textContent = '';\n    const sources = [];\n    let structuredData = null;\n\n    for (const block of (input.content || [])) {\n      // Extraire le texte\n      if (block.type === 'text') {\n        textContent += block.text;\n      }\n\n      // Extraire les sources web\n      if (block.type === 'web_search_tool_result') {\n        for (const result of (block.content || [])) {\n          if (result.type === 'web_search_result') {\n            sources.push({\n              title: result.title || 'Source',\n              url: result.url,\n              domain: getDomain(result.url)\n            });\n          }\n        }\n      }\n\n      // Extraire les données structurées (tool_use)\n      if (block.type === 'tool_use' && block.name !== 'web_search') {\n        structuredData = {\n          tool_name: block.name,\n          data: block.input\n        };\n      }\n    }\n\n    return [{\n      json: {\n        normalized: true,\n        provider: prevData.provider,\n        query: prevData.query,\n        content: textContent,\n        sources,\n        structured_data: structuredData,\n        search_performed: sources.length > 0,\n        has_structured_output: structuredData !== null,\n        usage\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        normalized: false,\n        provider: prevData.provider,\n        error: e.message\n      }\n    }];\n  }"
+        "jsCode": "// ============================================\n// NORMALIZE CLAUDE - With _trace support\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst usage = {\n  input_tokens: input.usage?.input_tokens || 0,\n  output_tokens: input.usage?.output_tokens || 0,\n  total_tokens: (input.usage?.input_tokens || 0) + (input.usage?.output_tokens || 0)\n};\n\nfunction getDomain(url) {\n  if (!url) return '';\n  const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n  return match ? match[1] : '';\n}\n\ntry {\n  let textContent = '';\n  const sources = [];\n  let structuredData = null;\n\n  for (const block of (input.content || [])) {\n    // Extract text\n    if (block.type === 'text') {\n      textContent += block.text;\n    }\n\n    // Extract web sources\n    if (block.type === 'web_search_tool_result') {\n      for (const result of (block.content || [])) {\n        if (result.type === 'web_search_result') {\n          sources.push({\n            title: result.title || 'Source',\n            url: result.url,\n            domain: getDomain(result.url)\n          });\n        }\n      }\n    }\n\n    // Extract structured data (tool_use)\n    if (block.type === 'tool_use' && block.name !== 'web_search') {\n      structuredData = {\n        tool_name: block.name,\n        data: block.input\n      };\n    }\n  }\n\n  return [{\n    json: {\n      normalized: true,\n      provider: prevData.provider,\n      query: prevData.query,\n      content: textContent,\n      sources,\n      structured_data: structuredData,\n      search_performed: sources.length > 0,\n      has_structured_output: structuredData !== null,\n      usage,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      normalized: false,\n      provider: prevData.provider,\n      error: e.message,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n}"
       },
       "id": "normalize-claude",
       "name": "Normalize Claude",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1552,
-        16
-      ]
+      "position": [1552, 16]
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validate Input').first().json;\n  const usage = {\n    input_tokens: input.usageMetadata?.promptTokenCount || 0,\n    output_tokens: input.usageMetadata?.candidatesTokenCount || 0,\n    total_tokens: input.usageMetadata?.totalTokenCount || 0\n  };\n\n  function getDomain(url) {\n    if (!url) return '';\n    const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n    return match ? match[1] : '';\n  }\n\n  try {\n    let textContent = '';\n    const sources = [];\n    let structuredData = null;\n\n    const candidate = input.candidates?.[0];\n    const parts = candidate?.content?.parts || [];\n\n    for (const part of parts) {\n      // Extraire le texte\n      if (part.text) {\n        textContent += part.text;\n      }\n\n      // Extraire les données structurées (functionCall)\n      if (part.functionCall && part.functionCall.name !== 'google_search') {\n        structuredData = {\n          tool_name: part.functionCall.name,\n          data: part.functionCall.args\n        };\n      }\n    }\n\n    // Extraire les sources (grounding metadata)\n    const grounding = candidate?.groundingMetadata;\n    const chunks = grounding?.groundingChunks || [];\n\n    for (const chunk of chunks) {\n      if (chunk.web) {\n        sources.push({\n          title: chunk.web.title || 'Source',\n          url: chunk.web.uri,\n          domain: getDomain(chunk.web.uri)\n        });\n      }\n    }\n\n    return [{\n      json: {\n        normalized: true,\n        provider: prevData.provider,\n        query: prevData.query,\n        content: textContent,\n        sources,\n        structured_data: structuredData,\n        search_performed: sources.length > 0,\n        has_structured_output: structuredData !== null,\n        usage\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        normalized: false,\n        provider: prevData.provider,\n        error: e.message\n      }\n    }];\n  }"
+        "jsCode": "// ============================================\n// NORMALIZE GEMINI - With _trace support\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst usage = {\n  input_tokens: input.usageMetadata?.promptTokenCount || 0,\n  output_tokens: input.usageMetadata?.candidatesTokenCount || 0,\n  total_tokens: input.usageMetadata?.totalTokenCount || 0\n};\n\nfunction getDomain(url) {\n  if (!url) return '';\n  const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n  return match ? match[1] : '';\n}\n\ntry {\n  let textContent = '';\n  const sources = [];\n  let structuredData = null;\n\n  const candidate = input.candidates?.[0];\n  const parts = candidate?.content?.parts || [];\n\n  for (const part of parts) {\n    // Extract text\n    if (part.text) {\n      textContent += part.text;\n    }\n\n    // Extract structured data (functionCall)\n    if (part.functionCall && part.functionCall.name !== 'google_search') {\n      structuredData = {\n        tool_name: part.functionCall.name,\n        data: part.functionCall.args\n      };\n    }\n  }\n\n  // Extract sources (grounding metadata)\n  const grounding = candidate?.groundingMetadata;\n  const chunks = grounding?.groundingChunks || [];\n\n  for (const chunk of chunks) {\n    if (chunk.web) {\n      sources.push({\n        title: chunk.web.title || 'Source',\n        url: chunk.web.uri,\n        domain: getDomain(chunk.web.uri)\n      });\n    }\n  }\n\n  return [{\n    json: {\n      normalized: true,\n      provider: prevData.provider,\n      query: prevData.query,\n      content: textContent,\n      sources,\n      structured_data: structuredData,\n      search_performed: sources.length > 0,\n      has_structured_output: structuredData !== null,\n      usage,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      normalized: false,\n      provider: prevData.provider,\n      error: e.message,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n}"
       },
       "id": "normalize-gemini",
       "name": "Normalize Gemini",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1568,
-        224
-      ]
+      "position": [1568, 224]
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validate Input').first().json;\n  const usage = {\n    input_tokens: input.usage?.prompt_tokens || 0,\n    output_tokens: input.usage?.completion_tokens || 0,\n    total_tokens: input.usage?.total_tokens || 0\n  };\n\n  function getDomain(url) {\n    if (!url) return '';\n    const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n    return match ? match[1] : '';\n  }\n\n  try {\n    let textContent = '';\n    const sources = [];\n    let structuredData = null;\n\n    const message = input.choices?.[0]?.message;\n\n    // Extraire le contenu texte\n    if (message?.content) {\n      textContent = message.content;\n    }\n\n    // Extraire les sources depuis les citations\n    const citations = input.citations || [];\n    for (const cite of citations) {\n      sources.push({\n        title: cite.title || 'Source',\n        url: cite.url,\n        domain: getDomain(cite.url)\n      });\n    }\n\n    // Extraire les données structurées (tool_calls)\n    const toolCalls = message?.tool_calls || [];\n    for (const call of toolCalls) {\n      if (call.type === 'function' && call.function.name !== 'web_search') {\n        structuredData = {\n          tool_name: call.function.name,\n          data: JSON.parse(call.function.arguments)\n        };\n        break;\n      }\n    }\n\n    return [{\n      json: {\n        normalized: true,\n        provider: prevData.provider,\n        query: prevData.query,\n        content: textContent,\n        sources,\n        structured_data: structuredData,\n        search_performed: sources.length > 0,\n        has_structured_output: structuredData !== null,\n        usage\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        normalized: false,\n        provider: prevData.provider,\n        error: e.message\n      }\n    }];\n  }\n"
+        "jsCode": "// ============================================\n// NORMALIZE MISTRAL - With _trace support\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst usage = {\n  input_tokens: input.usage?.prompt_tokens || 0,\n  output_tokens: input.usage?.completion_tokens || 0,\n  total_tokens: input.usage?.total_tokens || 0\n};\n\nfunction getDomain(url) {\n  if (!url) return '';\n  const match = url.match(/^https?:\\/\\/([^\\/]+)/);\n  return match ? match[1] : '';\n}\n\ntry {\n  let textContent = '';\n  const sources = [];\n  let structuredData = null;\n\n  const message = input.choices?.[0]?.message;\n\n  // Extract text content\n  if (message?.content) {\n    textContent = message.content;\n  }\n\n  // Extract sources from citations\n  const citations = input.citations || [];\n  for (const cite of citations) {\n    sources.push({\n      title: cite.title || 'Source',\n      url: cite.url,\n      domain: getDomain(cite.url)\n    });\n  }\n\n  // Extract structured data (tool_calls)\n  const toolCalls = message?.tool_calls || [];\n  for (const call of toolCalls) {\n    if (call.type === 'function' && call.function.name !== 'web_search') {\n      structuredData = {\n        tool_name: call.function.name,\n        data: JSON.parse(call.function.arguments)\n      };\n      break;\n    }\n  }\n\n  return [{\n    json: {\n      normalized: true,\n      provider: prevData.provider,\n      query: prevData.query,\n      content: textContent,\n      sources,\n      structured_data: structuredData,\n      search_performed: sources.length > 0,\n      has_structured_output: structuredData !== null,\n      usage,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      normalized: false,\n      provider: prevData.provider,\n      error: e.message,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request,\n      startTime: startTime,\n      raw_response: input\n    }\n  }];\n}"
       },
       "id": "normalize-mistral",
       "name": "Normalize Mistral",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1568,
-        432
-      ]
+      "position": [1568, 432]
     },
     {
       "parameters": {},
@@ -400,131 +386,88 @@
       "name": "Merge Results",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [
-        1952,
-        0
-      ]
+      "position": [1952, 0]
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validate Input').first().json;\n\n  try {\n    if (!input.normalized) {\n      return [{\n        json: {\n          success: false,\n          error: {\n            code: 500,\n            message: input.error || 'Failed to normalize response',\n            status: 'NORMALIZE_ERROR'\n          },\n          meta: { provider: prevData.provider },\n          usage: input.usage || null\n        }\n      }];\n    }\n\n    // Si données structurées (tool_use), les retourner directement\n    if (input.structured_data) {\n      return [{\n        json: {\n          success: true,\n          data: input.structured_data.data,\n          sources: input.sources || [],\n          meta: {\n            provider: prevData.provider,\n            tool_used: input.structured_data.tool_name,\n            search_performed: input.search_performed,\n            sources_count: (input.sources || []).length\n          },\n          usage: input.usage || null  // ← AJOUTÉ\n        }\n      }];\n    }\n\n    // Sinon, retour classique (texte brut)\n    return [{\n      json: {\n        success: true,\n        data: {\n          query: prevData.query,\n          content: input.content,\n          sources: input.sources || []\n        },\n        meta: {\n          provider: prevData.provider,\n          search_performed: input.search_performed,\n          sources_count: (input.sources || []).length\n        },\n        usage: input.usage || null  // ← AJOUTÉ\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to format output: ' + e.message,\n          status: 'FORMAT_ERROR'\n        },\n        meta: { provider: prevData.provider },\n        usage: input.usage || null\n      }\n    }];\n  }"
+        "jsCode": "// ============================================\n// FORMAT OUTPUT - With _trace (llm_response, service_response)\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = input.startTime || prevData.startTime || Date.now();\n\nconst userId = input.user_id || prevData.user_id;\nconst guildId = input.guild_id || prevData.guild_id;\nconst userRequest = input.user_request || prevData.user_request;\nconst rawResponse = input.raw_response || null;\n\ntry {\n  if (!input.normalized) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 'NORMALIZE_ERROR',\n          message: input.error || 'Failed to normalize response',\n          http_status: 500\n        },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: {\n          llm_response: null,\n          service_response: rawResponse,\n          provider: input.provider || prevData.provider,\n          model: prevData.model,\n          tokens: input.usage || { input: 0, output: 0 },\n          latency_ms: Date.now() - startTime,\n          user_id: userId,\n          guild_id: guildId,\n          user_request: userRequest\n        }\n      }\n    }];\n  }\n\n  // Build _trace object\n  const _trace = {\n    llm_response: input.content || null,\n    service_response: rawResponse,\n    provider: input.provider || prevData.provider,\n    model: prevData.model,\n    tokens: {\n      input: input.usage?.input_tokens || 0,\n      output: input.usage?.output_tokens || 0,\n      total: input.usage?.total_tokens || 0\n    },\n    latency_ms: Date.now() - startTime,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n\n  // If structured data (tool_use), return it directly\n  if (input.structured_data) {\n    return [{\n      json: {\n        success: true,\n        data: input.structured_data.data,\n        sources: input.sources || [],\n        meta: {\n          provider: input.provider || prevData.provider,\n          model: prevData.model,\n          tool_used: input.structured_data.tool_name,\n          search_performed: input.search_performed,\n          sources_count: (input.sources || []).length\n        },\n        usage: input.usage || null,\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: _trace\n      }\n    }];\n  }\n\n  // Otherwise, return classic text response\n  return [{\n    json: {\n      success: true,\n      data: {\n        query: prevData.query,\n        content: input.content,\n        sources: input.sources || []\n      },\n      meta: {\n        provider: input.provider || prevData.provider,\n        model: prevData.model,\n        search_performed: input.search_performed,\n        sources_count: (input.sources || []).length\n      },\n      usage: input.usage || null,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 'FORMAT_ERROR',\n        message: 'Failed to format output: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: {\n        llm_response: null,\n        service_response: rawResponse,\n        provider: prevData.provider,\n        model: prevData.model,\n        tokens: input.usage || { input: 0, output: 0 },\n        latency_ms: Date.now() - startTime,\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest\n      }\n    }\n  }];\n}"
       },
       "id": "format-output",
       "name": "Format Output",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        2048,
-        256
-      ]
+      "position": [2048, 256]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        2224,
-        160
-      ]
+      "position": [2224, 160]
     },
     {
       "parameters": {
-        "content": "## Recipes - Web Search (Multi-Provider)\n\n**Endpoint:** POST /webhook/recipes-web-search\n\n**Parameters:**\n- `query` (required): Search query\n- `provider`: openai, openai-mini, claude, claude-haiku, gemini (default), gemini-pro, mistral, mistral-premium\n- `options`: { search_depth, max_results, language, allowed_domains[], blocked_domains[] }\n- API keys: `openai_api_key`, `anthropic_api_key`, `google_api_key`, `mistral_api_key`\n\n**Notes:**\n- `allowed_domains` only works with Claude\n- Mistral search is NOT guaranteed (agent decides)\n- Gemini uses Google Search, OpenAI uses Bing, Claude/Mistral use Brave",
-        "height": 260,
-        "width": 700,
-        "color": 4
-      },
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        -688,
-        -208
-      ]
-    },
-    {
-      "parameters": {
-        "jsCode": "// Loop over input items and add a new field called 'myNewField' to the JSON of each one\nfor (const item of $input.all()) {\n  item.json.myNewField = 1;\n}\n\nreturn $input.all();"
+        "jsCode": "// ============================================\n// PREPARE CLAUDE BODY - With user_request injection\n// ============================================\n\nconst data = $input.first().json;\n\nconst tools = [\n  {\n    type: \"web_search_20250305\",\n    name: \"web_search\",\n    max_uses: data.options.max_results || 5\n  }\n];\n\n// If output schema provided, add it as tool\nif (data.output_schema) {\n  tools.push({\n    name: data.output_schema.name || \"structured_output\",\n    description: data.output_schema.description || \"Return structured data\",\n    input_schema: data.output_schema.input_schema\n  });\n}\n\n// Use messages if provided, otherwise create from query\nlet messages = data.messages || [{ role: \"user\", content: data.query }];\n\n// Inject user_request into the prompt if available\nif (data.user_request && !data.messages) {\n  const enhancedQuery = `User context: ${data.user_request}\\n\\nQuery: ${data.query}`;\n  messages = [{ role: \"user\", content: enhancedQuery }];\n}\n\n// Build prompt\nlet prompt = data.query;\n\n// If schema provided, ask Claude to use the tool\nif (data.output_schema) {\n  prompt += `\\n\\nIMPORTANT: Tu DOIS utiliser le tool \"${data.output_schema.name || 'structured_output'}\" pour retourner ta reponse de maniere structuree.`;\n}\n\nconst body = {\n  model: data.model,\n  max_tokens: 8192,\n  tools: tools,\n  messages: messages\n};\n\nreturn [{\n  json: {\n    ...data,\n    claude_body: JSON.stringify(body)\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1872,
-        400
-      ],
-      "id": "198c94b6-bd33-4949-9e19-c637ae672b15",
-      "name": "Code in JavaScript"
-    },
-    {
-      "parameters": {
-        "jsCode": " const data = $input.first().json;\n\n  const tools = [\n    {\n      type: \"web_search_20250305\",\n      name: \"web_search\",\n      max_uses: data.options.max_results || 5\n    }\n  ];\n\n  // Si un schéma de sortie est fourni, l'ajouter comme tool\n  if (data.output_schema) {\n    tools.push({\n      name: data.output_schema.name || \"structured_output\",\n      description: data.output_schema.description || \"Return structured data\",\n      input_schema: data.output_schema.input_schema\n    });\n  }\n\n  // NOUVEAU: Utiliser messages si fourni, sinon créer à partir de query\n  const messages = data.messages || [{ role: \"user\", content: data.query }];\n\n  // Construire le prompt\n  let prompt = data.query;\n\n  // Si schéma fourni, demander à Claude d'utiliser le tool\n  if (data.output_schema) {\n    prompt += `\\n\\nIMPORTANT: Tu DOIS utiliser le tool \"${data.output_schema.name || 'structured_output'}\" pour retourner ta\n   réponse de manière structurée.`;\n  }\n\n  const body = {\n    model: data.model,\n    max_tokens: 8192,\n    tools: tools,\n    messages: messages\n  };\n\n  return [{\n    json: {\n      ...data,\n      claude_body: JSON.stringify(body)\n    }\n  }];"
-      },
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        1056,
-        64
-      ],
-      "id": "1feb5b22-ce75-4431-bd49-4b951e884a0f",
+      "position": [1056, 64],
+      "id": "prepare-claude-body",
       "name": "Prepare Claude Body"
     },
     {
       "parameters": {
-        "jsCode": " const data = $input.first().json;\n\n  const tools = [];\n\n  // Si un schéma de sortie est fourni\n  if (data.output_schema) {\n    tools.push({\n      type: \"function\",\n      function: {\n        name: data.output_schema.name || \"structured_output\",\n        description: data.output_schema.description || \"Return structured data\",\n        parameters: data.output_schema.input_schema\n      }\n    });\n  }\n const messages = data.messages || [{ role: \"user\", content: data.query }];\n  const body = {\n    model: data.model,\n    max_tokens: 8192,\n    messages: messages,\n    web_search_options: {\n      search_context_size: data.options.search_depth === 'deep' ? 'high' : 'medium'\n    }\n  };\n\n  // Ajouter tools seulement si présent\n  if (tools.length > 0) {\n    body.tools = tools;\n    body.tool_choice = { type: \"function\", function: { name: data.output_schema.name } };\n  }\n\n  return [{\n    json: {\n      ...data,\n      openai_body: JSON.stringify(body)\n    }\n  }];"
+        "jsCode": "// ============================================\n// PREPARE OPENAI BODY - With user_request injection\n// ============================================\n\nconst data = $input.first().json;\n\nconst tools = [];\n\n// If output schema provided\nif (data.output_schema) {\n  tools.push({\n    type: \"function\",\n    function: {\n      name: data.output_schema.name || \"structured_output\",\n      description: data.output_schema.description || \"Return structured data\",\n      parameters: data.output_schema.input_schema\n    }\n  });\n}\n\n// Use messages if provided, otherwise create from query\nlet messages = data.messages || [{ role: \"user\", content: data.query }];\n\n// Inject user_request into the prompt if available\nif (data.user_request && !data.messages) {\n  const enhancedQuery = `User context: ${data.user_request}\\n\\nQuery: ${data.query}`;\n  messages = [{ role: \"user\", content: enhancedQuery }];\n}\n\nconst body = {\n  model: data.model,\n  max_tokens: 8192,\n  messages: messages,\n  web_search_options: {\n    search_context_size: data.options.search_depth === 'deep' ? 'high' : 'medium'\n  }\n};\n\n// Add tools only if present\nif (tools.length > 0) {\n  body.tools = tools;\n  body.tool_choice = { type: \"function\", function: { name: data.output_schema.name } };\n}\n\nreturn [{\n  json: {\n    ...data,\n    openai_body: JSON.stringify(body)\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1056,
-        -112
-      ],
-      "id": "723c29e7-d011-4cc2-9634-76236a56b8f4",
+      "position": [1056, -112],
+      "id": "prepare-openai-body",
       "name": "Prepare OpenAI Body"
     },
     {
       "parameters": {
-        "jsCode": "const data = $input.first().json;\n\n  const tools = [\n    { google_search: {} }  // Grounding avec Google Search\n  ];\n\n  // Si un schéma de sortie est fourni\n  if (data.output_schema) {\n    tools.push({\n      function_declarations: [{\n        name: data.output_schema.name || \"structured_output\",\n        description: data.output_schema.description || \"Return structured data\",\n        parameters: data.output_schema.input_schema\n      }]\n    });\n  }\n\n  // NOUVEAU: Convertir messages au format Gemini (contents)\n  let contents;\n  if (data.messages && data.messages.length > 0) {\n    contents = data.messages.map(m => ({\n      role: m.role === 'assistant' ? 'model' : 'user',\n      parts: [{ text: m.content }]\n    }));\n  } else {\n    contents = [{\n      role: \"user\",\n      parts: [{ text: data.query }]\n    }];\n  }\n\n  const body = {\n    contents: contents,\n    tools: tools,\n    generationConfig: {\n      maxOutputTokens: 8192\n    }\n  };\n\n  // Forcer l'utilisation du tool si schéma fourni\n  if (data.output_schema) {\n    body.tool_config = {\n      function_calling_config: {\n        mode: \"ANY\",\n        allowed_function_names: [data.output_schema.name]\n      }\n    };\n  }\n\n  return [{\n    json: {\n      ...data,\n      gemini_body: JSON.stringify(body)\n    }\n  }];"
+        "jsCode": "// ============================================\n// PREPARE GEMINI BODY - With user_request injection\n// ============================================\n\nconst data = $input.first().json;\n\nconst tools = [\n  { google_search: {} }  // Grounding with Google Search\n];\n\n// If output schema provided\nif (data.output_schema) {\n  tools.push({\n    function_declarations: [{\n      name: data.output_schema.name || \"structured_output\",\n      description: data.output_schema.description || \"Return structured data\",\n      parameters: data.output_schema.input_schema\n    }]\n  });\n}\n\n// Convert messages to Gemini format (contents)\nlet contents;\nif (data.messages && data.messages.length > 0) {\n  contents = data.messages.map(m => ({\n    role: m.role === 'assistant' ? 'model' : 'user',\n    parts: [{ text: m.content }]\n  }));\n} else {\n  // Inject user_request into query if available\n  let queryText = data.query;\n  if (data.user_request) {\n    queryText = `User context: ${data.user_request}\\n\\nQuery: ${data.query}`;\n  }\n  contents = [{\n    role: \"user\",\n    parts: [{ text: queryText }]\n  }];\n}\n\nconst body = {\n  contents: contents,\n  tools: tools,\n  generationConfig: {\n    maxOutputTokens: 8192\n  }\n};\n\n// Force tool usage if schema provided\nif (data.output_schema) {\n  body.tool_config = {\n    function_calling_config: {\n      mode: \"ANY\",\n      allowed_function_names: [data.output_schema.name]\n    }\n  };\n}\n\nreturn [{\n  json: {\n    ...data,\n    gemini_body: JSON.stringify(body)\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1072,
-        240
-      ],
-      "id": "b5f0eae4-b027-46ed-9686-f5bf8c11c737",
+      "position": [1072, 240],
+      "id": "prepare-gemini-body",
       "name": "Prepare Gemini Body"
     },
     {
       "parameters": {
-        "jsCode": "  const data = $input.first().json;\n\n  const tools = [\n    { type: \"web_search\" }  // Web search natif Mistral\n  ];\n\n  // Si un schéma de sortie est fourni\n  if (data.output_schema) {\n    tools.push({\n      type: \"function\",\n      function: {\n        name: data.output_schema.name || \"structured_output\",\n        description: data.output_schema.description || \"Return structured data\",\n        parameters: data.output_schema.input_schema\n      }\n    });\n  }\n\n  // NOUVEAU: Utiliser messages si fourni, sinon créer à partir de query\n  const messages = data.messages || [{ role: \"user\", content: data.query }];\n\n\n  const body = {\n    model: data.model,\n    max_tokens: 8192,\n    messages: messages,\n    tools: tools\n  };\n\n  // Forcer l'utilisation du tool si schéma fourni\n  if (data.output_schema) {\n    body.tool_choice = \"any\";\n  }\n\n  return [{\n    json: {\n      ...data,\n      mistral_body: JSON.stringify(body)\n    }\n  }];"
+        "jsCode": "// ============================================\n// PREPARE MISTRAL BODY - With user_request injection\n// ============================================\n\nconst data = $input.first().json;\n\nconst tools = [\n  { type: \"web_search\" }  // Native Mistral web search\n];\n\n// If output schema provided\nif (data.output_schema) {\n  tools.push({\n    type: \"function\",\n    function: {\n      name: data.output_schema.name || \"structured_output\",\n      description: data.output_schema.description || \"Return structured data\",\n      parameters: data.output_schema.input_schema\n    }\n  });\n}\n\n// Use messages if provided, otherwise create from query\nlet messages = data.messages || [{ role: \"user\", content: data.query }];\n\n// Inject user_request into the prompt if available\nif (data.user_request && !data.messages) {\n  const enhancedQuery = `User context: ${data.user_request}\\n\\nQuery: ${data.query}`;\n  messages = [{ role: \"user\", content: enhancedQuery }];\n}\n\nconst body = {\n  model: data.model,\n  max_tokens: 8192,\n  messages: messages,\n  tools: tools\n};\n\n// Force tool usage if schema provided\nif (data.output_schema) {\n  body.tool_choice = \"any\";\n}\n\nreturn [{\n  json: {\n    ...data,\n    mistral_body: JSON.stringify(body)\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1072,
-        448
-      ],
-      "id": "829e4388-597e-40b2-b16c-dd55a3c09841",
+      "position": [1072, 448],
+      "id": "prepare-mistral-body",
       "name": "Prepare Mistral Body"
     },
     {
       "parameters": {
-        "jsCode": "  const data = $input.first().json;\n\n  // Si pas de contexte à vérifier, passer directement\n  if (!data.allowed_context) {\n    return [{\n      json: {\n        ...data,\n        context_check: {\n          required: false,\n          valid: true\n        }\n      }\n    }];\n  }\n\n  const ctx = data.allowed_context;\n\n  // Construire le prompt de vérification (générique)\n  const checkPrompt = `Tu es un modérateur de contenu. Vérifie si une requête correspond au contexte autorisé.\n\n  CONTEXTE AUTORISÉ:\n  ${ctx.description}\n\n  REQUÊTE:\n  \"${data.query}\"\n\n  RÈGLES:\n  - Réponds UNIQUEMENT par un JSON valide\n  - {\"valid\": true} si la requête est dans le contexte\n  - {\"valid\": false, \"reason\": \"explication courte\"} si hors contexte\n  - Sois strict mais juste\n\n  JSON:`;\n\n  const llmBody = {\n    model: \"claude-3-5-haiku-latest\",\n    max_tokens: 100,\n    messages: [{\n      role: \"user\",\n      content: checkPrompt\n    }]\n  };\n\n  return [{\n    json: {\n      ...data,\n      context_check: {\n        required: true,\n        prompt: checkPrompt,\n        llm_body: JSON.stringify(llmBody)\n      }\n    }\n  }];"
+        "jsCode": "// ============================================\n// CHECK CONTEXT - Prepare context validation\n// ============================================\n\nconst data = $input.first().json;\n\n// If no context to check, pass through\nif (!data.allowed_context) {\n  return [{\n    json: {\n      ...data,\n      context_check: {\n        required: false,\n        valid: true\n      }\n    }\n  }];\n}\n\nconst ctx = data.allowed_context;\n\n// Build verification prompt (generic)\nconst checkPrompt = `Tu es un moderateur de contenu. Verifie si une requete correspond au contexte autorise.\n\nCONTEXTE AUTORISE:\n${ctx.description}\n\nREQUETE:\n\"${data.query}\"\n\nREGLES:\n- Reponds UNIQUEMENT par un JSON valide\n- {\"valid\": true} si la requete est dans le contexte\n- {\"valid\": false, \"reason\": \"explication courte\"} si hors contexte\n- Sois strict mais juste\n\nJSON:`;\n\nconst llmBody = {\n  model: \"claude-3-5-haiku-latest\",\n  max_tokens: 100,\n  messages: [{\n    role: \"user\",\n    content: checkPrompt\n  }]\n};\n\nreturn [{\n  json: {\n    ...data,\n    context_check: {\n      required: true,\n      prompt: checkPrompt,\n      llm_body: JSON.stringify(llmBody)\n    }\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        -112,
-        240
-      ],
-      "id": "a60a7e62-1e2e-485d-b77e-464561ecf4a9",
+      "position": [-112, 240],
+      "id": "check-context",
       "name": "Check Context"
     },
     {
@@ -564,11 +507,8 @@
       },
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        112,
-        -16
-      ],
-      "id": "64b84c31-27c4-4fdd-86fa-e79246ab15d7",
+      "position": [112, -16],
+      "id": "switch-context-required",
       "name": "Switch Context Required"
     },
     {
@@ -601,25 +541,19 @@
       },
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.3,
-      "position": [
-        320,
-        -96
-      ],
-      "id": "dedfbea0-9439-4fe6-95d5-ac47a043cf4b",
+      "position": [320, -96],
+      "id": "llm-context-check",
       "name": "LLM Context Check",
       "alwaysOutputData": true
     },
     {
       "parameters": {
-        "jsCode": "  const prevData = $('Check Context').first().json;\n  const llmResponse = $input.first().json;\n\n  // Vérifier si erreur LLM ou réponse vide\n  if (!llmResponse || llmResponse.error || !llmResponse.content) {\n    // Si erreur LLM, laisser passer (fail open)\n    return [{\n      json: {\n        ...prevData,\n        context_check: {\n          ...prevData.context_check,\n          valid: true,\n          error: llmResponse?.error?.message || 'LLM check failed, allowing request'\n        }\n      }\n    }];\n  }\n\n  try {\n    // Extraire le texte de la réponse Claude\n    const responseText = llmResponse.content?.[0]?.text || '';\n\n    // Parser le JSON de la réponse\n    const jsonMatch = responseText.match(/\\{[\\s\\S]*\\}/);\n\n    if (!jsonMatch) {\n      // Si pas de JSON valide, considérer comme valide par défaut\n      return [{\n        json: {\n          ...prevData,\n          context_check: {\n            ...prevData.context_check,\n            valid: true,\n            raw_response: responseText\n          }\n        }\n      }];\n    }\n\n    const parsed = JSON.parse(jsonMatch[0]);\n\n    return [{\n      json: {\n        ...prevData,\n        context_check: {\n          ...prevData.context_check,\n          valid: parsed.valid === true,\n          reason: parsed.reason || null,\n          raw_response: responseText\n        }\n      }\n    }];\n\n  } catch (e) {\n    // En cas d'erreur de parsing, laisser passer (fail open)\n    return [{\n      json: {\n        ...prevData,\n        context_check: {\n          ...prevData.context_check,\n          valid: true,\n          error: e.message\n        }\n      }\n    }];\n  }\n"
+        "jsCode": "// ============================================\n// PARSE CONTEXT RESPONSE\n// ============================================\n\nconst prevData = $('Check Context').first().json;\nconst llmResponse = $input.first().json;\n\n// Check for LLM error or empty response\nif (!llmResponse || llmResponse.error || !llmResponse.content) {\n  // If LLM error, allow request (fail open)\n  return [{\n    json: {\n      ...prevData,\n      context_check: {\n        ...prevData.context_check,\n        valid: true,\n        error: llmResponse?.error?.message || 'LLM check failed, allowing request'\n      }\n    }\n  }];\n}\n\ntry {\n  // Extract text from Claude response\n  const responseText = llmResponse.content?.[0]?.text || '';\n\n  // Parse JSON from response\n  const jsonMatch = responseText.match(/\\{[\\s\\S]*\\}/);\n\n  if (!jsonMatch) {\n    // If no valid JSON, consider valid by default\n    return [{\n      json: {\n        ...prevData,\n        context_check: {\n          ...prevData.context_check,\n          valid: true,\n          raw_response: responseText\n        }\n      }\n    }];\n  }\n\n  const parsed = JSON.parse(jsonMatch[0]);\n\n  return [{\n    json: {\n      ...prevData,\n      context_check: {\n        ...prevData.context_check,\n        valid: parsed.valid === true,\n        reason: parsed.reason || null,\n        raw_response: responseText\n      }\n    }\n  }];\n\n} catch (e) {\n  // On parsing error, allow request (fail open)\n  return [{\n    json: {\n      ...prevData,\n      context_check: {\n        ...prevData.context_check,\n        valid: true,\n        error: e.message\n      }\n    }\n  }];\n}"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        384,
-        176
-      ],
-      "id": "b49dc5af-6ee9-4c13-a73a-edeb43942655",
+      "position": [384, 176],
+      "id": "parse-context-response",
       "name": "Parse Context Response"
     },
     {
@@ -649,25 +583,41 @@
       },
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        528,
-        96
-      ],
-      "id": "374fc13d-285d-44bf-af69-fbe534fe550b",
+      "position": [528, 96],
+      "id": "switch-context-valid",
       "name": "Switch Context Valid"
     },
     {
       "parameters": {
-        "jsCode": "  const data = $input.first().json;\n  const ctx = data.allowed_context;\n\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 403,\n        message: data.context_check.reason || `Cette requête ne correspond pas au contexte autorisé`,\n        status: \"CONTEXT_VIOLATION\",\n        details: {\n          query: data.query,\n          allowed_context: ctx.description,\n          suggestion: ctx.suggestion || `Ce bot est dédié à: ${ctx.description}`\n        }\n      },\n      meta: {\n        provider: data.provider,\n        context_check: {\n          passed: false,\n          reason: data.context_check.reason\n        }\n      }\n    }\n  }];"
+        "jsCode": "// ============================================\n// CONTEXT ERROR RESPONSE - With _trace\n// ============================================\n\nconst data = $input.first().json;\nconst ctx = data.allowed_context;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 'CONTEXT_VIOLATION',\n      message: data.context_check.reason || 'Cette requete ne correspond pas au contexte autorise',\n      http_status: 403,\n      details: {\n        query: data.query,\n        allowed_context: ctx.description,\n        suggestion: ctx.suggestion || `Ce bot est dedie a: ${ctx.description}`\n      }\n    },\n    user_id: data.user_id,\n    guild_id: data.guild_id,\n    user_request: data.user_request,\n    _trace: {\n      llm_response: null,\n      service_response: { context_check: data.context_check },\n      provider: data.provider,\n      model: data.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - (data.startTime || Date.now()),\n      user_id: data.user_id,\n      guild_id: data.guild_id,\n      user_request: data.user_request\n    }\n  }\n}];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        624,
-        352
-      ],
-      "id": "004252e5-4087-4967-b168-75d2f43278bb",
+      "position": [624, 352],
+      "id": "context-error-response",
       "name": "Context Error Response"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 403,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-context-error",
+      "name": "Respond Context Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [864, 352]
     }
   ],
   "connections": {
@@ -704,7 +654,18 @@
         ],
         [
           {
-            "node": "Error: Validation",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -805,11 +766,6 @@
             "node": "Merge Results",
             "type": "main",
             "index": 1
-          },
-          {
-            "node": "Code in JavaScript",
-            "type": "main",
-            "index": 0
           }
         ]
       ]
@@ -975,7 +931,7 @@
       "main": [
         [
           {
-            "node": "Respond",
+            "node": "Respond Context Error",
             "type": "main",
             "index": 0
           }
@@ -986,32 +942,6 @@
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "91200d8b-58b3-47dc-8a8e-2e5be95e049d",
-  "activeVersionId": "91200d8b-58b3-47dc-8a8e-2e5be95e049d",
-  "versionCounter": 138,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-07T11:15:31.629Z",
-      "createdAt": "2026-01-07T11:15:31.629Z",
-      "role": "workflow:owner",
-      "workflowId": "Zq5SGUcoFvXndkLO",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "availableInMCP": true
+  }
 }

--- a/workflows/MCP_-_Analyze_Message.json
+++ b/workflows/MCP_-_Analyze_Message.json
@@ -9,6 +9,22 @@
   "nodes": [
     {
       "parameters": {
+        "content": "## MCP - Analyze Message\n\n**Endpoint:** POST /webhook/analyze-message\n\n**Description:** Analyse complète d'un message (sentiment, intentions, entités, priorité, langue)\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"text\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (crédits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requête utilisateur originale (contextualise l'analyse)\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte/message à analyser\" },\n    \"options\": { \"type\": \"object\", \"description\": \"Options d'analyse (sentiment, intent, entities, priority, language)\", \"default\": {\"sentiment\": true, \"intent\": true, \"entities\": true, \"priority\": true, \"language\": true} }\n  }\n}\n```\n\n**Note:** API keys (google_api_key, openai_api_key) fournies par le système.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"sentiment\", \"intents\", \"entities\", \"priority\", \"language\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 580,
+        "width": 340,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -100,
+        -80
+      ]
+    },
+    {
+      "parameters": {
         "httpMethod": "POST",
         "path": "analyze-message",
         "responseMode": "responseNode",
@@ -26,30 +42,11 @@
     },
     {
       "parameters": {
-        "conditions": {
-          "options": {
-            "caseSensitive": true,
-            "leftValue": "",
-            "typeValidation": "strict"
-          },
-          "conditions": [
-            {
-              "id": "condition-text",
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
-              "operator": {
-                "type": "string",
-                "operation": "exists"
-              }
-            }
-          ],
-          "combinator": "and"
-        },
-        "options": {}
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Analyze Message\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\nconst text = body.text || ctx.text;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\nif (!text) {\n  errors.push('text requis');\n}\n\n// --- API Keys passed from MCP Server ---\nconst googleApiKey = body.google_api_key || ctx.google_api_key || body.plugin_context?.api_keys?.google || '';\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\n\n// --- Options (all optional with defaults) ---\nconst options = body.options || ctx.options || {\n  sentiment: true,\n  intent: true,\n  entities: true,\n  priority: true,\n  language: true\n};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  options: options,\n  googleApiKey: googleApiKey,\n  openaiApiKey: openaiApiKey,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
         460,
@@ -58,32 +55,72 @@
     },
     {
       "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: 'Missing required field: text' } }) }}",
-        "options": {
-          "responseCode": 400
-        }
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
       },
-      "id": "error-invalid-input",
-      "name": "Error Invalid Input",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1.1,
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
       "position": [
         680,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        900,
         480
       ]
     },
     {
       "parameters": {
-        "jsCode": "// Prepare data for parallel processing\nconst body = $input.first().json.body;\nconst text = body.text;\nconst options = body.options || {\n  sentiment: true,\n  intent: true,\n  entities: true,\n  priority: true,\n  language: true\n};\n\n// API Keys passed from MCP Server\nconst googleApiKey = body.google_api_key || '';\nconst openaiApiKey = body.openai_api_key || '';\n\nreturn {\n  json: {\n    text: text,\n    options: options,\n    googleApiKey: googleApiKey,\n    openaiApiKey: openaiApiKey,\n    startTime: Date.now()\n  }\n};"
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       },
-      "id": "prepare-data",
-      "name": "Prepare Data",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
       "position": [
-        680,
-        300
+        1120,
+        480
       ]
     },
     {
@@ -150,7 +187,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un analyseur d'intentions pour un assistant IA. Analyse le message utilisateur.\\n\\n## Format de réponse OBLIGATOIRE\\n\\nRetourne EXACTEMENT ce JSON (respecte les clés):\\n\\n{\\n  \\\"intents\\\": [\\n    {\\n      \\\"type\\\": \\\"action_request|information_request|analysis_request|clarification|greeting|other\\\",\\n      \\\"action\\\": \\\"nom_action_snake_case\\\",\\n      \\\"target\\\": \\\"cible ou null\\\",\\n      \\\"confidence\\\": 0.0-1.0,\\n      \\\"reasoning\\\": \\\"explication courte\\\"\\n    }\\n  ],\\n  \\\"priority\\\": {\\n    \\\"level\\\": \\\"critical|high|medium|low\\\",\\n    \\\"score\\\": 0.0-1.0,\\n    \\\"indicators\\\": [],\\n    \\\"requires_confirmation\\\": false\\n  },\\n  \\\"language\\\": {\\n    \\\"code\\\": \\\"fr\\\",\\n    \\\"confidence\\\": 0.0-1.0\\n  }\\n}\\n\\n## Règles de confidence\\n\\n- 0.95+ : Intent explicite (\\\"Traduis ce texte en anglais\\\")\\n- 0.80-0.94 : Intent clair, détails manquants (\\\"Traduis ce document\\\")\\n- 0.60-0.79 : Intent ambigu (\\\"Aide-moi avec ce fichier\\\")\\n- 0.40-0.59 : Plusieurs intents possibles\\n- 0.20-0.39 : Intent très flou\\n- <0.20 : Impossible à déterminer\\n\\n## Exemple\\n\\nMessage: \\\"Traduis ce texte en anglais\\\"\\nRéponse:\\n{\\n  \\\"intents\\\": [{\\\"type\\\": \\\"action_request\\\", \\\"action\\\": \\\"translate_text\\\", \\\"target\\\": \\\"anglais\\\", \\\"confidence\\\": 0.95, \\\"reasoning\\\": \\\"Intent explicite avec langue cible\\\"}],\\n  \\\"priority\\\": {\\\"level\\\": \\\"medium\\\", \\\"score\\\": 0.5, \\\"indicators\\\": [], \\\"requires_confirmation\\\": false},\\n  \\\"language\\\": {\\\"code\\\": \\\"fr\\\", \\\"confidence\\\": 0.98}\\n}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"{{ $json.text }}\"\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 1000\n}",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un analyseur d'intentions pour un assistant IA. Analyse le message en tenant compte de la demande utilisateur.\\n\\n## Format de réponse OBLIGATOIRE\\n\\nRetourne EXACTEMENT ce JSON (respecte les clés):\\n\\n{\\n  \\\"intents\\\": [\\n    {\\n      \\\"type\\\": \\\"action_request|information_request|analysis_request|clarification|greeting|other\\\",\\n      \\\"action\\\": \\\"nom_action_snake_case\\\",\\n      \\\"target\\\": \\\"cible ou null\\\",\\n      \\\"confidence\\\": 0.0-1.0,\\n      \\\"reasoning\\\": \\\"explication courte\\\"\\n    }\\n  ],\\n  \\\"priority\\\": {\\n    \\\"level\\\": \\\"critical|high|medium|low\\\",\\n    \\\"score\\\": 0.0-1.0,\\n    \\\"indicators\\\": [],\\n    \\\"requires_confirmation\\\": false\\n  },\\n  \\\"language\\\": {\\n    \\\"code\\\": \\\"fr\\\",\\n    \\\"confidence\\\": 0.0-1.0\\n  }\\n}\\n\\n## Règles de confidence\\n\\n- 0.95+ : Intent explicite (\\\"Traduis ce texte en anglais\\\")\\n- 0.80-0.94 : Intent clair, détails manquants (\\\"Traduis ce document\\\")\\n- 0.60-0.79 : Intent ambigu (\\\"Aide-moi avec ce fichier\\\")\\n- 0.40-0.59 : Plusieurs intents possibles\\n- 0.20-0.39 : Intent très flou\\n- <0.20 : Impossible à déterminer\\n\\n## Exemple\\n\\nMessage: \\\"Traduis ce texte en anglais\\\"\\nRéponse:\\n{\\n  \\\"intents\\\": [{\\\"type\\\": \\\"action_request\\\", \\\"action\\\": \\\"translate_text\\\", \\\"target\\\": \\\"anglais\\\", \\\"confidence\\\": 0.95, \\\"reasoning\\\": \\\"Intent explicite avec langue cible\\\"}],\\n  \\\"priority\\\": {\\\"level\\\": \\\"medium\\\", \\\"score\\\": 0.5, \\\"indicators\\\": [], \\\"requires_confirmation\\\": false},\\n  \\\"language\\\": {\\\"code\\\": \\\"fr\\\", \\\"confidence\\\": 0.98}\\n}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"**Demande utilisateur:** {{ $json.user_request }}\\n\\n**Message à analyser:**\\n{{ $json.text }}\"\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 1000\n}",
         "options": {
           "timeout": 15000
         }
@@ -220,7 +257,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Merge all tagged results\nconst items = $input.all();\nconst prepareData = $('Prepare Data').first().json;\nconst text = prepareData.text;\nconst options = prepareData.options;\nconst startTime = prepareData.startTime;\n\n// Default values\nconst DEFAULT_PRIORITY = { level: 'medium', score: 0.5, indicators: [], requires_confirmation: false };\nconst DEFAULT_LANGUAGE = { code: 'unknown', confidence: 0 };\n\n// Find results by source tag\nlet sentimentData = null;\nlet entitiesData = null;\nlet openaiData = null;\n\nfor (const item of items) {\n  const source = item.json.source;\n  const data = item.json.data;\n  \n  if (source === 'sentiment') {\n    sentimentData = data;\n  } else if (source === 'entities') {\n    entitiesData = data;\n  } else if (source === 'openai') {\n    openaiData = data;\n  }\n}\n\n// Process sentiment\nlet sentimentResult = null;\ntry {\n  if (sentimentData && sentimentData.documentSentiment) {\n    const ds = sentimentData.documentSentiment;\n    sentimentResult = {\n      label: ds.score > 0.2 ? 'positive' : ds.score < -0.2 ? 'negative' : 'neutral',\n      score: ds.score,\n      magnitude: ds.magnitude,\n      confidence: Math.min(1, Math.abs(ds.score) + ds.magnitude / 2)\n    };\n  } else if (sentimentData && sentimentData.error) {\n    sentimentResult = { label: 'neutral', score: 0, magnitude: 0, confidence: 0, error: sentimentData.error.message || 'Google API error' };\n  } else {\n    sentimentResult = { label: 'neutral', score: 0, magnitude: 0, confidence: 0, error: 'No sentiment data' };\n  }\n} catch (e) {\n  sentimentResult = { label: 'neutral', score: 0, magnitude: 0, confidence: 0, error: 'Sentiment processing failed: ' + e.message };\n}\n\n// Process entities\nlet entitiesResult = [];\ntry {\n  if (entitiesData && entitiesData.entities) {\n    entitiesResult = entitiesData.entities.map(e => ({\n      type: e.type,\n      value: e.name,\n      salience: e.salience,\n      metadata: e.metadata || {}\n    }));\n  } else if (entitiesData && entitiesData.error) {\n    entitiesResult = [];\n  }\n} catch (e) {\n  entitiesResult = [];\n}\n\n// Process OpenAI (intents, priority, language)\nlet intentsResult = [];\nlet priorityResult = { ...DEFAULT_PRIORITY };\nlet languageResult = { ...DEFAULT_LANGUAGE };\n\ntry {\n  if (openaiData && openaiData.choices && openaiData.choices[0]) {\n    const content = openaiData.choices[0].message.content;\n    const parsed = JSON.parse(content);\n    \n    // Handle intents array - ensure it's always an array\n    if (Array.isArray(parsed.intents) && parsed.intents.length > 0) {\n      intentsResult = parsed.intents;\n    } else if (parsed.intent) {\n      // Handle single intent format\n      intentsResult = [parsed.intent];\n    } else {\n      intentsResult = [{ type: 'unknown', action: 'unknown', target: null, confidence: 0.1, reasoning: 'No intent detected' }];\n    }\n    \n    // Handle priority - always provide defaults\n    if (parsed.priority && typeof parsed.priority === 'object') {\n      priorityResult = {\n        level: parsed.priority.level || 'medium',\n        score: typeof parsed.priority.score === 'number' ? parsed.priority.score : 0.5,\n        indicators: Array.isArray(parsed.priority.indicators) ? parsed.priority.indicators : [],\n        requires_confirmation: parsed.priority.requires_confirmation === true\n      };\n    }\n    \n    // Handle language - always provide defaults\n    if (parsed.language && typeof parsed.language === 'object') {\n      languageResult = {\n        code: parsed.language.code || 'unknown',\n        confidence: typeof parsed.language.confidence === 'number' ? parsed.language.confidence : 0\n      };\n    }\n  } else if (openaiData && openaiData.error) {\n    intentsResult = [{ type: 'error', action: 'unknown', target: null, confidence: 0, reasoning: 'OpenAI API error: ' + (openaiData.error.message || 'Unknown') }];\n  } else {\n    intentsResult = [{ type: 'error', action: 'unknown', target: null, confidence: 0, reasoning: 'No OpenAI response received' }];\n  }\n} catch (e) {\n  intentsResult = [{ type: 'error', action: 'unknown', target: null, confidence: 0, reasoning: 'OpenAI parsing failed: ' + e.message }];\n}\n\n// Build final response - always include all fields\nconst response = {\n  success: true,\n  text: text,\n  analysis: {\n    sentiment: sentimentResult,\n    intents: intentsResult,\n    entities: entitiesResult,\n    priority: priorityResult,\n    language: languageResult\n  }\n};\n\nresponse.meta = {\n  providers: {\n    sentiment: 'google-cloud-nlp',\n    entities: 'google-cloud-nlp',\n    intents: 'openai-gpt4o-mini',\n    priority: 'openai-gpt4o-mini',\n    language: 'openai-gpt4o-mini'\n  },\n  processing_time_ms: Date.now() - startTime\n};\n\nreturn { json: response };"
+        "jsCode": "// ============================================\n// MERGE RESULTS - Analyze Message\n// ============================================\n\nconst items = $input.all();\nconst prevData = $('Validate Input').first().json;\nconst text = prevData.text;\nconst options = prevData.options;\nconst startTime = prevData.startTime;\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Default values\nconst DEFAULT_PRIORITY = { level: 'medium', score: 0.5, indicators: [], requires_confirmation: false };\nconst DEFAULT_LANGUAGE = { code: 'unknown', confidence: 0 };\n\n// Find results by source tag\nlet sentimentData = null;\nlet entitiesData = null;\nlet openaiData = null;\n\nfor (const item of items) {\n  const source = item.json.source;\n  const data = item.json.data;\n  \n  if (source === 'sentiment') {\n    sentimentData = data;\n  } else if (source === 'entities') {\n    entitiesData = data;\n  } else if (source === 'openai') {\n    openaiData = data;\n  }\n}\n\n// Process sentiment\nlet sentimentResult = null;\ntry {\n  if (sentimentData && sentimentData.documentSentiment) {\n    const ds = sentimentData.documentSentiment;\n    sentimentResult = {\n      label: ds.score > 0.2 ? 'positive' : ds.score < -0.2 ? 'negative' : 'neutral',\n      score: ds.score,\n      magnitude: ds.magnitude,\n      confidence: Math.min(1, Math.abs(ds.score) + ds.magnitude / 2)\n    };\n  } else if (sentimentData && sentimentData.error) {\n    sentimentResult = { label: 'neutral', score: 0, magnitude: 0, confidence: 0, error: sentimentData.error.message || 'Google API error' };\n  } else {\n    sentimentResult = { label: 'neutral', score: 0, magnitude: 0, confidence: 0, error: 'No sentiment data' };\n  }\n} catch (e) {\n  sentimentResult = { label: 'neutral', score: 0, magnitude: 0, confidence: 0, error: 'Sentiment processing failed: ' + e.message };\n}\n\n// Process entities\nlet entitiesResult = [];\ntry {\n  if (entitiesData && entitiesData.entities) {\n    entitiesResult = entitiesData.entities.map(e => ({\n      type: e.type,\n      value: e.name,\n      salience: e.salience,\n      metadata: e.metadata || {}\n    }));\n  } else if (entitiesData && entitiesData.error) {\n    entitiesResult = [];\n  }\n} catch (e) {\n  entitiesResult = [];\n}\n\n// Process OpenAI (intents, priority, language)\nlet intentsResult = [];\nlet priorityResult = { ...DEFAULT_PRIORITY };\nlet languageResult = { ...DEFAULT_LANGUAGE };\n\ntry {\n  if (openaiData && openaiData.choices && openaiData.choices[0]) {\n    const content = openaiData.choices[0].message.content;\n    const parsed = JSON.parse(content);\n    \n    // Handle intents array - ensure it's always an array\n    if (Array.isArray(parsed.intents) && parsed.intents.length > 0) {\n      intentsResult = parsed.intents;\n    } else if (parsed.intent) {\n      // Handle single intent format\n      intentsResult = [parsed.intent];\n    } else {\n      intentsResult = [{ type: 'unknown', action: 'unknown', target: null, confidence: 0.1, reasoning: 'No intent detected' }];\n    }\n    \n    // Handle priority - always provide defaults\n    if (parsed.priority && typeof parsed.priority === 'object') {\n      priorityResult = {\n        level: parsed.priority.level || 'medium',\n        score: typeof parsed.priority.score === 'number' ? parsed.priority.score : 0.5,\n        indicators: Array.isArray(parsed.priority.indicators) ? parsed.priority.indicators : [],\n        requires_confirmation: parsed.priority.requires_confirmation === true\n      };\n    }\n    \n    // Handle language - always provide defaults\n    if (parsed.language && typeof parsed.language === 'object') {\n      languageResult = {\n        code: parsed.language.code || 'unknown',\n        confidence: typeof parsed.language.confidence === 'number' ? parsed.language.confidence : 0\n      };\n    }\n  } else if (openaiData && openaiData.error) {\n    intentsResult = [{ type: 'error', action: 'unknown', target: null, confidence: 0, reasoning: 'OpenAI API error: ' + (openaiData.error.message || 'Unknown') }];\n  } else {\n    intentsResult = [{ type: 'error', action: 'unknown', target: null, confidence: 0, reasoning: 'No OpenAI response received' }];\n  }\n} catch (e) {\n  intentsResult = [{ type: 'error', action: 'unknown', target: null, confidence: 0, reasoning: 'OpenAI parsing failed: ' + e.message }];\n}\n\n// --- Build _trace for Langfuse observability ---\nconst llmResponse = openaiData?.choices?.[0]?.message?.content || null;\n\nconst _trace = {\n  llm_response: llmResponse,\n  providers: ['google', 'openai'],\n  parallel: true,\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  text: text\n};\n\n// Build final response - always include all fields\nreturn {\n  json: {\n    success: true,\n    data: {\n      text: text,\n      analysis: {\n        sentiment: sentimentResult,\n        intents: intentsResult,\n        entities: entitiesResult,\n        priority: priorityResult,\n        language: languageResult\n      }\n    },\n    meta: {\n      providers: {\n        sentiment: 'google-cloud-nlp',\n        entities: 'google-cloud-nlp',\n        intents: 'openai-gpt4o-mini',\n        priority: 'openai-gpt4o-mini',\n        language: 'openai-gpt4o-mini'\n      },\n      processing_time_ms: Date.now() - startTime\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: _trace\n  }\n};"
       },
       "id": "merge-results",
       "name": "Merge Results",
@@ -273,21 +310,14 @@
       "main": [
         [
           {
-            "node": "Prepare Data",
-            "type": "main",
-            "index": 0
-          }
-        ],
-        [
-          {
-            "node": "Error Invalid Input",
+            "node": "Valid?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Prepare Data": {
+    "Valid?": {
       "main": [
         [
           {
@@ -302,6 +332,24 @@
           },
           {
             "node": "OpenAI Intent+Priority",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }

--- a/workflows/MCP_-_Content_Analyzer.json
+++ b/workflows/MCP_-_Content_Analyzer.json
@@ -1,0 +1,246 @@
+{
+  "name": "MCP - Content Analyzer",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Content Analyzer\n\n**Endpoint:** POST /webhook/content-analyzer\n\n**Description:** Analyse le contenu image/document et retourne un plan de pipeline pour azy.mcp PipelineExecutor.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (contextualise l'analyse)\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image a analyser\" },\n    \"image_data\": { \"type\": \"string\", \"description\": \"Image en base64 (alternative a image_url)\" },\n    \"domain\": { \"type\": \"string\", \"description\": \"Domaine de l'analyse (general, recipes, etc.)\", \"default\": \"general\" },\n    \"available_tools\": { \"type\": \"array\", \"description\": \"Liste des outils disponibles pour le pipeline\", \"items\": { \"type\": \"string\" } }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": true,\n  \"output_fields\": [\"analysis\", \"pipeline\", \"confidence\"],\n  \"domain\": \"orchestration\"\n}\n```",
+        "height": 580,
+        "width": 340,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "content-analyzer",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "content-analyzer"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Content Analyzer\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Specific webhook parameters ---\nconst imageUrl = body.image_url || ctx.image_url || null;\nconst imageData = body.image_data || ctx.image_data || null;\nconst domain = body.domain || ctx.domain || 'general';\nconst availableTools = body.available_tools || ctx.available_tools || [];\n\n// Must have either image_url or image_data\nif (!imageUrl && !imageData) {\n  errors.push('image_url ou image_data (base64) requis');\n}\n\n// available_tools should be an array\nif (!Array.isArray(availableTools) || availableTools.length === 0) {\n  errors.push('available_tools (array non vide) requis');\n}\n\n// --- API Keys passed from MCP Server ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// Determine image source\nlet imageSource = 'url';\nlet imageContent = imageUrl;\nif (imageData && !imageUrl) {\n  imageSource = 'base64';\n  imageContent = imageData;\n}\n\nreturn {\n  valid: true,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  image_url: imageUrl,\n  image_data: imageData,\n  image_source: imageSource,\n  domain: domain,\n  available_tools: availableTools,\n  openaiApiKey: openaiApiKey,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const tools = data.available_tools.join(', ');\n  const domain = data.domain;\n  const userRequest = data.user_request;\n  \n  const systemPrompt = `Tu es un analyseur de contenu intelligent. Tu analyses une image et une requete utilisateur pour determiner:\n1. Le type de contenu (content_type)\n2. S'il y a du texte visible (has_text)\n3. Le type de texte si present (text_type)\n4. Les elements detectes (detected_items)\n5. La langue detectee (language)\n6. Un pipeline d'actions a executer\n\nDomaine: ${domain}\nOutils disponibles: ${tools}\n\nREGLES IMPORTANTES:\n- Reponds UNIQUEMENT en JSON valide\n- content_type: \"food_photo\" | \"handwritten_recipe\" | \"printed_recipe\" | \"document_pdf\" | \"screenshot\" | \"unknown\"\n- text_type: \"handwritten\" | \"printed\" | \"mixed\" | \"none\"\n- on_fail: \"abort\" | \"skip\" | \"fallback\"\n- Chaque step du pipeline doit utiliser un outil de la liste available_tools\n- Utilise \"$step_N.field\" pour referencer le resultat d'un step precedent\n\nFormat de reponse:\n{\n  \"analysis\": {\n    \"content_type\": \"...\",\n    \"has_text\": true/false,\n    \"text_type\": \"...\",\n    \"detected_items\": [\"item1\", \"item2\"],\n    \"language\": \"fr\" | \"en\" | null\n  },\n  \"pipeline\": [\n    { \"step\": 1, \"tool\": \"tool.name\", \"on_fail\": \"abort\", \"reason\": \"explication\" },\n    { \"step\": 2, \"tool\": \"autre.tool\", \"input\": \"$step_1.result\", \"on_fail\": \"skip\", \"reason\": \"explication\" }\n  ],\n  \"confidence\": 0.0-1.0\n}`;\n\n  const userPrompt = `**Demande utilisateur:** \"${userRequest}\"\n\nAnalyse cette image et determine le meilleur pipeline d'actions.`;\n\n  // Build messages with image\n  const imageContent = data.image_source === 'url' \n    ? { type: 'image_url', image_url: { url: data.image_url } }\n    : { type: 'image_url', image_url: { url: `data:image/jpeg;base64,${data.image_data}` } };\n\n  return JSON.stringify({\n    model: 'gpt-4o',\n    max_tokens: 1000,\n    temperature: 0.2,\n    messages: [\n      { role: 'system', content: systemPrompt },\n      { role: 'user', content: [\n        { type: 'text', text: userPrompt },\n        imageContent\n      ]}\n    ]\n  });\n})() }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "call-vision-llm",
+      "name": "Vision LLM (OpenAI)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PARSE LLM RESPONSE - Content Analyzer\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\nconst statusCode = input.statusCode || 200;\n\n// Initialize trace with llm_response format\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'openai',\n  model: 'gpt-4o',\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\n// Handle API error\nif (statusCode >= 400 || input.error) {\n  const errorMsg = input.body?.error?.message || input.error?.message || 'Vision LLM API error';\n  _trace.llm_response = `Error: ${errorMsg}`;\n  _trace.service_response = input.body || input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'LLM_ERROR',\n        message: errorMsg,\n        http_status: statusCode\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract response\nconst body = input.body || input;\nconst content = body.choices?.[0]?.message?.content || '';\nconst usage = body.usage || {};\n\n// Populate trace with LLM response\n_trace.llm_response = content;\n_trace.service_response = body;\n_trace.tokens = {\n  input: usage.prompt_tokens || 0,\n  output: usage.completion_tokens || 0\n};\n\n// Parse JSON from response\nlet parsed;\ntry {\n  // Handle markdown code blocks\n  let jsonStr = content;\n  const codeBlockMatch = content.match(/```(?:json)?\\s*([\\s\\S]*?)```/);\n  if (codeBlockMatch) {\n    jsonStr = codeBlockMatch[1].trim();\n  } else {\n    const rawMatch = content.match(/\\{[\\s\\S]*\\}/);\n    if (rawMatch) jsonStr = rawMatch[0];\n  }\n  \n  parsed = JSON.parse(jsonStr);\n} catch (e) {\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PARSE_ERROR',\n        message: 'Failed to parse LLM response: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Validate parsed response structure\nconst analysis = parsed.analysis || {};\nconst pipeline = parsed.pipeline || [];\nconst confidence = typeof parsed.confidence === 'number' ? Math.min(1, Math.max(0, parsed.confidence)) : 0.5;\n\n// Validate pipeline tools against available_tools\nconst availableTools = prevData.available_tools || [];\nconst invalidTools = pipeline.filter(step => !availableTools.includes(step.tool)).map(step => step.tool);\n\n// Normalize analysis fields\nconst normalizedAnalysis = {\n  content_type: analysis.content_type || 'unknown',\n  has_text: Boolean(analysis.has_text),\n  text_type: analysis.text_type || 'none',\n  detected_items: Array.isArray(analysis.detected_items) ? analysis.detected_items : [],\n  language: analysis.language || null\n};\n\n// Normalize pipeline\nconst normalizedPipeline = pipeline.map((step, idx) => ({\n  step: step.step || idx + 1,\n  tool: step.tool,\n  input: step.input || null,\n  on_fail: ['abort', 'skip', 'fallback'].includes(step.on_fail) ? step.on_fail : 'abort',\n  reason: step.reason || null\n}));\n\n_trace.latency_ms = Date.now() - startTime;\n\nreturn {\n  json: {\n    success: true,\n    data: {\n      analysis: normalizedAnalysis,\n      pipeline: normalizedPipeline,\n      confidence: confidence\n    },\n    meta: {\n      domain: prevData.domain,\n      available_tools: prevData.available_tools,\n      image_source: prevData.image_source,\n      invalid_tools: invalidTools.length > 0 ? invalidTools : undefined,\n      processing_time_ms: Date.now() - startTime\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: _trace\n  }\n};"
+      },
+      "id": "parse-response",
+      "name": "Parse LLM Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1180, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1420, 200]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Vision LLM (OpenAI)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Vision LLM (OpenAI)": {
+      "main": [
+        [
+          {
+            "node": "Parse LLM Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse LLM Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP_-_Cost_Calculator.json
+++ b/workflows/MCP_-_Cost_Calculator.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2025-12-18T15:17:20.000Z",
-  "createdAt": "2025-12-18T15:14:01.788Z",
-  "id": "sUkUNxu36VISWzke",
   "name": "MCP - Cost Calculator",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-cost",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "cost-calculator-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +18,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Cost Calculator\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Parametres specifiques au webhook ---\nconst model = body.model || ctx.model;\nconst inputTokens = body.input_tokens || ctx.input_tokens || 0;\nconst outputTokens = body.output_tokens || ctx.output_tokens || 0;\nconst requests = body.requests || ctx.requests || 1;\n\nif (!model) {\n  errors.push('model requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  model: model,\n  input_tokens: inputTokens,\n  output_tokens: outputTokens,\n  requests: requests,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +40,12 @@
           },
           "conditions": [
             {
-              "id": "condition-model",
-              "leftValue": "={{ $json.body.model }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +55,34 @@
       }
     },
     {
-      "id": "error-no-model",
-      "name": "Error: No Model",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'calculator',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: model\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"calculator\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,12 +91,9 @@
       "name": "Calculate Cost",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
-        "jsCode": "const body = $('Webhook').first().json.body;\n\n// LLM pricing per 1M tokens (as of 2024)\nconst PRICING = {\n  // OpenAI\n  'gpt-4o': { input: 2.50, output: 10.00 },\n  'gpt-4o-mini': { input: 0.15, output: 0.60 },\n  'gpt-4-turbo': { input: 10.00, output: 30.00 },\n  'gpt-4': { input: 30.00, output: 60.00 },\n  'gpt-3.5-turbo': { input: 0.50, output: 1.50 },\n  'o1-preview': { input: 15.00, output: 60.00 },\n  'o1-mini': { input: 3.00, output: 12.00 },\n  \n  // Anthropic\n  'claude-3-opus': { input: 15.00, output: 75.00 },\n  'claude-3-sonnet': { input: 3.00, output: 15.00 },\n  'claude-3-haiku': { input: 0.25, output: 1.25 },\n  'claude-3.5-sonnet': { input: 3.00, output: 15.00 },\n  \n  // Mistral\n  'mistral-large': { input: 2.00, output: 6.00 },\n  'mistral-medium': { input: 2.70, output: 8.10 },\n  'mistral-small': { input: 0.20, output: 0.60 },\n  'mistral-7b': { input: 0.25, output: 0.25 },\n  'mixtral-8x7b': { input: 0.70, output: 0.70 },\n  \n  // Google\n  'gemini-1.5-pro': { input: 1.25, output: 5.00 },\n  'gemini-1.5-flash': { input: 0.075, output: 0.30 },\n  'gemini-1.0-pro': { input: 0.50, output: 1.50 },\n  \n  // Embeddings\n  'text-embedding-3-small': { input: 0.02, output: 0 },\n  'text-embedding-3-large': { input: 0.13, output: 0 },\n  'text-embedding-ada-002': { input: 0.10, output: 0 }\n};\n\nconst model = body.model;\nconst inputTokens = body.input_tokens || 0;\nconst outputTokens = body.output_tokens || 0;\nconst requests = body.requests || 1;\n\nconst pricing = PRICING[model];\n\nif (!pricing) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 400,\n        message: `Unknown model: ${model}. Available: ${Object.keys(PRICING).join(', ')}`,\n        status: 'UNKNOWN_MODEL'\n      },\n      meta: { provider: 'calculator' }\n    }\n  }];\n}\n\nconst inputCost = (inputTokens / 1000000) * pricing.input;\nconst outputCost = (outputTokens / 1000000) * pricing.output;\nconst totalCost = (inputCost + outputCost) * requests;\n\nreturn [{\n  json: {\n    success: true,\n    data: {\n      model: model,\n      input_tokens: inputTokens,\n      output_tokens: outputTokens,\n      requests: requests,\n      costs: {\n        input_cost_usd: inputCost,\n        output_cost_usd: outputCost,\n        total_cost_usd: totalCost,\n        cost_per_request_usd: totalCost / requests\n      },\n      pricing: {\n        input_per_1m: pricing.input,\n        output_per_1m: pricing.output,\n        currency: 'USD'\n      }\n    },\n    meta: {\n      provider: 'calculator',\n      pricing_date: '2024-12'\n    }\n  }\n}];"
+        "jsCode": "// ============================================\n// CALCULATE COST - MCP Cost Calculator\n// ============================================\n\nconst prevData = $('Validate Input').first().json;\n\n// LLM pricing per 1M tokens (as of 2024)\nconst PRICING = {\n  // OpenAI\n  'gpt-4o': { input: 2.50, output: 10.00 },\n  'gpt-4o-mini': { input: 0.15, output: 0.60 },\n  'gpt-4-turbo': { input: 10.00, output: 30.00 },\n  'gpt-4': { input: 30.00, output: 60.00 },\n  'gpt-3.5-turbo': { input: 0.50, output: 1.50 },\n  'o1-preview': { input: 15.00, output: 60.00 },\n  'o1-mini': { input: 3.00, output: 12.00 },\n  \n  // Anthropic\n  'claude-3-opus': { input: 15.00, output: 75.00 },\n  'claude-3-sonnet': { input: 3.00, output: 15.00 },\n  'claude-3-haiku': { input: 0.25, output: 1.25 },\n  'claude-3.5-sonnet': { input: 3.00, output: 15.00 },\n  \n  // Mistral\n  'mistral-large': { input: 2.00, output: 6.00 },\n  'mistral-medium': { input: 2.70, output: 8.10 },\n  'mistral-small': { input: 0.20, output: 0.60 },\n  'mistral-7b': { input: 0.25, output: 0.25 },\n  'mixtral-8x7b': { input: 0.70, output: 0.70 },\n  \n  // Google\n  'gemini-1.5-pro': { input: 1.25, output: 5.00 },\n  'gemini-1.5-flash': { input: 0.075, output: 0.30 },\n  'gemini-1.0-pro': { input: 0.50, output: 1.50 },\n  \n  // Embeddings\n  'text-embedding-3-small': { input: 0.02, output: 0 },\n  'text-embedding-3-large': { input: 0.13, output: 0 },\n  'text-embedding-ada-002': { input: 0.10, output: 0 }\n};\n\nconst model = prevData.model;\nconst inputTokens = prevData.input_tokens;\nconst outputTokens = prevData.output_tokens;\nconst requests = prevData.requests;\n\nconst pricing = PRICING[model];\n\nif (!pricing) {\n  return {\n    success: false,\n    error: {\n      code: 'UNKNOWN_MODEL',\n      message: `Unknown model: ${model}. Available: ${Object.keys(PRICING).join(', ')}`,\n      http_status: 400\n    },\n    _trace: {\n      service_response: { error: 'unknown_model', model: model },\n      provider: 'calculator',\n      mode: 'error',\n      latency_ms: Date.now() - prevData.startTime,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  };\n}\n\nconst inputCost = (inputTokens / 1000000) * pricing.input;\nconst outputCost = (outputTokens / 1000000) * pricing.output;\nconst totalCost = (inputCost + outputCost) * requests;\n\nconst result = {\n  model: model,\n  input_tokens: inputTokens,\n  output_tokens: outputTokens,\n  requests: requests,\n  costs: {\n    input_cost_usd: inputCost,\n    output_cost_usd: outputCost,\n    total_cost_usd: totalCost,\n    cost_per_request_usd: totalCost / requests\n  },\n  pricing: {\n    input_per_1m: pricing.input,\n    output_per_1m: pricing.output,\n    currency: 'USD'\n  }\n};\n\nreturn {\n  success: true,\n  data: result,\n  meta: {\n    provider: 'calculator',\n    pricing_date: '2024-12'\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request,\n  _trace: {\n    service_response: result,\n    provider: 'calculator',\n    mode: 'success',\n    latency_ms: Date.now() - prevData.startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  }\n};"
       }
     },
     {
@@ -91,10 +101,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -103,18 +110,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 650,
-        "height": 280,
-        "content": "## MCP - Cost Calculator\n\n**Endpoint:** POST /webhook/cost-calculator\n\n**Parameters:**\n- `model` (required): LLM model name (gpt-4o, claude-3-sonnet, etc.)\n- `input_tokens` (optional): Number of input tokens (default: 0)\n- `output_tokens` (optional): Number of output tokens (default: 0)\n- `requests` (optional): Number of requests (default: 1)\n\n**Supported models:**\n- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo, o1-preview, o1-mini\n- Anthropic: claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet\n- Mistral: mistral-large, mistral-medium, mistral-small, mixtral-8x7b\n- Google: gemini-1.5-pro, gemini-1.5-flash\n- Embeddings: text-embedding-3-small/large, ada-002\n\n**Returns:** Cost breakdown in USD"
+        "width": 340,
+        "height": 580,
+        "content": "## MCP - Cost Calculator\n\n**Endpoint:** POST /webhook/cost-calculator\n\n**Description:** Calcule le cout d'utilisation des modeles LLM en USD.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"model\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Nom du modele LLM (gpt-4o, claude-3-sonnet, etc.)\" },\n    \"input_tokens\": { \"type\": \"integer\", \"description\": \"Nombre de tokens en entree (default: 0)\" },\n    \"output_tokens\": { \"type\": \"integer\", \"description\": \"Nombre de tokens en sortie (default: 0)\" },\n    \"requests\": { \"type\": \"integer\", \"description\": \"Nombre de requetes (default: 1)\" }\n  }\n}\n```\n\n**Modeles supportes:**\n- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo, o1-preview, o1-mini\n- Anthropic: claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet\n- Mistral: mistral-large, mistral-medium, mistral-small, mixtral-8x7b\n- Google: gemini-1.5-pro, gemini-1.5-flash\n- Embeddings: text-embedding-3-small/large, ada-002\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"costs\", \"pricing\"],\n  \"domain\": \"utility\"\n}\n```"
       }
     }
   ],
@@ -134,6 +138,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Calculate Cost",
             "type": "main",
             "index": 0
@@ -141,7 +156,18 @@
         ],
         [
           {
-            "node": "Error: No Model",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -162,33 +188,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "4880ee5f-fb0f-4528-9944-f14892834dfb",
-  "activeVersionId": "4880ee5f-fb0f-4528-9944-f14892834dfb",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:14:01.791Z",
-      "createdAt": "2025-12-18T15:14:01.791Z",
-      "role": "workflow:owner",
-      "workflowId": "sUkUNxu36VISWzke",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_DOCX_Extractor.json
+++ b/workflows/MCP_-_DOCX_Extractor.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2025-12-18T15:17:18.000Z",
-  "createdAt": "2025-12-18T15:14:12.289Z",
-  "id": "cqaSoP1kK5rAKNDp",
   "name": "MCP - DOCX Extractor",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-docx",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "docx-extractor-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +18,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP DOCX Extractor\n// RFC-014 extraction with optional context fields\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (extract for tracing, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required parameters specific to this webhook ---\nconst fileUrl = body.file_url || ctx.file_url;\nconst fileBase64 = body.file_base64 || ctx.file_base64;\n\nif (!fileUrl && !fileBase64) {\n  errors.push('file_url or file_base64 required');\n}\n\n// --- Optional parameters ---\nconst outputFormat = body.output_format || ctx.output_format || 'text';\nconst includeMetadata = body.include_metadata || ctx.include_metadata || false;\nconst includeImages = body.include_images || ctx.include_images || false;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || null;\nconst useVision = body.use_vision || ctx.use_vision || false;\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  file_url: fileUrl,\n  file_base64: fileBase64,\n  output_format: outputFormat,\n  include_metadata: includeMetadata,\n  include_images: includeImages,\n  openai_api_key: openaiApiKey,\n  use_vision: useVision,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +40,12 @@
           },
           "conditions": [
             {
-              "id": "condition-file",
-              "leftValue": "={{ $json.body.file_url || $json.body.file_base64 }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +55,34 @@
       }
     },
     {
-      "id": "error-no-file",
-      "name": "Error: No File",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'docx-extractor',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: file_url or file_base64\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"docx-extractor\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,13 +91,10 @@
       "name": "Download File",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
         "method": "GET",
-        "url": "={{ $json.body.file_url }}",
+        "url": "={{ $('Validate Input').first().json.file_url }}",
         "options": {
           "response": {
             "response": {
@@ -101,12 +111,9 @@
       "name": "Extract DOCX Content",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
-        "jsCode": "const webhookData = $('Webhook').first().json;\nconst body = webhookData.body;\nconst outputFormat = body.output_format || 'text';\n\n// For DOCX extraction, we'll use a simple approach\n// In production, this would use mammoth.js or similar library\n// Since n8n Code node has limited module access, we'll extract basic content\n\ntry {\n  let fileContent;\n  \n  if (body.file_base64) {\n    fileContent = body.file_base64;\n  } else {\n    // File was downloaded\n    const items = $input.all();\n    if (items[0]?.json?.error) {\n      return [{\n        json: {\n          success: false,\n          error: {\n            code: 500,\n            message: 'Failed to download file: ' + (items[0].json.error.message || 'Unknown error'),\n            status: 'DOWNLOAD_ERROR'\n          },\n          meta: { provider: 'docx-extractor' }\n        }\n      }];\n    }\n    fileContent = items[0]?.binary?.data?.data || '';\n  }\n  \n  // DOCX is a ZIP file containing XML\n  // Basic extraction approach - in production use mammoth.js\n  // This is a placeholder that demonstrates the workflow structure\n  \n  const result = {\n    success: true,\n    data: {\n      content: 'DOCX extraction requires mammoth.js library. Please configure n8n with custom nodes for full DOCX support.',\n      format: outputFormat,\n      metadata: {\n        file_type: 'docx',\n        extraction_method: 'placeholder'\n      },\n      note: 'For production use, install mammoth npm package in n8n custom function node'\n    },\n    meta: {\n      provider: 'docx-extractor',\n      output_format: outputFormat\n    }\n  };\n  \n  // If we have OpenAI key, use GPT-4 Vision for extraction from rendered preview\n  if (body.openai_api_key && body.use_vision) {\n    result.data.vision_extraction_available = true;\n  }\n  \n  return [{ json: result }];\n  \n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 500,\n        message: 'Failed to extract DOCX: ' + e.message,\n        status: 'EXTRACTION_ERROR'\n      },\n      meta: { provider: 'docx-extractor' }\n    }\n  }];\n}"
+        "jsCode": "// ============================================\n// EXTRACT DOCX CONTENT - MCP DOCX Extractor\n// ============================================\n\nconst prevData = $('Validate Input').first().json;\nconst outputFormat = prevData.output_format;\n\ntry {\n  let fileContent;\n  \n  if (prevData.file_base64) {\n    fileContent = prevData.file_base64;\n  } else {\n    // File was downloaded\n    const items = $input.all();\n    if (items[0]?.json?.error) {\n      return [{\n        json: {\n          success: false,\n          _trace: {\n            service_response: { download_error: items[0].json.error.message || 'Unknown error' },\n            provider: 'docx-extractor',\n            mode: 'error',\n            latency_ms: Date.now() - prevData.startTime,\n            user_id: prevData.user_id,\n            guild_id: prevData.guild_id,\n            user_request: prevData.user_request\n          },\n          error: {\n            code: 'DOWNLOAD_ERROR',\n            message: 'Failed to download file: ' + (items[0].json.error.message || 'Unknown error'),\n            http_status: 500\n          },\n          user_id: prevData.user_id,\n          guild_id: prevData.guild_id,\n          user_request: prevData.user_request\n        }\n      }];\n    }\n    fileContent = items[0]?.binary?.data?.data || '';\n  }\n  \n  // DOCX is a ZIP file containing XML\n  // Basic extraction approach - in production use mammoth.js\n  // This is a placeholder that demonstrates the workflow structure\n  \n  const extractionResult = {\n    content: 'DOCX extraction requires mammoth.js library. Please configure n8n with custom nodes for full DOCX support.',\n    format: outputFormat,\n    metadata: {\n      file_type: 'docx',\n      extraction_method: 'placeholder'\n    },\n    note: 'For production use, install mammoth npm package in n8n custom function node'\n  };\n  \n  // If we have OpenAI key, use GPT-4 Vision for extraction from rendered preview\n  if (prevData.openai_api_key && prevData.use_vision) {\n    extractionResult.vision_extraction_available = true;\n  }\n  \n  return [{\n    json: {\n      success: true,\n      data: extractionResult,\n      meta: {\n        provider: 'docx-extractor',\n        output_format: outputFormat\n      },\n      _trace: {\n        service_response: extractionResult,\n        provider: 'docx-extractor',\n        mode: 'success',\n        latency_ms: Date.now() - prevData.startTime,\n        user_id: prevData.user_id,\n        guild_id: prevData.guild_id,\n        user_request: prevData.user_request\n      },\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    }\n  }];\n  \n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      _trace: {\n        service_response: { extraction_error: e.message },\n        provider: 'docx-extractor',\n        mode: 'error',\n        latency_ms: Date.now() - prevData.startTime,\n        user_id: prevData.user_id,\n        guild_id: prevData.guild_id,\n        user_request: prevData.user_request\n      },\n      error: {\n        code: 'EXTRACTION_ERROR',\n        message: 'Failed to extract DOCX: ' + e.message,\n        http_status: 500\n      },\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    }\n  }];\n}"
       }
     },
     {
@@ -114,10 +121,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
+      "position": [1340, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -126,18 +130,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 650,
-        "height": 300,
-        "content": "## MCP - DOCX Extractor\n\n**Endpoint:** POST /webhook/docx-extractor\n\n**Parameters:**\n- `file_url` (required*): URL of DOCX file\n- `file_base64` (required*): Base64-encoded DOCX file\n- `output_format` (optional): text | html | markdown (default: text)\n- `include_metadata` (optional): Extract document metadata\n- `include_images` (optional): Extract embedded images\n- `openai_api_key` (optional): For vision-based extraction\n- `use_vision` (optional): Use GPT-4 Vision for complex layouts\n\n*One of file_url or file_base64 is required\n\n**Returns:** Extracted text/HTML/markdown content with metadata\n\n**Note:** Full extraction requires mammoth.js configuration"
+        "width": 340,
+        "height": 700,
+        "content": "## MCP - DOCX Extractor\n\n**Endpoint:** POST /webhook/docx-extractor\n\n**Description:** Extrait le contenu textuel de fichiers DOCX avec support pour differents formats de sortie.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"file_url|file_base64\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du fichier DOCX\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Fichier DOCX encode en base64\" },\n    \"output_format\": { \"type\": \"string\", \"enum\": [\"text\", \"html\", \"markdown\"], \"default\": \"text\" },\n    \"include_metadata\": { \"type\": \"boolean\", \"default\": false },\n    \"include_images\": { \"type\": \"boolean\", \"default\": false },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"Pour extraction vision\" },\n    \"use_vision\": { \"type\": \"boolean\", \"default\": false }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": true,\n  \"output_fields\": [\"content\", \"format\", \"metadata\"],\n  \"domain\": \"document\"\n}\n```\n\n**Note:** L'extraction complete necessite mammoth.js."
       }
     }
   ],
@@ -157,6 +158,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Download File",
             "type": "main",
             "index": 0
@@ -164,7 +176,18 @@
         ],
         [
           {
-            "node": "Error: No File",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -196,33 +219,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "ee6efd59-36c8-4239-8989-1f656c298675",
-  "activeVersionId": "ee6efd59-36c8-4239-8989-1f656c298675",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:14:12.291Z",
-      "createdAt": "2025-12-18T15:14:12.291Z",
-      "role": "workflow:owner",
-      "workflowId": "cqaSoP1kK5rAKNDp",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Documents_Estimate.json
+++ b/workflows/MCP_-_Documents_Estimate.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2026-01-19T14:52:12.934Z",
-  "createdAt": "2026-01-19T14:52:01.701Z",
-  "id": "6T0xLTZnCo750HEf",
   "name": "MCP - Documents Estimate",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-estimate",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "documents-estimate-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -25,27 +16,92 @@
       }
     },
     {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Documents Estimate\n// RFC-014 Extraction Pattern\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (extract for tracing, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required: file_url OR file_base64 ---\nconst fileUrl = body.file_url || ctx.file_url;\nconst fileBase64 = body.file_base64 || ctx.file_base64;\n\nconst hasFile = !!(fileUrl || fileBase64);\nif (!hasFile) {\n  errors.push('file_url or file_base64 required');\n}\n\n// --- Optional parameters with defaults ---\nconst fileType = body.file_type || ctx.file_type || (fileUrl?.split('.').pop()?.toLowerCase()) || 'unknown';\nconst action = body.action || ctx.action || 'translate';\nconst pluginContext = body.plugin_context || ctx.plugin_context || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  file_url: fileUrl,\n  file_base64: fileBase64,\n  file_type: fileType,\n  action: action,\n  plugin_context: pluginContext,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'documents-estimate',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "estimate-logic",
       "name": "Estimate and Calculate",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        480,
-        300
-      ],
+      "position": [900, 200],
       "parameters": {
-        "jsCode": "const body = $input.first().json.body || {};\n\n// Valider l'entrée\nconst hasFile = !!(body.file_url || body.file_base64);\nif (!hasFile) {\n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'INVALID_FORMAT',\n        message: 'Missing file_url or file_base64'\n      }\n    }\n  };\n}\n\n// Détecter le type de fichier\nconst fileType = body.file_type || (body.file_url?.split('.').pop()?.toLowerCase()) || 'unknown';\nconst action = body.action || 'translate';\n\n// Pricing par défaut\nconst defaultPricing = {\n  translate: { base: 5, per_1k_tokens: 1.0, per_page: 2, ocr_bonus: 3, max: 50 },\n  summarize: { base: 3, per_1k_tokens: 0.5, per_page: 1, ocr_bonus: 3, max: 30 }\n};\nconst pricing = body.plugin_context?.pricing?.[action] || defaultPricing[action] || defaultPricing.translate;\n\n// OCR thresholds configurables (Phase 2.2)\nconst defaultOcrThresholds = {\n  min_confidence: 0.7,\n  hebrew_min_confidence: 0.6,\n  aramaic_min_confidence: 0.5,\n  retry_on_low_confidence: true\n};\nconst ocrThresholds = body.plugin_context?.ocr_thresholds || defaultOcrThresholds;\n\n// Déterminer si OCR est requis\nconst imageTypes = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'tiff'];\nconst isImage = imageTypes.includes(fileType?.toLowerCase());\nconst ocrRequired = isImage || fileType === 'pdf';\n\n// Détecter langue potentielle pour ajuster seuils OCR\nconst detectedLanguage = body.params?.source_language || body.plugin_context?.detected_language || 'unknown';\nconst isHebrewContent = detectedLanguage === 'hebrew' || detectedLanguage === 'he';\nconst isAramaicContent = detectedLanguage === 'aramaic' || detectedLanguage === 'arc';\n\n// Ajuster le seuil de confiance selon la langue\nlet minConfidenceThreshold = ocrThresholds.min_confidence;\nif (isHebrewContent) {\n  minConfidenceThreshold = ocrThresholds.hebrew_min_confidence;\n} else if (isAramaicContent) {\n  minConfidenceThreshold = ocrThresholds.aramaic_min_confidence;\n}\n\n// Estimation selon le type\nlet estimatedPages, estimatedTokens, ocrConfidencePreview;\n\nif (isImage) {\n  estimatedPages = 1;\n  estimatedTokens = 500;\n  ocrConfidencePreview = isHebrewContent ? 0.75 : (isAramaicContent ? 0.65 : 0.85);\n} else if (fileType === 'pdf') {\n  estimatedPages = 5;\n  estimatedTokens = 2500;\n  ocrConfidencePreview = isHebrewContent ? 0.80 : (isAramaicContent ? 0.70 : 0.90);\n} else {\n  estimatedPages = 3;\n  estimatedTokens = 1500;\n  ocrConfidencePreview = 1.0;\n}\n\n// Calcul des crédits: base + (tokens/1000 * rate) + (pages * page_rate) + ocr_bonus\nconst base = pricing.base || 5;\nconst tokenCost = (estimatedTokens / 1000) * (pricing.per_1k_tokens || 1.0);\nconst pageCost = estimatedPages * (pricing.per_page || 2);\nconst ocrCost = ocrRequired ? (pricing.ocr_bonus || 3) : 0;\n\nconst total = base + tokenCost + pageCost + ocrCost;\nconst maxCredits = pricing.max || 50;\nconst estimatedCredits = Math.min(Math.ceil(total), maxCredits);\n\n// Marge de sécurité de 10%\nconst tokensWithMargin = Math.ceil(estimatedTokens * 1.1);\n\n// Warnings\nconst warnings = [];\nif (ocrConfidencePreview < minConfidenceThreshold) {\n  warnings.push(`OCR confidence (${ocrConfidencePreview}) below threshold (${minConfidenceThreshold})`);\n}\nif (ocrConfidencePreview < 0.8) {\n  warnings.push('OCR confidence may vary on full document');\n}\nif (estimatedPages > 10) {\n  warnings.push('Document exceeds recommended 10 pages limit');\n}\nif (isHebrewContent || isAramaicContent) {\n  warnings.push(`${isHebrewContent ? 'Hebrew' : 'Aramaic'} content detected - using specialized OCR thresholds`);\n}\n\nreturn {\n  json: {\n    success: true,\n    estimation: {\n      tokens: tokensWithMargin,\n      pages: estimatedPages,\n      ocr_required: ocrRequired,\n      ocr_confidence_preview: ocrConfidencePreview,\n      detected_language: detectedLanguage\n    },\n    credits: {\n      estimated: estimatedCredits,\n      breakdown: {\n        base: base,\n        tokens: Math.round(tokenCost * 100) / 100,\n        pages: pageCost,\n        ocr: ocrCost\n      },\n      max_possible: maxCredits\n    },\n    ocr_thresholds: {\n      applied: minConfidenceThreshold,\n      config: ocrThresholds\n    },\n    warnings: warnings\n  }\n};"
+        "jsCode": "// ============================================\n// ESTIMATE AND CALCULATE - MCP Documents Estimate\n// ============================================\n\nconst prevData = $('Validate Input').first().json;\n\nconst fileType = prevData.file_type;\nconst action = prevData.action;\nconst pluginContext = prevData.plugin_context || {};\n\n// Pricing par defaut\nconst defaultPricing = {\n  translate: { base: 5, per_1k_tokens: 1.0, per_page: 2, ocr_bonus: 3, max: 50 },\n  summarize: { base: 3, per_1k_tokens: 0.5, per_page: 1, ocr_bonus: 3, max: 30 }\n};\nconst pricing = pluginContext.pricing?.[action] || defaultPricing[action] || defaultPricing.translate;\n\n// OCR thresholds configurables (Phase 2.2)\nconst defaultOcrThresholds = {\n  min_confidence: 0.7,\n  hebrew_min_confidence: 0.6,\n  aramaic_min_confidence: 0.5,\n  retry_on_low_confidence: true\n};\nconst ocrThresholds = pluginContext.ocr_thresholds || defaultOcrThresholds;\n\n// Determiner si OCR est requis\nconst imageTypes = ['png', 'jpg', 'jpeg', 'webp', 'gif', 'bmp', 'tiff'];\nconst isImage = imageTypes.includes(fileType?.toLowerCase());\nconst ocrRequired = isImage || fileType === 'pdf';\n\n// Detecter langue potentielle pour ajuster seuils OCR\nconst detectedLanguage = pluginContext.detected_language || 'unknown';\nconst isHebrewContent = detectedLanguage === 'hebrew' || detectedLanguage === 'he';\nconst isAramaicContent = detectedLanguage === 'aramaic' || detectedLanguage === 'arc';\n\n// Ajuster le seuil de confiance selon la langue\nlet minConfidenceThreshold = ocrThresholds.min_confidence;\nif (isHebrewContent) {\n  minConfidenceThreshold = ocrThresholds.hebrew_min_confidence;\n} else if (isAramaicContent) {\n  minConfidenceThreshold = ocrThresholds.aramaic_min_confidence;\n}\n\n// Estimation selon le type\nlet estimatedPages, estimatedTokens, ocrConfidencePreview;\n\nif (isImage) {\n  estimatedPages = 1;\n  estimatedTokens = 500;\n  ocrConfidencePreview = isHebrewContent ? 0.75 : (isAramaicContent ? 0.65 : 0.85);\n} else if (fileType === 'pdf') {\n  estimatedPages = 5;\n  estimatedTokens = 2500;\n  ocrConfidencePreview = isHebrewContent ? 0.80 : (isAramaicContent ? 0.70 : 0.90);\n} else {\n  estimatedPages = 3;\n  estimatedTokens = 1500;\n  ocrConfidencePreview = 1.0;\n}\n\n// Calcul des credits: base + (tokens/1000 * rate) + (pages * page_rate) + ocr_bonus\nconst base = pricing.base || 5;\nconst tokenCost = (estimatedTokens / 1000) * (pricing.per_1k_tokens || 1.0);\nconst pageCost = estimatedPages * (pricing.per_page || 2);\nconst ocrCost = ocrRequired ? (pricing.ocr_bonus || 3) : 0;\n\nconst total = base + tokenCost + pageCost + ocrCost;\nconst maxCredits = pricing.max || 50;\nconst estimatedCredits = Math.min(Math.ceil(total), maxCredits);\n\n// Marge de securite de 10%\nconst tokensWithMargin = Math.ceil(estimatedTokens * 1.1);\n\n// Warnings\nconst warnings = [];\nif (ocrConfidencePreview < minConfidenceThreshold) {\n  warnings.push(`OCR confidence (${ocrConfidencePreview}) below threshold (${minConfidenceThreshold})`);\n}\nif (ocrConfidencePreview < 0.8) {\n  warnings.push('OCR confidence may vary on full document');\n}\nif (estimatedPages > 10) {\n  warnings.push('Document exceeds recommended 10 pages limit');\n}\nif (isHebrewContent || isAramaicContent) {\n  warnings.push(`${isHebrewContent ? 'Hebrew' : 'Aramaic'} content detected - using specialized OCR thresholds`);\n}\n\nconst latencyMs = Date.now() - prevData.startTime;\n\nconst result = {\n  estimation: {\n    tokens: tokensWithMargin,\n    pages: estimatedPages,\n    ocr_required: ocrRequired,\n    ocr_confidence_preview: ocrConfidencePreview,\n    detected_language: detectedLanguage\n  },\n  credits: {\n    estimated: estimatedCredits,\n    breakdown: {\n      base: base,\n      tokens: Math.round(tokenCost * 100) / 100,\n      pages: pageCost,\n      ocr: ocrCost\n    },\n    max_possible: maxCredits\n  },\n  ocr_thresholds: {\n    applied: minConfidenceThreshold,\n    config: ocrThresholds\n  },\n  warnings: warnings\n};\n\nreturn {\n  success: true,\n  data: result,\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request,\n  _trace: {\n    service_response: result,\n    provider: 'documents-estimate',\n    mode: 'success',\n    latency_ms: latencyMs,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  }\n};"
       }
     },
     {
-      "id": "respond-estimate",
+      "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        720,
-        300
-      ],
+      "position": [1120, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -54,18 +110,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 550,
-        "height": 280,
-        "content": "## MCP - Documents Estimate (RFC-014)\n\n**Endpoint:** POST /webhook/documents/estimate\n\n**Input:**\n- `file_url` or `file_base64`: Document\n- `file_type`: pdf | png | jpg | etc.\n- `action`: translate | summarize\n- `plugin_context.pricing`: Pricing config\n- `plugin_context.ocr_thresholds`: { min_confidence, hebrew_min_confidence, aramaic_min_confidence }\n\n**Output:**\n- `estimation`: { tokens, pages, ocr_required, detected_language }\n- `credits`: { estimated, breakdown, max_possible }\n- `ocr_thresholds`: { applied, config }\n- `warnings`: array"
+        "width": 340,
+        "height": 700,
+        "content": "## MCP - Documents Estimate\n\n**Endpoint:** POST /webhook/documents/estimate\n\n**Description:** Estime le nombre de tokens, pages et credits requis pour traiter un document.\n\n**InputSchema:**\n```json\n{\n  \"required\": [],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (optional, tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (optional, tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur (optional, tracing)\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du document\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Document en base64\" },\n    \"file_type\": { \"type\": \"string\", \"description\": \"Type de fichier (pdf, png, etc.)\" },\n    \"action\": { \"type\": \"string\", \"description\": \"Action: translate | summarize\" },\n    \"plugin_context\": { \"type\": \"object\", \"description\": \"Config pricing/ocr_thresholds\" }\n  },\n  \"oneOf\": [\n    { \"required\": [\"file_url\"] },\n    { \"required\": [\"file_base64\"] }\n  ]\n}\n```\n\n**Output:**\n- `estimation`: { tokens, pages, ocr_required, detected_language }\n- `credits`: { estimated, breakdown, max_possible }\n- `ocr_thresholds`: { applied, config }\n- `warnings`: array\n- `_trace`: { service_response, provider, mode, latency_ms, user_id, guild_id, user_request }\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"estimation\", \"credits\", \"ocr_thresholds\", \"warnings\"],\n  \"domain\": \"documents\"\n}\n```"
       }
     }
   ],
@@ -74,7 +127,47 @@
       "main": [
         [
           {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Estimate and Calculate",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -95,33 +188,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "bd872b3b-b72e-4df8-88ac-7d7720bb1649",
-  "activeVersionId": "bd872b3b-b72e-4df8-88ac-7d7720bb1649",
-  "versionCounter": 21,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-19T14:52:01.704Z",
-      "createdAt": "2026-01-19T14:52:01.704Z",
-      "role": "workflow:owner",
-      "workflowId": "6T0xLTZnCo750HEf",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Documents_Process.json
+++ b/workflows/MCP_-_Documents_Process.json
@@ -1,73 +1,125 @@
 {
-  "updatedAt": "2026-01-21T11:07:41.000Z",
-  "createdAt": "2026-01-20T10:20:14.966Z",
-  "id": "XLp1gPkeRwEvpdWE",
   "name": "MCP - Documents Process",
-  "description": null,
-  "active": false,
-  "isArchived": false,
   "nodes": [
     {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 700,
+        "content": "## MCP - Documents Process\n\n**Endpoint:** POST /webhook/documents/process\n\n**Description:** Process document with async callback. Routes to appropriate processor (translate, summarize, ocr) and sends result via callback URL.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"job_id\", \"file_url|file_base64\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"job_id\": { \"type\": \"string\", \"description\": \"Unique job identifier\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Original user request\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL of file to process\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Base64 encoded file\" },\n    \"file_type\": { \"type\": \"string\", \"default\": \"pdf\" },\n    \"action\": { \"type\": \"string\", \"enum\": [\"translate\", \"summarize\", \"ocr\"], \"default\": \"translate\" },\n    \"params\": { \"type\": \"object\", \"description\": \"Action parameters\" },\n    \"plugin_context\": { \"type\": \"object\", \"description\": \"Plugin config with api_keys\" },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL to send result\" }\n  }\n}\n```\n\n**RFC-014 Support:**\n- Accepts both root-level and context.* fields\n- Returns immediate ACK, result via callback\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": true,\n  \"output_fields\": [\"job_id\", \"success\", \"result\", \"metrics\"],\n  \"domain\": \"document-processing\"\n}\n```"
+      }
+    },
+    {
+      "id": "webhook-process",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "documents-process-webhook",
       "parameters": {
         "httpMethod": "POST",
         "path": "documents/process",
         "responseMode": "responseNode",
         "options": {}
-      },
-      "id": "webhook-process",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        304
-      ],
-      "webhookId": "documents-process-webhook"
+      }
     },
     {
-      "parameters": {
-        "jsCode": "const body = $input.first().json.body || {};\n\n// Support RFC-014 structure: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// Valider l'entrée - check both structures\nconst hasFile = !!(ctx.file_url || ctx.file_base64 || body.file_url || body.file_base64);\nconst hasJobId = !!(body.job_id || ctx.job_id);\n\nif (!hasFile || !hasJobId) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_FORMAT',\n          message: 'Missing required fields: file_url/file_base64 and job_id'\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\n// Extraire le contexte - prefer context.* over root level (RFC-014)\nconst context = {\n  job_id: body.job_id || ctx.job_id,\n  conversation_id: body.conversation_id || ctx.conversation_id,\n  user_id: body.user_id || ctx.user_id,\n  guild_id: body.guild_id || ctx.guild_id,\n  channel_id: body.channel_id || ctx.channel_id,\n  file_url: ctx.file_url || body.file_url,\n  file_base64: ctx.file_base64 || body.file_base64,\n  file_type: ctx.file_type || body.file_type || 'pdf',\n  action: body.action || ctx.action || 'translate',\n  params: body.params || ctx.params || {},\n  plugin_context: body.plugin_context || ctx.plugin_context || {},\n  callback_url: body.callback_url || ctx.callback_url,\n  start_time: Date.now()\n};\n\n// Vérifier si custom action et récupérer l'URL\nconst customActions = context.plugin_context?.custom_actions || {};\nconst isCustomAction = Object.keys(customActions).includes(context.action);\nconst customWebhookUrl = isCustomAction ? customActions[context.action]?.webhook_url : null;\n\n// Valider l'URL du webhook custom\nif (isCustomAction && !customWebhookUrl) {\n  return {\n    json: {\n      valid: false,\n      response: {\n        success: false,\n        error: {\n          code: 'INVALID_CONFIG',\n          message: `Custom action '${context.action}' has no webhook_url configured`\n        }\n      },\n      status_code: 400\n    }\n  };\n}\n\nreturn {\n  json: {\n    valid: true,\n    response: {\n      success: true,\n      message: 'Processing started',\n      job_id: context.job_id\n    },\n    status_code: 200,\n    context: context,\n    is_custom_action: isCustomAction,\n    custom_webhook_url: customWebhookUrl\n  }\n};"
-      },
-      "id": "validate-and-ack",
-      "name": "Validate and Acknowledge",
+      "id": "validate-input",
+      "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        480,
-        304
-      ]
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Documents Process\n// RFC-014 Compliant with Optional Tracing Fields\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, no validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required fields ---\nconst jobId = body.job_id || ctx.job_id;\nconst fileUrl = ctx.file_url || body.file_url;\nconst fileBase64 = ctx.file_base64 || body.file_base64;\n\nif (!jobId) {\n  errors.push('job_id required');\n}\nif (!fileUrl && !fileBase64) {\n  errors.push('file_url or file_base64 required');\n}\n\n// --- Optional parameters with defaults ---\nconst fileType = ctx.file_type || body.file_type || 'pdf';\nconst action = body.action || ctx.action || 'translate';\nconst params = body.params || ctx.params || {};\nconst pluginContext = body.plugin_context || ctx.plugin_context || {};\nconst callbackUrl = body.callback_url || ctx.callback_url;\nconst conversationId = body.conversation_id || ctx.conversation_id;\nconst channelId = body.channel_id || ctx.channel_id;\n\n// Verify custom action webhook URL if applicable\nconst customActions = pluginContext?.custom_actions || {};\nconst isCustomAction = Object.keys(customActions).includes(action);\nconst customWebhookUrl = isCustomAction ? customActions[action]?.webhook_url : null;\n\nif (isCustomAction && !customWebhookUrl) {\n  errors.push(`Custom action '${action}' has no webhook_url configured`);\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    job_id: jobId\n  };\n}\n\n// Build context object\nconst context = {\n  job_id: jobId,\n  conversation_id: conversationId,\n  user_id: userId,\n  guild_id: guildId,\n  channel_id: channelId,\n  file_url: fileUrl,\n  file_base64: fileBase64,\n  file_type: fileType,\n  action: action,\n  params: params,\n  plugin_context: pluginContext,\n  callback_url: callbackUrl,\n  start_time: Date.now()\n};\n\nreturn {\n  valid: true,\n  context: context,\n  is_custom_action: isCustomAction,\n  custom_webhook_url: customWebhookUrl,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
     },
     {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  job_id: input.job_id,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'documents-process',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', ')\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json.response }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": "={{ $json.status_code }}"
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      },
+      }
+    },
+    {
       "id": "respond-ack",
       "name": "Respond ACK",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        720,
-        304
-      ]
-    },
-    {
+      "position": [900, 200],
       "parameters": {
-        "jsCode": "const input = $input.first().json;\n\n// Si invalide, on s'arrête\nif (!input.valid) {\n  return [];\n}\n\n// Continuer avec le contexte\nreturn {\n  json: input\n};"
-      },
-      "id": "check-valid",
-      "name": "Check Valid",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        960,
-        304
-      ]
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, message: 'Processing started', job_id: $json.context.job_id, _trace: { service_response: { status: 'accepted' }, provider: 'documents-process', mode: 'ack', latency_ms: Date.now() - $json.startTime, user_id: $json.user_id, guild_id: $json.guild_id, user_request: $json.user_request } } }}",
+        "options": {
+          "responseCode": 200
+        }
+      }
     },
     {
+      "id": "route-and-process",
+      "name": "Route and Process",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 200],
+      "onError": "continueRegularOutput",
       "parameters": {
         "method": "POST",
         "url": "={{ $json.is_custom_action ? $json.custom_webhook_url : ($json.context.action === 'translate' ? ($env.N8N_WEBHOOK_BASE_URL || 'http://localhost:5678') + '/webhook/pdf-layout-translator' : ($env.N8N_WEBHOOK_BASE_URL || 'http://localhost:5678') + '/webhook/image-ocr') }}",
@@ -82,62 +134,31 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "= {{ JSON.stringify($json.is_custom_action ? { file_url: $json.context.file_url, file_base64:\n  $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id:\n  $json.context.user_id, channel_id: $json.context.channel_id }, params: $json.context.params, plugin_context:\n  $json.context.plugin_context, job_id: $json.context.job_id } : ($json.context.action === 'translate' ? { file_url:\n  $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: {\n  guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id },\n  target_language: $json.context.params.target_language || 'en', mistral_api_key:\n  $json.context.plugin_context.api_keys?.mistral, api_key: $json.context.plugin_context.api_keys?.anthropic,\n  openai_api_key: $json.context.plugin_context.api_keys?.openai, ocr_thresholds:\n  $json.context.plugin_context.ocr_thresholds } : { image_url: $json.context.file_url, image_base64:\n  $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id:\n  $json.context.user_id, channel_id: $json.context.channel_id }, mistral_api_key:\n  $json.context.plugin_context.api_keys?.mistral, ocr_thresholds: $json.context.plugin_context.ocr_thresholds })) }}",
+        "jsonBody": "={{ JSON.stringify($json.is_custom_action ? { file_url: $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id }, params: $json.context.params, plugin_context: $json.context.plugin_context, job_id: $json.context.job_id } : ($json.context.action === 'translate' ? { file_url: $json.context.file_url, file_base64: $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id }, target_language: $json.context.params.target_language || 'en', mistral_api_key: $json.context.plugin_context.api_keys?.mistral, api_key: $json.context.plugin_context.api_keys?.anthropic, openai_api_key: $json.context.plugin_context.api_keys?.openai, ocr_thresholds: $json.context.plugin_context.ocr_thresholds } : { image_url: $json.context.file_url, image_base64: $json.context.file_base64, file_type: $json.context.file_type, context: { guild_id: $json.context.guild_id, user_id: $json.context.user_id, channel_id: $json.context.channel_id }, mistral_api_key: $json.context.plugin_context.api_keys?.mistral, ocr_thresholds: $json.context.plugin_context.ocr_thresholds })) }}",
         "options": {
           "timeout": 300000
         }
-      },
-      "id": "route-and-process",
-      "name": "Route and Process",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        1200,
-        304
-      ],
-      "onError": "continueRegularOutput"
+      }
     },
     {
-      "parameters": {
-        "jsCode": "const result = $input.first().json;\nconst prevNode = $('Check Valid').first().json;\nconst context = prevNode.context;\nconst startTime = context.start_time;\nconst processingTime = Date.now() - startTime;\n\n// Déterminer si succès ou erreur\nconst isSuccess = result.success !== false && !result.error;\nconst hasData = result.data || result.text || result.result;\n\nlet callback;\n\nif (isSuccess && hasData) {\n  // Succès\n  const text = result.data?.text || result.data?.translated_text || result.text || JSON.stringify(result.data || result);\n  callback = {\n    job_id: context.job_id,\n    conversation_id: context.conversation_id,\n    user_id: context.user_id,\n    guild_id: context.guild_id,\n    channel_id: context.channel_id,\n    success: true,\n    result: {\n      text: text,\n      output_type: 'text',\n      word_count: text.split(/\\s+/).length\n    },\n    metrics: {\n      tokens_used: result.meta?.usage?.total_tokens || result.usage?.total_tokens || Math.ceil(text.length / 4),\n      processing_time_ms: processingTime,\n      ocr_confidence: result.meta?.ocr_confidence || result.data?.ocr_confidence || 0.9,\n      pages_processed: result.meta?.usage?.pages_processed || result.data?.page_count || 1\n    },\n    error: null\n  };\n} else {\n  // Erreur\n  const errorCode = result.error?.code || result.error?.status || 'INTERNAL_ERROR';\n  const errorMessage = result.error?.message || 'Processing failed';\n  \n  callback = {\n    job_id: context.job_id,\n    conversation_id: context.conversation_id,\n    user_id: context.user_id,\n    guild_id: context.guild_id,\n    channel_id: context.channel_id,\n    success: false,\n    result: null,\n    metrics: {\n      tokens_used: 0,\n      processing_time_ms: processingTime,\n      ocr_confidence: 0,\n      pages_processed: 0\n    },\n    error: {\n      code: errorCode,\n      message: errorMessage,\n      retriable: ['LLM_RATE_LIMITED', 'TIMEOUT', 'INTERNAL_ERROR'].includes(errorCode),\n      refund: {\n        recommended: true,\n        percentage: errorCode === 'PARTIAL_SUCCESS' ? 50 : 100,\n        reason: `Processing failed: ${errorMessage}`\n      }\n    }\n  };\n}\n\nreturn {\n  json: {\n    callback: callback,\n    callback_url: context.callback_url\n  }\n};"
-      },
       "id": "format-callback",
       "name": "Format Callback",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1440,
-        304
-      ]
+      "position": [1340, 200],
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT CALLBACK with _trace\n// ============================================\n\nconst result = $input.first().json;\nconst prevNode = $('Validate Input').first().json;\nconst context = prevNode.context;\nconst startTime = context.start_time;\nconst processingTime = Date.now() - startTime;\n\n// Determine success or error\nconst isSuccess = result.success !== false && !result.error;\nconst hasData = result.data || result.text || result.result;\n\nlet callback;\nlet serviceResponse;\n\nif (isSuccess && hasData) {\n  // Success\n  const text = result.data?.text || result.data?.translated_text || result.text || JSON.stringify(result.data || result);\n  \n  serviceResponse = {\n    text: text,\n    output_type: 'text',\n    word_count: text.split(/\\s+/).length,\n    tokens_used: result.meta?.usage?.total_tokens || result.usage?.total_tokens || Math.ceil(text.length / 4),\n    ocr_confidence: result.meta?.ocr_confidence || result.data?.ocr_confidence || 0.9,\n    pages_processed: result.meta?.usage?.pages_processed || result.data?.page_count || 1\n  };\n  \n  callback = {\n    job_id: context.job_id,\n    conversation_id: context.conversation_id,\n    user_id: context.user_id,\n    guild_id: context.guild_id,\n    channel_id: context.channel_id,\n    success: true,\n    result: {\n      text: text,\n      output_type: 'text',\n      word_count: serviceResponse.word_count\n    },\n    metrics: {\n      tokens_used: serviceResponse.tokens_used,\n      processing_time_ms: processingTime,\n      ocr_confidence: serviceResponse.ocr_confidence,\n      pages_processed: serviceResponse.pages_processed\n    },\n    error: null,\n    _trace: {\n      service_response: serviceResponse,\n      provider: 'documents-process',\n      mode: 'success',\n      latency_ms: processingTime,\n      user_id: context.user_id,\n      guild_id: context.guild_id,\n      user_request: prevNode.user_request\n    }\n  };\n} else {\n  // Error\n  const errorCode = result.error?.code || result.error?.status || 'INTERNAL_ERROR';\n  const errorMessage = result.error?.message || 'Processing failed';\n  \n  serviceResponse = {\n    error_code: errorCode,\n    error_message: errorMessage\n  };\n  \n  callback = {\n    job_id: context.job_id,\n    conversation_id: context.conversation_id,\n    user_id: context.user_id,\n    guild_id: context.guild_id,\n    channel_id: context.channel_id,\n    success: false,\n    result: null,\n    metrics: {\n      tokens_used: 0,\n      processing_time_ms: processingTime,\n      ocr_confidence: 0,\n      pages_processed: 0\n    },\n    error: {\n      code: errorCode,\n      message: errorMessage,\n      retriable: ['LLM_RATE_LIMITED', 'TIMEOUT', 'INTERNAL_ERROR'].includes(errorCode),\n      refund: {\n        recommended: true,\n        percentage: errorCode === 'PARTIAL_SUCCESS' ? 50 : 100,\n        reason: `Processing failed: ${errorMessage}`\n      }\n    },\n    _trace: {\n      service_response: serviceResponse,\n      provider: 'documents-process',\n      mode: 'error',\n      latency_ms: processingTime,\n      user_id: context.user_id,\n      guild_id: context.guild_id,\n      user_request: prevNode.user_request\n    }\n  };\n}\n\nreturn {\n  json: {\n    callback: callback,\n    callback_url: context.callback_url\n  }\n};"
+      }
     },
     {
-      "parameters": {
-        "jsCode": "const input = $input.first().json;\n\n// Si pas de callback URL, on log seulement\nif (!input.callback_url) {\n  return {\n    json: {\n      status: 'no_callback',\n      callback: input.callback\n    }\n  };\n}\n\n// Envoyer le callback\ntry {\n  const response = await fetch(input.callback_url, {\n    method: 'POST',\n    headers: { 'Content-Type': 'application/json' },\n    body: JSON.stringify(input.callback)\n  });\n  \n  return {\n    json: {\n      status: 'callback_sent',\n      callback_status: response.status,\n      callback: input.callback\n    }\n  };\n} catch (error) {\n  return {\n    json: {\n      status: 'callback_failed',\n      error: error.message,\n      callback: input.callback\n    }\n  };\n}"
-      },
       "id": "send-callback",
       "name": "Send Callback",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1680,
-        304
-      ]
-    },
-    {
+      "position": [1560, 200],
       "parameters": {
-        "content": "## MCP - Documents Process (RFC-014 Phase 2)\n\n**Endpoint:** POST /webhook/documents/process\n\n**Purpose:** Process document with async callback\n\n**RFC-014 Input Structure:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"context\": {\n    \"file_url\": \"https://...\" OR \"file_base64\": \"...\",\n    \"action\": \"translate|summarize|ocr\",\n    \"params\": { \"target_language\": \"fr\" }\n  },\n  \"plugin_context\": { \"api_keys\": {...} },\n  \"callback_url\": \"https://...\"\n}\n```\n\n**Legacy Input (also supported):**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"file_url\": \"https://...\",\n  \"action\": \"translate\",\n  \"params\": {...},\n  \"callback_url\": \"...\"\n}\n```\n\n**Response:** Immediate ACK with job_id, result via callback",
-        "height": 300,
-        "width": 650,
-        "color": 6
-      },
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        64
-      ]
+        "jsCode": "// ============================================\n// SEND CALLBACK\n// ============================================\n\nconst input = $input.first().json;\n\n// If no callback URL, log only\nif (!input.callback_url) {\n  return {\n    json: {\n      status: 'no_callback',\n      callback: input.callback\n    }\n  };\n}\n\n// Send callback\ntry {\n  const response = await fetch(input.callback_url, {\n    method: 'POST',\n    headers: { 'Content-Type': 'application/json' },\n    body: JSON.stringify(input.callback)\n  });\n  \n  return {\n    json: {\n      status: 'callback_sent',\n      callback_status: response.status,\n      callback: input.callback\n    }\n  };\n} catch (error) {\n  return {\n    json: {\n      status: 'callback_failed',\n      error: error.message,\n      callback: input.callback\n    }\n  };\n}"
+      }
     }
   ],
   "connections": {
@@ -145,14 +166,25 @@
       "main": [
         [
           {
-            "node": "Validate and Acknowledge",
+            "node": "Validate Input",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Validate and Acknowledge": {
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
       "main": [
         [
           {
@@ -160,21 +192,28 @@
             "type": "main",
             "index": 0
           }
-        ]
-      ]
-    },
-    "Respond ACK": {
-      "main": [
+        ],
         [
           {
-            "node": "Check Valid",
+            "node": "Build Error",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Check Valid": {
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond ACK": {
       "main": [
         [
           {
@@ -210,33 +249,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "7559ac35-5067-4b76-9749-b6e547e25343",
-  "activeVersionId": null,
-  "versionCounter": 12,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-20T10:20:14.971Z",
-      "createdAt": "2026-01-20T10:20:14.971Z",
-      "role": "workflow:owner",
-      "workflowId": "XLp1gPkeRwEvpdWE",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Entity_-_Comment.json
+++ b/workflows/MCP_-_Entity_-_Comment.json
@@ -1,0 +1,621 @@
+{
+  "name": "MCP - Entity - Comment",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Entity - Comment\n\n**Endpoint:** POST /webhook/entity-comment\n\n**Description:** Manages comments on entities (recipes, documents, courses, etc.) stored in PostgreSQL.\n\n**InputSchema:**\n```json\n{\n  \"type\": \"object\",\n  \"required\": [\"action\", \"entity_id\", \"user_id\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"comment\", \"list\", \"edit\", \"delete\"], \"description\": \"Action CRUD\" },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID de l'entite\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type d'entite: recipe, document, course, etc.\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"Discord user ID\" },\n    \"content\": { \"type\": \"string\", \"description\": \"Contenu du commentaire (requis pour comment/edit)\" },\n    \"comment_id\": { \"type\": \"string\", \"description\": \"UUID du commentaire (requis pour edit/delete)\" },\n    \"parent_id\": { \"type\": \"string\", \"description\": \"UUID du commentaire parent (pour reponses)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (optionnel)\" },\n    \"limit\": { \"type\": \"integer\", \"default\": 20, \"description\": \"Nombre max de commentaires (pour action=list)\" },\n    \"offset\": { \"type\": \"integer\", \"default\": 0, \"description\": \"Pagination offset (pour action=list)\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"comment_id\", \"comments\", \"created_at\", \"updated_at\"],\n  \"domain\": \"entity\"\n}\n```",
+        "height": 700,
+        "width": 420,
+        "color": 5
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "entity-comment",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-entity-comment",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [300, 400],
+      "webhookId": "entity-comment-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Entity Comment\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\nconst startTime = Date.now();\n\n// --- Get tenant_id from header ---\nconst tenantId = headers['x-tenant-id'] || headers['X-Tenant-ID'] || null;\n\n// --- Required fields ---\nconst action = (body.action || ctx.action || '').toLowerCase();\nconst validActions = ['comment', 'list', 'edit', 'delete'];\nif (!action || !validActions.includes(action)) {\n  errors.push(`action invalide: '${action}' (doit etre: ${validActions.join(', ')})`);\n}\n\nconst entityId = body.entity_id || ctx.entity_id || '';\nconst uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;\nif (!entityId) {\n  errors.push('entity_id requis');\n} else if (!uuidRegex.test(entityId)) {\n  errors.push('entity_id invalide (format UUID requis)');\n}\n\nconst userId = body.user_id || ctx.user_id || '';\nif (!userId || userId.trim().length === 0) {\n  errors.push('user_id requis');\n}\n\n// --- Optional fields ---\nconst entityType = body.entity_type || ctx.entity_type || 'entity';\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst content = body.content || ctx.content || '';\nconst commentId = body.comment_id || ctx.comment_id || '';\nconst parentId = body.parent_id || ctx.parent_id || null;\nconst limit = parseInt(body.limit || ctx.limit || 20);\nconst offset = parseInt(body.offset || ctx.offset || 0);\n\n// --- Conditional validations based on action ---\nif ((action === 'comment' || action === 'edit') && (!content || content.trim().length === 0)) {\n  errors.push('content requis pour action=' + action);\n}\n\nif ((action === 'edit' || action === 'delete') && !commentId) {\n  errors.push('comment_id requis pour action=' + action);\n} else if ((action === 'edit' || action === 'delete') && commentId && !uuidRegex.test(commentId)) {\n  errors.push('comment_id invalide (format UUID requis)');\n}\n\nif (parentId && !uuidRegex.test(parentId)) {\n  errors.push('parent_id invalide (format UUID requis)');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId || null,\n    guild_id: guildId,\n    startTime: startTime\n  };\n}\n\nreturn {\n  valid: true,\n  action: action,\n  entity_id: entityId,\n  entity_type: entityType,\n  user_id: userId.trim(),\n  guild_id: guildId,\n  content: content.trim(),\n  comment_id: commentId || null,\n  parent_id: parentId,\n  tenant_id: tenantId,\n  limit: limit,\n  offset: offset,\n  startTime: startTime\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [520, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [740, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\nconst startTime = input.startTime || Date.now();\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'postgresql',\n    mode: 'error',\n    latency_ms: Date.now() - startTime,\n    user_id: input.user_id,\n    guild_id: input.guild_id\n  }\n};"
+      },
+      "id": "build-validation-error",
+      "name": "Build Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 560]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1180, 560]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "comment",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "comment",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "list",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "list",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "edit",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "edit",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "delete",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "delete",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "none"
+        }
+      },
+      "id": "switch-action",
+      "name": "Switch Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [960, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/comment",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ action: 'comment', user_id: $json.user_id, guild_id: $json.guild_id, content: $json.content, parent_id: $json.parent_id }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-create-comment",
+      "name": "API Create Comment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 80],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/comments",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "limit",
+              "value": "={{ $json.limit }}"
+            },
+            {
+              "name": "offset",
+              "value": "={{ $json.offset }}"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-list-comments",
+      "name": "API List Comments",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 220],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/comment",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ action: 'edit', user_id: $json.user_id, comment_id: $json.comment_id, content: $json.content }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-edit-comment",
+      "name": "API Edit Comment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 360],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/comment",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ action: 'delete', user_id: $json.user_id, comment_id: $json.comment_id }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-delete-comment",
+      "name": "API Delete Comment",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 500],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT CREATE COMMENT RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to create comment',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'comment',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    comment_id: body.comment_id || body.id,\n    entity_id: prevData.entity_id,\n    content: prevData.content,\n    user_id: prevData.user_id,\n    created_at: body.created_at || new Date().toISOString()\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: body,\n    provider: 'postgresql',\n    action: 'comment',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-create-response",
+      "name": "Format Create Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 80]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT LIST COMMENTS RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to list comments',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'list',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Extract comments array\nconst comments = body.comments || body.data || (Array.isArray(body) ? body : []);\nconst total = body.total || body.count || comments.length;\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    comments: comments,\n    total: total\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: { comments_count: comments.length, total: total },\n    provider: 'postgresql',\n    action: 'list',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    pagination: { limit: prevData.limit, offset: prevData.offset },\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-list-response",
+      "name": "Format List Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 220]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT EDIT COMMENT RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to edit comment',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'edit',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    comment_id: prevData.comment_id,\n    content: prevData.content,\n    updated_at: body.updated_at || new Date().toISOString()\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: body,\n    provider: 'postgresql',\n    action: 'edit',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    comment_id: prevData.comment_id,\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-edit-response",
+      "name": "Format Edit Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 360]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT DELETE COMMENT RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to delete comment',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'delete',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    deleted: true,\n    comment_id: prevData.comment_id\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: body,\n    provider: 'postgresql',\n    action: 'delete',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    comment_id: prevData.comment_id,\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-delete-response",
+      "name": "Format Delete Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 500]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1680, 280]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Switch Action",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond 400",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Action": {
+      "main": [
+        [
+          {
+            "node": "API Create Comment",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API List Comments",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API Edit Comment",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API Delete Comment",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Create Comment": {
+      "main": [
+        [
+          {
+            "node": "Format Create Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API List Comments": {
+      "main": [
+        [
+          {
+            "node": "Format List Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Edit Comment": {
+      "main": [
+        [
+          {
+            "node": "Format Edit Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Delete Comment": {
+      "main": [
+        [
+          {
+            "node": "Format Delete Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Create Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format List Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Edit Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Delete Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  }
+}

--- a/workflows/MCP_-_Entity_-_Rating.json
+++ b/workflows/MCP_-_Entity_-_Rating.json
@@ -1,0 +1,520 @@
+{
+  "name": "MCP - Entity - Rating",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Entity - Rating\n\n**Endpoint:** POST /webhook/entity-rating\n\n**Description:** Manages entity ratings (recipes, documents, courses, etc.) stored in PostgreSQL.\n\n**InputSchema:**\n```json\n{\n  \"type\": \"object\",\n  \"required\": [\"action\", \"entity_id\", \"user_id\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"rate\", \"get\", \"delete\"], \"description\": \"rate=noter, get=obtenir stats, delete=supprimer note\" },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID de l'entite\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type d'entite: recipe, document, course, etc.\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"Discord user ID\" },\n    \"rating\": { \"type\": \"integer\", \"minimum\": 1, \"maximum\": 5, \"description\": \"Note 1-5 (requis pour action=rate)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (optionnel)\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"rating\", \"new_average\", \"total_ratings\", \"user_rating\"],\n  \"domain\": \"entity\"\n}\n```",
+        "height": 640,
+        "width": 420,
+        "color": 5
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "entity-rating",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-entity-rating",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [300, 400],
+      "webhookId": "entity-rating-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Entity Rating\n// RFC-049 Entity Storage Architecture\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\nconst startTime = Date.now();\n\n// --- Get tenant_id from header ---\nconst tenantId = headers['x-tenant-id'] || headers['X-Tenant-ID'] || null;\n\n// --- Required fields ---\nconst action = (body.action || ctx.action || '').toLowerCase();\nconst validActions = ['rate', 'get', 'delete'];\nif (!action || !validActions.includes(action)) {\n  errors.push(`action invalide: '${action}' (doit etre: ${validActions.join(', ')})`);\n}\n\nconst entityId = body.entity_id || ctx.entity_id || '';\nconst uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;\nif (!entityId) {\n  errors.push('entity_id requis');\n} else if (!uuidRegex.test(entityId)) {\n  errors.push('entity_id invalide (format UUID requis)');\n}\n\nconst userId = body.user_id || ctx.user_id || '';\nif (!userId || userId.trim().length === 0) {\n  errors.push('user_id requis');\n}\n\n// --- Optional fields ---\nconst entityType = body.entity_type || ctx.entity_type || 'entity';\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst rating = body.rating !== undefined ? body.rating : (ctx.rating !== undefined ? ctx.rating : null);\n\n// --- Conditional validations based on action ---\nif (action === 'rate') {\n  if (rating === null || rating === undefined) {\n    errors.push('rating requis pour action=rate');\n  } else if (!Number.isInteger(rating) || rating < 1 || rating > 5) {\n    errors.push('rating doit etre un entier entre 1 et 5');\n  }\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId || null,\n    guild_id: guildId,\n    startTime: startTime\n  };\n}\n\nreturn {\n  valid: true,\n  action: action,\n  entity_id: entityId,\n  entity_type: entityType,\n  user_id: userId.trim(),\n  guild_id: guildId,\n  rating: rating,\n  tenant_id: tenantId,\n  startTime: startTime\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [520, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [740, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\nconst startTime = input.startTime || Date.now();\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'postgresql',\n    mode: 'error',\n    latency_ms: Date.now() - startTime,\n    user_id: input.user_id,\n    guild_id: input.guild_id\n  }\n};"
+      },
+      "id": "build-validation-error",
+      "name": "Build Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 560]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-validation-error",
+      "name": "Respond 400",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1180, 560]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "rate",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "rate",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "get",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "get",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            },
+            {
+              "outputKey": "delete",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "delete",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "none"
+        }
+      },
+      "id": "switch-action",
+      "name": "Switch Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [960, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/rate",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ user_id: $json.user_id, guild_id: $json.guild_id, rating: $json.rating }) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-rate-entity",
+      "name": "API Rate Entity",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 120],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/rate",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "user_id",
+              "value": "={{ $json.user_id }}"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-get-rating",
+      "name": "API Get Rating",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 280],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}/rate",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "user_id",
+              "value": "={{ $json.user_id }}"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id || '' }}"
+            }
+          ]
+        },
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "api-delete-rating",
+      "name": "API Delete Rating",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 440],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT RATE RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to rate entity',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'rate',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    rating: prevData.rating,\n    new_average: body.new_average || body.average || null,\n    total_ratings: body.total_ratings || body.total || null\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: body,\n    provider: 'postgresql',\n    action: 'rate',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-rate-response",
+      "name": "Format Rate Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 120]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT GET RATING RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to get rating',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'get',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    average_rating: body.average || body.average_rating || null,\n    total_ratings: body.total_ratings || body.total || null,\n    user_rating: body.user_rating || body.rating || null\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: body,\n    provider: 'postgresql',\n    action: 'get',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-get-response",
+      "name": "Format Get Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 280]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT DELETE RATING RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latency = Date.now() - startTime;\n\n// Handle API errors\nconst statusCode = input.statusCode || 200;\nconst body = input.body || input;\n\nif (statusCode >= 400 || body.error || body.detail) {\n  return {\n    success: false,\n    error: {\n      code: 'API_ERROR',\n      message: body.error?.message || body.detail || 'Failed to delete rating',\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    _trace: {\n      service_response: body,\n      provider: 'postgresql',\n      action: 'delete',\n      latency_ms: latency,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id\n    }\n  };\n}\n\n// Success response\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    deleted: true,\n    new_average: body.new_average || body.average || null\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  _trace: {\n    service_response: body,\n    provider: 'postgresql',\n    action: 'delete',\n    entity_type: prevData.entity_type,\n    entity_id: prevData.entity_id,\n    latency_ms: latency,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "format-delete-response",
+      "name": "Format Delete Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1440, 440]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1680, 280]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Switch Action",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond 400",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Action": {
+      "main": [
+        [
+          {
+            "node": "API Rate Entity",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API Get Rating",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API Delete Rating",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Rate Entity": {
+      "main": [
+        [
+          {
+            "node": "Format Rate Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Get Rating": {
+      "main": [
+        [
+          {
+            "node": "Format Get Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Delete Rating": {
+      "main": [
+        [
+          {
+            "node": "Format Delete Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Rate Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Get Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Delete Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP_-_Entity_-_Save.json
+++ b/workflows/MCP_-_Entity_-_Save.json
@@ -1,0 +1,1134 @@
+{
+  "name": "MCP - Entity - Save",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Entity - Save\n\n**Endpoint:** POST /webhook/entity-save\n\n**Description:** RFC-049 Entity Storage Architecture. Saves entities to both MongoDB (via API) AND Qdrant. Uses same UUID for entity_id and qdrant_point_id.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"action\", \"entity_type\", \"data\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"save\", \"update\", \"delete\"] },\n    \"entity_type\": { \"type\": \"string\", \"enum\": [\"recipe\", \"document\", \"course\", \"quiz\", \"flashcard\"] },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID (requis pour update/delete)\" },\n    \"data\": { \"type\": \"object\", \"description\": \"Entity data\" },\n    \"embedding\": { \"type\": \"array\", \"description\": \"Pre-computed embedding (optional)\" },\n    \"user_id\": { \"type\": \"string\" },\n    \"guild_id\": { \"type\": \"string\" },\n    \"qdrant_host\": { \"type\": \"string\" },\n    \"qdrant_port\": { \"type\": \"integer\" },\n    \"qdrant_collection\": { \"type\": \"string\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"Qdrant API key (fallback)\" },\n    \"openai_api_key\": { \"type\": \"string\" }\n  }\n}\n```\n\n**Headers:**\n- X-Tenant-ID: Required (resolved by MCP - Tenant - Resolve)",
+        "height": 620,
+        "width": 420,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 80]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "entity-save",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [500, 400],
+      "webhookId": "entity-save-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Entity Save\n// RFC-049 Entity Storage Architecture\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Get tenant_id from header (RFC-049) ---\nconst tenantId = headers['x-tenant-id'] || headers['X-Tenant-ID'] || null;\n\n// --- OPTIONAL context fields (for tracing) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\n\n// --- REQUIRED fields ---\nconst action = body.action || ctx.action;\nconst entityType = body.entity_type || ctx.entity_type;\nconst data = body.data || ctx.data;\n\n// Validate required fields\nif (!action) {\n  errors.push('action requis');\n} else if (!['save', 'update', 'delete'].includes(action)) {\n  errors.push('action doit etre save, update ou delete');\n}\n\nif (!entityType) {\n  errors.push('entity_type requis');\n} else if (!['recipe', 'document', 'course', 'quiz', 'flashcard'].includes(entityType)) {\n  errors.push('entity_type invalide');\n}\n\nif (!data && action !== 'delete') {\n  errors.push('data requis');\n}\n\n// entity_id required for update/delete\nconst entityId = body.entity_id || ctx.entity_id || null;\nif ((action === 'update' || action === 'delete') && !entityId) {\n  errors.push('entity_id requis pour update/delete');\n}\n\n// Qdrant parameters\nconst qdrantHost = body.qdrant_host || ctx.qdrant_host || null;\nconst qdrantPort = body.qdrant_port || ctx.qdrant_port || null;\nconst qdrantCollection = body.qdrant_collection || ctx.qdrant_collection || null;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || null;\n\n// API key fallback (RFC-049)\nconst qdrantApiKey = body.qdrant_api_key || body.api_key || ctx.qdrant_api_key || ctx.api_key || null;\n\n// Pre-computed embedding (optional)\nconst embedding = body.embedding || ctx.embedding || null;\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    tenant_id: tenantId\n  };\n}\n\n// Build text for embedding (generic)\nconst embeddingText = data ? [\n  data.title || '',\n  data.description || '',\n  (data.tags || []).join(' '),\n  (data.ingredients || []).map(i => typeof i === 'string' ? i : i.name).join(' '),\n  data.content || ''\n].join(' ').trim() : '';\n\nconst qdrantUrl = qdrantHost && qdrantPort ? `http://${qdrantHost}:${qdrantPort}` : null;\n\nreturn {\n  valid: true,\n  action: action,\n  entity_type: entityType,\n  entity_id: entityId,\n  data: data,\n  embedding: embedding,\n  embedding_text: embeddingText,\n  tenant_id: tenantId,\n  user_id: userId,\n  guild_id: guildId,\n  qdrant_url: qdrantUrl,\n  qdrant_collection: qdrantCollection,\n  qdrant_api_key: qdrantApiKey,\n  openai_api_key: openaiApiKey,\n  has_qdrant_config: !!(qdrantUrl && qdrantCollection),\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [720, 400]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [940, 400]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  }\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 560]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1380, 560]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "save",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "save"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "update",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "update"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "delete",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "delete"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-action",
+      "name": "Switch Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1160, 280]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE SAVE - Generate UUID for entity_id\n// RFC-049: Same UUID for entity_id and qdrant_point_id\n// ============================================\n\nconst input = $input.first().json;\n\nfunction generateUUID() {\n  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {\n    var r = Math.random() * 16 | 0;\n    var v = c === 'x' ? r : (r & 0x3 | 0x8);\n    return v.toString(16);\n  });\n}\n\n// Generate a single UUID for both entity_id and qdrant_point_id\nconst entityId = generateUUID();\n\nreturn {\n  ...input,\n  entity_id: entityId,\n  qdrant_point_id: entityId\n};"
+      },
+      "id": "prepare-save",
+      "name": "Prepare Save",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1400, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.N8N_API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"entity_id\": \"{{ $json.entity_id }}\",\n  \"guild_id\": {{ $json.guild_id ? '\"' + $json.guild_id + '\"' : 'null' }},\n  \"user_id\": {{ $json.user_id ? '\"' + $json.user_id + '\"' : 'null' }},\n  \"data\": {{ JSON.stringify($json.data) }}\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "api-save",
+      "name": "API Save",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1640, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.N8N_API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"guild_id\": {{ $json.guild_id ? '\"' + $json.guild_id + '\"' : 'null' }},\n  \"user_id\": {{ $json.user_id ? '\"' + $json.user_id + '\"' : 'null' }},\n  \"data\": {{ JSON.stringify($json.data) }}\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "api-update",
+      "name": "API Update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1400, 280],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "={{ $env.API_URL }}/api/n8n/entities/{{ $json.entity_type }}/{{ $json.entity_id }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.N8N_API_KEY }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "api-delete",
+      "name": "API Delete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1400, 460],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS API SAVE RESPONSE\n// Prepare for Qdrant storage\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Save').first().json;\n\n// Check for API errors\nif (input.error || input.statusCode >= 400) {\n  return {\n    ...prevData,\n    api_success: false,\n    api_error: input.error?.message || input.message || 'API save failed',\n    api_response: input\n  };\n}\n\nreturn {\n  ...prevData,\n  api_success: true,\n  api_response: input,\n  // Use entity_id from API response if provided, otherwise use our generated one\n  entity_id: input.data?.entity_id || input.entity_id || prevData.entity_id,\n  qdrant_point_id: input.data?.entity_id || input.entity_id || prevData.entity_id\n};"
+      },
+      "id": "process-api-save",
+      "name": "Process API Save",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1880, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.has_qdrant_config }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-qdrant-config"
+            },
+            {
+              "leftValue": "={{ $json.api_success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-api-success"
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-qdrant-save",
+      "name": "Store in Qdrant?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2120, 100]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.embedding?.length > 0 }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-has-embedding"
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-has-embedding",
+      "name": "Has Embedding?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2360, 0]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/embeddings",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openai_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"text-embedding-3-small\",\n  \"input\": \"{{ $json.embedding_text }}\"\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "generate-embedding",
+      "name": "Generate Embedding",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2600, 100],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE EMBEDDING FROM OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Save').first().json;\n\nif (input.error) {\n  return {\n    ...prevData,\n    embedding: null,\n    embedding_error: input.error.message\n  };\n}\n\nconst embedding = input.data?.[0]?.embedding;\n\nreturn {\n  ...prevData,\n  embedding: embedding\n};"
+      },
+      "id": "prepare-embedding",
+      "name": "Prepare Embedding",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2840, 100]
+    },
+    {
+      "parameters": {},
+      "id": "merge-embedding",
+      "name": "Merge Embedding",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [3080, 0]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $json.qdrant_url }}/collections/{{ $json.qdrant_collection }}/points",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $json.qdrant_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"points\": [\n    {\n      \"id\": \"{{ $json.qdrant_point_id }}\",\n      \"vector\": {{ JSON.stringify($json.embedding) }},\n      \"payload\": {\n        \"tenant_id\": {{ $json.tenant_id ? '\"' + $json.tenant_id + '\"' : 'null' }},\n        \"guild_id\": {{ $json.guild_id ? '\"' + $json.guild_id + '\"' : 'null' }},\n        \"entity_type\": \"{{ $json.entity_type }}\",\n        \"title\": {{ $json.data.title ? '\"' + $json.data.title.replace(/\"/g, '\\\\\"') + '\"' : 'null' }},\n        \"tags\": {{ JSON.stringify($json.data.tags || []) }}\n      }\n    }\n  ]\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "qdrant-save",
+      "name": "Qdrant Save",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [3320, 0],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {},
+      "id": "skip-qdrant-save",
+      "name": "Skip Qdrant",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [2360, 200]
+    },
+    {
+      "parameters": {},
+      "id": "merge-save-final",
+      "name": "Merge Save",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [3560, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD SAVE SUCCESS RESPONSE\n// RFC-049 Format\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Save').first().json;\nconst startTime = $('Validate Input').first().json.startTime || Date.now();\n\nconst qdrantSuccess = input.status === 'ok' || input.result?.status === 'acknowledged';\n\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    qdrant_point_id: prevData.qdrant_point_id,\n    entity_type: prevData.entity_type,\n    saved_in_db: prevData.api_success,\n    saved_in_qdrant: qdrantSuccess\n  },\n  _trace: {\n    service_response: {\n      api: prevData.api_response,\n      qdrant: input\n    },\n    provider: 'api+qdrant',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "build-save-success",
+      "name": "Build Save Success",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [3800, 100]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS API UPDATE RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Check for API errors\nif (input.error || input.statusCode >= 400) {\n  return {\n    ...prevData,\n    api_success: false,\n    api_error: input.error?.message || input.message || 'API update failed',\n    api_response: input,\n    qdrant_point_id: prevData.entity_id\n  };\n}\n\nreturn {\n  ...prevData,\n  api_success: true,\n  api_response: input,\n  qdrant_point_id: prevData.entity_id\n};"
+      },
+      "id": "process-api-update",
+      "name": "Process API Update",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1640, 280]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.has_qdrant_config }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-qdrant-config"
+            },
+            {
+              "leftValue": "={{ $json.api_success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-api-success"
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-qdrant-update",
+      "name": "Update Qdrant?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1880, 280]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.qdrant_url }}/collections/{{ $json.qdrant_collection }}/points/payload",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $json.qdrant_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"points\": [\"{{ $json.qdrant_point_id }}\"],\n  \"payload\": {\n    \"tenant_id\": {{ $json.tenant_id ? '\"' + $json.tenant_id + '\"' : 'null' }},\n    \"guild_id\": {{ $json.guild_id ? '\"' + $json.guild_id + '\"' : 'null' }},\n    \"entity_type\": \"{{ $json.entity_type }}\",\n    \"title\": {{ $json.data.title ? '\"' + $json.data.title.replace(/\"/g, '\\\\\"') + '\"' : 'null' }},\n    \"tags\": {{ JSON.stringify($json.data.tags || []) }}\n  }\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "qdrant-update",
+      "name": "Qdrant Update",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2120, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {},
+      "id": "skip-qdrant-update",
+      "name": "Skip Qdrant Update",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [2120, 360]
+    },
+    {
+      "parameters": {},
+      "id": "merge-update-final",
+      "name": "Merge Update",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [2360, 280]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD UPDATE SUCCESS RESPONSE\n// RFC-049 Format\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Update').first().json;\nconst startTime = $('Validate Input').first().json.startTime || Date.now();\n\nconst qdrantSuccess = input.status === 'ok' || input.result?.status === 'acknowledged';\n\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    qdrant_point_id: prevData.qdrant_point_id,\n    entity_type: prevData.entity_type,\n    saved_in_db: prevData.api_success,\n    saved_in_qdrant: qdrantSuccess\n  },\n  _trace: {\n    service_response: {\n      api: prevData.api_response,\n      qdrant: input\n    },\n    provider: 'api+qdrant',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "build-update-success",
+      "name": "Build Update Success",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2600, 280]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS API DELETE RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Check for API errors\nif (input.error || input.statusCode >= 400) {\n  return {\n    ...prevData,\n    api_success: false,\n    api_error: input.error?.message || input.message || 'API delete failed',\n    api_response: input,\n    qdrant_point_id: prevData.entity_id\n  };\n}\n\nreturn {\n  ...prevData,\n  api_success: true,\n  api_response: input,\n  qdrant_point_id: prevData.entity_id\n};"
+      },
+      "id": "process-api-delete",
+      "name": "Process API Delete",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1640, 460]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.has_qdrant_config }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-qdrant-config"
+            },
+            {
+              "leftValue": "={{ $json.api_success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "id": "check-api-success"
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-qdrant-delete",
+      "name": "Delete from Qdrant?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1880, 460]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.qdrant_url }}/collections/{{ $json.qdrant_collection }}/points/delete",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $json.qdrant_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"points\": [\"{{ $json.qdrant_point_id }}\"]\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "qdrant-delete",
+      "name": "Qdrant Delete",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2120, 380],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {},
+      "id": "skip-qdrant-delete",
+      "name": "Skip Qdrant Delete",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [2120, 540]
+    },
+    {
+      "parameters": {},
+      "id": "merge-delete-final",
+      "name": "Merge Delete",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [2360, 460]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD DELETE SUCCESS RESPONSE\n// RFC-049 Format\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Delete').first().json;\nconst startTime = $('Validate Input').first().json.startTime || Date.now();\n\nconst qdrantSuccess = input.status === 'ok' || input.result?.status === 'acknowledged';\n\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    qdrant_point_id: prevData.qdrant_point_id,\n    entity_type: prevData.entity_type,\n    deleted_from_db: prevData.api_success,\n    deleted_from_qdrant: qdrantSuccess\n  },\n  _trace: {\n    service_response: {\n      api: prevData.api_response,\n      qdrant: input\n    },\n    provider: 'api+qdrant',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      },
+      "id": "build-delete-success",
+      "name": "Build Delete Success",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2600, 460]
+    },
+    {
+      "parameters": {},
+      "id": "merge-all-actions",
+      "name": "Merge All Actions",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [4040, 280],
+      "parameters_count": 3
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [4280, 280]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Switch Action",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Action": {
+      "main": [
+        [
+          {
+            "node": "Prepare Save",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API Update",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "API Delete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Save": {
+      "main": [
+        [
+          {
+            "node": "API Save",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Save": {
+      "main": [
+        [
+          {
+            "node": "Process API Save",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process API Save": {
+      "main": [
+        [
+          {
+            "node": "Store in Qdrant?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Store in Qdrant?": {
+      "main": [
+        [
+          {
+            "node": "Has Embedding?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Skip Qdrant",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Embedding?": {
+      "main": [
+        [
+          {
+            "node": "Merge Embedding",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Generate Embedding",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Embedding": {
+      "main": [
+        [
+          {
+            "node": "Prepare Embedding",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Embedding": {
+      "main": [
+        [
+          {
+            "node": "Merge Embedding",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Embedding": {
+      "main": [
+        [
+          {
+            "node": "Qdrant Save",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Qdrant Save": {
+      "main": [
+        [
+          {
+            "node": "Merge Save",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Skip Qdrant": {
+      "main": [
+        [
+          {
+            "node": "Merge Save",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Save": {
+      "main": [
+        [
+          {
+            "node": "Build Save Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Save Success": {
+      "main": [
+        [
+          {
+            "node": "Merge All Actions",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Update": {
+      "main": [
+        [
+          {
+            "node": "Process API Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process API Update": {
+      "main": [
+        [
+          {
+            "node": "Update Qdrant?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Qdrant?": {
+      "main": [
+        [
+          {
+            "node": "Qdrant Update",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Skip Qdrant Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Qdrant Update": {
+      "main": [
+        [
+          {
+            "node": "Merge Update",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Skip Qdrant Update": {
+      "main": [
+        [
+          {
+            "node": "Merge Update",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Update": {
+      "main": [
+        [
+          {
+            "node": "Build Update Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Update Success": {
+      "main": [
+        [
+          {
+            "node": "Merge All Actions",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "API Delete": {
+      "main": [
+        [
+          {
+            "node": "Process API Delete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process API Delete": {
+      "main": [
+        [
+          {
+            "node": "Delete from Qdrant?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delete from Qdrant?": {
+      "main": [
+        [
+          {
+            "node": "Qdrant Delete",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Skip Qdrant Delete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Qdrant Delete": {
+      "main": [
+        [
+          {
+            "node": "Merge Delete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Skip Qdrant Delete": {
+      "main": [
+        [
+          {
+            "node": "Merge Delete",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Delete": {
+      "main": [
+        [
+          {
+            "node": "Build Delete Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Delete Success": {
+      "main": [
+        [
+          {
+            "node": "Merge All Actions",
+            "type": "main",
+            "index": 2
+          }
+        ]
+      ]
+    },
+    "Merge All Actions": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  }
+}

--- a/workflows/MCP_-_Entity_-_Save.json
+++ b/workflows/MCP_-_Entity_-_Save.json
@@ -8,11 +8,14 @@
         "width": 420,
         "color": 6
       },
-      "id": "doc-sticky",
+      "id": "5ada5805-6542-49c6-bb11-6d4cef4793a0",
       "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [40, 80]
+      "position": [
+        40,
+        80
+      ]
     },
     {
       "parameters": {
@@ -21,22 +24,28 @@
         "responseMode": "responseNode",
         "options": {}
       },
-      "id": "webhook",
+      "id": "0c29046e-982a-40cd-a263-498a200d5d1d",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [500, 400],
+      "position": [
+        500,
+        400
+      ],
       "webhookId": "entity-save-webhook"
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Entity Save\n// RFC-049 Entity Storage Architecture\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Get tenant_id from header (RFC-049) ---\nconst tenantId = headers['x-tenant-id'] || headers['X-Tenant-ID'] || null;\n\n// --- OPTIONAL context fields (for tracing) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\n\n// --- REQUIRED fields ---\nconst action = body.action || ctx.action;\nconst entityType = body.entity_type || ctx.entity_type;\nconst data = body.data || ctx.data;\n\n// Validate required fields\nif (!action) {\n  errors.push('action requis');\n} else if (!['save', 'update', 'delete'].includes(action)) {\n  errors.push('action doit etre save, update ou delete');\n}\n\nif (!entityType) {\n  errors.push('entity_type requis');\n} else if (!['recipe', 'document', 'course', 'quiz', 'flashcard'].includes(entityType)) {\n  errors.push('entity_type invalide');\n}\n\nif (!data && action !== 'delete') {\n  errors.push('data requis');\n}\n\n// entity_id required for update/delete\nconst entityId = body.entity_id || ctx.entity_id || null;\nif ((action === 'update' || action === 'delete') && !entityId) {\n  errors.push('entity_id requis pour update/delete');\n}\n\n// Qdrant parameters\nconst qdrantHost = body.qdrant_host || ctx.qdrant_host || null;\nconst qdrantPort = body.qdrant_port || ctx.qdrant_port || null;\nconst qdrantCollection = body.qdrant_collection || ctx.qdrant_collection || null;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || null;\n\n// API key fallback (RFC-049)\nconst qdrantApiKey = body.qdrant_api_key || body.api_key || ctx.qdrant_api_key || ctx.api_key || null;\n\n// Pre-computed embedding (optional)\nconst embedding = body.embedding || ctx.embedding || null;\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    tenant_id: tenantId\n  };\n}\n\n// Build text for embedding (generic)\nconst embeddingText = data ? [\n  data.title || '',\n  data.description || '',\n  (data.tags || []).join(' '),\n  (data.ingredients || []).map(i => typeof i === 'string' ? i : i.name).join(' '),\n  data.content || ''\n].join(' ').trim() : '';\n\nconst qdrantUrl = qdrantHost && qdrantPort ? `http://${qdrantHost}:${qdrantPort}` : null;\n\nreturn {\n  valid: true,\n  action: action,\n  entity_type: entityType,\n  entity_id: entityId,\n  data: data,\n  embedding: embedding,\n  embedding_text: embeddingText,\n  tenant_id: tenantId,\n  user_id: userId,\n  guild_id: guildId,\n  qdrant_url: qdrantUrl,\n  qdrant_collection: qdrantCollection,\n  qdrant_api_key: qdrantApiKey,\n  openai_api_key: openaiApiKey,\n  has_qdrant_config: !!(qdrantUrl && qdrantCollection),\n  startTime: Date.now()\n};"
       },
-      "id": "validate-input",
+      "id": "0650d19f-fb44-4fbf-9433-11027f962b56",
       "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [720, 400]
+      "position": [
+        720,
+        400
+      ]
     },
     {
       "parameters": {
@@ -61,21 +70,27 @@
         },
         "options": {}
       },
-      "id": "check-valid",
+      "id": "a46ae591-44e3-49c6-9350-a23a76b8b3d7",
       "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [940, 400]
+      "position": [
+        940,
+        400
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  }\n};"
       },
-      "id": "build-error",
+      "id": "94fca31f-6c9f-4628-8c07-b38a376b5800",
       "name": "Build Error",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1160, 560]
+      "position": [
+        1160,
+        560
+      ]
     },
     {
       "parameters": {
@@ -93,11 +108,14 @@
           }
         }
       },
-      "id": "respond-error",
+      "id": "6f8d68ac-f20d-4d28-97e1-573a1a6bc84f",
       "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [1380, 560]
+      "position": [
+        1380,
+        560
+      ]
     },
     {
       "parameters": {
@@ -173,21 +191,27 @@
         },
         "options": {}
       },
-      "id": "switch-action",
+      "id": "638d765c-002c-4069-a6ea-0007e8e6b16f",
       "name": "Switch Action",
       "type": "n8n-nodes-base.switch",
       "typeVersion": 3.2,
-      "position": [1160, 280]
+      "position": [
+        1160,
+        280
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// PREPARE SAVE - Generate UUID for entity_id\n// RFC-049: Same UUID for entity_id and qdrant_point_id\n// ============================================\n\nconst input = $input.first().json;\n\nfunction generateUUID() {\n  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {\n    var r = Math.random() * 16 | 0;\n    var v = c === 'x' ? r : (r & 0x3 | 0x8);\n    return v.toString(16);\n  });\n}\n\n// Generate a single UUID for both entity_id and qdrant_point_id\nconst entityId = generateUUID();\n\nreturn {\n  ...input,\n  entity_id: entityId,\n  qdrant_point_id: entityId\n};"
       },
-      "id": "prepare-save",
+      "id": "6c0a4003-97ee-48f3-ab44-677b67b212fd",
       "name": "Prepare Save",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1400, 100]
+      "position": [
+        1400,
+        100
+      ]
     },
     {
       "parameters": {
@@ -217,11 +241,14 @@
           "timeout": 30000
         }
       },
-      "id": "api-save",
+      "id": "09e17784-e0a2-40ba-a529-fe10e6f84751",
       "name": "API Save",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1640, 100],
+      "position": [
+        1640,
+        100
+      ],
       "onError": "continueRegularOutput"
     },
     {
@@ -252,11 +279,14 @@
           "timeout": 30000
         }
       },
-      "id": "api-update",
+      "id": "67d31900-30e7-44d8-9b58-03fa71e56452",
       "name": "API Update",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1400, 280],
+      "position": [
+        1400,
+        280
+      ],
       "onError": "continueRegularOutput"
     },
     {
@@ -280,22 +310,28 @@
           "timeout": 30000
         }
       },
-      "id": "api-delete",
+      "id": "a5994317-57b3-4f6a-99f9-c2bc699f123a",
       "name": "API Delete",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [1400, 460],
+      "position": [
+        1400,
+        460
+      ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// PROCESS API SAVE RESPONSE\n// Prepare for Qdrant storage\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Save').first().json;\n\n// Check for API errors\nif (input.error || input.statusCode >= 400) {\n  return {\n    ...prevData,\n    api_success: false,\n    api_error: input.error?.message || input.message || 'API save failed',\n    api_response: input\n  };\n}\n\nreturn {\n  ...prevData,\n  api_success: true,\n  api_response: input,\n  // Use entity_id from API response if provided, otherwise use our generated one\n  entity_id: input.data?.entity_id || input.entity_id || prevData.entity_id,\n  qdrant_point_id: input.data?.entity_id || input.entity_id || prevData.entity_id\n};"
       },
-      "id": "process-api-save",
+      "id": "6c30ed79-f7b4-4bed-b54e-68ba02498806",
       "name": "Process API Save",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1880, 100]
+      "position": [
+        1880,
+        100
+      ]
     },
     {
       "parameters": {
@@ -332,11 +368,14 @@
         },
         "options": {}
       },
-      "id": "check-qdrant-save",
+      "id": "d3ab006b-bea0-4964-beeb-959ebc6584b7",
       "name": "Store in Qdrant?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [2120, 100]
+      "position": [
+        2120,
+        100
+      ]
     },
     {
       "parameters": {
@@ -363,11 +402,14 @@
         },
         "options": {}
       },
-      "id": "check-has-embedding",
+      "id": "87d827e9-cc4f-4596-9394-f7005f0aa6b1",
       "name": "Has Embedding?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [2360, 0]
+      "position": [
+        2360,
+        0
+      ]
     },
     {
       "parameters": {
@@ -393,30 +435,39 @@
           "timeout": 30000
         }
       },
-      "id": "generate-embedding",
+      "id": "ed76ec13-0e2f-4f0f-9033-b60a7e2ef1f1",
       "name": "Generate Embedding",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2600, 100],
+      "position": [
+        2600,
+        100
+      ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// PREPARE EMBEDDING FROM OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Save').first().json;\n\nif (input.error) {\n  return {\n    ...prevData,\n    embedding: null,\n    embedding_error: input.error.message\n  };\n}\n\nconst embedding = input.data?.[0]?.embedding;\n\nreturn {\n  ...prevData,\n  embedding: embedding\n};"
       },
-      "id": "prepare-embedding",
+      "id": "1471ff6c-7d67-4d5f-a8a2-977cb1516eea",
       "name": "Prepare Embedding",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2840, 100]
+      "position": [
+        2840,
+        100
+      ]
     },
     {
       "parameters": {},
-      "id": "merge-embedding",
+      "id": "e025213f-57be-4927-b004-21dc05fe65bc",
       "name": "Merge Embedding",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [3080, 0]
+      "position": [
+        3080,
+        0
+      ]
     },
     {
       "parameters": {
@@ -442,48 +493,63 @@
           "timeout": 30000
         }
       },
-      "id": "qdrant-save",
+      "id": "07763c66-286f-4f73-82bd-714ce8e8bc34",
       "name": "Qdrant Save",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [3320, 0],
+      "position": [
+        3320,
+        0
+      ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {},
-      "id": "skip-qdrant-save",
+      "id": "d539b291-9be3-4493-bf56-48dc66d59537",
       "name": "Skip Qdrant",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [2360, 200]
+      "position": [
+        2360,
+        200
+      ]
     },
     {
       "parameters": {},
-      "id": "merge-save-final",
+      "id": "68522eba-7d1e-4fa7-af55-6c0a556748a5",
       "name": "Merge Save",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [3560, 100]
+      "position": [
+        3560,
+        100
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// BUILD SAVE SUCCESS RESPONSE\n// RFC-049 Format\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Save').first().json;\nconst startTime = $('Validate Input').first().json.startTime || Date.now();\n\nconst qdrantSuccess = input.status === 'ok' || input.result?.status === 'acknowledged';\n\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    qdrant_point_id: prevData.qdrant_point_id,\n    entity_type: prevData.entity_type,\n    saved_in_db: prevData.api_success,\n    saved_in_qdrant: qdrantSuccess\n  },\n  _trace: {\n    service_response: {\n      api: prevData.api_response,\n      qdrant: input\n    },\n    provider: 'api+qdrant',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
       },
-      "id": "build-save-success",
+      "id": "243636a1-fb14-444b-bb9c-490d7ef6a849",
       "name": "Build Save Success",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [3800, 100]
+      "position": [
+        3800,
+        100
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// PROCESS API UPDATE RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Check for API errors\nif (input.error || input.statusCode >= 400) {\n  return {\n    ...prevData,\n    api_success: false,\n    api_error: input.error?.message || input.message || 'API update failed',\n    api_response: input,\n    qdrant_point_id: prevData.entity_id\n  };\n}\n\nreturn {\n  ...prevData,\n  api_success: true,\n  api_response: input,\n  qdrant_point_id: prevData.entity_id\n};"
       },
-      "id": "process-api-update",
+      "id": "f92bba13-a94f-4bff-bfa6-381d168f2dee",
       "name": "Process API Update",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1640, 280]
+      "position": [
+        1640,
+        280
+      ]
     },
     {
       "parameters": {
@@ -520,11 +586,14 @@
         },
         "options": {}
       },
-      "id": "check-qdrant-update",
+      "id": "b9ed7f7e-b673-44ac-97bb-b524b744c61e",
       "name": "Update Qdrant?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [1880, 280]
+      "position": [
+        1880,
+        280
+      ]
     },
     {
       "parameters": {
@@ -550,48 +619,63 @@
           "timeout": 30000
         }
       },
-      "id": "qdrant-update",
+      "id": "6624a541-42bf-421f-8b7e-792c28b170a1",
       "name": "Qdrant Update",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2120, 200],
+      "position": [
+        2120,
+        200
+      ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {},
-      "id": "skip-qdrant-update",
+      "id": "cc44e4c5-8c1a-4743-9628-23ee6f1c6095",
       "name": "Skip Qdrant Update",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [2120, 360]
+      "position": [
+        2120,
+        360
+      ]
     },
     {
       "parameters": {},
-      "id": "merge-update-final",
+      "id": "74283b19-9523-4395-85db-653ee4194b73",
       "name": "Merge Update",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [2360, 280]
+      "position": [
+        2360,
+        280
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// BUILD UPDATE SUCCESS RESPONSE\n// RFC-049 Format\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Update').first().json;\nconst startTime = $('Validate Input').first().json.startTime || Date.now();\n\nconst qdrantSuccess = input.status === 'ok' || input.result?.status === 'acknowledged';\n\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    qdrant_point_id: prevData.qdrant_point_id,\n    entity_type: prevData.entity_type,\n    saved_in_db: prevData.api_success,\n    saved_in_qdrant: qdrantSuccess\n  },\n  _trace: {\n    service_response: {\n      api: prevData.api_response,\n      qdrant: input\n    },\n    provider: 'api+qdrant',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
       },
-      "id": "build-update-success",
+      "id": "30b5afcc-f42f-4349-80ee-5282f54cd9ad",
       "name": "Build Update Success",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2600, 280]
+      "position": [
+        2600,
+        280
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// PROCESS API DELETE RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Check for API errors\nif (input.error || input.statusCode >= 400) {\n  return {\n    ...prevData,\n    api_success: false,\n    api_error: input.error?.message || input.message || 'API delete failed',\n    api_response: input,\n    qdrant_point_id: prevData.entity_id\n  };\n}\n\nreturn {\n  ...prevData,\n  api_success: true,\n  api_response: input,\n  qdrant_point_id: prevData.entity_id\n};"
       },
-      "id": "process-api-delete",
+      "id": "ceadeeae-3a7e-4640-9418-bd4b4f627e90",
       "name": "Process API Delete",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [1640, 460]
+      "position": [
+        1640,
+        460
+      ]
     },
     {
       "parameters": {
@@ -628,11 +712,14 @@
         },
         "options": {}
       },
-      "id": "check-qdrant-delete",
+      "id": "56e213c0-da92-4a1a-bb36-860ac6858c56",
       "name": "Delete from Qdrant?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [1880, 460]
+      "position": [
+        1880,
+        460
+      ]
     },
     {
       "parameters": {
@@ -658,47 +745,61 @@
           "timeout": 30000
         }
       },
-      "id": "qdrant-delete",
+      "id": "3b016dec-fec8-4ee3-b0c6-0f92974399dd",
       "name": "Qdrant Delete",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [2120, 380],
+      "position": [
+        2120,
+        380
+      ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {},
-      "id": "skip-qdrant-delete",
+      "id": "7a941a8c-d085-43d7-8be0-cf37b2601975",
       "name": "Skip Qdrant Delete",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [2120, 540]
+      "position": [
+        2120,
+        540
+      ]
     },
     {
       "parameters": {},
-      "id": "merge-delete-final",
+      "id": "e949c276-9f53-4cbc-8c47-950b48eb815b",
       "name": "Merge Delete",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [2360, 460]
+      "position": [
+        2360,
+        460
+      ]
     },
     {
       "parameters": {
         "jsCode": "// ============================================\n// BUILD DELETE SUCCESS RESPONSE\n// RFC-049 Format\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Process API Delete').first().json;\nconst startTime = $('Validate Input').first().json.startTime || Date.now();\n\nconst qdrantSuccess = input.status === 'ok' || input.result?.status === 'acknowledged';\n\nreturn {\n  success: true,\n  data: {\n    entity_id: prevData.entity_id,\n    qdrant_point_id: prevData.qdrant_point_id,\n    entity_type: prevData.entity_type,\n    deleted_from_db: prevData.api_success,\n    deleted_from_qdrant: qdrantSuccess\n  },\n  _trace: {\n    service_response: {\n      api: prevData.api_response,\n      qdrant: input\n    },\n    provider: 'api+qdrant',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
       },
-      "id": "build-delete-success",
+      "id": "27d18233-9afb-4771-af48-0f23b8e43b76",
       "name": "Build Delete Success",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [2600, 460]
+      "position": [
+        2600,
+        460
+      ]
     },
     {
       "parameters": {},
-      "id": "merge-all-actions",
+      "id": "d381de3d-4da5-4e6b-b79d-db60f9b40ac0",
       "name": "Merge All Actions",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [4040, 280],
-      "parameters_count": 3
+      "position": [
+        4040,
+        280
+      ]
     },
     {
       "parameters": {
@@ -716,11 +817,14 @@
           }
         }
       },
-      "id": "respond-success",
+      "id": "55f76612-3602-439d-a06e-b5cf788f3152",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [4280, 280]
+      "position": [
+        4280,
+        280
+      ]
     }
   ],
   "connections": {

--- a/workflows/MCP_-_Entity_-_Search.json
+++ b/workflows/MCP_-_Entity_-_Search.json
@@ -1,0 +1,665 @@
+{
+  "name": "MCP - Entity - Search",
+  "nodes": [
+    {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80],
+      "parameters": {
+        "color": 6,
+        "width": 400,
+        "height": 780,
+        "content": "## MCP - Entity - Search\n\n**Endpoint:** POST /webhook/entity-search\n\n**Description:** Recherche semantique multi-tenant dans Qdrant avec enrichissement MongoDB optionnel. Remplace MCP Qdrant - Search (RFC-049).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"action\", \"query\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"search\", \"similar\"], \"description\": \"search=par query, similar=par entity_id\" },\n    \"query\": { \"type\": \"string\", \"description\": \"Texte de recherche (pour action=search)\" },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID pour recherche similaire (pour action=similar)\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Filtrer par type d'entite\" },\n    \"limit\": { \"type\": \"integer\", \"default\": 10, \"description\": \"Nombre de resultats max\" },\n    \"enrich\": { \"type\": \"boolean\", \"default\": false, \"description\": \"Enrichir depuis MongoDB\" },\n    \"fields\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"description\": \"Champs a recuperer depuis DB\" },\n    \"filters\": { \"type\": \"object\", \"description\": \"Filtres additionnels Qdrant\" },\n    \"user_id\": { \"type\": \"string\" },\n    \"guild_id\": { \"type\": \"string\" },\n    \"qdrant_host\": { \"type\": \"string\" },\n    \"qdrant_port\": { \"type\": \"integer\" },\n    \"qdrant_collection\": { \"type\": \"string\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"Qdrant API key (fallback)\" },\n    \"openai_api_key\": { \"type\": \"string\" }\n  }\n}\n```\n\n**Headers:**\n- `X-Tenant-ID`: Tenant identifier (REQUIRED for multi-tenant isolation)\n\n**Multi-tenant:** CRITICAL - Qdrant queries MUST filter by tenant_id.\n\n**Returns:**\n- `results`: Array avec score et payload\n- `entity`: Donnees enrichies MongoDB (si enrich=true)\n- `_trace`: Informations de tracabilite"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "entity-search-webhook",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "entity-search",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Entity Search\n// RFC-049: Multi-tenant Qdrant with MongoDB enrichment\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- CRITICAL: Multi-tenant isolation via X-Tenant-ID header ---\nconst tenantId = headers['x-tenant-id'] || headers['X-Tenant-ID'] || body.tenant_id || ctx.tenant_id;\n\nif (!tenantId) {\n  errors.push('X-Tenant-ID header requis pour isolation multi-tenant');\n}\n\n// --- OPTIONAL context fields (tracing only) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- REQUIRED parameters ---\nconst action = body.action || ctx.action;\nconst query = body.query || ctx.query;\nconst entityId = body.entity_id || ctx.entity_id;\n\nif (!action) {\n  errors.push('action requis (search ou similar)');\n} else if (!['search', 'similar'].includes(action)) {\n  errors.push('action doit etre search ou similar');\n}\n\nif (action === 'search' && !query) {\n  errors.push('query requis pour action=search');\n}\n\nif (action === 'similar' && !entityId) {\n  errors.push('entity_id requis pour action=similar');\n}\n\n// --- Qdrant configuration ---\nconst qdrantHost = body.qdrant_host || ctx.qdrant_host;\nconst qdrantPort = body.qdrant_port || ctx.qdrant_port;\nconst qdrantCollection = body.qdrant_collection || ctx.qdrant_collection;\n\n// Fallback: qdrant_api_key = body.qdrant_api_key || body.api_key (legacy compatibility)\nconst qdrantApiKey = body.qdrant_api_key || ctx.qdrant_api_key || body.api_key || ctx.api_key || '';\n\nif (!qdrantHost) {\n  errors.push('qdrant_host requis');\n}\nif (!qdrantPort) {\n  errors.push('qdrant_port requis');\n}\nif (!qdrantCollection) {\n  errors.push('qdrant_collection requis');\n}\n\n// --- OpenAI for embeddings (required for action=search) ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai;\n\nif (action === 'search' && !openaiApiKey) {\n  errors.push('openai_api_key requis pour action=search');\n}\n\n// --- Optional enrichment parameters ---\nconst enrich = body.enrich || ctx.enrich || false;\nconst fields = body.fields || ctx.fields || [];\nconst entityType = body.entity_type || ctx.entity_type || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nconst qdrantUrl = `http://${qdrantHost}:${qdrantPort}`;\n\nreturn {\n  valid: true,\n  action: action,\n  query: query || '',\n  entity_id: entityId || '',\n  entity_type: entityType,\n  limit: body.limit || ctx.limit || 10,\n  filters: body.filters || ctx.filters || {},\n  enrich: enrich,\n  fields: fields,\n  tenant_id: tenantId,\n  qdrant_url: qdrantUrl,\n  qdrant_collection: qdrantCollection,\n  qdrant_api_key: qdrantApiKey,\n  openai_api_key: openaiApiKey || '',\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'qdrant+api',\n    model: 'text-embedding-3-small',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "switch-action",
+      "name": "Switch Action",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [900, 200],
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "search",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "search",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "outputKey": "similar",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.action }}",
+                    "rightValue": "similar",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "none"
+        }
+      }
+    },
+    {
+      "id": "generate-embedding",
+      "name": "Generate Embedding",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 100],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/embeddings",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openai_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"text-embedding-3-small\",\n  \"input\": {{ JSON.stringify($json.query) }}\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "search-qdrant",
+      "name": "Search Qdrant",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 100],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $('Validate Input').first().json.qdrant_url }}/collections/{{ $('Validate Input').first().json.qdrant_collection }}/points/search",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $('Validate Input').first().json.qdrant_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"vector\": {{ JSON.stringify($json.data[0].embedding) }},\n  \"limit\": {{ $('Validate Input').first().json.limit }},\n  \"with_payload\": true,\n  \"with_vector\": false,\n  \"score_threshold\": 0.5,\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"tenant_id\",\n        \"match\": {\n          \"value\": {{ JSON.stringify($('Validate Input').first().json.tenant_id) }}\n        }\n      }\n    ]\n  }\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "get-entity-vector",
+      "name": "Get Entity Vector",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.qdrant_url }}/collections/{{ $json.qdrant_collection }}/points/search",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $json.qdrant_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"tenant_id\",\n        \"match\": {\n          \"value\": {{ JSON.stringify($json.tenant_id) }}\n        }\n      },\n      {\n        \"key\": \"entity_id\",\n        \"match\": {\n          \"value\": {{ JSON.stringify($json.entity_id) }}\n        }\n      }\n    ]\n  },\n  \"limit\": 1,\n  \"with_payload\": true,\n  \"with_vector\": true\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "search-similar",
+      "name": "Search Similar",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 300],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $('Validate Input').first().json.qdrant_url }}/collections/{{ $('Validate Input').first().json.qdrant_collection }}/points/search",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "api-key",
+              "value": "={{ $('Validate Input').first().json.qdrant_api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"vector\": {{ $json.result && $json.result[0] && $json.result[0].vector ? JSON.stringify($json.result[0].vector) : '[]' }},\n  \"limit\": {{ $('Validate Input').first().json.limit + 1 }},\n  \"with_payload\": true,\n  \"with_vector\": false,\n  \"score_threshold\": 0.5,\n  \"filter\": {\n    \"must\": [\n      {\n        \"key\": \"tenant_id\",\n        \"match\": {\n          \"value\": {{ JSON.stringify($('Validate Input').first().json.tenant_id) }}\n        }\n      }\n    ],\n    \"must_not\": [\n      {\n        \"key\": \"entity_id\",\n        \"match\": {\n          \"value\": {{ JSON.stringify($('Validate Input').first().json.entity_id) }}\n        }\n      }\n    ]\n  }\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "merge-results",
+      "name": "Merge Results",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1620, 200],
+      "parameters": {
+        "mode": "chooseBranch",
+        "output": "empty"
+      }
+    },
+    {
+      "id": "prepare-enrichment",
+      "name": "Prepare Enrichment",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1840, 200],
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE ENRICHMENT - Process Qdrant results\n// RFC-049: Prepare for optional MongoDB enrichment\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Handle API errors\nif (input.error || input.status?.error) {\n  return {\n    success: false,\n    qdrant_error: true,\n    error_message: input.error?.message || input.status?.error || 'Qdrant search failed',\n    raw_response: input,\n    prevData: prevData\n  };\n}\n\n// Extract results from Qdrant response\nconst results = (input.result || []).map(item => ({\n  entity_id: item.payload?.entity_id || item.id,\n  score: item.score,\n  payload: item.payload || {}\n}));\n\n// Extract entity IDs for batch enrichment\nconst entityIds = results.map(r => r.entity_id).filter(id => id);\n\nreturn {\n  success: true,\n  results: results,\n  entity_ids: entityIds,\n  enrich: prevData.enrich,\n  entity_type: prevData.entity_type,\n  fields: prevData.fields,\n  tenant_id: prevData.tenant_id,\n  prevData: prevData\n};"
+      }
+    },
+    {
+      "id": "if-enrich",
+      "name": "Enrich?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2060, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-enrich",
+              "leftValue": "={{ $json.enrich }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            },
+            {
+              "id": "check-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            },
+            {
+              "id": "check-entity-type",
+              "leftValue": "={{ $json.entity_type }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEquals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "batch-enrich",
+      "name": "Batch Enrich MongoDB",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2280, 100],
+      "parameters": {
+        "method": "POST",
+        "url": "=http://localhost:3000/api/n8n/entities/{{ $json.entity_type }}/batch",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-API-Key",
+              "value": "={{ $json.prevData.qdrant_api_key }}"
+            },
+            {
+              "name": "X-Tenant-ID",
+              "value": "={{ $json.tenant_id }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"ids\": {{ JSON.stringify($json.entity_ids) }},\n  \"fields\": {{ JSON.stringify($json.fields) }}\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "merge-enriched",
+      "name": "Merge Enriched",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2520, 100],
+      "parameters": {
+        "jsCode": "// ============================================\n// MERGE ENRICHED - Combine Qdrant with MongoDB data\n// RFC-049: Join search results with entity details\n// ============================================\n\nconst input = $input.first().json;\nconst prepData = $('Prepare Enrichment').first().json;\n\n// If enrichment request failed, continue with Qdrant data only\nif (input.error || !input.data) {\n  return {\n    results: prepData.results,\n    enrichment_failed: true,\n    enrichment_error: input.error?.message || 'Batch enrichment failed',\n    prevData: prepData.prevData\n  };\n}\n\n// Create lookup map from MongoDB response\nconst entityMap = {};\nif (input.data && Array.isArray(input.data)) {\n  input.data.forEach(entity => {\n    if (entity._id || entity.id) {\n      entityMap[entity._id || entity.id] = entity;\n    }\n  });\n}\n\n// Merge Qdrant results with MongoDB entities\nconst mergedResults = prepData.results.map(result => {\n  const entityData = entityMap[result.entity_id] || null;\n  return {\n    entity_id: result.entity_id,\n    score: result.score,\n    payload: result.payload,\n    entity: entityData\n  };\n});\n\nreturn {\n  results: mergedResults,\n  enriched: true,\n  prevData: prepData.prevData\n};"
+      }
+    },
+    {
+      "id": "skip-enrichment",
+      "name": "Skip Enrichment",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2280, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// SKIP ENRICHMENT - Pass through Qdrant results\n// ============================================\n\nconst input = $input.first().json;\n\nconst results = input.results.map(result => ({\n  entity_id: result.entity_id,\n  score: result.score,\n  payload: result.payload,\n  entity: null\n}));\n\nreturn {\n  results: results,\n  enriched: false,\n  prevData: input.prevData\n};"
+      }
+    },
+    {
+      "id": "merge-final",
+      "name": "Merge Final",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [2740, 200],
+      "parameters": {
+        "mode": "chooseBranch",
+        "output": "empty"
+      }
+    },
+    {
+      "id": "format-output",
+      "name": "Format Output",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2960, 200],
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OUTPUT - MCP Entity Search\n// RFC-049: Final response with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = input.prevData || $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Initialize trace\nconst _trace = {\n  service_response: {},\n  provider: 'qdrant+api',\n  model: 'text-embedding-3-small',\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\ntry {\n  // Check for Qdrant error from Prepare Enrichment\n  const prepData = $('Prepare Enrichment').first().json;\n  \n  if (prepData.qdrant_error) {\n    _trace.service_response = { qdrant: prepData.raw_response };\n    _trace.latency_ms = Date.now() - startTime;\n    \n    return {\n      json: {\n        success: false,\n        error: {\n          code: 'SEARCH_ERROR',\n          message: prepData.error_message,\n          http_status: 500\n        },\n        meta: { provider: 'qdrant+api', collection: prevData.qdrant_collection },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: _trace\n      }\n    };\n  }\n\n  const results = input.results || [];\n\n  // Apply additional filters if any\n  let filtered = results;\n  const filters = prevData.filters || {};\n\n  if (filters.entity_type && prevData.entity_type) {\n    filtered = filtered.filter(r => r.payload?.entity_type === prevData.entity_type);\n  }\n\n  // Populate trace\n  _trace.service_response = {\n    qdrant: { result_count: results.length },\n    api: input.enriched ? { enriched_count: results.filter(r => r.entity).length } : null\n  };\n  _trace.latency_ms = Date.now() - startTime;\n\n  return {\n    json: {\n      success: true,\n      data: {\n        results: filtered.slice(0, prevData.limit),\n        total: filtered.length\n      },\n      meta: {\n        provider: 'qdrant+api',\n        collection: prevData.qdrant_collection,\n        action: prevData.action,\n        enriched: input.enriched || false,\n        tenant_id: prevData.tenant_id\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n} catch (e) {\n  _trace.service_response = { error: e.message };\n  _trace.latency_ms = Date.now() - startTime;\n\n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PROCESS_ERROR',\n        message: 'Failed to process search results: ' + e.message,\n        http_status: 500\n      },\n      meta: { provider: 'qdrant+api' },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [3180, 200],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Switch Action",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Action": {
+      "main": [
+        [
+          {
+            "node": "Generate Embedding",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Get Entity Vector",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Embedding": {
+      "main": [
+        [
+          {
+            "node": "Search Qdrant",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search Qdrant": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Entity Vector": {
+      "main": [
+        [
+          {
+            "node": "Search Similar",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Search Similar": {
+      "main": [
+        [
+          {
+            "node": "Merge Results",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Results": {
+      "main": [
+        [
+          {
+            "node": "Prepare Enrichment",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Enrichment": {
+      "main": [
+        [
+          {
+            "node": "Enrich?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Enrich?": {
+      "main": [
+        [
+          {
+            "node": "Batch Enrich MongoDB",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Skip Enrichment",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Batch Enrich MongoDB": {
+      "main": [
+        [
+          {
+            "node": "Merge Enriched",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge Enriched": {
+      "main": [
+        [
+          {
+            "node": "Merge Final",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Skip Enrichment": {
+      "main": [
+        [
+          {
+            "node": "Merge Final",
+            "type": "main",
+            "index": 1
+          }
+        ]
+      ]
+    },
+    "Merge Final": {
+      "main": [
+        [
+          {
+            "node": "Format Output",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Output": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP_-_Feedback_Analyzer.json
+++ b/workflows/MCP_-_Feedback_Analyzer.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2025-12-18T10:49:30.000Z",
-  "createdAt": "2025-12-18T10:49:15.425Z",
-  "id": "9HKS632YxiHgek7p",
   "name": "MCP - Feedback Analyzer",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-feedback",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "analyze-feedback-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +18,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Feedback Analyzer\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Webhook-specific parameters ---\nconst comment = body.comment || ctx.comment;\nconst feedbackType = body.feedback_type || ctx.feedback_type || 'unknown';\nconst language = body.language || ctx.language || 'fr';\n\nif (!comment) {\n  errors.push('comment requis');\n}\n\n// --- API Keys (passed by system, do not validate) ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  comment: comment,\n  feedback_type: feedbackType,\n  language: language,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  openaiApiKey: openaiApiKey,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +40,12 @@
           },
           "conditions": [
             {
-              "id": "condition-comment",
-              "leftValue": "={{ $json.body.comment }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +55,34 @@
       }
     },
     {
-      "id": "error-no-comment",
-      "name": "Error: No Comment",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 480],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: comment\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,10 +91,7 @@
       "name": "OpenAI Analyze Feedback",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/chat/completions",
@@ -91,7 +101,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.openai_api_key }}"
+              "value": "=Bearer {{ $json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -101,7 +111,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un analyseur expert de feedback utilisateur. Ton rôle est d'extraire des insights actionnables pour ajuster le comportement d'un assistant IA.\\n\\n## Catégories de feedback\\n- length: Longueur de la réponse (trop long, trop court)\\n- accuracy: Pertinence/Compréhension (pas ce qui était demandé, hors sujet)\\n- tone: Ton de la réponse (trop formel, pas assez professionnel)\\n- speed: Rapidité de réponse\\n- confirmation: Demandes de confirmation (trop de questions)\\n- detail: Niveau de détail (trop technique, pas assez détaillé)\\n- format: Format de réponse (préfère les listes, plus structuré)\\n- other: Autre (y compris feedback positif)\\n\\n## Problèmes détectables (detected_problems)\\n- misunderstanding: Mauvaise compréhension de la demande\\n- off_topic: Réponse hors sujet\\n- too_verbose: Trop verbeux\\n- too_brief: Trop bref\\n- wrong_tone: Ton inapproprié\\n- too_slow: Temps de réponse trop long\\n- too_many_questions: Trop de demandes de confirmation\\n- missing_info: Information manquante\\n- incorrect_info: Information incorrecte\\n- good_response: Réponse satisfaisante (feedback positif)\\n\\n## Préférences utilisateur possibles\\n| Clé | Valeurs possibles |\\n|-----|-------------------|\\n| response_length | short, medium, detailed |\\n| comprehension | confirm_understanding, act_directly |\\n| confirmation_level | always, sensitive_only, never |\\n| tone | formal, casual, neutral |\\n| detail_level | minimal, moderate, comprehensive |\\n| response_format | prose, bullet_points, structured |\\n\\n## Format de sortie\\nRetourne UNIQUEMENT un JSON valide avec cette structure exacte:\\n{\\n  \\\"category\\\": \\\"string (une des catégories ci-dessus)\\\",\\n  \\\"issue\\\": \\\"string ou null (description courte du problème)\\\",\\n  \\\"detected_problems\\\": [\\\"array de problèmes détectés\\\"],\\n  \\\"user_preference\\\": {\\n    \\\"key\\\": \\\"clé de préférence\\\",\\n    \\\"value\\\": \\\"valeur\\\",\\n    \\\"description\\\": \\\"explication en français\\\"\\n  } ou null si feedback positif sans préférence claire,\\n  \\\"suggested_action\\\": \\\"string (comment ajuster le comportement)\\\",\\n  \\\"confidence\\\": 0.0 à 1.0\\n}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Analyse ce feedback utilisateur:\\n\\nType de feedback: {{ $json.body.feedback_type || 'unknown' }}\\nCommentaire: \\\"{{ $json.body.comment }}\\\"\\nLangue: {{ $json.body.language || 'fr' }}\"\n    }\n  ],\n  \"temperature\": 0.3,\n  \"max_tokens\": 1024\n}",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un analyseur expert de feedback utilisateur. Ton rôle est d'extraire des insights actionnables pour ajuster le comportement d'un assistant IA.\\n\\n## Catégories de feedback\\n- length: Longueur de la réponse (trop long, trop court)\\n- accuracy: Pertinence/Compréhension (pas ce qui était demandé, hors sujet)\\n- tone: Ton de la réponse (trop formel, pas assez professionnel)\\n- speed: Rapidité de réponse\\n- confirmation: Demandes de confirmation (trop de questions)\\n- detail: Niveau de détail (trop technique, pas assez détaillé)\\n- format: Format de réponse (préfère les listes, plus structuré)\\n- other: Autre (y compris feedback positif)\\n\\n## Problèmes détectables (detected_problems)\\n- misunderstanding: Mauvaise compréhension de la demande\\n- off_topic: Réponse hors sujet\\n- too_verbose: Trop verbeux\\n- too_brief: Trop bref\\n- wrong_tone: Ton inapproprié\\n- too_slow: Temps de réponse trop long\\n- too_many_questions: Trop de demandes de confirmation\\n- missing_info: Information manquante\\n- incorrect_info: Information incorrecte\\n- good_response: Réponse satisfaisante (feedback positif)\\n\\n## Préférences utilisateur possibles\\n| Clé | Valeurs possibles |\\n|-----|-------------------|\\n| response_length | short, medium, detailed |\\n| comprehension | confirm_understanding, act_directly |\\n| confirmation_level | always, sensitive_only, never |\\n| tone | formal, casual, neutral |\\n| detail_level | minimal, moderate, comprehensive |\\n| response_format | prose, bullet_points, structured |\\n\\n## Format de sortie\\nRetourne UNIQUEMENT un JSON valide avec cette structure exacte:\\n{\\n  \\\"category\\\": \\\"string (une des catégories ci-dessus)\\\",\\n  \\\"issue\\\": \\\"string ou null (description courte du problème)\\\",\\n  \\\"detected_problems\\\": [\\\"array de problèmes détectés\\\"],\\n  \\\"user_preference\\\": {\\n    \\\"key\\\": \\\"clé de préférence\\\",\\n    \\\"value\\\": \\\"valeur\\\",\\n    \\\"description\\\": \\\"explication en français\\\"\\n  } ou null si feedback positif sans préférence claire,\\n  \\\"suggested_action\\\": \\\"string (comment ajuster le comportement)\\\",\\n  \\\"confidence\\\": 0.0 à 1.0\\n}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"**Demande utilisateur:** {{ $json.user_request }}\\n\\n**Feedback à analyser:**\\nType de feedback: {{ $json.feedback_type }}\\nCommentaire: \\\"{{ $json.comment }}\\\"\\nLangue: {{ $json.language }}\"\n    }\n  ],\n  \"temperature\": 0.3,\n  \"max_tokens\": 1024\n}",
         "options": {
           "timeout": 30000
         }
@@ -113,12 +123,9 @@
       "name": "Parse Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\nconst startTime = Date.now();\n\nconst results = items.map(item => {\n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'OpenAI API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          processing_time_ms: Date.now() - startTime\n        }\n      }\n    };\n  }\n\n  try {\n    const content = item.json.choices?.[0]?.message?.content || '{}';\n    const analysis = JSON.parse(content);\n    \n    // Validate required fields\n    const validCategories = ['length', 'accuracy', 'tone', 'speed', 'confirmation', 'detail', 'format', 'other'];\n    if (!validCategories.includes(analysis.category)) {\n      analysis.category = 'other';\n    }\n    \n    // Ensure detected_problems is an array\n    if (!Array.isArray(analysis.detected_problems)) {\n      analysis.detected_problems = [];\n    }\n    \n    // Ensure confidence is a number between 0 and 1\n    if (typeof analysis.confidence !== 'number' || analysis.confidence < 0 || analysis.confidence > 1) {\n      analysis.confidence = 0.5;\n    }\n    \n    return {\n      json: {\n        success: true,\n        analysis: {\n          category: analysis.category,\n          issue: analysis.issue || null,\n          detected_problems: analysis.detected_problems,\n          user_preference: analysis.user_preference || null,\n          suggested_action: analysis.suggested_action || null,\n          confidence: analysis.confidence\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          processing_time_ms: Date.now() - startTime\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse analysis response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          processing_time_ms: Date.now() - startTime\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
+        "jsCode": "// ============================================\n// PARSE RESPONSE - MCP Feedback Analyzer\n// ============================================\n\nconst items = $input.all();\nconst prevData = $('Validate Input').first().json;\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\nconst startTime = prevData.startTime;\n\nconst results = items.map(item => {\n  const latencyMs = Date.now() - startTime;\n  \n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'OpenAI API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          processing_time_ms: latencyMs\n        },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: {\n          service_response: item.json.error,\n          llm_response: null,\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          latency_ms: latencyMs,\n          user_id: userId,\n          guild_id: guildId,\n          user_request: userRequest\n        }\n      }\n    };\n  }\n\n  try {\n    const content = item.json.choices?.[0]?.message?.content || '{}';\n    const analysis = JSON.parse(content);\n    \n    // Validate required fields\n    const validCategories = ['length', 'accuracy', 'tone', 'speed', 'confirmation', 'detail', 'format', 'other'];\n    if (!validCategories.includes(analysis.category)) {\n      analysis.category = 'other';\n    }\n    \n    // Ensure detected_problems is an array\n    if (!Array.isArray(analysis.detected_problems)) {\n      analysis.detected_problems = [];\n    }\n    \n    // Ensure confidence is a number between 0 and 1\n    if (typeof analysis.confidence !== 'number' || analysis.confidence < 0 || analysis.confidence > 1) {\n      analysis.confidence = 0.5;\n    }\n    \n    const analysisResult = {\n      category: analysis.category,\n      issue: analysis.issue || null,\n      detected_problems: analysis.detected_problems,\n      user_preference: analysis.user_preference || null,\n      suggested_action: analysis.suggested_action || null,\n      confidence: analysis.confidence\n    };\n    \n    return {\n      json: {\n        success: true,\n        analysis: analysisResult,\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          processing_time_ms: latencyMs\n        },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: {\n          service_response: analysisResult,\n          llm_response: content,\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          latency_ms: latencyMs,\n          user_id: userId,\n          guild_id: guildId,\n          user_request: userRequest\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse analysis response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          processing_time_ms: latencyMs\n        },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: {\n          service_response: { parse_error: e.message },\n          llm_response: item.json.choices?.[0]?.message?.content,\n          provider: 'openai',\n          model: 'gpt-4o-mini',\n          latency_ms: latencyMs,\n          user_id: userId,\n          guild_id: guildId,\n          user_request: userRequest\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
       }
     },
     {
@@ -126,10 +133,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
+      "position": [1340, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -138,18 +142,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 650,
-        "height": 280,
-        "content": "## MCP - Feedback Analyzer\n\n**Endpoint:** POST /webhook/analyze-feedback\n\n**Parameters:**\n- `comment` (required): User feedback comment to analyze\n- `openai_api_key` (required): OpenAI API key\n- `feedback_type` (optional): positive | negative | neutral (default: unknown)\n- `language` (optional): fr | en (default: fr)\n\n**Returns:**\n- `category`: length | accuracy | tone | speed | confirmation | detail | format | other\n- `issue`: Description of the identified problem\n- `detected_problems`: Array of detected issues\n- `user_preference`: Preference to store (key, value, description)\n- `suggested_action`: How to adjust LLM behavior\n- `confidence`: 0.0 to 1.0\n\n**Model:** gpt-4o-mini (fast, cost-effective for classification)"
+        "width": 340,
+        "height": 620,
+        "content": "## MCP - Feedback Analyzer\n\n**Endpoint:** POST /webhook/analyze-feedback\n\n**Description:** Analyse le feedback utilisateur pour extraire des insights actionnables et ajuster le comportement de l'assistant IA.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"comment\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"comment\": { \"type\": \"string\", \"description\": \"Commentaire feedback a analyser\" },\n    \"feedback_type\": { \"type\": \"string\", \"description\": \"positive | negative | neutral\", \"default\": \"unknown\" },\n    \"language\": { \"type\": \"string\", \"description\": \"Langue (fr, en)\", \"default\": \"fr\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"category\", \"issue\", \"detected_problems\", \"user_preference\", \"suggested_action\", \"confidence\"],\n  \"domain\": \"feedback_analysis\"\n}\n```\n\n**Model:** gpt-4o-mini"
       }
     }
   ],
@@ -169,6 +170,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI Analyze Feedback",
             "type": "main",
             "index": 0
@@ -176,7 +188,18 @@
         ],
         [
           {
-            "node": "Error: No Comment",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -208,33 +231,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "a7f66e78-bdea-4246-bb9f-2aec7af708ab",
-  "activeVersionId": "a7f66e78-bdea-4246-bb9f-2aec7af708ab",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T10:49:15.429Z",
-      "createdAt": "2025-12-18T10:49:15.429Z",
-      "role": "workflow:owner",
-      "workflowId": "9HKS632YxiHgek7p",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Google_Drive_OCR.json
+++ b/workflows/MCP_-_Google_Drive_OCR.json
@@ -1,11 +1,5 @@
 {
-  "updatedAt": "2025-12-23T09:23:42.456Z",
-  "createdAt": "2025-12-23T09:23:34.859Z",
-  "id": "syDUdlVjTrV9QqPI",
   "name": "MCP - Google Drive OCR",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-drive-ocr",
@@ -25,60 +19,87 @@
       }
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Google Drive OCR\n// RFC-014 compliant extraction\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- REQUIRED fields ---\nconst googleAccessToken = body.google_access_token || ctx.google_access_token;\nconst fileId = body.file_id || ctx.file_id || null;\nconst folderId = body.folder_id || ctx.folder_id || null;\n\nif (!googleAccessToken) {\n  errors.push('google_access_token requis');\n}\nif (!fileId && !folderId) {\n  errors.push('file_id ou folder_id requis');\n}\n\n// --- Optional fields with defaults ---\nconst mistralApiKey = body.mistral_api_key || ctx.mistral_api_key || '';\nconst maxFiles = body.max_files || ctx.max_files || 100;\nconst includeImages = body.include_images || ctx.include_images || false;\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  google_access_token: googleAccessToken,\n  mistral_api_key: mistralApiKey,\n  file_id: fileId,\n  folder_id: folderId,\n  max_files: maxFiles,\n  include_images: includeImages,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
         460,
         300
-      ],
+      ]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
             "caseSensitive": true,
             "leftValue": "",
-            "typeValidation": "loose"
+            "typeValidation": "strict"
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.google_access_token }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
-              }
-            },
-            {
-              "leftValue": "={{ $json.body.file_id || $json.body.folder_id }}",
-              "rightValue": "",
-              "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        680,
+        300
+      ]
     },
     {
-      "id": "error-no-input",
-      "name": "Error: Missing Input",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
-        700,
-        460
-      ],
+        900,
+        480
+      ]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameters. Provide google_access_token and either file_id or folder_id.\", \"status\": \"BAD_REQUEST\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1120,
+        480
+      ]
     },
     {
       "id": "route-operation",
@@ -86,7 +107,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
-        700,
+        900,
         200
       ],
       "parameters": {
@@ -98,7 +119,7 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.file_id }}",
+              "leftValue": "={{ $json.file_id }}",
               "rightValue": "",
               "operator": {
                 "type": "string",
@@ -117,7 +138,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        940,
+        1140,
         100
       ],
       "parameters": {
@@ -129,7 +150,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $('Webhook').first().json.body.google_access_token }}"
+              "value": "=Bearer {{ $('Validate Input').first().json.google_access_token }}"
             }
           ]
         },
@@ -138,7 +159,7 @@
           "parameters": [
             {
               "name": "q",
-              "value": "='\"{{ $('Webhook').first().json.body.folder_id }}\" in parents and (mimeType=\"image/png\" or mimeType=\"image/jpeg\" or mimeType=\"application/pdf\")'"
+              "value": "='\"{{ $('Validate Input').first().json.folder_id }}\" in parents and (mimeType=\"image/png\" or mimeType=\"image/jpeg\" or mimeType=\"application/pdf\")'"
             },
             {
               "name": "fields",
@@ -146,7 +167,7 @@
             },
             {
               "name": "pageSize",
-              "value": "={{ $('Webhook').first().json.body.max_files || 100 }}"
+              "value": "={{ $('Validate Input').first().json.max_files }}"
             }
           ]
         },
@@ -162,19 +183,19 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        940,
+        1140,
         300
       ],
       "parameters": {
         "method": "GET",
-        "url": "=https://www.googleapis.com/drive/v3/files/{{ $('Webhook').first().json.body.file_id }}?alt=media",
+        "url": "=https://www.googleapis.com/drive/v3/files/{{ $('Validate Input').first().json.file_id }}?alt=media",
         "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $('Webhook').first().json.body.google_access_token }}"
+              "value": "=Bearer {{ $('Validate Input').first().json.google_access_token }}"
             }
           ]
         },
@@ -195,19 +216,19 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        940,
+        1140,
         500
       ],
       "parameters": {
         "method": "GET",
-        "url": "=https://www.googleapis.com/drive/v3/files/{{ $('Webhook').first().json.body.file_id }}",
+        "url": "=https://www.googleapis.com/drive/v3/files/{{ $('Validate Input').first().json.file_id }}",
         "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $('Webhook').first().json.body.google_access_token }}"
+              "value": "=Bearer {{ $('Validate Input').first().json.google_access_token }}"
             }
           ]
         },
@@ -232,7 +253,7 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1180,
+        1380,
         300
       ],
       "parameters": {
@@ -244,7 +265,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $('Webhook').first().json.body.mistral_api_key }}"
+              "value": "=Bearer {{ $('Validate Input').first().json.mistral_api_key }}"
             },
             {
               "name": "Content-Type",
@@ -254,7 +275,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"mistral-ocr-latest\", \"document\": { \"type\": \"image_url\", \"image_url\": 'data:' + ($('Get File Metadata').first().json.mimeType || 'image/png') + ';base64,' + $binary.data.data }, \"include_image_base64\": $('Webhook').first().json.body.include_images || false } }}",
+        "jsonBody": "={{ { \"model\": \"mistral-ocr-latest\", \"document\": { \"type\": \"image_url\", \"image_url\": 'data:' + ($('Get File Metadata').first().json.mimeType || 'image/png') + ';base64,' + $binary.data.data }, \"include_image_base64\": $('Validate Input').first().json.include_images || false } }}",
         "options": {
           "timeout": 120000
         }
@@ -264,75 +285,93 @@
     {
       "id": "format-list-output",
       "name": "Format List Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
-        1180,
+        1380,
         100
       ],
       "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"operation\": \"list_files\", \"data\": { \"files\": $json.files || [], \"folder_id\": $('Webhook').first().json.body.folder_id }, \"meta\": { \"provider\": \"google_drive\", \"count\": ($json.files || []).length } } }}"
+        "jsCode": "// ============================================\n// FORMAT LIST OUTPUT - with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime;\n\nconst files = input.files || [];\n\nreturn {\n  success: true,\n  operation: 'list_files',\n  data: {\n    files: files,\n    folder_id: prevData.folder_id\n  },\n  meta: {\n    provider: 'google_drive',\n    count: files.length\n  },\n  _trace: {\n    service_response: { file_count: files.length },\n    provider: 'google_drive',\n    mode: 'list',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request\n};"
       }
     },
     {
       "id": "format-ocr-output",
       "name": "Format OCR Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
       "position": [
-        1420,
+        1620,
         300
       ],
       "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"operation\": \"ocr\", \"data\": { \"text\": $json.pages?.map(p => p.markdown).join('\\n\\n') || '', \"pages\": $json.pages || [], \"file\": { \"id\": $('Webhook').first().json.body.file_id, \"name\": $('Get File Metadata').first().json.name, \"mimeType\": $('Get File Metadata').first().json.mimeType } }, \"meta\": { \"provider\": \"mistral\", \"model\": $json.model || 'mistral-ocr-latest', \"usage\": { \"pages_processed\": $json.usage_info?.pages_processed || 1, \"doc_size_bytes\": $json.usage_info?.doc_size_bytes || 0 } } } }}"
+        "jsCode": "// ============================================\n// FORMAT OCR OUTPUT - with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst metadata = $('Get File Metadata').first().json;\nconst startTime = prevData.startTime;\n\nconst pages = input.pages || [];\nconst text = pages.map(p => p.markdown).join('\\n\\n') || '';\n\nreturn {\n  success: true,\n  operation: 'ocr',\n  data: {\n    text: text,\n    pages: pages,\n    file: {\n      id: prevData.file_id,\n      name: metadata.name,\n      mimeType: metadata.mimeType\n    }\n  },\n  meta: {\n    provider: 'mistral',\n    model: input.model || 'mistral-ocr-latest',\n    usage: {\n      pages_processed: input.usage_info?.pages_processed || 1,\n      doc_size_bytes: input.usage_info?.doc_size_bytes || 0\n    }\n  },\n  _trace: {\n    service_response: {\n      pages_processed: input.usage_info?.pages_processed || pages.length,\n      text_length: text.length\n    },\n    provider: 'mistral',\n    mode: 'ocr',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request\n};"
       }
     },
     {
       "id": "respond-list",
       "name": "Respond List",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
+      "typeVersion": 1.1,
       "position": [
-        1420,
+        1620,
         100
       ],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       }
     },
     {
       "id": "respond-ocr",
       "name": "Respond OCR",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
+      "typeVersion": 1.1,
       "position": [
-        1660,
+        1860,
         300
       ],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       }
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
       "position": [
         240,
-        60
+        0
       ],
       "parameters": {
         "color": 6,
-        "width": 600,
-        "height": 280,
-        "content": "## MCP - Google Drive OCR\n\n**Endpoint:** POST /webhook/google-drive-ocr\n\n**Parameters:**\n- `google_access_token` (required): Google OAuth2 access token\n- `mistral_api_key` (required for OCR): Mistral API key\n- `folder_id` (string): List files in folder\n- `file_id` (string): Process specific file with OCR\n- `max_files` (int): Max files to list (default: 100)\n- `include_images` (bool): Include base64 images in OCR response\n\n**Operations:**\n- List files: provide `folder_id`\n- OCR file: provide `file_id` + `mistral_api_key`\n\n**API:** Mistral OCR (mistral-ocr-latest) + Google Drive v3"
+        "width": 660,
+        "height": 400,
+        "content": "## MCP - Google Drive OCR\n\n**Endpoint:** POST /webhook/google-drive-ocr\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"google_access_token\"],\n  \"properties\": {\n    \"google_access_token\": { \"type\": \"string\", \"description\": \"Google OAuth2 access token\" },\n    \"folder_id\": { \"type\": \"string\", \"description\": \"List files in folder\" },\n    \"file_id\": { \"type\": \"string\", \"description\": \"Process specific file with OCR\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key (required for OCR)\" },\n    \"max_files\": { \"type\": \"integer\", \"description\": \"Max files to list\", \"default\": 100 },\n    \"include_images\": { \"type\": \"boolean\", \"description\": \"Include base64 images in OCR response\", \"default\": false },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**Note:** Requires `google_access_token` AND (`folder_id` OR `file_id`).\n\n**Operations:**\n- List files: provide `folder_id`\n- OCR file: provide `file_id` + `mistral_api_key`\n\n**API:** Mistral OCR (mistral-ocr-latest) + Google Drive v3"
       }
     }
   ],
@@ -352,6 +391,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Route Operation",
             "type": "main",
             "index": 0
@@ -359,7 +409,18 @@
         ],
         [
           {
-            "node": "Error: Missing Input",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -449,31 +510,5 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "3bf3f117-9848-4b11-ae71-72fdb5dc2def",
-  "activeVersionId": "3bf3f117-9848-4b11-ae71-72fdb5dc2def",
-  "versionCounter": 352,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-23T09:23:34.863Z",
-      "createdAt": "2025-12-23T09:23:34.863Z",
-      "role": "workflow:owner",
-      "workflowId": "syDUdlVjTrV9QqPI",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }

--- a/workflows/MCP_-_Image_Embedder.json
+++ b/workflows/MCP_-_Image_Embedder.json
@@ -1,21 +1,25 @@
 {
-  "updatedAt": "2025-12-18T15:17:14.000Z",
-  "createdAt": "2025-12-18T15:14:35.001Z",
-  "id": "HGu8rrdZeX4unms2",
   "name": "MCP - Image Embedder",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Image Embedder\n\n**Endpoint:** POST /webhook/image-embedder\n\n**Description:** Analyse une image via GPT-4o-mini et genere un embedding semantique\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image a analyser\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Image encodee en base64\" }\n  }\n}\n```\n\n**Note:** image_url OU image_base64 requis (au moins un des deux). API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"embedding\", \"analysis\", \"dimensions\"],\n  \"domain\": \"vision\"\n}\n```",
+        "height": 580,
+        "width": 340,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80]
+    },
     {
       "id": "webhook-img-embed",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "image-embedder-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -25,14 +29,16 @@
       }
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Image Embedder\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request || '';\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Image parameters (one of them required) ---\nconst imageUrl = body.image_url || ctx.image_url;\nconst imageBase64 = body.image_base64 || ctx.image_base64;\n\nif (!imageUrl && !imageBase64) {\n  errors.push('image_url ou image_base64 requis');\n}\n\n// --- API Keys (passed by the system) ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\n\nif (!openaiApiKey) {\n  errors.push('openai_api_key requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// --- Build image URL for API ---\nlet finalImageUrl = imageUrl;\nif (!imageUrl && imageBase64) {\n  // Check if it's already a data URL\n  if (imageBase64.startsWith('data:')) {\n    finalImageUrl = imageBase64;\n  } else {\n    finalImageUrl = 'data:image/jpeg;base64,' + imageBase64;\n  }\n}\n\nreturn {\n  valid: true,\n  imageUrl: finalImageUrl,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  openaiApiKey: openaiApiKey,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,46 +48,63 @@
           },
           "conditions": [
             {
-              "id": "condition-image",
-              "leftValue": "={{ $json.body.image_url || $json.body.image_base64 }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-image",
-      "name": "Error: No Image",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: image_url or image_base64\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"model\": \"clip\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
       "id": "openai-vision",
       "name": "OpenAI Vision Embed",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/chat/completions",
@@ -91,7 +114,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.openai_api_key }}"
+              "value": "=Bearer {{ $json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -101,7 +124,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are an image analysis expert. Generate a detailed semantic description of the image that can be used for similarity search and embedding. Return JSON with:\\n- description: Detailed description (2-3 sentences)\\n- objects: Array of detected objects\\n- scene: Overall scene type (indoor, outdoor, abstract, etc.)\\n- colors: Dominant colors\\n- mood: Image mood/atmosphere\\n- tags: Array of relevant tags for search\\n- style: Image style (photo, illustration, diagram, etc.)\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"Analyze this image and generate semantic metadata for embedding:\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"{{ $json.body.image_url || ('data:image/jpeg;base64,' + $json.body.image_base64) }}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"max_tokens\": 500\n}",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are an image analysis expert. Generate a detailed semantic description of the image that can be used for similarity search and embedding. Return JSON with:\\n- description: Detailed description (2-3 sentences)\\n- objects: Array of detected objects\\n- scene: Overall scene type (indoor, outdoor, abstract, etc.)\\n- colors: Dominant colors\\n- mood: Image mood/atmosphere\\n- tags: Array of relevant tags for search\\n- style: Image style (photo, illustration, diagram, etc.)\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"**Demande utilisateur:** {{ $json.user_request }}\\n\\nAnalyze this image and generate semantic metadata for embedding:\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"{{ $json.imageUrl }}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"max_tokens\": 500\n}",
         "options": {
           "timeout": 60000
         }
@@ -113,10 +136,7 @@
       "name": "Generate Embedding",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/embeddings",
@@ -126,7 +146,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $('Webhook').first().json.body.openai_api_key }}"
+              "value": "=Bearer {{ $('Validate Input').first().json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -148,43 +168,31 @@
       "name": "Parse Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1140,
-        200
-      ],
+      "position": [1340, 200],
       "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\nconst visionData = $('OpenAI Vision Embed').first().json;\n\nconst results = items.map(item => {\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini + text-embedding-3-small'\n        }\n      }\n    };\n  }\n\n  try {\n    // Parse vision analysis\n    let analysis = {};\n    try {\n      analysis = JSON.parse(visionData.choices?.[0]?.message?.content || '{}');\n    } catch (e) {\n      analysis = { description: visionData.choices?.[0]?.message?.content || '' };\n    }\n    \n    // Get embedding\n    const embedding = item.json.data?.[0]?.embedding || [];\n    \n    return {\n      json: {\n        success: true,\n        data: {\n          embedding: embedding,\n          dimensions: embedding.length,\n          analysis: {\n            description: analysis.description || '',\n            objects: analysis.objects || [],\n            scene: analysis.scene || '',\n            colors: analysis.colors || [],\n            mood: analysis.mood || '',\n            tags: analysis.tags || [],\n            style: analysis.style || ''\n          }\n        },\n        meta: {\n          provider: 'openai',\n          vision_model: 'gpt-4o-mini',\n          embedding_model: 'text-embedding-3-small'\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to process image: ' + e.message,\n          status: 'PROCESS_ERROR'\n        },\n        meta: {\n          provider: 'openai'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
+        "jsCode": "// ============================================\n// PARSE RESPONSE - Image Embedder\n// ============================================\n\nconst items = $input.all();\nconst prevData = $('Validate Input').first().json;\nconst visionData = $('OpenAI Vision Embed').first().json;\n\n// --- Build trace helper ---\nconst buildTrace = (serviceResponse) => ({\n  llm_response: visionData,\n  service_response: serviceResponse,\n  provider: 'openai',\n  mode: 'sync',\n  latency_ms: Date.now() - (prevData.startTime || Date.now()),\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request\n});\n\nconst results = items.map(item => {\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        _trace: buildTrace(item.json),\n        error: {\n          code: item.json.error.code || 'API_ERROR',\n          message: item.json.error.message || 'API error',\n          http_status: 500\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini + text-embedding-3-small'\n        },\n        user_id: prevData.user_id,\n        guild_id: prevData.guild_id,\n        user_request: prevData.user_request\n      }\n    };\n  }\n\n  try {\n    // Parse vision analysis\n    let analysis = {};\n    try {\n      analysis = JSON.parse(visionData.choices?.[0]?.message?.content || '{}');\n    } catch (e) {\n      analysis = { description: visionData.choices?.[0]?.message?.content || '' };\n    }\n    \n    // Get embedding\n    const embedding = item.json.data?.[0]?.embedding || [];\n    \n    return {\n      json: {\n        success: true,\n        _trace: buildTrace(item.json),\n        data: {\n          embedding: embedding,\n          dimensions: embedding.length,\n          analysis: {\n            description: analysis.description || '',\n            objects: analysis.objects || [],\n            scene: analysis.scene || '',\n            colors: analysis.colors || [],\n            mood: analysis.mood || '',\n            tags: analysis.tags || [],\n            style: analysis.style || ''\n          }\n        },\n        meta: {\n          provider: 'openai',\n          vision_model: 'gpt-4o-mini',\n          embedding_model: 'text-embedding-3-small'\n        },\n        user_id: prevData.user_id,\n        guild_id: prevData.guild_id,\n        user_request: prevData.user_request\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        _trace: buildTrace({ error: e.message }),\n        error: {\n          code: 'PROCESS_ERROR',\n          message: 'Failed to process image: ' + e.message,\n          http_status: 500\n        },\n        meta: {\n          provider: 'openai'\n        },\n        user_id: prevData.user_id,\n        guild_id: prevData.guild_id,\n        user_request: prevData.user_request\n      }\n    };\n  }\n});\n\nreturn results;"
       }
     },
     {
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1360,
-        200
-      ],
+      "typeVersion": 1.1,
+      "position": [1560, 200],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 650,
-        "height": 300,
-        "content": "## MCP - Image Embedder\n\n**Endpoint:** POST /webhook/image-embedder\n\n**Parameters:**\n- `image_url` (required*): URL of image to embed\n- `image_base64` (required*): Base64-encoded image\n- `openai_api_key` (required): OpenAI API key\n\n*One of image_url or image_base64 is required\n\n**Process:**\n1. GPT-4o-mini analyzes image → semantic description\n2. Description embedded via text-embedding-3-small\n\n**Returns:**\n- `embedding`: Vector embedding (1536 dimensions)\n- `analysis`: description, objects, scene, colors, mood, tags, style\n\n**Use case:** Image similarity search, visual search"
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       }
     }
   ],
@@ -204,6 +212,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI Vision Embed",
             "type": "main",
             "index": 0
@@ -211,7 +230,18 @@
         ],
         [
           {
-            "node": "Error: No Image",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -254,33 +284,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "ffb9f253-c488-44fc-894e-990c48e4b035",
-  "activeVersionId": "ffb9f253-c488-44fc-894e-990c48e4b035",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:14:35.003Z",
-      "createdAt": "2025-12-18T15:14:35.003Z",
-      "role": "workflow:owner",
-      "workflowId": "HGu8rrdZeX4unms2",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Image_OCR.json
+++ b/workflows/MCP_-_Image_OCR.json
@@ -1,17 +1,11 @@
 {
-  "updatedAt": "2026-01-21T11:21:55.262Z",
-  "createdAt": "2026-01-21T11:21:46.942Z",
-  "id": "yJO9eAWF92oaDd6x",
   "name": "MCP - Image OCR",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "parameters": {
-        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**Input (RFC-014):**\n```json\n{\n  \"context\": {\n    \"image_url\": \"https://...\",\n    \"file_type\": \"jpg\",\n    \"project_id\": \"...\",\n    \"guild_id\": \"...\",\n    \"user_id\": \"...\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Legacy Input:**\n```json\n{\n  \"image_url\": \"https://...\",\n  \"mistral_api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"text\": \"...\", \"pages\": [...] },\n  \"meta\": { \"provider\": \"mistral\" }\n}\n```",
-        "height": 420,
-        "width": 340,
+        "content": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"image_url OR image_base64\", \"mistral_api_key\"],\n  \"properties\": {\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL of image to OCR\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Base64-encoded image\" },\n    \"file_type\": { \"type\": \"string\", \"description\": \"Image type (jpg, png, etc.)\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key\" },\n    \"include_images\": { \"type\": \"boolean\", \"description\": \"Include images in response\", \"default\": false },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"image_url\": \"https://...\",\n    \"file_type\": \"jpg\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"text\": \"...\", \"pages\": [...] },\n  \"meta\": { \"provider\": \"mistral\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** Mistral OCR (mistral-ocr-latest)",
+        "height": 600,
+        "width": 400,
         "color": 6
       },
       "id": "doc-sticky",
@@ -20,7 +14,7 @@
       "typeVersion": 1,
       "position": [
         -60,
-        -140
+        -200
       ]
     },
     {
@@ -42,7 +36,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// VALIDATION INPUT - RFC-014 Compatible\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\n// --- Extract image ---\nconst imageUrl_raw = ctx.image_url || ctx.file_url || body.image_url;\nconst imageBase64_raw = ctx.image_base64 || ctx.file_base64 || body.image_base64;\nconst fileType = ctx.file_type || body.file_type;\n\n// --- Extract API key ---\nconst mistralKey = body.mistral_api_key \n  || ctx.mistral_api_key \n  || body.plugin_context?.api_keys?.mistral \n  || ctx.plugin_context?.api_keys?.mistral;\n\n// --- Extract context fields ---\nconst projectId = ctx.project_id || body.project_id || body.plugin_context?.plugin_id;\nconst guildId = ctx.guild_id || body.guild_id;\nconst userId = ctx.user_id || body.user_id;\nconst channelId = ctx.channel_id || body.channel_id;\n\n// --- Validation ---\nconst hasImage = !!(imageUrl_raw || imageBase64_raw);\nconst hasMistralKey = !!mistralKey;\n\nconst errors = [];\nif (!hasImage) errors.push('image_url ou image_base64 requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors\n  };\n}\n\n// --- Detect MIME type ---\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  return 'image/png';\n}\n\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// --- Prepare image URL ---\nlet imageUrl = '';\nlet detectedMime = 'image/png';\n\nif (imageUrl_raw) {\n  imageUrl = imageUrl_raw;\n} else if (imageBase64_raw) {\n  detectedMime = fileType ? (getMimeFromExtension(fileType) || 'image/png') : detectMimeFromBase64(imageBase64_raw);\n  imageUrl = 'data:' + detectedMime + ';base64,' + imageBase64_raw;\n}\n\nreturn {\n  valid: true,\n  imageUrl: imageUrl,\n  detectedMime: detectedMime,\n  mistralApiKey: mistralKey,\n  includeImages: body.include_images || ctx.include_images || false,\n  source: imageUrl_raw ? 'url' : 'base64',\n  context: {\n    project_id: projectId,\n    guild_id: guildId,\n    user_id: userId,\n    channel_id: channelId\n  }\n};"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - RFC-014 Compatible\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Extract image ---\nconst imageUrl_raw = ctx.image_url || ctx.file_url || body.image_url;\nconst imageBase64_raw = ctx.image_base64 || ctx.file_base64 || body.image_base64;\nconst fileType = ctx.file_type || body.file_type;\n\n// --- Extract API key ---\nconst mistralKey = body.mistral_api_key \n  || ctx.mistral_api_key \n  || body.plugin_context?.api_keys?.mistral \n  || ctx.plugin_context?.api_keys?.mistral;\n\n// --- Extract context fields ---\nconst projectId = ctx.project_id || body.project_id || body.plugin_context?.plugin_id;\nconst channelId = ctx.channel_id || body.channel_id;\n\n// --- Validation ---\nconst hasImage = !!(imageUrl_raw || imageBase64_raw);\nconst hasMistralKey = !!mistralKey;\n\nif (!hasImage) errors.push('image_url ou image_base64 requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// --- Detect MIME type ---\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  return 'image/png';\n}\n\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// --- Prepare image URL ---\nlet imageUrl = '';\nlet detectedMime = 'image/png';\n\nif (imageUrl_raw) {\n  imageUrl = imageUrl_raw;\n} else if (imageBase64_raw) {\n  detectedMime = fileType ? (getMimeFromExtension(fileType) || 'image/png') : detectMimeFromBase64(imageBase64_raw);\n  imageUrl = 'data:' + detectedMime + ';base64,' + imageBase64_raw;\n}\n\nreturn {\n  valid: true,\n  imageUrl: imageUrl,\n  detectedMime: detectedMime,\n  mistralApiKey: mistralKey,\n  includeImages: body.include_images || ctx.include_images || false,\n  source: imageUrl_raw ? 'url' : 'base64',\n  context: {\n    project_id: projectId,\n    guild_id: guildId,\n    user_id: userId,\n    channel_id: channelId\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
@@ -77,7 +71,7 @@
         "options": {}
       },
       "id": "if-valid",
-      "name": "Input Valid?",
+      "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
@@ -126,7 +120,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// FORMAT SUCCESS/ERROR RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// --- Check for API error ---\nif (statusCode >= 400 || input.error) {\n  const errorMessage = data.message || data.error?.message || input.error?.message || 'Mistral API error';\n  return {\n    success: false,\n    error: {\n      code: 'OCR_API_ERROR',\n      message: errorMessage,\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    context: prevData.context\n  };\n}\n\n// --- Extract text from pages ---\nconst text = data.pages?.map(p => p.markdown).join('\\n\\n') || '';\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    pages: data.pages || [],\n    model: data.model || 'mistral-ocr-latest',\n    source: prevData.source\n  },\n  meta: {\n    provider: 'mistral',\n    usage: {\n      pages_processed: data.usage_info?.pages_processed || 1,\n      doc_size_bytes: data.usage_info?.doc_size_bytes || 0\n    }\n  },\n  context: prevData.context\n};"
+        "jsCode": "// ============================================\n// FORMAT SUCCESS/ERROR RESPONSE - with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// --- Check for API error ---\nif (statusCode >= 400 || input.error) {\n  const errorMessage = data.message || data.error?.message || input.error?.message || 'Mistral API error';\n  return {\n    success: false,\n    error: {\n      code: 'OCR_API_ERROR',\n      message: errorMessage,\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    _trace: {\n      service_response: { error: errorMessage, http_status: statusCode },\n      provider: 'mistral',\n      mode: 'error',\n      latency_ms: Date.now() - startTime,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  };\n}\n\n// --- Extract text from pages ---\nconst pages = data.pages || [];\nconst text = pages.map(p => p.markdown).join('\\n\\n') || '';\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    pages: pages,\n    model: data.model || 'mistral-ocr-latest',\n    source: prevData.source\n  },\n  meta: {\n    provider: 'mistral',\n    usage: {\n      pages_processed: data.usage_info?.pages_processed || 1,\n      doc_size_bytes: data.usage_info?.doc_size_bytes || 0\n    }\n  },\n  _trace: {\n    service_response: {\n      pages_processed: data.usage_info?.pages_processed || pages.length,\n      text_length: text.length\n    },\n    provider: 'mistral',\n    mode: 'ocr',\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request\n};"
       },
       "id": "format-response",
       "name": "Format Response",
@@ -139,10 +133,10 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  }\n};"
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR - with _trace\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
       },
       "id": "build-error",
-      "name": "Build Error Response",
+      "name": "Build Error",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -217,14 +211,14 @@
       "main": [
         [
           {
-            "node": "Input Valid?",
+            "node": "Valid?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Input Valid?": {
+    "Valid?": {
       "main": [
         [
           {
@@ -235,7 +229,7 @@
         ],
         [
           {
-            "node": "Build Error Response",
+            "node": "Build Error",
             "type": "main",
             "index": 0
           }
@@ -264,7 +258,7 @@
         ]
       ]
     },
-    "Build Error Response": {
+    "Build Error": {
       "main": [
         [
           {
@@ -280,31 +274,5 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "e625233d-a02a-40d7-b1fc-afa17437a70d",
-  "activeVersionId": "e625233d-a02a-40d7-b1fc-afa17437a70d",
-  "versionCounter": 12,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-21T11:21:46.944Z",
-      "createdAt": "2026-01-21T11:21:46.944Z",
-      "role": "workflow:owner",
-      "workflowId": "yJO9eAWF92oaDd6x",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }

--- a/workflows/MCP_-_LLM_Intention.json
+++ b/workflows/MCP_-_LLM_Intention.json
@@ -1,12 +1,19 @@
 {
-  "updatedAt": "2026-01-31T22:00:25.000Z",
-  "createdAt": "2026-01-21T21:20:49.985Z",
-  "id": "tA1bPSUvjbZzYajG",
   "name": "MCP - LLM Intention",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - LLM Intention\n\n**Endpoint:** POST /webhook/llm-intention\n\n**Description:** Analyse l'intention utilisateur via LLM et propose des actions appropriees.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"message\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (contextualise l'analyse)\" },\n    \"message\": { \"type\": \"string\", \"description\": \"Message a analyser (alias: query)\" },\n    \"context\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"type\": { \"type\": \"string\", \"description\": \"Domaine: recipe|torah|general\" },\n        \"allowed_actions\": { \"type\": \"array\", \"description\": \"Actions autorisees\" },\n        \"min_score\": { \"type\": \"number\", \"default\": 0.7 },\n        \"auto_fallback\": { \"type\": \"boolean\", \"default\": false }\n      }\n    },\n    \"history\": { \"type\": \"array\", \"description\": \"Historique conversation [{role, content}]\" },\n    \"attached_file\": { \"type\": \"object\", \"description\": \"Fichier joint {name, type, url}\" }\n  }\n}\n```\n\n**Note:** API keys (anthropic_api_key) fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"intent\", \"query_analysis\", \"proposed_actions\", \"is_relevant\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 680,
+        "width": 360,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, -80]
+    },
     {
       "parameters": {
         "httpMethod": "POST",
@@ -18,24 +25,18 @@
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        304
-      ],
+      "position": [240, 304],
       "webhookId": "llm-intention-webhook"
     },
     {
       "parameters": {
-        "jsCode": "const body = $input.first().json.body || {};\n\n// Validate required fields\nconst message = body.message || body.query; \n// Support both (query for backwards compat)\nconst context = body.context || {};\nconst pluginContext = body.plugin_context || {};\nconst apiKey = pluginContext.api_keys?.anthropic;\n\n// NEW RFC-016: history and attached_file\nconst history = body.history || [];\nconst attachedFile = body.attached_file || null;\n\nconst errors = [];\nif (!message || message.trim() === '') errors.push('message requis');\nif (!context.type) errors.push('context.type requis');\nif (!apiKey) errors.push('plugin_context.api_keys.anthropic requis');\n\n// Validate history format (array of {role, content})\nif (history.length > 0) {\n  const validHistory = history.every(h => h.role && h.content);\n  if (!validHistory) errors.push('history[] doit contenir {role, content}');\n}\n\n// Truncate history to max 10 messages (RFC-016 recommendation)\nconst truncatedHistory = history.slice(-10);\n\nif (errors.length > 0) {\n  return {\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: errors.join(', '),\n        status: 'BAD_REQUEST'\n      }\n    }\n  };\n}\n\n// Extract config with defaults\nconst minScore = context.min_score || 0.7;\nconst autoFallback = context.auto_fallback === true;\nconst allowedActions = context.allowed_actions || context.allowed_intents || ['search', 'info', 'help'];\nconst llmModel = pluginContext.llm_model || 'claude-3-haiku-20240307';\n\nreturn {\n  json: {\n    valid: true,\n    message: message.trim(),\n    query: message.trim(), // Keep for backwards compat\n    context: {\n      type: context.type,\n      allowed_actions: allowedActions,\n      min_score: minScore,\n      auto_fallback: autoFallback\n    },\n    history: truncatedHistory,\n    attached_file: attachedFile,\n    plugin_context: pluginContext,\n    llm_model: llmModel,\n    api_key: apiKey,\n    user: body.user || {}\n  }\n};"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Intention (RFC-014)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields (RFC-014) ---\nconst userId = body.user_id || ctx.user_id || body.user?.user_id;\nconst guildId = body.guild_id || ctx.guild_id || body.user?.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Webhook-specific required fields ---\nconst message = body.message || body.query || ctx.message;\nconst contextType = ctx.type || body.context?.type;\n\nif (!message || message.trim() === '') {\n  errors.push('message requis');\n}\nif (!contextType) {\n  errors.push('context.type requis');\n}\n\n// --- API Keys passed from MCP Server ---\nconst anthropicApiKey = body.anthropic_api_key || ctx.anthropic_api_key || body.plugin_context?.api_keys?.anthropic || '';\n\nif (!anthropicApiKey) {\n  errors.push('anthropic_api_key requis (via plugin_context.api_keys.anthropic)');\n}\n\n// --- Optional fields ---\nconst history = body.history || ctx.history || [];\nconst attachedFile = body.attached_file || ctx.attached_file || null;\nconst minScore = ctx.min_score || body.context?.min_score || 0.7;\nconst autoFallback = ctx.auto_fallback === true || body.context?.auto_fallback === true;\nconst allowedActions = ctx.allowed_actions || body.context?.allowed_actions || body.context?.allowed_intents || ['search', 'info', 'help'];\nconst llmModel = body.plugin_context?.llm_model || ctx.llm_model || 'claude-3-haiku-20240307';\nconst pluginContext = body.plugin_context || ctx.plugin_context || {};\nconst user = body.user || ctx.user || {};\n\n// Validate history format (array of {role, content})\nif (history.length > 0) {\n  const validHistory = history.every(h => h.role && h.content);\n  if (!validHistory) {\n    errors.push('history[] doit contenir {role, content}');\n  }\n}\n\n// Truncate history to max 10 messages\nconst truncatedHistory = history.slice(-10);\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  message: message.trim(),\n  query: message.trim(), // Backwards compat\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  context: {\n    type: contextType,\n    allowed_actions: allowedActions,\n    min_score: minScore,\n    auto_fallback: autoFallback\n  },\n  history: truncatedHistory,\n  attached_file: attachedFile,\n  plugin_context: pluginContext,\n  llm_model: llmModel,\n  api_key: anthropicApiKey,\n  user: user,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        480,
-        304
-      ]
+      "position": [480, 304]
     },
     {
       "parameters": {
@@ -61,18 +62,25 @@
         "options": {}
       },
       "id": "if-valid",
-      "name": "Input Valid?",
+      "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        720,
-        304
-      ]
+      "position": [720, 304]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [940, 480]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ JSON.stringify({ success: false, error: $json.error }) }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
           "responseCode": 400,
           "responseHeaders": {
@@ -89,10 +97,17 @@
       "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1056,
-        464
-      ]
+      "position": [1160, 480]
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\n\n// Build system prompt with user_request context\nconst systemPrompt = `Tu es un assistant d'analyse d'intention pour le contexte \"${input.context.type}\".\n\n**Demande utilisateur originale:** \"${input.user_request}\"\n\nRÈGLES:\n1. Analyse la requête utilisateur ET l'historique de conversation\n2. Tiens compte de la demande utilisateur originale ci-dessus pour contextualiser\n3. Détermine le response_type approprié\n4. Propose des actions avec leur ID (PAS de webhook)\n5. Réponds UNIQUEMENT en JSON valide\n\nDÉFINITION DU CONTEXTE \"${input.context.type}\":\n${input.context.type === 'recipe' ? `\nPour \"recipe\", TOUTES ces questions sont PERTINENTES (is_relevant: true):\n- Recettes et préparations\n- Techniques culinaires (couper, découper, trancher, émincer, etc.)\n- Conseils de cuisson (temps, température, méthode)\n- Questions sur les ingrédients\n- Astuces cuisine, conservation, équipement\n\nSEULES ces questions sont HORS CONTEXTE (is_relevant: false):\n- Questions sans rapport avec la cuisine/alimentation\n` : input.context.type === 'torah' ? `\nPour \"torah\", accepter: traduction, étude, commentaires, recherche textuelle.\n` : `\nContexte général: accepter les questions d'information et de recherche.\n`}\n\nACTIONS DISPONIBLES (utilise ces IDs):\n- \"search\" : Recherche web\n- \"local_search\" : Recherche base locale\n- \"scrape\" : Extraire contenu d'une URL\n- \"info\" : Réponse informative simple\n\nFORMAT DE SORTIE JSON:\n{\n  \"response_type\": \"message\" | \"action_proposal\" | \"clarification_needed\",\n  \"message\": \"Réponse à l'utilisateur\",\n  \"intent\": { \"type\": \"...\", \"confidence\": 0.0-1.0 },\n  \"query_analysis\": {\n    \"original\": \"requête originale\",\n    \"reformulation\": \"requête reformulée\",\n    \"extracted_terms\": \"termes clés en STRING (pas un array)\",\n    \"detected_language\": \"fr\",\n    \"spelling_corrected\": false\n  },\n  \"proposed_actions\": [{\n    \"id\": \"search\",\n    \"label\": \"Label affiché\",\n    \"description\": \"Description de l'action\",\n    \"params\": { \"query\": \"termes de recherche\" },\n    \"requires_confirmation\": false\n  }],\n  \"is_relevant\": true,\n  \"rejection_reason\": null\n}\n\nIMPORTANT:\n- N'INCLUS JAMAIS de champ \"webhook\" dans proposed_actions\n- extracted_terms DOIT être une STRING, pas un array\n- En cas de doute sur la pertinence, mets is_relevant: true`;\n\n// Build messages array with history\nconst messages = [];\n\n// Add history (already truncated to 10 in validation)\nif (input.history && input.history.length > 0) {\n  for (const h of input.history) {\n    messages.push({ role: h.role, content: h.content });\n  }\n}\n\n// Add current user message\nlet userContent = input.message;\nif (input.attached_file) {\n  const fileName = input.attached_file.name || 'document';\n  const fileType = input.attached_file.type || 'unknown';\n  userContent = `[Fichier joint: ${fileName} (${fileType})]\\n\\n${input.message}`;\n}\nmessages.push({ role: 'user', content: userContent });\n\n// Build final payload\nconst payload = {\n  model: input.llm_model,\n  max_tokens: 1000,\n  system: systemPrompt,\n  messages: messages\n};\n\nreturn {\n  json: {\n    ...input,\n    llm_payload: payload\n  }\n};"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 200],
+      "id": "build-llm-payload",
+      "name": "Build LLM Payload"
     },
     {
       "parameters": {
@@ -131,24 +146,18 @@
       "name": "LLM Analyze Intent",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1088,
-        224
-      ],
+      "position": [1200, 200],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Build LLM Payload').first().json;\n  const statusCode = input.statusCode || 200;\n\n  // Handle LLM API error\n  if (statusCode >= 400) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: statusCode,\n          message: input.body?.error?.message || 'LLM API error',\n          status: 'LLM_ERROR'\n        }\n      }\n    };\n  }\n\n  // Extract LLM response\n  const content = input.body?.content?.[0]?.text || '';\n\n  // Parse JSON from LLM response\n  let analysis;\n  try {\n    const jsonMatch = content.match(/\\{[\\s\\S]*\\}/);\n    if (jsonMatch) {\n      analysis = JSON.parse(jsonMatch[0]);\n    } else {\n      throw new Error('No JSON found in response');\n    }\n  } catch (e) {\n    // Default analysis if parsing fails\n    analysis = {\n      response_type: 'message',\n      message: content || 'Je n\\'ai pas compris votre demande.',\n      intent: { type: 'unknown', confidence: 0.5 },\n      query_analysis: {\n        original: prevData.message,\n        reformulation: prevData.message,\n        extracted_terms: '',\n        detected_language: 'fr',\n        spelling_corrected: false\n      },\n      proposed_actions: [],\n      is_relevant: true,\n      rejection_reason: null\n    };\n  }\n\n  // Ensure RFC-016 format\n  const result = {\n    success: true,\n    response_type: analysis.response_type || 'message',\n    message: analysis.message || '',\n    intent: analysis.intent || { type: 'unknown', confidence: 0 },\n    query_analysis: analysis.query_analysis || {\n      original: prevData.message,\n      reformulation: prevData.message,\n      extracted_terms: '',\n      detected_language: 'fr',\n      spelling_corrected: false\n    },\n    proposed_actions: analysis.proposed_actions || [],\n    is_relevant: analysis.is_relevant !== false,\n    rejection_reason: analysis.rejection_reason || null,\n    // Pass through for next nodes\n    context: prevData.context,\n    plugin_context: prevData.plugin_context,\n    user: prevData.user,\n    message_original: prevData.message\n  };\n\n  return { json: result };"
+        "jsCode": "// ============================================\n// PARSE LLM RESPONSE - LLM Intention\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Build LLM Payload').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\nconst statusCode = input.statusCode || 200;\n\n// Initialize trace with llm_response format\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'anthropic',\n  model: prevData.llm_model,\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\n// Handle LLM API error\nif (statusCode >= 400) {\n  const errorMsg = input.body?.error?.message || 'LLM API error';\n  _trace.llm_response = `Error: ${errorMsg}`;\n  _trace.service_response = input.body || input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'LLM_ERROR',\n        message: errorMsg,\n        http_status: statusCode\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract LLM response\nconst body = input.body || input;\nconst content = body.content?.[0]?.text || '';\nconst usage = body.usage || {};\n\n// Populate trace with LLM response\n_trace.llm_response = content;\n_trace.service_response = body;\n_trace.tokens = {\n  input: usage.input_tokens || 0,\n  output: usage.output_tokens || 0\n};\n\n// Parse JSON from LLM response\nlet analysis;\ntry {\n  const jsonMatch = content.match(/\\{[\\s\\S]*\\}/);\n  if (jsonMatch) {\n    analysis = JSON.parse(jsonMatch[0]);\n  } else {\n    throw new Error('No JSON found in response');\n  }\n} catch (e) {\n  // Default analysis if parsing fails\n  analysis = {\n    response_type: 'message',\n    message: content || 'Je n\\'ai pas compris votre demande.',\n    intent: { type: 'unknown', confidence: 0.5 },\n    query_analysis: {\n      original: prevData.message,\n      reformulation: prevData.message,\n      extracted_terms: '',\n      detected_language: 'fr',\n      spelling_corrected: false\n    },\n    proposed_actions: [],\n    is_relevant: true,\n    rejection_reason: null\n  };\n}\n\n_trace.latency_ms = Date.now() - startTime;\n\n// Ensure RFC-016 format\nconst result = {\n  success: true,\n  response_type: analysis.response_type || 'message',\n  message: analysis.message || '',\n  intent: analysis.intent || { type: 'unknown', confidence: 0 },\n  query_analysis: analysis.query_analysis || {\n    original: prevData.message,\n    reformulation: prevData.message,\n    extracted_terms: '',\n    detected_language: 'fr',\n    spelling_corrected: false\n  },\n  proposed_actions: analysis.proposed_actions || [],\n  is_relevant: analysis.is_relevant !== false,\n  rejection_reason: analysis.rejection_reason || null,\n  // Pass through for next nodes\n  context: prevData.context,\n  plugin_context: prevData.plugin_context,\n  user: prevData.user,\n  message_original: prevData.message,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: startTime,\n  _trace: _trace\n};\n\nreturn { json: result };"
       },
       "id": "parse-llm",
       "name": "Parse LLM Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1280,
-        224
-      ]
+      "position": [1420, 200]
     },
     {
       "parameters": {
@@ -178,23 +187,17 @@
       "name": "Is Relevant?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        1440,
-        304
-      ]
+      "position": [1640, 304]
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n\n  return {\n    json: {\n      success: true,\n      response_type: 'message',\n      message: input.rejection_reason || `Cette requête ne concerne pas le contexte ${input.context?.type ||\n  'demandé'}.`,\n      intent: {\n        type: 'out_of_context',\n        confidence: input.intent?.confidence || 0\n      },\n      query_analysis: input.query_analysis || {\n        original: input.message_original,\n        reformulation: input.message_original,\n        extracted_terms: '',\n        detected_language: 'fr',\n        spelling_corrected: false\n      },\n      proposed_actions: [],\n      is_relevant: false,\n      rejection_reason: input.rejection_reason\n    }\n  };"
+        "jsCode": "// ============================================\n// BUILD REJECT RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst startTime = input.startTime || Date.now();\n\nconst _trace = {\n  llm_response: input._trace?.llm_response || null,\n  service_response: { rejection: true, reason: input.rejection_reason },\n  provider: 'anthropic',\n  model: input._trace?.model || 'claude-3-haiku-20240307',\n  tokens: input._trace?.tokens || { input: 0, output: 0 },\n  latency_ms: Date.now() - startTime,\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};\n\nreturn {\n  json: {\n    success: true,\n    response_type: 'message',\n    message: input.rejection_reason || `Cette requête ne concerne pas le contexte ${input.context?.type || 'demandé'}.`,\n    intent: {\n      type: 'out_of_context',\n      confidence: input.intent?.confidence || 0\n    },\n    query_analysis: input.query_analysis || {\n      original: input.message_original,\n      reformulation: input.message_original,\n      extracted_terms: '',\n      detected_language: 'fr',\n      spelling_corrected: false\n    },\n    proposed_actions: [],\n    is_relevant: false,\n    rejection_reason: input.rejection_reason,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request,\n    _trace: _trace\n  }\n};"
       },
       "id": "build-reject",
       "name": "Build Reject Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1680,
-        464
-      ]
+      "position": [1880, 464]
     },
     {
       "parameters": {
@@ -211,7 +214,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({\n  query: $json.analysis.extracted_terms,\n  collection: $json.context.type,\n  limit: 5,\n  plugin_context: $json.plugin_context\n}) }}",
+        "jsonBody": "={{ JSON.stringify({\n  query: $json.query_analysis?.extracted_terms || $json.message_original,\n  collection: $json.context.type,\n  limit: 5,\n  plugin_context: $json.plugin_context,\n  user_id: $json.user_id,\n  guild_id: $json.guild_id,\n  user_request: $json.user_request\n}) }}",
         "options": {
           "response": {
             "response": {
@@ -225,24 +228,18 @@
       "name": "Qdrant Search",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1680,
-        304
-      ],
+      "position": [1880, 200],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "  const qdrantResponse = $input.first().json;\n  const prevData = $('Parse LLM Response').first().json;\n\n  // Webhooks: utilise ceux du context si fournis, sinon defaults\n  const webhooks = prevData.context?.webhooks || {\n    search: '/webhook/llm-web-search',\n    scrape: '/webhook/web-scraper',\n    local_search: '/webhook/qdrant-search'\n  };\n\n  // NOUVEAU: Si pas relevant, ne pas proposer d'actions\n  if (!prevData.is_relevant) {\n    return {\n      json: {\n        success: true,\n        response_type: 'message',\n        message: prevData.message || 'Requête hors contexte.',\n        intent: prevData.intent,\n        query_analysis: prevData.query_analysis,\n        proposed_actions: [],\n        is_relevant: false,\n        rejection_reason: prevData.rejection_reason\n      }\n    };\n  }\n\n  // Extract Qdrant results\n  const qdrantBody = qdrantResponse.body || qdrantResponse;\n  const qdrantSuccess = qdrantBody.success !== false;\n  const qdrantResults = qdrantBody.data?.results || [];\n\n  // Find best score\n  let bestScore = 0;\n  if (qdrantResults.length > 0) {\n    bestScore = Math.max(...qdrantResults.map(r => r.score || 0));\n  }\n\n  // Check against threshold\n  const minScore = prevData.context?.min_score || 0.7;\n  const aboveThreshold = bestScore >= minScore;\n\n  // Start with LLM analysis\n  let responseType = prevData.response_type || 'message';\n  let message = prevData.message || '';\n\n  // Nettoyer les proposed_actions du LLM (supprimer les webhooks inventés)\n  let proposedActions = (prevData.proposed_actions || []).map(action => ({\n    ...action,\n    webhook: null  // On ne fait pas confiance aux webhooks du LLM\n  }));\n\n  // Enrich proposed_actions based on Qdrant results\n  if (qdrantResults.length > 0 && aboveThreshold) {\n    // Good results found - add them to context\n    responseType = 'action_proposal';\n    message = message || `J'ai trouvé ${qdrantResults.length} résultat(s) pertinent(s).`;\n\n    // Add search results action if not already present\n    const hasSearchAction = proposedActions.some(a => a.id === 'return_results');\n    if (!hasSearchAction) {\n      proposedActions.unshift({\n        id: 'return_results',\n        label: 'Voir les résultats',\n        description: `${qdrantResults.length} résultat(s) trouvé(s) (score: ${Math.round(bestScore * 100)}%)`,\n        webhook: null,\n        params: { results: qdrantResults },\n        requires_confirmation: false,\n        estimate: null\n      });\n    }\n  } else if (qdrantResults.length === 0 || !aboveThreshold) {\n    // No good results - propose web search if relevant\n    const hasWebSearch = proposedActions.some(a => a.id === 'web_search' || a.id === 'search');\n    if (!hasWebSearch && prevData.is_relevant) {\n      const autoFallback = prevData.context?.auto_fallback === true;\n      responseType = 'action_proposal';\n      const reason = qdrantResults.length === 0\n        ? 'Aucun résultat trouvé dans la base locale.'\n        : `Résultats peu pertinents (score: ${Math.round(bestScore * 100)}%).`;\n\n      if (autoFallback) {\n        message = message || `${reason} Recherche web en cours...`;\n      } else {\n        message = message || `${reason} Voulez-vous chercher sur le web ?`;\n      }\n\n      proposedActions.push({\n        id: 'search',\n        label: 'Rechercher sur le web',\n        description: 'Lancer une recherche web pour trouver des résultats',\n        webhook: webhooks.search,  // ← Utilise le webhook du context ou le default\n        params: {\n          query: Array.isArray(prevData.query_analysis?.extracted_terms)\n            ? prevData.query_analysis.extracted_terms.join(' ')\n            : (prevData.query_analysis?.extracted_terms || prevData.message_original)\n        },\n        requires_confirmation: !autoFallback,\n        estimate: { credits: 1, unit: 'search', quantity: 1 }\n      });\n    }\n  }\n\n  return {\n    json: {\n      success: true,\n      response_type: responseType,\n      message: message,\n      intent: prevData.intent,\n      query_analysis: prevData.query_analysis,\n      proposed_actions: proposedActions,\n      is_relevant: prevData.is_relevant,\n      rejection_reason: null,\n      _qdrant: {\n        searched: true,\n        result_count: qdrantResults.length,\n        best_score: bestScore,\n        above_threshold: aboveThreshold\n      }\n    }\n  };"
+        "jsCode": "// ============================================\n// BUILD FINAL RESPONSE - LLM Intention\n// ============================================\n\nconst qdrantResponse = $input.first().json;\nconst prevData = $('Parse LLM Response').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Webhooks: utilise ceux du context si fournis, sinon defaults\nconst webhooks = prevData.context?.webhooks || {\n  search: '/webhook/llm-web-search',\n  scrape: '/webhook/web-scraper',\n  local_search: '/webhook/qdrant-search'\n};\n\n// NOUVEAU: Si pas relevant, ne pas proposer d'actions\nif (!prevData.is_relevant) {\n  const _trace = {\n    llm_response: prevData._trace?.llm_response || null,\n    service_response: { qdrant_skipped: true, reason: 'not_relevant' },\n    provider: 'anthropic',\n    model: prevData._trace?.model || 'claude-3-haiku-20240307',\n    tokens: prevData._trace?.tokens || { input: 0, output: 0 },\n    latency_ms: Date.now() - startTime,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n  \n  return {\n    json: {\n      success: true,\n      response_type: 'message',\n      message: prevData.message || 'Requête hors contexte.',\n      intent: prevData.intent,\n      query_analysis: prevData.query_analysis,\n      proposed_actions: [],\n      is_relevant: false,\n      rejection_reason: prevData.rejection_reason,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract Qdrant results\nconst qdrantBody = qdrantResponse.body || qdrantResponse;\nconst qdrantSuccess = qdrantBody.success !== false;\nconst qdrantResults = qdrantBody.data?.results || [];\n\n// Find best score\nlet bestScore = 0;\nif (qdrantResults.length > 0) {\n  bestScore = Math.max(...qdrantResults.map(r => r.score || 0));\n}\n\n// Check against threshold\nconst minScore = prevData.context?.min_score || 0.7;\nconst aboveThreshold = bestScore >= minScore;\n\n// Start with LLM analysis\nlet responseType = prevData.response_type || 'message';\nlet message = prevData.message || '';\n\n// Nettoyer les proposed_actions du LLM (supprimer les webhooks inventés)\nlet proposedActions = (prevData.proposed_actions || []).map(action => ({\n  ...action,\n  webhook: null  // On ne fait pas confiance aux webhooks du LLM\n}));\n\n// Enrich proposed_actions based on Qdrant results\nif (qdrantResults.length > 0 && aboveThreshold) {\n  // Good results found - add them to context\n  responseType = 'action_proposal';\n  message = message || `J'ai trouvé ${qdrantResults.length} résultat(s) pertinent(s).`;\n\n  // Add search results action if not already present\n  const hasSearchAction = proposedActions.some(a => a.id === 'return_results');\n  if (!hasSearchAction) {\n    proposedActions.unshift({\n      id: 'return_results',\n      label: 'Voir les résultats',\n      description: `${qdrantResults.length} résultat(s) trouvé(s) (score: ${Math.round(bestScore * 100)}%)`,\n      webhook: null,\n      params: { results: qdrantResults },\n      requires_confirmation: false,\n      estimate: null\n    });\n  }\n} else if (qdrantResults.length === 0 || !aboveThreshold) {\n  // No good results - propose web search if relevant\n  const hasWebSearch = proposedActions.some(a => a.id === 'web_search' || a.id === 'search');\n  if (!hasWebSearch && prevData.is_relevant) {\n    const autoFallback = prevData.context?.auto_fallback === true;\n    responseType = 'action_proposal';\n    const reason = qdrantResults.length === 0\n      ? 'Aucun résultat trouvé dans la base locale.'\n      : `Résultats peu pertinents (score: ${Math.round(bestScore * 100)}%).`;\n\n    if (autoFallback) {\n      message = message || `${reason} Recherche web en cours...`;\n    } else {\n      message = message || `${reason} Voulez-vous chercher sur le web ?`;\n    }\n\n    proposedActions.push({\n      id: 'search',\n      label: 'Rechercher sur le web',\n      description: 'Lancer une recherche web pour trouver des résultats',\n      webhook: webhooks.search,\n      params: {\n        query: Array.isArray(prevData.query_analysis?.extracted_terms)\n          ? prevData.query_analysis.extracted_terms.join(' ')\n          : (prevData.query_analysis?.extracted_terms || prevData.message_original)\n      },\n      requires_confirmation: !autoFallback,\n      estimate: { credits: 1, unit: 'search', quantity: 1 }\n    });\n  }\n}\n\n// Build _trace for Langfuse observability\nconst _trace = {\n  llm_response: prevData._trace?.llm_response || null,\n  service_response: {\n    qdrant: {\n      searched: true,\n      result_count: qdrantResults.length,\n      best_score: bestScore,\n      above_threshold: aboveThreshold\n    }\n  },\n  provider: 'anthropic',\n  model: prevData._trace?.model || 'claude-3-haiku-20240307',\n  tokens: prevData._trace?.tokens || { input: 0, output: 0 },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  json: {\n    success: true,\n    response_type: responseType,\n    message: message,\n    intent: prevData.intent,\n    query_analysis: prevData.query_analysis,\n    proposed_actions: proposedActions,\n    is_relevant: prevData.is_relevant,\n    rejection_reason: null,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _qdrant: {\n      searched: true,\n      result_count: qdrantResults.length,\n      best_score: bestScore,\n      above_threshold: aboveThreshold\n    },\n    _trace: _trace\n  }\n};"
       },
       "id": "build-response",
       "name": "Build Final Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1920,
-        304
-      ]
+      "position": [2120, 200]
     },
     {
       "parameters": {
@@ -264,10 +261,7 @@
       "name": "Respond Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        2160,
-        304
-      ]
+      "position": [2360, 200]
     },
     {
       "parameters": {
@@ -289,39 +283,7 @@
       "name": "Respond Reject",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1920,
-        464
-      ]
-    },
-    {
-      "parameters": {
-        "content": " ## MCP - LLM Intention (RFC-016)\n\n  **Endpoint:** POST /webhook/llm-intention\n\n  ### Input\n  ```json\n  {\n    \"message\": \"requête utilisateur\",\n    \"context\": {\n      \"type\": \"recipe|torah|general\",\n      \"allowed_actions\": [\"search\", \"web_search\", \"extract\"],\n      \"min_score\": 0.7\n    },\n    \"history\": [\n      {\"role\": \"user\", \"content\": \"message précédent\"},\n      {\"role\": \"assistant\", \"content\": \"réponse précédente\"}\n    ],\n    \"attached_file\": {\n      \"name\": \"document.pdf\",\n      \"type\": \"application/pdf\",\n      \"url\": \"https://...\"\n    },\n    \"plugin_context\": {\n      \"api_keys\": { \"anthropic\": \"sk-ant-...\" },\n      \"llm_model\": \"claude-3-haiku-20240307\"\n    },\n    \"user\": { \"user_id\": \"...\", \"guild_id\": \"...\" }\n  }\n\n  Output\n\n  {\n    \"success\": true,\n    \"response_type\": \"message|action_proposal|clarification_needed\",\n    \"message\": \"Réponse à afficher\",\n    \"intent\": { \"type\": \"search\", \"confidence\": 0.95 },\n    \"query_analysis\": {\n      \"original\": \"...\",\n      \"reformulation\": \"...\",\n      \"extracted_terms\": \"...\",\n      \"detected_language\": \"fr\",\n      \"spelling_corrected\": false\n    },\n    \"proposed_actions\": [{\n      \"id\": \"web_search\",\n      \"label\": \"Rechercher sur le web\",\n      \"description\": \"...\",\n      \"webhook\": \"/webhook/llm-web-search\",\n      \"params\": { \"query\": \"...\" },\n      \"requires_confirmation\": true,\n      \"estimate\": { \"credits\": 1, \"unit\": \"search\", \"quantity\": 1 }\n    }],\n    \"is_relevant\": true\n  }\n\n  Response Types\n\n  - message: Réponse simple (salutation, info)\n  - action_proposal: Actions à confirmer par l'utilisateur\n  - clarification_needed: Besoin de précisions\n",
-        "height": 320,
-        "width": 650,
-        "color": 6
-      },
-      "id": "sticky-doc",
-      "name": "Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        96,
-        -16
-      ]
-    },
-    {
-      "parameters": {
-        "jsCode": "const input = $input.first().json;\n\n  // Build system prompt\n\n   const systemPrompt = `Tu es un assistant d'analyse d'intention pour le contexte \"${input.context.type}\".\n\n  RÈGLES:\n  1. Analyse la requête utilisateur ET l'historique de conversation\n  2. Détermine le response_type approprié\n  3. Propose des actions avec leur ID (PAS de webhook)\n  4. Réponds UNIQUEMENT en JSON valide\n\n  DÉFINITION DU CONTEXTE \"${input.context.type}\":\n  ${input.context.type === 'recipe' ? `\n  Pour \"recipe\", TOUTES ces questions sont PERTINENTES (is_relevant: true):\n  - Recettes et préparations\n  - Techniques culinaires (couper, découper, trancher, émincer, etc.)\n  - Conseils de cuisson (temps, température, méthode)\n  - Questions sur les ingrédients\n  - Astuces cuisine, conservation, équipement\n\n  SEULES ces questions sont HORS CONTEXTE (is_relevant: false):\n  - Questions sans rapport avec la cuisine/alimentation\n  ` : input.context.type === 'torah' ? `\n  Pour \"torah\", accepter: traduction, étude, commentaires, recherche textuelle.\n  ` : `\n  Contexte général: accepter les questions d'information et de recherche.\n  `}\n\n  ACTIONS DISPONIBLES (utilise ces IDs):\n  - \"search\" : Recherche web\n  - \"local_search\" : Recherche base locale\n  - \"scrape\" : Extraire contenu d'une URL\n  - \"info\" : Réponse informative simple\n\n  FORMAT DE SORTIE JSON:\n  {\n    \"response_type\": \"message\" | \"action_proposal\" | \"clarification_needed\",\n    \"message\": \"Réponse à l'utilisateur\",\n    \"intent\": { \"type\": \"...\", \"confidence\": 0.0-1.0 },\n    \"query_analysis\": {\n      \"original\": \"requête originale\",\n      \"reformulation\": \"requête reformulée\",\n      \"extracted_terms\": \"termes clés en STRING (pas un array)\",\n      \"detected_language\": \"fr\",\n      \"spelling_corrected\": false\n    },\n    \"proposed_actions\": [{\n      \"id\": \"search\",\n      \"label\": \"Label affiché\",\n      \"description\": \"Description de l'action\",\n      \"params\": { \"query\": \"termes de recherche\" },\n      \"requires_confirmation\": false\n    }],\n    \"is_relevant\": true,\n    \"rejection_reason\": null\n  }\n\n  IMPORTANT:\n  - N'INCLUS JAMAIS de champ \"webhook\" dans proposed_actions\n  - extracted_terms DOIT être une STRING, pas un array\n  - En cas de doute sur la pertinence, mets is_relevant: true`;\n\n  // Build messages array with history\n  const messages = [];\n\n  // Add history (already truncated to 10 in validation)\n  if (input.history && input.history.length > 0) {\n    for (const h of input.history) {\n      messages.push({ role: h.role, content: h.content });\n    }\n  }\n\n  // Add current user message\n  let userContent = input.message;\n  if (input.attached_file) {\n    const fileName = input.attached_file.name || 'document';\n    const fileType = input.attached_file.type || 'unknown';\n    userContent = `[Fichier joint: ${fileName} (${fileType})]\\n\\n${input.message}`;\n  }\n  messages.push({ role: 'user', content: userContent });\n\n  // Build final payload\n  const payload = {\n    model: input.llm_model,\n    max_tokens: 1000,\n    system: systemPrompt,\n    messages: messages\n  };\n\n  return {\n    json: {\n      ...input,\n      llm_payload: payload\n    }\n  };"
-      },
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        928,
-        224
-      ],
-      "id": "8fbab672-04b8-484c-b1cd-5b6271b6f5f9",
-      "name": "Build LLM Payload"
+      "position": [2120, 464]
     }
   ],
   "connections": {
@@ -340,14 +302,14 @@
       "main": [
         [
           {
-            "node": "Input Valid?",
+            "node": "Valid?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Input Valid?": {
+    "Valid?": {
       "main": [
         [
           {
@@ -358,7 +320,29 @@
         ],
         [
           {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
             "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build LLM Payload": {
+      "main": [
+        [
+          {
+            "node": "LLM Analyze Intent",
             "type": "main",
             "index": 0
           }
@@ -437,48 +421,11 @@
           }
         ]
       ]
-    },
-    "Build LLM Payload": {
-      "main": [
-        [
-          {
-            "node": "LLM Analyze Intent",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
     }
   },
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "2da812e0-b758-4fa0-826f-e3fcbc9eb410",
-  "activeVersionId": "2da812e0-b758-4fa0-826f-e3fcbc9eb410",
-  "versionCounter": 41,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-21T21:20:49.988Z",
-      "createdAt": "2026-01-21T21:20:49.988Z",
-      "role": "workflow:owner",
-      "workflowId": "tA1bPSUvjbZzYajG",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }

--- a/workflows/MCP_-_LLM_Summarizer.json
+++ b/workflows/MCP_-_LLM_Summarizer.json
@@ -1,38 +1,44 @@
 {
-  "updatedAt": "2025-12-15T15:08:09.498Z",
-  "createdAt": "2025-12-15T15:08:02.653Z",
-  "id": "cf4qppzmHzEYasfU",
   "name": "MCP - LLM Summarizer",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-llm-sum",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
-      "webhookId": "llm-summarizer-webhook",
+      "parameters": {
+        "content": "## MCP - LLM Summarizer\n\n**Endpoint:** POST /webhook/llm-summarizer\n\n**Description:** Summarizes text using multiple LLM providers (Anthropic, OpenAI, Mistral).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\"],\n  \"properties\": {\n    \"text\": { \"type\": \"string\", \"description\": \"Text to summarize (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized summary\" },\n    \"provider\": { \"type\": \"string\", \"description\": \"LLM provider: anthropic (default), openai, mistral\" },\n    \"format\": { \"type\": \"string\", \"description\": \"Output format: bullet-points, paragraph, executive-summary\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 1024)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"summary\", \"original_length\", \"summary_length\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 520,
+        "width": 380,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "llm-summarizer",
         "responseMode": "responseNode",
         "options": {}
-      }
+      },
+      "id": "webhook-llm-sum",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "llm-summarizer-webhook"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Summarizer\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required field ---\nconst text = body.text || ctx.text;\nif (!text || typeof text !== 'string' || text.trim().length === 0) {\n  errors.push('text requis (chaine non vide)');\n}\n\n// --- Context fields for tracing ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst provider = (body.provider || ctx.provider || 'anthropic').toLowerCase();\nconst format = body.format || ctx.format || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 1024);\n\n// Validate provider\nconst validProviders = ['anthropic', 'openai', 'mistral'];\nif (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider} (doit etre: ${validProviders.join(', ')})`);\n}\n\n// Validate format if provided\nconst validFormats = ['bullet-points', 'paragraph', 'executive-summary'];\nif (format && !validFormats.includes(format)) {\n  errors.push(`format invalide: ${format} (doit etre: ${validFormats.join(', ')})`);\n}\n\n// --- API Keys from env or request ---\nconst anthropicKey = body.anthropic_api_key || body.plugin_context?.api_keys?.anthropic || $env.ANTHROPIC_API_KEY || '';\nconst openaiKey = body.openai_api_key || body.plugin_context?.api_keys?.openai || $env.OPENAI_API_KEY || '';\nconst mistralKey = body.mistral_api_key || body.plugin_context?.api_keys?.mistral || $env.MISTRAL_API_KEY || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text.trim(),\n  provider: provider,\n  format: format,\n  max_tokens: maxTokens,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  anthropicKey: anthropicKey,\n  openaiKey: openaiKey,\n  mistralKey: mistralKey,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
-      "position": [
-        460,
-        300
-      ],
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,45 +48,58 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-text",
-      "name": "Error: No Text",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: text\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": $json.body.provider || \"anthropic\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
-      "id": "route-provider",
-      "name": "Route Provider",
-      "type": "n8n-nodes-base.switch",
-      "typeVersion": 3.2,
-      "position": [
-        700,
-        200
-      ],
       "parameters": {
         "rules": {
           "values": [
@@ -94,7 +113,7 @@
                 },
                 "conditions": [
                   {
-                    "leftValue": "={{ $json.body.provider }}",
+                    "leftValue": "={{ $json.provider }}",
                     "rightValue": "openai",
                     "operator": {
                       "type": "string",
@@ -116,7 +135,7 @@
                 },
                 "conditions": [
                   {
-                    "leftValue": "={{ $json.body.provider }}",
+                    "leftValue": "={{ $json.provider }}",
                     "rightValue": "mistral",
                     "operator": {
                       "type": "string",
@@ -133,176 +152,164 @@
         "options": {
           "fallbackOutput": "extra"
         }
-      }
-    },
-    {
-      "id": "openai-summarize",
-      "name": "OpenAI Summarize",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
-      "position": [
-        940,
-        100
-      ],
-      "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "gpt-4o-mini",
-        "messages": {
-          "values": [
-            {
-              "content": "You are a professional summarizer. Create clear, concise summaries that capture the main points and key information.",
-              "role": "system"
-            },
-            {
-              "content": "={{ 'Summarize the following text' + ($json.body.format ? ' in ' + $json.body.format + ' format' : '') + ':\\n\\n' + $json.body.text }}",
-              "role": "user"
-            }
-          ]
-        },
-        "options": {
-          "temperature": 0.3,
-          "maxTokens": "={{ $json.body.max_tokens || 1024 }}"
-        }
       },
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      }
+      "id": "route-provider",
+      "name": "Route Provider",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [920, 200]
     },
     {
-      "id": "mistral-summarize",
-      "name": "Mistral Summarize",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        940,
-        250
-      ],
       "parameters": {
         "method": "POST",
-        "url": "https://api.mistral.ai/v1/chat/completions",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "mistralCloudApi",
-        "sendBody": true,
-        "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"mistral-small-latest\", \"messages\": [{ \"role\": \"system\", \"content\": \"You are a professional summarizer. Create clear, concise summaries.\" }, { \"role\": \"user\", \"content\": \"Summarize the following text\" + ($json.body.format ? \" in \" + $json.body.format + \" format\" : \"\") + \":\\n\\n\" + $json.body.text }], \"max_tokens\": $json.body.max_tokens || 1024, \"temperature\": 0.3 } }}"
-      },
-      "credentials": {
-        "mistralCloudApi": {
-          "id": "mistral-credentials",
-          "name": "Mistral account"
-        }
-      }
-    },
-    {
-      "id": "anthropic-summarize",
-      "name": "Anthropic Summarize (Default)",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        940,
-        400
-      ],
-      "parameters": {
-        "method": "POST",
-        "url": "https://api.anthropic.com/v1/messages",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "anthropicApi",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
             {
-              "name": "anthropic-version",
-              "value": "2023-06-01"
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"claude-3-5-sonnet-20241022\", \"max_tokens\": $json.body.max_tokens || 1024, \"messages\": [{ \"role\": \"user\", \"content\": \"Summarize the following text\" + ($json.body.format ? \" in \" + $json.body.format + \" format\" : \"\") + \":\\n\\n\" + $json.body.text }] } }}"
-      },
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-credentials",
-          "name": "Anthropic account"
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  let prompt = 'Summarize the following text';\n  if (data.format) prompt += ` in ${data.format} format`;\n  if (data.user_request) prompt += `. User context: ${data.user_request}`;\n  prompt += `:\\n\\n${data.text}`;\n  return JSON.stringify({\n    model: 'gpt-4o-mini',\n    messages: [\n      { role: 'system', content: 'You are a professional summarizer. Create clear, concise summaries that capture the main points and key information.' },\n      { role: 'user', content: prompt }\n    ],\n    max_tokens: data.max_tokens || 1024,\n    temperature: 0.3\n  });\n})() }}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "id": "openai-summarize",
+      "name": "OpenAI Summarize",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1160, 60],
+      "onError": "continueRegularOutput"
     },
     {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.mistral.ai/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.mistralKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  let prompt = 'Summarize the following text';\n  if (data.format) prompt += ` in ${data.format} format`;\n  if (data.user_request) prompt += `. User context: ${data.user_request}`;\n  prompt += `:\\n\\n${data.text}`;\n  return JSON.stringify({\n    model: 'mistral-small-latest',\n    messages: [\n      { role: 'system', content: 'You are a professional summarizer. Create clear, concise summaries.' },\n      { role: 'user', content: prompt }\n    ],\n    max_tokens: data.max_tokens || 1024,\n    temperature: 0.3\n  });\n})() }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "mistral-summarize",
+      "name": "Mistral Summarize",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1160, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropicKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  let prompt = 'Summarize the following text';\n  if (data.format) prompt += ` in ${data.format} format`;\n  if (data.user_request) prompt += `. User context: ${data.user_request}`;\n  prompt += `:\\n\\n${data.text}`;\n  return JSON.stringify({\n    model: 'claude-sonnet-4-20250514',\n    max_tokens: data.max_tokens || 1024,\n    messages: [{ role: 'user', content: prompt }]\n  });\n})() }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "anthropic-summarize",
+      "name": "Anthropic Summarize",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1160, 340],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: 'gpt-4o-mini',\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst summary = input.choices?.[0]?.message?.content || '';\nconst originalLength = prevData.text.length;\nconst summaryLength = summary.length;\n\nconst _trace = {\n  llm_response: summary,\n  service_response: input,\n  provider: 'openai',\n  model: 'gpt-4o-mini',\n  tokens: {\n    input: input.usage?.prompt_tokens || 0,\n    output: input.usage?.completion_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    summary: summary,\n    original_length: originalLength,\n    summary_length: summaryLength\n  },\n  meta: {\n    provider: 'openai',\n    model: 'gpt-4o-mini',\n    format: prevData.format\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
       "id": "format-openai",
       "name": "Format OpenAI",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        1160,
-        100
-      ],
-      "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.message.content, \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": $json.message.content.length }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
-      }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1400, 60]
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT MISTRAL RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error || input.message) {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error?.message || input.message || 'Mistral API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'mistral',\n      model: 'mistral-small-latest',\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst summary = input.choices?.[0]?.message?.content || '';\nconst originalLength = prevData.text.length;\nconst summaryLength = summary.length;\n\nconst _trace = {\n  llm_response: summary,\n  service_response: input,\n  provider: 'mistral',\n  model: 'mistral-small-latest',\n  tokens: {\n    input: input.usage?.prompt_tokens || 0,\n    output: input.usage?.completion_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    summary: summary,\n    original_length: originalLength,\n    summary_length: summaryLength\n  },\n  meta: {\n    provider: 'mistral',\n    model: 'mistral-small-latest',\n    format: prevData.format\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
       "id": "format-mistral",
       "name": "Format Mistral",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        1160,
-        250
-      ],
-      "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.choices[0]?.message?.content || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.choices[0]?.message?.content || '').length }, \"meta\": { \"provider\": \"mistral\", \"model\": \"mistral-small-latest\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
-      }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1400, 200]
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ANTHROPIC RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error || input.type === 'error') {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error?.message || 'Anthropic API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'anthropic',\n      model: 'claude-sonnet-4-20250514',\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst summary = input.content?.[0]?.text || '';\nconst originalLength = prevData.text.length;\nconst summaryLength = summary.length;\n\nconst _trace = {\n  llm_response: summary,\n  service_response: input,\n  provider: 'anthropic',\n  model: input.model || 'claude-sonnet-4-20250514',\n  tokens: {\n    input: input.usage?.input_tokens || 0,\n    output: input.usage?.output_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    summary: summary,\n    original_length: originalLength,\n    summary_length: summaryLength\n  },\n  meta: {\n    provider: 'anthropic',\n    model: input.model || 'claude-sonnet-4-20250514',\n    format: prevData.format\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
       "id": "format-anthropic",
       "name": "Format Anthropic",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        1160,
-        400
-      ],
-      "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.content[0]?.text || '', \"original_length\": $('Webhook').first().json.body.text.length, \"summary_length\": ($json.content[0]?.text || '').length }, \"meta\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\" } } }}"
-      }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1400, 340]
     },
     {
-      "id": "respond-success",
-      "name": "Respond Success",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1380,
-        250
-      ],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 550,
-        "height": 220,
-        "content": "## MCP - LLM Summarizer\n\n**Endpoint:** POST /webhook/llm-summarizer\n\n**Parameters:**\n- `text` (required): Text to summarize\n- `provider` (optional): anthropic (default), openai, mistral\n- `format` (optional): bullet-points, paragraph, executive-summary\n- `max_tokens` (optional): Max output tokens (default: 1024)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Summary with length stats and provider info"
-      }
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1640, 200]
     }
   ],
   "connections": {
@@ -321,6 +328,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Route Provider",
             "type": "main",
             "index": 0
@@ -328,7 +346,18 @@
         ],
         [
           {
-            "node": "Error: No Text",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -353,7 +382,7 @@
         ],
         [
           {
-            "node": "Anthropic Summarize (Default)",
+            "node": "Anthropic Summarize",
             "type": "main",
             "index": 0
           }
@@ -382,7 +411,7 @@
         ]
       ]
     },
-    "Anthropic Summarize (Default)": {
+    "Anthropic Summarize": {
       "main": [
         [
           {
@@ -397,7 +426,7 @@
       "main": [
         [
           {
-            "node": "Respond Success",
+            "node": "Respond",
             "type": "main",
             "index": 0
           }
@@ -408,7 +437,7 @@
       "main": [
         [
           {
-            "node": "Respond Success",
+            "node": "Respond",
             "type": "main",
             "index": 0
           }
@@ -419,7 +448,7 @@
       "main": [
         [
           {
-            "node": "Respond Success",
+            "node": "Respond",
             "type": "main",
             "index": 0
           }
@@ -430,32 +459,6 @@
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "bde58db0-3494-452e-943f-86b2183fd5ae",
-  "activeVersionId": "bde58db0-3494-452e-943f-86b2183fd5ae",
-  "versionCounter": 383,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-15T15:08:02.656Z",
-      "createdAt": "2025-12-15T15:08:02.656Z",
-      "role": "workflow:owner",
-      "workflowId": "cf4qppzmHzEYasfU",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "availableInMCP": true
+  }
 }

--- a/workflows/MCP_-_LLM_URL_Extractor.json
+++ b/workflows/MCP_-_LLM_URL_Extractor.json
@@ -1,0 +1,535 @@
+{
+  "name": "MCP - LLM URL Extractor",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - LLM URL Extractor\n\n**Endpoint:** POST /webhook/llm-url-extractor\n\n**Description:** Extracts structured information from a URL using LLM analysis.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"url\"],\n  \"properties\": {\n    \"url\": { \"type\": \"string\", \"description\": \"URL to fetch and extract information from (required)\" },\n    \"extraction_schema\": { \"type\": \"object\", \"description\": \"JSON schema defining what to extract\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized extraction\" },\n    \"provider\": { \"type\": \"string\", \"description\": \"LLM provider: anthropic (default), openai\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 2048)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"extracted_data\", \"source_url\", \"content_length\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 560,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "llm-url-extractor",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-llm-url",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "llm-url-extractor-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM URL Extractor\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required field ---\nlet url = body.url || ctx.url || '';\n\n// Ensure url is a string\nif (typeof url !== 'string') {\n  url = String(url || '');\n}\n\nif (!url || url.trim().length === 0) {\n  errors.push('url requis (chaine non vide)');\n} else {\n  // Validate URL format using regex (more reliable in n8n environment)\n  const urlPattern = /^https?:\\/\\/[^\\s/$.?#].[^\\s]*$/i;\n  if (!urlPattern.test(url.trim())) {\n    errors.push('url invalide (format URL requis, ex: https://example.com)');\n  }\n}\n\n// --- Optional context fields for tracing (no validation errors if missing) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst provider = (body.provider || ctx.provider || 'anthropic').toLowerCase();\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 2048);\nconst extractionSchema = body.extraction_schema || ctx.extraction_schema || null;\n\n// Validate provider\nconst validProviders = ['anthropic', 'openai'];\nif (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider} (doit etre: ${validProviders.join(', ')})`);\n}\n\n// --- API Keys from env or request ---\nconst anthropicKey = body.anthropic_api_key || body.plugin_context?.api_keys?.anthropic || $env.ANTHROPIC_API_KEY || '';\nconst openaiKey = body.openai_api_key || body.plugin_context?.api_keys?.openai || $env.OPENAI_API_KEY || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  url: url.trim(),\n  provider: provider,\n  max_tokens: maxTokens,\n  extraction_schema: extractionSchema,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  anthropicKey: anthropicKey,\n  openaiKey: openaiKey,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
+    },
+    {
+      "parameters": {
+        "url": "={{ $json.url }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.9,fr;q=0.8"
+            }
+          ]
+        },
+        "options": {
+          "redirect": {
+            "redirect": {
+              "maxRedirects": 5
+            }
+          },
+          "response": {
+            "response": {
+              "fullResponse": true,
+              "neverError": true
+            }
+          },
+          "timeout": 60000
+        }
+      },
+      "id": "fetch-url",
+      "name": "Fetch URL",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// EXTRACT CONTENT FROM HTML\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\n// Check for fetch errors\nif (input.error || (input.statusCode && input.statusCode >= 400)) {\n  return {\n    success: false,\n    fetchError: true,\n    errorMessage: input.error?.message || `HTTP ${input.statusCode} error`,\n    statusCode: input.statusCode || 500,\n    ...prevData\n  };\n}\n\n// Get HTML from response - handle both fullResponse and direct response\nlet html = '';\nif (typeof input === 'string') {\n  html = input;\n} else if (input.body) {\n  html = typeof input.body === 'string' ? input.body : JSON.stringify(input.body);\n} else if (input.data) {\n  html = typeof input.data === 'string' ? input.data : JSON.stringify(input.data);\n}\n\n// Simple content extraction\nfunction extractContent(html) {\n  if (!html) return { title: '', content: '', excerpt: '' };\n  \n  // Remove scripts, styles, comments\n  let clean = html\n    .replace(/<script[^>]*>[\\s\\S]*?<\\/script>/gi, '')\n    .replace(/<style[^>]*>[\\s\\S]*?<\\/style>/gi, '')\n    .replace(/<!--[\\s\\S]*?-->/g, '')\n    .replace(/<noscript[^>]*>[\\s\\S]*?<\\/noscript>/gi, '');\n  \n  // Extract title\n  const titleMatch = clean.match(/<title[^>]*>([^<]*)<\\/title>/i);\n  const title = titleMatch ? titleMatch[1].trim() : '';\n  \n  // Try to find main content in order of specificity\n  let content = '';\n  const articleMatch = clean.match(/<article[^>]*>([\\s\\S]*?)<\\/article>/i);\n  const mainMatch = clean.match(/<main[^>]*>([\\s\\S]*?)<\\/main>/i);\n  const divContentMatch = clean.match(/<div[^>]*(?:id|class)=[\"'][^\"']*content[^\"']*[\"'][^>]*>([\\s\\S]*?)<\\/div>/i);\n  \n  if (articleMatch) {\n    content = articleMatch[1];\n  } else if (mainMatch) {\n    content = mainMatch[1];\n  } else if (divContentMatch) {\n    content = divContentMatch[1];\n  } else {\n    const bodyMatch = clean.match(/<body[^>]*>([\\s\\S]*?)<\\/body>/i);\n    content = bodyMatch ? bodyMatch[1] : clean;\n  }\n  \n  // Remove HTML tags and clean up\n  const textContent = content\n    .replace(/<[^>]+>/g, ' ')\n    .replace(/\\s+/g, ' ')\n    .replace(/&nbsp;/g, ' ')\n    .replace(/&amp;/g, '&')\n    .replace(/&lt;/g, '<')\n    .replace(/&gt;/g, '>')\n    .replace(/&quot;/g, '\"')\n    .replace(/&#39;/g, \"'\")\n    .trim();\n  \n  return {\n    title: title,\n    content: textContent,\n    excerpt: textContent.substring(0, 500) + (textContent.length > 500 ? '...' : '')\n  };\n}\n\nconst extracted = extractContent(html);\n\nreturn {\n  ...prevData,\n  fetchError: false,\n  pageTitle: extracted.title,\n  pageContent: extracted.content,\n  pageExcerpt: extracted.excerpt,\n  contentLength: extracted.content.length,\n  rawHtmlLength: html.length,\n  finalUrl: input.headers?.location || prevData.url\n};"
+      },
+      "id": "extract-content",
+      "name": "Extract Content",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 200]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-fetch-error",
+              "leftValue": "={{ $json.fetchError }}",
+              "rightValue": false,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-fetch-success",
+      "name": "Fetch OK?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1340, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD FETCH ERROR\n// ============================================\n\nconst input = $input.first().json;\nconst startTime = input.startTime || Date.now();\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { \n      fetch_error: input.errorMessage,\n      status_code: input.statusCode\n    },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: Date.now() - startTime,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'FETCH_ERROR',\n    message: input.errorMessage,\n    http_status: 502\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-fetch-error",
+      "name": "Build Fetch Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1560, 380]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 502,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-fetch-error",
+      "name": "Respond Fetch Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1780, 380]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "openai",
+              "conditions": {
+                "options": {
+                  "caseSensitive": false,
+                  "leftValue": "",
+                  "typeValidation": "loose"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "openai",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "extra"
+        }
+      },
+      "id": "route-provider",
+      "name": "Route Provider",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1560, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  \n  let systemPrompt = 'You are an expert information extractor. Analyze the provided web page content and extract the key information in a structured JSON format.';\n  \n  if (data.extraction_schema) {\n    systemPrompt += ` Follow this extraction schema: ${JSON.stringify(data.extraction_schema)}`;\n  }\n  \n  let userPrompt = `Extract structured information from this web page:\\n\\nTitle: ${data.pageTitle}\\n\\nContent:\\n${data.pageContent.substring(0, 8000)}`;\n  \n  if (data.user_request) {\n    userPrompt += `\\n\\nUser context: ${data.user_request}`;\n  }\n  \n  return JSON.stringify({\n    model: 'gpt-4o-mini',\n    messages: [\n      { role: 'system', content: systemPrompt },\n      { role: 'user', content: userPrompt }\n    ],\n    max_tokens: data.max_tokens || 2048,\n    temperature: 0.3,\n    response_format: { type: 'json_object' }\n  });\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "openai-extract",
+      "name": "OpenAI Extract",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1780, 0],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "none",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropicKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  \n  let systemPrompt = 'You are an expert information extractor. Analyze the provided web page content and extract the key information in a structured JSON format. Always respond with valid JSON only.';\n  \n  if (data.extraction_schema) {\n    systemPrompt += ` Follow this extraction schema: ${JSON.stringify(data.extraction_schema)}`;\n  }\n  \n  let userPrompt = `Extract structured information from this web page:\\n\\nTitle: ${data.pageTitle}\\n\\nContent:\\n${data.pageContent.substring(0, 8000)}`;\n  \n  if (data.user_request) {\n    userPrompt += `\\n\\nUser context: ${data.user_request}`;\n  }\n  \n  return JSON.stringify({\n    model: 'claude-sonnet-4-20250514',\n    max_tokens: data.max_tokens || 2048,\n    system: systemPrompt,\n    messages: [{ role: 'user', content: userPrompt }]\n  });\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "anthropic-extract",
+      "name": "Anthropic Extract",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1780, 160],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Extract Content').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: 'gpt-4o-mini',\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst rawResponse = input.choices?.[0]?.message?.content || '{}';\nlet extractedData = {};\ntry {\n  extractedData = JSON.parse(rawResponse);\n} catch (e) {\n  extractedData = { raw_text: rawResponse };\n}\n\nconst _trace = {\n  llm_response: extractedData,\n  service_response: input,\n  provider: 'openai',\n  model: 'gpt-4o-mini',\n  tokens: {\n    input: input.usage?.prompt_tokens || 0,\n    output: input.usage?.completion_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    extracted_data: extractedData,\n    source_url: prevData.url,\n    page_title: prevData.pageTitle,\n    content_length: prevData.contentLength\n  },\n  meta: {\n    provider: 'openai',\n    model: 'gpt-4o-mini'\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
+      "id": "format-openai",
+      "name": "Format OpenAI",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2020, 0]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ANTHROPIC RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Extract Content').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error || input.type === 'error') {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error?.message || 'Anthropic API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'anthropic',\n      model: 'claude-sonnet-4-20250514',\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst rawResponse = input.content?.[0]?.text || '{}';\nlet extractedData = {};\ntry {\n  extractedData = JSON.parse(rawResponse);\n} catch (e) {\n  extractedData = { raw_text: rawResponse };\n}\n\nconst _trace = {\n  llm_response: extractedData,\n  service_response: input,\n  provider: 'anthropic',\n  model: input.model || 'claude-sonnet-4-20250514',\n  tokens: {\n    input: input.usage?.input_tokens || 0,\n    output: input.usage?.output_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    extracted_data: extractedData,\n    source_url: prevData.url,\n    page_title: prevData.pageTitle,\n    content_length: prevData.contentLength\n  },\n  meta: {\n    provider: 'anthropic',\n    model: input.model || 'claude-sonnet-4-20250514'\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
+      "id": "format-anthropic",
+      "name": "Format Anthropic",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2020, 160]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2260, 80]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Fetch URL",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch URL": {
+      "main": [
+        [
+          {
+            "node": "Extract Content",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Content": {
+      "main": [
+        [
+          {
+            "node": "Fetch OK?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch OK?": {
+      "main": [
+        [
+          {
+            "node": "Route Provider",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Fetch Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Fetch Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Fetch Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route Provider": {
+      "main": [
+        [
+          {
+            "node": "OpenAI Extract",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Anthropic Extract",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Extract": {
+      "main": [
+        [
+          {
+            "node": "Format OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Anthropic Extract": {
+      "main": [
+        [
+          {
+            "node": "Format Anthropic",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Anthropic": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  }
+}

--- a/workflows/MCP_-_Language_Detector.json
+++ b/workflows/MCP_-_Language_Detector.json
@@ -1,21 +1,25 @@
 {
-  "updatedAt": "2025-12-18T15:17:10.000Z",
-  "createdAt": "2025-12-18T15:14:50.310Z",
-  "id": "bggGYdqahk01bt0B",
   "name": "MCP - Language Detector",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80],
+      "parameters": {
+        "color": 6,
+        "width": 340,
+        "height": 580,
+        "content": "## MCP - Language Detector\n\n**Endpoint:** POST /webhook/language-detector\n\n**Description:** Detecte la langue d'un texte et retourne des informations detaillees.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"text\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte a analyser pour detection de langue\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Returns:**\n- `code`: ISO 639-1 language code (en, fr, es, de, zh, ja, ar, etc.)\n- `name`: Full language name in English\n- `confidence`: Detection confidence (0.0 to 1.0)\n- `script`: Writing script (latin, cyrillic, arabic, han, etc.)\n- `is_mixed`: Boolean if multiple languages detected\n- `languages`: Array of detected languages if mixed\n\n**Model:** gpt-4o-mini (fast, cost-effective)\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"code\", \"name\", \"confidence\", \"script\"],\n  \"domain\": \"language\"\n}\n```"
+      }
+    },
     {
       "id": "webhook-lang",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "language-detector-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +31,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Language Detector\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Specific webhook parameters ---\nconst text = body.text || ctx.text;\n\nif (!text) {\n  errors.push('text requis');\n}\n\n// --- API Keys passed from MCP Server ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  openaiApiKey: openaiApiKey,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +53,12 @@
           },
           "conditions": [
             {
-              "id": "condition-text",
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +68,34 @@
       }
     },
     {
-      "id": "error-no-text",
-      "name": "Error: No Text",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'openai',\n    model: 'gpt-4o-mini',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: text\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"model\": \"gpt-4o-mini\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,10 +104,7 @@
       "name": "OpenAI Detect Language",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/chat/completions",
@@ -91,7 +114,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.openai_api_key }}"
+              "value": "=Bearer {{ $json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -101,7 +124,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a language detection expert. Detect the language of the given text and return a JSON object with:\\n- code: ISO 639-1 code (e.g., 'en', 'fr', 'es', 'de', 'zh', 'ja', 'ar')\\n- name: Full language name in English\\n- confidence: Confidence score 0.0 to 1.0\\n- script: Writing script (latin, cyrillic, arabic, han, etc.)\\n- is_mixed: Boolean if multiple languages detected\\n- languages: Array of detected languages if mixed\\n\\nReturn ONLY valid JSON.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Detect the language of this text:\\n\\n{{ $json.body.text.substring(0, 1000) }}\"\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 256\n}",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const userRequest = data.user_request;\n  const textSample = data.text.substring(0, 1000);\n  \n  const systemPrompt = `You are a language detection expert. Detect the language of the given text and return a JSON object with:\n- code: ISO 639-1 code (e.g., 'en', 'fr', 'es', 'de', 'zh', 'ja', 'ar')\n- name: Full language name in English\n- confidence: Confidence score 0.0 to 1.0\n- script: Writing script (latin, cyrillic, arabic, han, etc.)\n- is_mixed: Boolean if multiple languages detected\n- languages: Array of detected languages if mixed\n\nUser context: \"${userRequest}\"\n\nReturn ONLY valid JSON.`;\n\n  return JSON.stringify({\n    model: 'gpt-4o-mini',\n    response_format: { type: 'json_object' },\n    messages: [\n      { role: 'system', content: systemPrompt },\n      { role: 'user', content: `Detect the language of this text:\\n\\n${textSample}` }\n    ],\n    temperature: 0.1,\n    max_tokens: 256\n  });\n})() }}",
         "options": {
           "timeout": 30000
         }
@@ -113,43 +136,31 @@
       "name": "Parse Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\n\nconst results = items.map(item => {\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'OpenAI API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini'\n        }\n      }\n    };\n  }\n\n  try {\n    const content = item.json.choices?.[0]?.message?.content || '{}';\n    const detection = JSON.parse(content);\n    \n    return {\n      json: {\n        success: true,\n        data: {\n          code: detection.code || 'unknown',\n          name: detection.name || 'Unknown',\n          confidence: detection.confidence || 0,\n          script: detection.script || 'unknown',\n          is_mixed: detection.is_mixed || false,\n          languages: detection.languages || null,\n          text_sample: webhookData.body.text.substring(0, 100) + (webhookData.body.text.length > 100 ? '...' : '')\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini'\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse detection response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: 'gpt-4o-mini'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
+        "jsCode": "// ============================================\n// PARSE LLM RESPONSE - Language Detector\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\nconst statusCode = input.statusCode || 200;\n\n// Initialize trace with llm_response format\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'openai',\n  model: 'gpt-4o-mini',\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\n// Handle API error\nif (statusCode >= 400 || input.error) {\n  const errorMsg = input.body?.error?.message || input.error?.message || 'OpenAI API error';\n  _trace.llm_response = `Error: ${errorMsg}`;\n  _trace.service_response = input.body || input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'LLM_ERROR',\n        message: errorMsg,\n        http_status: statusCode\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract response\nconst body = input.body || input;\nconst content = body.choices?.[0]?.message?.content || '{}';\nconst usage = body.usage || {};\n\n// Populate trace with LLM response\n_trace.llm_response = content;\n_trace.service_response = body;\n_trace.tokens = {\n  input: usage.prompt_tokens || 0,\n  output: usage.completion_tokens || 0\n};\n\n// Parse JSON from response\nlet detection;\ntry {\n  detection = JSON.parse(content);\n} catch (e) {\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PARSE_ERROR',\n        message: 'Failed to parse detection response: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n_trace.latency_ms = Date.now() - startTime;\n\nreturn {\n  json: {\n    success: true,\n    data: {\n      code: detection.code || 'unknown',\n      name: detection.name || 'Unknown',\n      confidence: detection.confidence || 0,\n      script: detection.script || 'unknown',\n      is_mixed: detection.is_mixed || false,\n      languages: detection.languages || null,\n      text_sample: prevData.text.substring(0, 100) + (prevData.text.length > 100 ? '...' : '')\n    },\n    meta: {\n      provider: 'openai',\n      model: 'gpt-4o-mini'\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: _trace\n  }\n};"
       }
     },
     {
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
+      "typeVersion": 1.1,
+      "position": [1360, 200],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 650,
-        "height": 260,
-        "content": "## MCP - Language Detector\n\n**Endpoint:** POST /webhook/language-detector\n\n**Parameters:**\n- `text` (required): Text to analyze\n- `openai_api_key` (required): OpenAI API key\n\n**Returns:**\n- `code`: ISO 639-1 language code (en, fr, es, de, zh, ja, ar, etc.)\n- `name`: Full language name in English\n- `confidence`: Detection confidence (0.0 to 1.0)\n- `script`: Writing script (latin, cyrillic, arabic, han, etc.)\n- `is_mixed`: Boolean if multiple languages detected\n- `languages`: Array of detected languages if mixed\n\n**Model:** gpt-4o-mini (fast, cost-effective)"
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       }
     }
   ],
@@ -169,6 +180,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI Detect Language",
             "type": "main",
             "index": 0
@@ -176,7 +198,18 @@
         ],
         [
           {
-            "node": "Error: No Text",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -208,33 +241,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "b4eecac0-5b63-4255-806e-39ac4a90b6c0",
-  "activeVersionId": "b4eecac0-5b63-4255-806e-39ac4a90b6c0",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:14:50.313Z",
-      "createdAt": "2025-12-18T15:14:50.313Z",
-      "role": "workflow:owner",
-      "workflowId": "bggGYdqahk01bt0B",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Mathpix.json
+++ b/workflows/MCP_-_Mathpix.json
@@ -1,38 +1,44 @@
 {
-  "updatedAt": "2025-12-18T15:12:59.000Z",
-  "createdAt": "2025-12-18T15:12:51.984Z",
-  "id": "o6hfceJb86t0k52C",
   "name": "MCP - Mathpix",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-mathpix",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
-      "webhookId": "mathpix-webhook",
+      "parameters": {
+        "content": "## MCP - Mathpix\n\n**Endpoint:** POST /webhook/mathpix\n\n**Description:** OCR mathematique via Mathpix API. Convertit images de formules/equations en LaTeX, MathML, AsciiMath.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"image_url|image_base64\", \"mathpix_app_id\", \"mathpix_app_key\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur pour tracabilite\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete originale de l'utilisateur\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image avec equations\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Image encodee en base64\" },\n    \"mathpix_app_id\": { \"type\": \"string\", \"description\": \"Mathpix App ID\" },\n    \"mathpix_app_key\": { \"type\": \"string\", \"description\": \"Mathpix App Key\" },\n    \"formats\": { \"type\": \"array\", \"description\": \"Formats de sortie\", \"default\": [\"latex_styled\", \"text\", \"data\"] },\n    \"include_asciimath\": { \"type\": \"boolean\", \"default\": true },\n    \"include_latex\": { \"type\": \"boolean\", \"default\": true },\n    \"include_mathml\": { \"type\": \"boolean\", \"default\": false },\n    \"include_svg\": { \"type\": \"boolean\", \"default\": false }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": true,\n  \"output_fields\": [\"latex\", \"text\", \"confidence\", \"asciimath\", \"mathml\"],\n  \"domain\": \"math_ocr\"\n}\n```",
+        "height": 640,
+        "width": 380,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "mathpix",
         "responseMode": "responseNode",
         "options": {}
-      }
+      },
+      "id": "webhook-mathpix",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "mathpix-webhook"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Mathpix OCR\n// RFC-014 Extraction with context.* fallback\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (extract for tracing, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- REQUIRED parameters ---\nconst imageUrl = body.image_url || ctx.image_url || null;\nconst imageBase64 = body.image_base64 || ctx.image_base64 || null;\nconst mathpixAppId = body.mathpix_app_id || ctx.mathpix_app_id || null;\nconst mathpixAppKey = body.mathpix_app_key || ctx.mathpix_app_key || null;\n\n// Validate required fields\nif (!imageUrl && !imageBase64) {\n  errors.push('image_url ou image_base64 requis');\n}\nif (!mathpixAppId) {\n  errors.push('mathpix_app_id requis');\n}\nif (!mathpixAppKey) {\n  errors.push('mathpix_app_key requis');\n}\n\n// --- OPTIONAL parameters with defaults ---\nconst formats = body.formats || ctx.formats || ['latex_styled', 'text', 'data'];\nconst includeAsciimath = body.include_asciimath !== undefined ? body.include_asciimath : (ctx.include_asciimath !== undefined ? ctx.include_asciimath : true);\nconst includeLatex = body.include_latex !== undefined ? body.include_latex : (ctx.include_latex !== undefined ? ctx.include_latex : true);\nconst includeMathml = body.include_mathml || ctx.include_mathml || false;\nconst includeSvg = body.include_svg || ctx.include_svg || false;\nconst improveMathpix = body.improve_mathpix || ctx.improve_mathpix || false;\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// Determine image source\nlet imageSource = 'url';\nlet imageSrc = imageUrl;\nif (imageBase64 && !imageUrl) {\n  imageSource = 'base64';\n  imageSrc = 'data:image/jpeg;base64,' + imageBase64;\n}\n\nreturn {\n  valid: true,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  image_url: imageUrl,\n  image_base64: imageBase64,\n  image_source: imageSource,\n  image_src: imageSrc,\n  mathpix_app_id: mathpixAppId,\n  mathpix_app_key: mathpixAppKey,\n  formats: formats,\n  include_asciimath: includeAsciimath,\n  include_latex: includeLatex,\n  include_mathml: includeMathml,\n  include_svg: includeSvg,\n  improve_mathpix: improveMathpix,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,46 +48,58 @@
           },
           "conditions": [
             {
-              "id": "condition-image",
-              "leftValue": "={{ $json.body.image_url || $json.body.image_base64 }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-image",
-      "name": "Error: No Image",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'mathpix',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: image_url or image_base64\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"mathpix\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
-      "id": "mathpix-ocr",
-      "name": "Mathpix OCR",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
       "parameters": {
         "method": "POST",
         "url": "https://api.mathpix.com/v3/text",
@@ -91,11 +109,11 @@
           "parameters": [
             {
               "name": "app_id",
-              "value": "={{ $json.body.mathpix_app_id }}"
+              "value": "={{ $json.mathpix_app_id }}"
             },
             {
               "name": "app_key",
-              "value": "={{ $json.body.mathpix_app_key }}"
+              "value": "={{ $json.mathpix_app_key }}"
             },
             {
               "name": "Content-Type",
@@ -105,56 +123,49 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"src\": \"{{ $json.body.image_url || ('data:image/jpeg;base64,' + $json.body.image_base64) }}\",\n  \"formats\": {{ JSON.stringify($json.body.formats || ['latex_styled', 'text', 'data']) }},\n  \"data_options\": {\n    \"include_asciimath\": {{ $json.body.include_asciimath || true }},\n    \"include_latex\": {{ $json.body.include_latex !== false }},\n    \"include_mathml\": {{ $json.body.include_mathml || false }},\n    \"include_svg\": {{ $json.body.include_svg || false }}\n  },\n  \"metadata\": {\n    \"improve_mathpix\": {{ $json.body.improve_mathpix || false }}\n  }\n}",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  return JSON.stringify({\n    src: data.image_src,\n    formats: data.formats,\n    data_options: {\n      include_asciimath: data.include_asciimath,\n      include_latex: data.include_latex,\n      include_mathml: data.include_mathml,\n      include_svg: data.include_svg\n    },\n    metadata: {\n      improve_mathpix: data.improve_mathpix\n    }\n  });\n})() }}",
         "options": {
           "timeout": 60000
         }
       },
+      "id": "mathpix-ocr",
+      "name": "Mathpix OCR",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200],
       "onError": "continueRegularOutput"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// PARSE RESPONSE - Mathpix OCR\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\nconst statusCode = input.statusCode || 200;\n\n// Initialize trace\nconst _trace = {\n  service_response: null,\n  provider: 'mathpix',\n  mode: 'ocr',\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\n// Handle API error\nif (statusCode >= 400 || input.error) {\n  const errorMsg = input.error_info?.message || input.error?.message || input.error || 'Mathpix API error';\n  _trace.service_response = input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: input.error_info?.code || 'API_ERROR',\n        message: errorMsg,\n        http_status: statusCode\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\ntry {\n  const data = input.body || input;\n  \n  // Extract different format outputs\n  const result = {\n    text: data.text || '',\n    latex: data.latex_styled || data.latex || '',\n    latex_confidence: data.latex_confidence || 0,\n    asciimath: data.asciimath || null,\n    mathml: data.mathml || null,\n    data: data.data || []\n  };\n  \n  // Parse detected elements if available\n  const elements = (data.data || []).map(d => ({\n    type: d.type,\n    value: d.value,\n    latex: d.latex,\n    position: d.position\n  }));\n  \n  _trace.service_response = data;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: true,\n      data: {\n        text: result.text,\n        latex: result.latex,\n        latex_display: result.latex ? `$$${result.latex}$$` : '',\n        latex_inline: result.latex ? `$${result.latex}$` : '',\n        confidence: result.latex_confidence,\n        asciimath: result.asciimath,\n        mathml: result.mathml,\n        elements: elements,\n        is_math: data.is_printed || data.is_handwritten || false,\n        is_handwritten: data.is_handwritten || false\n      },\n      meta: {\n        provider: 'mathpix',\n        confidence: result.latex_confidence,\n        detection_score: data.detection_score || 0,\n        processing_time_ms: Date.now() - startTime\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n} catch (e) {\n  _trace.service_response = { parse_error: e.message };\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PARSE_ERROR',\n        message: 'Failed to parse Mathpix response: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}"
+      },
       "id": "parse-response",
       "name": "Parse Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
-      "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\n\nconst results = items.map(item => {\n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error_info?.code || 500,\n          message: item.json.error_info?.message || item.json.error || 'Mathpix API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'mathpix'\n        }\n      }\n    };\n  }\n\n  try {\n    const data = item.json;\n    \n    // Extract different format outputs\n    const result = {\n      text: data.text || '',\n      latex: data.latex_styled || data.latex || '',\n      latex_confidence: data.latex_confidence || 0,\n      asciimath: data.asciimath || null,\n      mathml: data.mathml || null,\n      data: data.data || []\n    };\n    \n    // Parse detected elements if available\n    const elements = (data.data || []).map(d => ({\n      type: d.type,\n      value: d.value,\n      latex: d.latex,\n      position: d.position\n    }));\n    \n    return {\n      json: {\n        success: true,\n        data: {\n          text: result.text,\n          latex: result.latex,\n          latex_display: result.latex ? `$$${result.latex}$$` : '',\n          latex_inline: result.latex ? `$${result.latex}$` : '',\n          confidence: result.latex_confidence,\n          asciimath: result.asciimath,\n          mathml: result.mathml,\n          elements: elements,\n          is_math: data.is_printed || data.is_handwritten || false,\n          is_handwritten: data.is_handwritten || false\n        },\n        meta: {\n          provider: 'mathpix',\n          confidence: result.latex_confidence,\n          detection_score: data.detection_score || 0\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse Mathpix response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'mathpix'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
-      }
+      "position": [1180, 200]
     },
     {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 700,
-        "height": 340,
-        "content": "## MCP - Mathpix\n\n**Endpoint:** POST /webhook/mathpix\n\n**Parameters:**\n- `image_url` (required*): URL of image with math/equations\n- `image_base64` (required*): Base64-encoded image\n- `mathpix_app_id` (required): Mathpix App ID\n- `mathpix_app_key` (required): Mathpix App Key\n- `formats` (optional): Output formats (default: ['latex_styled', 'text', 'data'])\n- `include_asciimath` (optional): Include AsciiMath output (default: true)\n- `include_latex` (optional): Include LaTeX output (default: true)\n- `include_mathml` (optional): Include MathML output (default: false)\n- `include_svg` (optional): Include SVG rendering (default: false)\n\n*One of image_url or image_base64 is required\n\n**Returns:**\n- `latex`: LaTeX representation of math\n- `latex_display`: Display math ($$...$$)\n- `latex_inline`: Inline math ($...$)\n- `text`: Plain text representation\n- `confidence`: Recognition confidence\n- `is_handwritten`: Handwriting detection\n\n**Use cases:** Math OCR, equation extraction, homework help"
-      }
+      "typeVersion": 1.1,
+      "position": [1420, 200]
     }
   ],
   "connections": {
@@ -173,6 +184,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Mathpix OCR",
             "type": "main",
             "index": 0
@@ -180,7 +202,18 @@
         ],
         [
           {
-            "node": "Error: No Image",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -212,33 +245,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "f70329f3-8bdd-4de5-acd5-2ca04c71bd8d",
-  "activeVersionId": "f70329f3-8bdd-4de5-acd5-2ca04c71bd8d",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:12:51.988Z",
-      "createdAt": "2025-12-18T15:12:51.988Z",
-      "role": "workflow:owner",
-      "workflowId": "o6hfceJb86t0k52C",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_PDF_Layout_Translator.json
+++ b/workflows/MCP_-_PDF_Layout_Translator.json
@@ -1,17 +1,11 @@
 {
-  "updatedAt": "2026-01-20T19:33:52.000Z",
-  "createdAt": "2026-01-19T18:10:46.974Z",
-  "id": "P4K8eUBaspgYvpmp",
   "name": "MCP - PDF Layout Translator",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "parameters": {
-        "content": "## MCP - PDF Layout Translator\n\n**Endpoint:** POST /webhook/pdf-layout-translator\n\n**Pattern:** Async avec job_id\n\n**Input:**\n- `file_url` OU `file_base64`: PDF à traiter\n- `mistral_api_key`: Pour OCR Pixtral\n- `api_key`: Anthropic API key (traduction)\n- `openai_api_key`: Pour vérification GPT\n- `target_language` (optionnel): Default 'fr'\n- `source_language` (optionnel): Default 'auto'\n\n**Response immédiate:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_xxx\",\n  \"status\": \"started\"\n}\n```\n\n**Statut:** GET /webhook/torah-job-status?job_id=xxx",
-        "height": 380,
-        "width": 320,
+        "content": "## MCP - PDF Layout Translator\n\n**Endpoint:** POST /webhook/pdf-layout-translator\n\n**Pattern:** Async avec job_id\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"file_url|file_base64\", \"mistral_api_key\", \"api_key\", \"openai_api_key\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\", \"target_language\", \"source_language\", \"callback_url\"],\n  \"properties\": {\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL of PDF to process\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Base64 encoded PDF\" },\n    \"file_type\": { \"type\": \"string\", \"default\": \"pdf\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key for Pixtral OCR\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"Anthropic API key for translation\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"OpenAI API key for verification\" },\n    \"target_language\": { \"type\": \"string\", \"default\": \"fr\" },\n    \"source_language\": { \"type\": \"string\", \"default\": \"auto\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Original user request\" },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL to send result\" }\n  }\n}\n```\n\n**RFC-014 Support:**\n- Accepts both root-level and context.* fields\n- Returns immediate ACK with job_id, result via callback\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": true,\n  \"output_fields\": [\"job_id\", \"success\", \"status\", \"_trace\"],\n  \"domain\": \"document-processing\"\n}\n```",
+        "height": 680,
+        "width": 400,
         "color": 6
       },
       "id": "sticky-doc",
@@ -42,10 +36,10 @@
     },
     {
       "parameters": {
-        "jsCode": "const input = $input.first().json;\nconst body = input.body || input;\n\n// Validation\nconst hasFile = !!(body.file_url || body.file_base64);\nconst hasMistralKey = !!body.mistral_api_key;\nconst hasAnthropicKey = !!body.api_key || !!body.anthropic_api_key;\nconst hasOpenAIKey = !!body.openai_api_key;\n\nconst errors = [];\nif (!hasFile) errors.push('file_url ou file_base64 requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\nif (!hasAnthropicKey) errors.push('api_key (Anthropic) requis');\nif (!hasOpenAIKey) errors.push('openai_api_key requis');\n\n// Fonction pour détecter le MIME type depuis les magic bytes base64\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  if (prefix.startsWith('Qk')) return 'image/bmp';\n  if (prefix.startsWith('JVBER') || prefix.startsWith('JVBERi')) return 'application/pdf';\n  return null;\n}\n\n// Fonction pour obtenir le MIME type depuis l'extension\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp',\n    'tiff': 'image/tiff', 'tif': 'image/tiff',\n    'pdf': 'application/pdf'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// Préparer l'URL du fichier avec détection MIME intelligente\nlet fileUrl = '';\nlet detectedMime = 'application/pdf';\n\nif (body.file_url) {\n  fileUrl = body.file_url;\n} else if (body.file_base64) {\n  // 1. Essayer depuis file_type param\n  if (body.file_type) {\n    detectedMime = getMimeFromExtension(body.file_type) || 'application/pdf';\n  }\n  // 2. Fallback: détecter depuis magic bytes\n  if (detectedMime === 'application/pdf') {\n    const detected = detectMimeFromBase64(body.file_base64);\n    if (detected) detectedMime = detected;\n  }\n  fileUrl = 'data:' + detectedMime + ';base64,' + body.file_base64;\n}\n\n// Job ID\nconst jobId = 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\n\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    jobId: jobId,\n    fileUrl: fileUrl,\n    detectedMime: detectedMime,\n    sourceLanguage: body.source_language || 'auto',\n    targetLanguage: body.target_language || 'fr',\n    mistralApiKey: body.mistral_api_key,\n    anthropicApiKey: body.api_key || body.anthropic_api_key,\n    openaiApiKey: body.openai_api_key,\n    callbackUrl: body.callback_url || null\n  }\n}];"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP PDF Layout Translator\n// RFC-014 Compliant with Optional Tracing Fields\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\nconst startTime = Date.now();\n\n// --- OPTIONAL context fields (for tracing only, NO validation errors if missing) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required fields with RFC-014 context fallback ---\nconst fileUrl = body.file_url || ctx.file_url;\nconst fileBase64 = body.file_base64 || ctx.file_base64;\nconst mistralApiKey = body.mistral_api_key || ctx.mistral_api_key;\nconst anthropicApiKey = body.api_key || body.anthropic_api_key || ctx.api_key || ctx.anthropic_api_key;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key;\n\n// Validation of required fields\nif (!fileUrl && !fileBase64) {\n  errors.push('file_url or file_base64 required');\n}\nif (!mistralApiKey) {\n  errors.push('mistral_api_key required');\n}\nif (!anthropicApiKey) {\n  errors.push('api_key (Anthropic) required');\n}\nif (!openaiApiKey) {\n  errors.push('openai_api_key required');\n}\n\n// MIME type detection functions\nfunction detectMimeFromBase64(base64) {\n  const prefix = base64.substring(0, 20);\n  if (prefix.startsWith('/9j/')) return 'image/jpeg';\n  if (prefix.startsWith('iVBOR')) return 'image/png';\n  if (prefix.startsWith('R0lG')) return 'image/gif';\n  if (prefix.startsWith('UklGR')) return 'image/webp';\n  if (prefix.startsWith('Qk')) return 'image/bmp';\n  if (prefix.startsWith('JVBER') || prefix.startsWith('JVBERi')) return 'application/pdf';\n  return null;\n}\n\nfunction getMimeFromExtension(ext) {\n  const map = {\n    'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',\n    'png': 'image/png', 'gif': 'image/gif',\n    'webp': 'image/webp', 'bmp': 'image/bmp',\n    'tiff': 'image/tiff', 'tif': 'image/tiff',\n    'pdf': 'application/pdf'\n  };\n  return map[(ext || '').toLowerCase()] || null;\n}\n\n// Prepare file URL with intelligent MIME detection\nlet preparedFileUrl = '';\nlet detectedMime = 'application/pdf';\nconst fileType = body.file_type || ctx.file_type;\n\nif (fileUrl) {\n  preparedFileUrl = fileUrl;\n} else if (fileBase64) {\n  // 1. Try from file_type param\n  if (fileType) {\n    detectedMime = getMimeFromExtension(fileType) || 'application/pdf';\n  }\n  // 2. Fallback: detect from magic bytes\n  if (detectedMime === 'application/pdf') {\n    const detected = detectMimeFromBase64(fileBase64);\n    if (detected) detectedMime = detected;\n  }\n  preparedFileUrl = 'data:' + detectedMime + ';base64,' + fileBase64;\n}\n\n// Generate job ID\nconst jobId = 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\n\n// Return result with tracing fields\nreturn [{\n  json: {\n    valid: errors.length === 0,\n    errors: errors,\n    jobId: jobId,\n    fileUrl: preparedFileUrl,\n    detectedMime: detectedMime,\n    sourceLanguage: body.source_language || ctx.source_language || 'auto',\n    targetLanguage: body.target_language || ctx.target_language || 'fr',\n    mistralApiKey: mistralApiKey,\n    anthropicApiKey: anthropicApiKey,\n    openaiApiKey: openaiApiKey,\n    callbackUrl: body.callback_url || ctx.callback_url || null,\n    // Tracing fields (RFC-014)\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    startTime: startTime\n  }\n}];"
       },
       "id": "validation",
-      "name": "Validation",
+      "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -77,7 +71,7 @@
         "options": {}
       },
       "id": "if-valid",
-      "name": "Input Valid?",
+      "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
@@ -113,7 +107,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const input = $input.first().json;\nconst prevData = $('Validation').first().json;\n\nconst data = input.body || input;\nconst apiJobId = data.job_id || prevData.jobId;\n\nreturn [{\n  json: {\n    ...prevData,\n    jobId: apiJobId\n  }\n}];"
+        "jsCode": "const input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\n\nconst data = input.body || input;\nconst apiJobId = data.job_id || prevData.jobId;\n\nreturn [{\n  json: {\n    ...prevData,\n    jobId: apiJobId\n  }\n}];"
       },
       "id": "extract-job-id",
       "name": "Extract Job ID",
@@ -127,7 +121,7 @@
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ JSON.stringify({ success: true, job_id: $json.jobId, status: 'started', message: 'PDF processing started' }) }}",
+        "responseBody": "={{ JSON.stringify({ success: true, job_id: $json.jobId, status: 'started', message: 'PDF processing started', _trace: { service_response: { status: 'accepted', job_id: $json.jobId }, provider: 'pdf-layout-translator', mode: 'ack', latency_ms: Date.now() - $('Validate Input').first().json.startTime, user_id: $('Validate Input').first().json.user_id, guild_id: $('Validate Input').first().json.guild_id, user_request: $('Validate Input').first().json.user_request } }) }}",
         "options": {
           "responseCode": 200,
           "responseHeaders": {
@@ -290,10 +284,10 @@
     },
     {
       "parameters": {
-        "jsCode": "const input = $input.first().json;\n\nreturn [{\n  json: {\n    success: false,\n    error: {\n      code: 400,\n      message: input.errors.join(', '),\n      status: 'BAD_REQUEST'\n    }\n  }\n}];"
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst latencyMs = Date.now() - (input.startTime || Date.now());\n\nreturn [{\n  json: {\n    success: false,\n    job_id: input.jobId,\n    error: {\n      code: 'VALIDATION_ERROR',\n      message: input.errors.join(', ')\n    },\n    _trace: {\n      service_response: { validation_errors: input.errors },\n      provider: 'pdf-layout-translator',\n      mode: 'error',\n      latency_ms: latencyMs,\n      user_id: input.user_id,\n      guild_id: input.guild_id,\n      user_request: input.user_request\n    }\n  }\n}];"
       },
       "id": "build-error",
-      "name": "Build Error Response",
+      "name": "Build Error",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
@@ -361,25 +355,25 @@
       "main": [
         [
           {
-            "node": "Validation",
+            "node": "Validate Input",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Validation": {
+    "Validate Input": {
       "main": [
         [
           {
-            "node": "Input Valid?",
+            "node": "Valid?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Input Valid?": {
+    "Valid?": {
       "main": [
         [
           {
@@ -390,7 +384,7 @@
         ],
         [
           {
-            "node": "Build Error Response",
+            "node": "Build Error",
             "type": "main",
             "index": 0
           }
@@ -503,7 +497,7 @@
         ]
       ]
     },
-    "Build Error Response": {
+    "Build Error": {
       "main": [
         [
           {
@@ -528,33 +522,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "e893bb6e-3b13-4d59-8b81-0084f5b2eb60",
-  "activeVersionId": "e893bb6e-3b13-4d59-8b81-0084f5b2eb60",
-  "versionCounter": 30,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-19T18:10:46.982Z",
-      "createdAt": "2026-01-19T18:10:46.982Z",
-      "role": "workflow:owner",
-      "workflowId": "P4K8eUBaspgYvpmp",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Qdrant_-_Search.json
+++ b/workflows/MCP_-_Qdrant_-_Search.json
@@ -1,43 +1,49 @@
 {
-  "updatedAt": "2026-01-12T14:27:23.000Z",
-  "createdAt": "2026-01-07T11:15:03.682Z",
-  "id": "H57j1dGyBNtnMrLf",
   "name": "MCP - Qdrant - Search",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80],
+      "parameters": {
+        "color": 6,
+        "width": 340,
+        "height": 620,
+        "content": "## MCP - Qdrant - Search\n\n**Endpoint:** POST /webhook/qdrant-search\n\n**Description:** Recherche semantique dans Qdrant avec embeddings OpenAI.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"query\", \"entity_type\", \"qdrant_host\", \"qdrant_port\", \"qdrant_collection\", \"openai_api_key\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"query\": { \"type\": \"string\", \"description\": \"Requete de recherche\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type d'entite a rechercher\" },\n    \"limit\": { \"type\": \"integer\", \"description\": \"Max resultats (default: 10)\" },\n    \"filters\": { \"type\": \"object\", \"description\": \"Filtres optionnels\" },\n    \"qdrant_host\": { \"type\": \"string\", \"description\": \"Host Qdrant\" },\n    \"qdrant_port\": { \"type\": \"integer\", \"description\": \"Port Qdrant\" },\n    \"qdrant_collection\": { \"type\": \"string\", \"description\": \"Nom collection\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"Cle API OpenAI\" }\n  }\n}\n```\n\n**Note:** user_id, guild_id, user_request sont OPTIONNELS (tracing uniquement).\n\n**Returns:**\n- `results`: Array de resultats avec score\n- `total`: Nombre total de resultats\n- `query`: Requete originale\n- `_trace`: Informations de tracabilite\n\n**Model:** text-embedding-3-small"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "qdrant-search-webhook",
       "parameters": {
         "httpMethod": "POST",
         "path": "qdrant-search",
         "responseMode": "responseNode",
         "options": {}
-      },
-      "id": "webhook",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        304
-      ],
-      "webhookId": "recipes-search-webhook"
+      }
     },
     {
-      "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const body = input.body || input;\n\n  const errors = [];\n\n  if (!body.query) {\n    errors.push('Missing required parameter: query');\n  }\n  if (!body.entity_type) {\n    errors.push('Missing required parameter: entity_type');\n  }\n  if (!body.qdrant_host) {\n    errors.push('Missing required parameter: qdrant_host');\n  }\n  if (!body.qdrant_port) {\n    errors.push('Missing required parameter: qdrant_port');\n  }\n  if (!body.qdrant_collection) {\n    errors.push('Missing required parameter: qdrant_collection');\n  }\n  if (!body.openai_api_key) {\n    errors.push('Missing required parameter: openai_api_key');\n  }\n\n  if (errors.length > 0) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: errors.join(', '),\n          status: 'BAD_REQUEST'\n        }\n      }\n    }];\n  }\n\n  const qdrantUrl = `http://${body.qdrant_host}:${body.qdrant_port}`;\n\n  return [{\n    json: {\n      valid: true,\n      query: body.query,\n      entity_type: body.entity_type,\n      limit: body.limit || 10,\n      filters: body.filters || {},\n      user_id: body.user_id,\n      qdrant_url: qdrantUrl,\n      qdrant_collection: body.qdrant_collection,\n      openai_api_key: body.openai_api_key\n    }\n  }];"
-      },
       "id": "validate-input",
       "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        464,
-        304
-      ]
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Qdrant Search\n// RFC-014 context extraction with tracing fields\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (tracing only, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- REQUIRED webhook parameters ---\nconst query = body.query || ctx.query;\nconst entityType = body.entity_type || ctx.entity_type;\nconst qdrantHost = body.qdrant_host || ctx.qdrant_host;\nconst qdrantPort = body.qdrant_port || ctx.qdrant_port;\nconst qdrantCollection = body.qdrant_collection || ctx.qdrant_collection;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai;\n\nif (!query) {\n  errors.push('query requis');\n}\nif (!entityType) {\n  errors.push('entity_type requis');\n}\nif (!qdrantHost) {\n  errors.push('qdrant_host requis');\n}\nif (!qdrantPort) {\n  errors.push('qdrant_port requis');\n}\nif (!qdrantCollection) {\n  errors.push('qdrant_collection requis');\n}\nif (!openaiApiKey) {\n  errors.push('openai_api_key requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nconst qdrantUrl = `http://${qdrantHost}:${qdrantPort}`;\n\nreturn {\n  valid: true,\n  query: query,\n  entity_type: entityType,\n  limit: body.limit || ctx.limit || 10,\n  filters: body.filters || ctx.filters || {},\n  qdrant_url: qdrantUrl,\n  qdrant_collection: qdrantCollection,\n  qdrant_api_key: body.qdrant_api_key || ctx.qdrant_api_key || '',\n  openai_api_key: openaiApiKey,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
     },
     {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -47,6 +53,7 @@
           },
           "conditions": [
             {
+              "id": "check-valid",
               "leftValue": "={{ $json.valid }}",
               "rightValue": true,
               "operator": {
@@ -58,34 +65,46 @@
           "combinator": "and"
         },
         "options": {}
-      },
-      "id": "check-valid",
-      "name": "Valid?",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
-      "position": [
-        688,
-        304
-      ]
+      }
     },
     {
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
       "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ { success: false, error: $json.error, meta: { provider: 'qdrant' } } }}",
-        "options": {
-          "responseCode": 400
-        }
-      },
-      "id": "error-validation",
-      "name": "Error: Validation",
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'openai',\n    model: 'text-embedding-3-small',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        912,
-        464
-      ]
+      "position": [1120, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
     },
     {
+      "id": "generate-embedding",
+      "name": "Generate Embedding",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/embeddings",
@@ -109,17 +128,14 @@
           "timeout": 30000
         }
       },
-      "id": "generate-embedding",
-      "name": "Generate Embedding",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        912,
-        208
-      ],
       "onError": "continueRegularOutput"
     },
     {
+      "id": "search-qdrant",
+      "name": "Search Qdrant",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 200],
       "parameters": {
         "method": "POST",
         "url": "={{ $('Validate Input').first().json.qdrant_url }}/collections/{{ $('Validate Input').first().json.qdrant_collection }}/points/search",
@@ -143,59 +159,39 @@
           "timeout": 30000
         }
       },
-      "id": "search-qdrant",
-      "name": "Search Qdrant",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        1152,
-        208
-      ],
       "onError": "continueRegularOutput"
     },
     {
-      "parameters": {
-        "jsCode": " const input = $input.first().json;\n  const prevData = $('Validate Input').first().json;\n\n  try {\n    if (input.error || input.status?.error) {\n      return [{\n        json: {\n          success: false,\n          error: {\n            code: 500,\n            message: input.error?.message || input.status?.error || 'Qdrant search failed',\n            status: 'SEARCH_ERROR'\n          },\n          meta: { provider: 'qdrant', collection: prevData.qdrant_collection }\n        }\n      }];\n    }\n\n    const results = (input.result || []).map(item => ({\n      id: item.id,\n      score: item.score,\n      entity: item.payload || {}\n    }));\n\n    // Apply filters if any\n    let filtered = results;\n    const filters = prevData.filters;\n\n    if (filters.max_time_minutes) {\n      filtered = filtered.filter(r => {\n        const total = (r.entity.prep_time_minutes || 0) + (r.entity.cook_time_minutes || 0);\n        return total <= filters.max_time_minutes;\n      });\n    }\n\n    if (filters.vegetarian) {\n      filtered = filtered.filter(r => r.entity.tags?.includes('vegetarian') || r.entity.tags?.includes('végétarien'));\n    }\n\n    if (filters.vegan) {\n      filtered = filtered.filter(r => r.entity.tags?.includes('vegan') || r.entity.tags?.includes('végan'));\n    }\n\n    return [{\n      json: {\n        success: true,\n        data: {\n          results: filtered,\n          total: filtered.length,\n          query: prevData.query,\n          entity_type: prevData.entity_type\n        },\n        meta: {\n          provider: 'qdrant',\n          collection: prevData.qdrant_collection,\n          query_embedding_used: true,\n          original_count: results.length,\n          filtered_count: filtered.length\n        }\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to process search results: ' + e.message,\n          status: 'PROCESS_ERROR'\n        },\n        meta: { provider: 'qdrant' }\n      }\n    }];\n  }"
-      },
       "id": "format-output",
       "name": "Format Output",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1392,
-        208
-      ]
+      "position": [1380, 200],
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OUTPUT - MCP Qdrant Search\n// With _trace for analyzable webhooks\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Initialize trace\nconst _trace = {\n  service_response: null,\n  provider: 'qdrant',\n  model: 'text-embedding-3-small',\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\ntry {\n  // Handle API errors\n  if (input.error || input.status?.error) {\n    _trace.service_response = input;\n    _trace.latency_ms = Date.now() - startTime;\n    \n    return {\n      json: {\n        success: false,\n        error: {\n          code: 'SEARCH_ERROR',\n          message: input.error?.message || input.status?.error || 'Qdrant search failed',\n          http_status: 500\n        },\n        meta: { provider: 'qdrant', collection: prevData.qdrant_collection },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest,\n        _trace: _trace\n      }\n    };\n  }\n\n  const results = (input.result || []).map(item => ({\n    id: item.id,\n    score: item.score,\n    entity: item.payload || {}\n  }));\n\n  // Apply filters if any\n  let filtered = results;\n  const filters = prevData.filters;\n\n  if (filters.max_time_minutes) {\n    filtered = filtered.filter(r => {\n      const total = (r.entity.prep_time_minutes || 0) + (r.entity.cook_time_minutes || 0);\n      return total <= filters.max_time_minutes;\n    });\n  }\n\n  if (filters.vegetarian) {\n    filtered = filtered.filter(r => r.entity.tags?.includes('vegetarian') || r.entity.tags?.includes('vegetarien'));\n  }\n\n  if (filters.vegan) {\n    filtered = filtered.filter(r => r.entity.tags?.includes('vegan') || r.entity.tags?.includes('vegan'));\n  }\n\n  // Populate trace\n  _trace.service_response = input;\n  _trace.latency_ms = Date.now() - startTime;\n\n  return {\n    json: {\n      success: true,\n      data: {\n        results: filtered,\n        total: filtered.length,\n        query: prevData.query,\n        entity_type: prevData.entity_type\n      },\n      meta: {\n        provider: 'qdrant',\n        collection: prevData.qdrant_collection,\n        query_embedding_used: true,\n        original_count: results.length,\n        filtered_count: filtered.length\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n} catch (e) {\n  _trace.service_response = { error: e.message };\n  _trace.latency_ms = Date.now() - startTime;\n\n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PROCESS_ERROR',\n        message: 'Failed to process search results: ' + e.message,\n        http_status: 500\n      },\n      meta: { provider: 'qdrant' },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}"
+      }
     },
     {
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1632,
-        208
-      ]
-    },
-    {
+      "position": [1620, 200],
       "parameters": {
-        "content": "## Recipes - Search (Qdrant)\n\n**Endpoint:** POST /webhook/recipes-search\n\n**Parameters:**\n- `query` (required): Search query\n- `limit` (optional): Max results (default: 10)\n- `filters`: { max_time_minutes, vegetarian, vegan }\n- `user_id` (optional): For tracking\n\n**Returns:** Semantically similar recipes from Qdrant",
-        "height": 180,
-        "width": 500,
-        "color": 4
-      },
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ]
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
     }
   ],
   "connections": {
@@ -232,7 +228,18 @@
         ],
         [
           {
-            "node": "Error: Validation",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -275,33 +282,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "79351bbb-7d5f-4374-8bbd-58155cff82be",
-  "activeVersionId": "79351bbb-7d5f-4374-8bbd-58155cff82be",
-  "versionCounter": 60,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-07T11:15:03.687Z",
-      "createdAt": "2026-01-07T11:15:03.687Z",
-      "role": "workflow:owner",
-      "workflowId": "H57j1dGyBNtnMrLf",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Quiz_Generator.json
+++ b/workflows/MCP_-_Quiz_Generator.json
@@ -1,38 +1,44 @@
 {
-  "updatedAt": "2025-12-18T10:04:13.000Z",
-  "createdAt": "2025-12-18T10:03:40.706Z",
-  "id": "SUlOgPqXDRlXPkpN",
   "name": "MCP - Quiz Generator",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-quiz",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
-      "webhookId": "quiz-generator-webhook",
+      "parameters": {
+        "content": "## MCP - Quiz Generator\n\n**Endpoint:** POST /webhook/quiz-generator\n\n**Description:** Genere des quiz educatifs a partir de texte, sujet ou URL.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"data\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"data\": { \"type\": \"string\", \"description\": \"Texte, sujet ou URL pour generer le quiz\" },\n    \"source\": { \"type\": \"string\", \"enum\": [\"text\", \"topic\", \"url\"], \"default\": \"text\" },\n    \"options\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"num_questions\": { \"type\": \"integer\", \"default\": 10 },\n        \"question_types\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"default\": [\"multiple_choice\", \"true_false\"] },\n        \"difficulty\": { \"type\": \"string\", \"enum\": [\"easy\", \"medium\", \"hard\"], \"default\": \"medium\" },\n        \"language\": { \"type\": \"string\", \"default\": \"fr\" },\n        \"include_explanations\": { \"type\": \"boolean\", \"default\": true }\n      }\n    }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"quiz\", \"questions\", \"metadata\"],\n  \"domain\": \"education\"\n}\n```",
+        "height": 680,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "quiz-generator",
         "responseMode": "responseNode",
         "options": {}
-      }
+      },
+      "id": "webhook-quiz",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "quiz-generator-webhook"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Quiz Generator\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Specific webhook parameters ---\nconst data = body.data || ctx.data || null;\nconst source = body.source || ctx.source || 'text';\nconst options = body.options || ctx.options || {};\n\n// Validate required data parameter\nif (!data) {\n  errors.push('data requis (texte, sujet ou URL)');\n}\n\n// Validate source enum\nif (!['text', 'topic', 'url'].includes(source)) {\n  errors.push('source doit etre text, topic ou url');\n}\n\n// Parse options with defaults\nconst numQuestions = options.num_questions || 10;\nconst questionTypes = options.question_types || ['multiple_choice', 'true_false'];\nconst difficulty = options.difficulty || 'medium';\nconst language = options.language || 'fr';\nconst includeExplanations = options.include_explanations !== false;\n\n// Validate difficulty enum\nif (!['easy', 'medium', 'hard'].includes(difficulty)) {\n  errors.push('difficulty doit etre easy, medium ou hard');\n}\n\n// --- API Keys passed from MCP Server ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\nconst model = body.model || ctx.model || 'gpt-4o';\n\nif (!openaiApiKey) {\n  errors.push('openai_api_key requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  data: data,\n  source: source,\n  num_questions: numQuestions,\n  question_types: questionTypes,\n  difficulty: difficulty,\n  language: language,\n  include_explanations: includeExplanations,\n  openaiApiKey: openaiApiKey,\n  model: model,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
-      "position": [
-        460,
-        300
-      ],
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,45 +48,58 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.data }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-data",
-      "name": "Error: No Data",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: data (text, topic or URL)\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
-      "id": "openai-quiz",
-      "name": "OpenAI Generate Quiz",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/chat/completions",
@@ -90,7 +109,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.openai_api_key }}"
+              "value": "=Bearer {{ $json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -100,56 +119,49 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"{{ $json.body.model || 'gpt-4o' }}\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un expert en création de quiz éducatifs. Génère un quiz basé sur le contenu fourni.\\n\\nRègles:\\n1. Chaque question doit être claire et non ambiguë\\n2. Les options de réponse doivent être plausibles\\n3. Les explications doivent être pédagogiques\\n4. Respecte la distribution de difficulté demandée\\n5. Réponds UNIQUEMENT en JSON valide selon le schéma fourni\\n\\nSchéma JSON attendu:\\n{\\n  \\\"quiz\\\": {\\n    \\\"title\\\": \\\"string\\\",\\n    \\\"description\\\": \\\"string\\\",\\n    \\\"questions\\\": [\\n      {\\n        \\\"id\\\": number,\\n        \\\"type\\\": \\\"multiple_choice\\\" | \\\"true_false\\\" | \\\"fill_blank\\\",\\n        \\\"question\\\": \\\"string\\\",\\n        \\\"options\\\": [{\\\"id\\\": \\\"A\\\", \\\"text\\\": \\\"string\\\"}, ...] (pour multiple_choice),\\n        \\\"correct_answer\\\": \\\"string\\\" | boolean,\\n        \\\"explanation\\\": \\\"string\\\" (si include_explanations=true),\\n        \\\"difficulty\\\": \\\"easy\\\" | \\\"medium\\\" | \\\"hard\\\"\\n      }\\n    ],\\n    \\\"metadata\\\": {\\n      \\\"total_questions\\\": number,\\n      \\\"difficulty_distribution\\\": {\\\"easy\\\": n, \\\"medium\\\": n, \\\"hard\\\": n}\\n    }\\n  }\\n}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Génère un quiz avec les paramètres suivants:\\n\\nSource ({{ $json.body.source || 'text' }}): {{ $json.body.data }}\\n\\nNombre de questions: {{ $json.body.options?.num_questions || 10 }}\\nTypes de questions: {{ JSON.stringify($json.body.options?.question_types || ['multiple_choice', 'true_false']) }}\\nDifficulté: {{ $json.body.options?.difficulty || 'medium' }}\\nLangue: {{ $json.body.options?.language || 'fr' }}\\nInclure explications: {{ $json.body.options?.include_explanations !== false ? 'oui' : 'non' }}\"\n    }\n  ],\n  \"temperature\": 0.7,\n  \"max_tokens\": 4096\n}",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const userRequest = data.user_request;\n  const source = data.source;\n  const content = data.data;\n  const numQuestions = data.num_questions;\n  const questionTypes = JSON.stringify(data.question_types);\n  const difficulty = data.difficulty;\n  const language = data.language;\n  const includeExplanations = data.include_explanations;\n  \n  const systemPrompt = `Tu es un expert en creation de quiz educatifs. Genere un quiz base sur le contenu fourni.\n\nRegles:\n1. Chaque question doit etre claire et non ambigue\n2. Les options de reponse doivent etre plausibles\n3. Les explications doivent etre pedagogiques\n4. Respecte la distribution de difficulte demandee\n5. Reponds UNIQUEMENT en JSON valide selon le schema fourni\n\nSchema JSON attendu:\n{\n  \"quiz\": {\n    \"title\": \"string\",\n    \"description\": \"string\",\n    \"questions\": [\n      {\n        \"id\": number,\n        \"type\": \"multiple_choice\" | \"true_false\" | \"fill_blank\",\n        \"question\": \"string\",\n        \"options\": [{\"id\": \"A\", \"text\": \"string\"}, ...] (pour multiple_choice),\n        \"correct_answer\": \"string\" | boolean,\n        \"explanation\": \"string\" (si include_explanations=true),\n        \"difficulty\": \"easy\" | \"medium\" | \"hard\"\n      }\n    ],\n    \"metadata\": {\n      \"total_questions\": number,\n      \"difficulty_distribution\": {\"easy\": n, \"medium\": n, \"hard\": n}\n    }\n  }\n}`;\n\n  const userPrompt = `**Demande utilisateur:** \"${userRequest}\"\n\nGenere un quiz avec les parametres suivants:\n\nSource (${source}): ${content}\n\nNombre de questions: ${numQuestions}\nTypes de questions: ${questionTypes}\nDifficulte: ${difficulty}\nLangue: ${language}\nInclure explications: ${includeExplanations ? 'oui' : 'non'}`;\n\n  return JSON.stringify({\n    model: data.model,\n    response_format: { type: 'json_object' },\n    messages: [\n      { role: 'system', content: systemPrompt },\n      { role: 'user', content: userPrompt }\n    ],\n    temperature: 0.7,\n    max_tokens: 4096\n  });\n})() }}",
         "options": {
           "timeout": 120000
         }
       },
+      "id": "openai-quiz",
+      "name": "OpenAI Generate Quiz",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200],
       "onError": "continueRegularOutput"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// PARSE LLM RESPONSE - Quiz Generator\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\nconst statusCode = input.statusCode || 200;\n\n// Initialize trace with llm_response format\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'openai',\n  model: prevData.model || 'gpt-4o',\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\n// Handle API error\nif (statusCode >= 400 || input.error) {\n  const errorMsg = input.body?.error?.message || input.error?.message || 'OpenAI API error';\n  _trace.llm_response = `Error: ${errorMsg}`;\n  _trace.service_response = input.body || input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'LLM_ERROR',\n        message: errorMsg,\n        http_status: statusCode\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract response\nconst body = input.body || input;\nconst content = body.choices?.[0]?.message?.content || '';\nconst usage = body.usage || {};\n\n// Populate trace with LLM response\n_trace.llm_response = content;\n_trace.service_response = body;\n_trace.tokens = {\n  input: usage.prompt_tokens || 0,\n  output: usage.completion_tokens || 0\n};\n\n// Parse JSON from response\nlet parsed;\ntry {\n  // Handle markdown code blocks\n  let jsonStr = content;\n  const codeBlockMatch = content.match(/```(?:json)?\\s*([\\s\\S]*?)```/);\n  if (codeBlockMatch) {\n    jsonStr = codeBlockMatch[1].trim();\n  } else {\n    const rawMatch = content.match(/\\{[\\s\\S]*\\}/);\n    if (rawMatch) jsonStr = rawMatch[0];\n  }\n  \n  parsed = JSON.parse(jsonStr);\n} catch (e) {\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PARSE_ERROR',\n        message: 'Failed to parse quiz response: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract quiz data\nconst quiz = parsed.quiz || parsed;\n\n_trace.latency_ms = Date.now() - startTime;\n\nreturn {\n  json: {\n    success: true,\n    data: quiz,\n    meta: {\n      provider: 'openai',\n      model: prevData.model || 'gpt-4o',\n      source: prevData.source,\n      difficulty: prevData.difficulty,\n      language: prevData.language,\n      tokens_used: (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),\n      processing_time_ms: Date.now() - startTime\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: _trace\n  }\n};"
+      },
       "id": "parse-response",
-      "name": "Parse Quiz Response",
+      "name": "Parse LLM Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
-      "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\n\nconst results = items.map(item => {\n  try {\n    const content = item.json.choices?.[0]?.message?.content || '{}';\n    const parsed = JSON.parse(content);\n    \n    return {\n      json: {\n        success: true,\n        data: parsed,\n        meta: {\n          provider: 'openai',\n          model: item.json.model || webhookData.body.model || 'gpt-4o',\n          execution_mode: webhookData.body.execution_mode || 'online',\n          tokens_used: item.json.usage?.total_tokens || 0\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse quiz response: ' + e.message,\n          status: 'INTERNAL_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          execution_mode: webhookData.body.execution_mode || 'online'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
-      }
+      "position": [1180, 200]
     },
     {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 600,
-        "height": 260,
-        "content": "## MCP - Quiz Generator\n\n**Endpoint:** POST /webhook/quiz-generator\n\n**Parameters:**\n- `data` (required): Text, topic or URL to generate quiz from\n- `source` (optional): text | topic | url (default: text)\n- `openai_api_key` (required): OpenAI API key\n- `model` (optional): gpt-4o, gpt-4o-mini (default: gpt-4o)\n- `options.num_questions` (optional): Number of questions (default: 10)\n- `options.question_types` (optional): [multiple_choice, true_false, fill_blank]\n- `options.difficulty` (optional): easy | medium | hard (default: medium)\n- `options.language` (optional): fr | en (default: fr)\n- `options.include_explanations` (optional): boolean (default: true)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Quiz with questions, answers, and explanations"
-      }
+      "typeVersion": 1.1,
+      "position": [1420, 200]
     }
   ],
   "connections": {
@@ -168,6 +180,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI Generate Quiz",
             "type": "main",
             "index": 0
@@ -175,7 +198,18 @@
         ],
         [
           {
-            "node": "Error: No Data",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -186,14 +220,14 @@
       "main": [
         [
           {
-            "node": "Parse Quiz Response",
+            "node": "Parse LLM Response",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Parse Quiz Response": {
+    "Parse LLM Response": {
       "main": [
         [
           {
@@ -207,33 +241,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "1bea7843-9c60-4100-b02f-aa86b60310b7",
-  "activeVersionId": "1bea7843-9c60-4100-b02f-aa86b60310b7",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T10:03:40.711Z",
-      "createdAt": "2025-12-18T10:03:40.711Z",
-      "role": "workflow:owner",
-      "workflowId": "SUlOgPqXDRlXPkpN",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Script_Detector.json
+++ b/workflows/MCP_-_Script_Detector.json
@@ -1,0 +1,431 @@
+{
+  "name": "MCP - Script Detector",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Script Detector\n\n**Endpoint:** POST /webhook/script-detector\n\n**Purpose:** Detect writing script (hebrew, arabic, latin, etc.) from text, images, or PDFs.\n\n**InputSchema:**\n```json\n{\n  \"required\": [],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte a analyser (mode gratuit Unicode)\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image a analyser\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Image en base64 (alternative a image_url)\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du fichier (PDF ou image)\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme via openai_api_key.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": true,\n  \"output_fields\": [\"primary_script\", \"scripts\", \"is_rtl\", \"recommended_providers\"],\n  \"domain\": \"script_detection\"\n}\n```\n\n---\n\n### Mode 1: Text (GRATUIT - analyse Unicode)\n```json\n{ \"text\": \"שלום עולם Hello\" }\n```\n\n### Mode 2: Image (OpenAI Vision)\n```json\n{\n  \"image_url\": \"https://...\",\n  \"openai_api_key\": \"sk-...\"\n}\n```\n\n### Mode 3: PDF (Vision sur page 1)\n```json\n{\n  \"file_url\": \"https://...document.pdf\",\n  \"openai_api_key\": \"sk-...\"\n}\n```\n\n**Scripts:** hebrew, arabic, latin, cyrillic, greek, han, hiragana, katakana, hangul, thai, devanagari, tamil, etc.",
+        "height": 820,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -200]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "script-detector",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-script",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [0, 300],
+      "webhookId": "script-detector"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Script Detector (Multi-mode)\n// RFC-014: Support context.* extraction\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- RFC-014: Context fields for traceability ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Extract all possible inputs ---\nconst text = ctx.text || body.text;\nconst imageUrl = ctx.image_url || body.image_url;\nconst imageBase64 = ctx.image_base64 || body.image_base64;\nconst fileUrl = ctx.file_url || body.file_url;\nconst fileType = ctx.file_type || body.file_type;\n\n// --- Extract API key ---\nconst openaiKey = body.openai_api_key \n  || ctx.openai_api_key \n  || body.plugin_context?.api_keys?.openai \n  || ctx.plugin_context?.api_keys?.openai;\n\n// --- Determine mode ---\nlet mode = 'unknown';\n\nif (text && text.trim().length > 0) {\n  mode = 'text';\n} else if (imageUrl || imageBase64) {\n  mode = 'image';\n  if (!openaiKey) errors.push('openai_api_key requis pour les images');\n} else if (fileUrl) {\n  const ext = (fileUrl.split('.').pop() || '').toLowerCase().split('?')[0];\n  if (ext === 'pdf') {\n    mode = 'pdf';\n    if (!openaiKey) errors.push('openai_api_key requis pour les PDFs');\n  } else if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext)) {\n    mode = 'image';\n    if (!openaiKey) errors.push('openai_api_key requis pour les images');\n  } else {\n    errors.push('Format fichier non supporte: ' + ext + '. Utilisez jpg, png, pdf, ou fournissez du texte.');\n  }\n} else {\n  errors.push('Fournir text, image_url, image_base64, ou file_url');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    mode: mode,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// --- Prepare image URL for Vision modes ---\nlet preparedImageUrl = '';\nif (mode === 'image') {\n  if (imageUrl) {\n    preparedImageUrl = imageUrl;\n  } else if (imageBase64) {\n    // Detect MIME\n    const prefix = imageBase64.substring(0, 20);\n    let mime = 'image/png';\n    if (prefix.startsWith('/9j/')) mime = 'image/jpeg';\n    else if (prefix.startsWith('iVBOR')) mime = 'image/png';\n    else if (prefix.startsWith('R0lG')) mime = 'image/gif';\n    else if (prefix.startsWith('UklGR')) mime = 'image/webp';\n    preparedImageUrl = 'data:' + mime + ';base64,' + imageBase64;\n  }\n} else if (mode === 'pdf') {\n  preparedImageUrl = fileUrl;\n}\n\nreturn {\n  valid: true,\n  mode: mode,\n  text: text || null,\n  imageUrl: preparedImageUrl,\n  fileUrl: fileUrl || null,\n  openaiApiKey: openaiKey || null,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [220, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [440, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// RFC-014: _trace with service_response\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: input.mode || 'unknown',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 500]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [880, 500]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "outputKey": "text",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.mode }}",
+                    "rightValue": "text",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "outputKey": "image",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.mode }}",
+                    "rightValue": "image",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            },
+            {
+              "outputKey": "pdf",
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.mode }}",
+                    "rightValue": "pdf",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              }
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-mode",
+      "name": "Switch Mode",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [660, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// ANALYZE TEXT - Unicode Range Detection (GRATUIT)\n// RFC-014: _trace with service_response\n// ============================================\n\nconst input = $input.first().json;\nconst text = input.text || '';\nconst startTime = input.startTime || Date.now();\n\n// Context fields\nconst userId = input.user_id;\nconst guildId = input.guild_id;\nconst userRequest = input.user_request;\n\n// Unicode ranges for script detection\nconst SCRIPT_RANGES = {\n  hebrew: /[\\u0590-\\u05FF\\uFB1D-\\uFB4F]/g,\n  arabic: /[\\u0600-\\u06FF\\u0750-\\u077F\\u08A0-\\u08FF\\uFB50-\\uFDFF\\uFE70-\\uFEFF]/g,\n  latin: /[A-Za-z\\u00C0-\\u024F\\u1E00-\\u1EFF]/g,\n  cyrillic: /[\\u0400-\\u04FF\\u0500-\\u052F]/g,\n  greek: /[\\u0370-\\u03FF\\u1F00-\\u1FFF]/g,\n  han: /[\\u4E00-\\u9FFF\\u3400-\\u4DBF\\uF900-\\uFAFF]/g,\n  hiragana: /[\\u3040-\\u309F]/g,\n  katakana: /[\\u30A0-\\u30FF]/g,\n  hangul: /[\\uAC00-\\uD7AF\\u1100-\\u11FF\\u3130-\\u318F]/g,\n  thai: /[\\u0E00-\\u0E7F]/g,\n  devanagari: /[\\u0900-\\u097F]/g,\n  tamil: /[\\u0B80-\\u0BFF]/g,\n  telugu: /[\\u0C00-\\u0C7F]/g,\n  bengali: /[\\u0980-\\u09FF]/g,\n  gujarati: /[\\u0A80-\\u0AFF]/g,\n  punjabi: /[\\u0A00-\\u0A7F]/g,\n  malayalam: /[\\u0D00-\\u0D7F]/g,\n  kannada: /[\\u0C80-\\u0CFF]/g,\n  armenian: /[\\u0530-\\u058F]/g,\n  georgian: /[\\u10A0-\\u10FF]/g,\n  ethiopic: /[\\u1200-\\u137F]/g\n};\n\n// Diacritics detection\nconst DIACRITICS = {\n  hebrew_nikud: /[\\u05B0-\\u05BD\\u05BF\\u05C1\\u05C2\\u05C4\\u05C5\\u05C7]/g,\n  arabic_harakat: /[\\u064B-\\u0652\\u0670]/g,\n  latin_accents: /[\\u0300-\\u036F]/g\n};\n\n// Count characters per script\nconst counts = {};\nlet totalScriptChars = 0;\n\nfor (const [script, regex] of Object.entries(SCRIPT_RANGES)) {\n  const matches = text.match(regex) || [];\n  if (matches.length > 0) {\n    counts[script] = matches.length;\n    totalScriptChars += matches.length;\n  }\n}\n\n// Build scripts array sorted by count\nconst scripts = Object.entries(counts)\n  .map(([script, count]) => ({\n    script: script,\n    confidence: Math.min(0.95, 0.5 + (count / Math.max(totalScriptChars, 1)) * 0.5),\n    percentage: Math.round((count / Math.max(totalScriptChars, 1)) * 100)\n  }))\n  .sort((a, b) => b.percentage - a.percentage);\n\nconst primaryScript = scripts.length > 0 ? scripts[0].script : 'unknown';\n\n// RTL detection\nconst rtlScripts = ['hebrew', 'arabic', 'persian', 'urdu'];\nconst isRtl = rtlScripts.includes(primaryScript);\n\n// Diacritics detection\nlet hasDiacritics = false;\nif (primaryScript === 'hebrew') {\n  hasDiacritics = DIACRITICS.hebrew_nikud.test(text);\n} else if (primaryScript === 'arabic') {\n  hasDiacritics = DIACRITICS.arabic_harakat.test(text);\n} else if (primaryScript === 'latin') {\n  hasDiacritics = DIACRITICS.latin_accents.test(text);\n}\n\n// Provider recommendations\nconst providerMap = {\n  'hebrew': ['mistral', 'google_vision', 'tesseract'],\n  'arabic': ['google_vision', 'azure', 'mistral'],\n  'han': ['google_vision', 'azure', 'mistral'],\n  'hiragana': ['google_vision', 'azure'],\n  'katakana': ['google_vision', 'azure'],\n  'hangul': ['google_vision', 'azure'],\n  'devanagari': ['google_vision', 'azure'],\n  'latin': ['mistral', 'google_vision', 'tesseract'],\n  'cyrillic': ['google_vision', 'mistral', 'tesseract'],\n  'greek': ['google_vision', 'mistral', 'tesseract']\n};\n\nconst recommendedProviders = providerMap[primaryScript] || ['mistral', 'google_vision', 'tesseract'];\n\n// Sample text\nconst sampleText = text.substring(0, 50) + (text.length > 50 ? '...' : '');\n\nconst latencyMs = Date.now() - startTime;\n\nreturn {\n  success: true,\n  data: {\n    primary_script: primaryScript,\n    scripts: scripts.length > 0 ? scripts : [{ script: 'unknown', confidence: 0, percentage: 0 }],\n    is_rtl: isRtl,\n    has_diacritics: hasDiacritics,\n    recommended_providers: recommendedProviders,\n    sample_text: sampleText,\n    char_count: totalScriptChars\n  },\n  _trace: {\n    service_response: {\n      primary_script: primaryScript,\n      scripts_detected: scripts.length,\n      char_count: totalScriptChars\n    },\n    provider: 'unicode_analysis',\n    mode: 'text',\n    latency_ms: latencyMs,\n    cost: 0,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};"
+      },
+      "id": "analyze-text",
+      "name": "Analyze Text (Unicode)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 100]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a script/writing system detection expert. Analyze the image and identify the writing systems (scripts) present.\\n\\nReturn a JSON object with:\\n- primary_script: The dominant script (hebrew, arabic, latin, cyrillic, greek, han, hiragana, katakana, hangul, thai, devanagari, tamil, telugu, bengali, gujarati, punjabi, malayalam, kannada, sinhala, tibetan, armenian, georgian, ethiopic, mongolian, or 'unknown')\\n- scripts: Array of detected scripts with confidence (0.0-1.0) and percentage (estimated % of text in that script)\\n- is_rtl: Boolean if the primary script is right-to-left (hebrew, arabic, persian, urdu)\\n- has_diacritics: Boolean if text has diacritical marks (nikud for hebrew, harakat for arabic, accents for latin)\\n- recommended_providers: Array of OCR providers best suited for this script, ordered by preference. Options: 'mistral', 'google_vision', 'azure', 'tesseract', 'mathpix'\\n- sample_text: If readable, include a short sample (max 50 chars) of text you can see\\n\\nBe conservative with confidence scores. If you're unsure, return lower confidence.\\nReturn ONLY valid JSON.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"Detect the writing script(s) in this image. Focus on identifying the script/writing system, not the language.{{ $json.user_request ? '\\\\n\\\\nUser context: ' + $json.user_request : '' }}\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"{{ $json.imageUrl }}\",\n            \"detail\": \"low\"\n          }\n        }\n      ]\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 512\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "openai-vision-image",
+      "name": "OpenAI Vision (Image)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.openaiApiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"gpt-4o-mini\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"You are a script/writing system detection expert. Analyze this PDF document and identify the writing systems (scripts) present.\\n\\nReturn a JSON object with:\\n- primary_script: The dominant script (hebrew, arabic, latin, cyrillic, greek, han, hiragana, katakana, hangul, thai, devanagari, tamil, telugu, bengali, gujarati, punjabi, malayalam, kannada, sinhala, tibetan, armenian, georgian, ethiopic, mongolian, or 'unknown')\\n- scripts: Array of detected scripts with confidence (0.0-1.0) and percentage (estimated % of text in that script)\\n- is_rtl: Boolean if the primary script is right-to-left (hebrew, arabic, persian, urdu)\\n- has_diacritics: Boolean if text has diacritical marks (nikud for hebrew, harakat for arabic, accents for latin)\\n- recommended_providers: Array of OCR providers best suited for this script, ordered by preference. Options: 'mistral', 'google_vision', 'azure', 'tesseract', 'mathpix'\\n- sample_text: If readable, include a short sample (max 50 chars) of text you can see\\n- has_math: Boolean if mathematical formulas are detected (recommend mathpix if true)\\n\\nBe conservative with confidence scores. If you're unsure, return lower confidence.\\nReturn ONLY valid JSON.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"Detect the writing script(s) in this PDF document. Focus on identifying the script/writing system and whether it contains mathematical formulas.{{ $json.user_request ? '\\\\n\\\\nUser context: ' + $json.user_request : '' }}\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"{{ $json.fileUrl }}\",\n            \"detail\": \"low\"\n          }\n        }\n      ]\n    }\n  ],\n  \"temperature\": 0.1,\n  \"max_tokens\": 512\n}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "id": "openai-vision-pdf",
+      "name": "OpenAI Vision (PDF)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 500],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// NORMALIZE IMAGE RESPONSE\n// RFC-014: _trace with llm_response\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst statusCode = input.statusCode || 200;\n\n// Context fields\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Initialize trace\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'openai',\n  model: 'gpt-4o-mini',\n  mode: 'image',\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nif (statusCode >= 400 || input.error) {\n  const errorMessage = input.error?.message || input.message || 'OpenAI API error';\n  _trace.llm_response = `Error: ${errorMessage}`;\n  _trace.service_response = input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    success: false,\n    error: {\n      code: 'VISION_API_ERROR',\n      message: errorMessage,\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    _trace: _trace,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\ntry {\n  const content = input.choices?.[0]?.message?.content || '{}';\n  const usage = input.usage || {};\n  const detection = JSON.parse(content);\n  \n  _trace.llm_response = content;\n  _trace.service_response = input;\n  _trace.tokens = {\n    input: usage.prompt_tokens || 0,\n    output: usage.completion_tokens || 0\n  };\n  _trace.latency_ms = Date.now() - startTime;\n  \n  const primaryScript = detection.primary_script || 'unknown';\n  const scripts = detection.scripts || [{ script: primaryScript, confidence: 0.5, percentage: 100 }];\n  const isRtl = detection.is_rtl || ['hebrew', 'arabic', 'persian', 'urdu'].includes(primaryScript);\n  \n  const providerMap = {\n    'hebrew': ['mistral', 'google_vision', 'tesseract'],\n    'arabic': ['google_vision', 'azure', 'mistral'],\n    'han': ['google_vision', 'azure', 'mistral'],\n    'latin': ['mistral', 'google_vision', 'tesseract'],\n    'cyrillic': ['google_vision', 'mistral', 'tesseract']\n  };\n  \n  const recommendedProviders = detection.recommended_providers || providerMap[primaryScript] || ['mistral', 'google_vision', 'tesseract'];\n  \n  return {\n    success: true,\n    data: {\n      primary_script: primaryScript,\n      scripts: scripts,\n      is_rtl: isRtl,\n      has_diacritics: detection.has_diacritics || false,\n      recommended_providers: recommendedProviders,\n      sample_text: detection.sample_text || null\n    },\n    _trace: _trace,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n} catch (e) {\n  _trace.llm_response = `Parse error: ${e.message}`;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    success: false,\n    error: { code: 'PARSE_ERROR', message: e.message, http_status: 500 },\n    _trace: _trace,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}"
+      },
+      "id": "normalize-image",
+      "name": "Normalize Image Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// NORMALIZE PDF RESPONSE\n// RFC-014: _trace with llm_response\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst statusCode = input.statusCode || 200;\n\n// Context fields\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Initialize trace\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'openai',\n  model: 'gpt-4o-mini',\n  mode: 'pdf',\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nif (statusCode >= 400 || input.error) {\n  const errorMessage = input.error?.message || input.message || 'OpenAI API error';\n  _trace.llm_response = `Error: ${errorMessage}`;\n  _trace.service_response = input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    success: false,\n    error: {\n      code: 'VISION_API_ERROR',\n      message: errorMessage,\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    _trace: _trace,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\ntry {\n  const content = input.choices?.[0]?.message?.content || '{}';\n  const usage = input.usage || {};\n  const detection = JSON.parse(content);\n  \n  _trace.llm_response = content;\n  _trace.service_response = input;\n  _trace.tokens = {\n    input: usage.prompt_tokens || 0,\n    output: usage.completion_tokens || 0\n  };\n  _trace.latency_ms = Date.now() - startTime;\n  \n  const primaryScript = detection.primary_script || 'unknown';\n  const scripts = detection.scripts || [{ script: primaryScript, confidence: 0.5, percentage: 100 }];\n  const isRtl = detection.is_rtl || ['hebrew', 'arabic', 'persian', 'urdu'].includes(primaryScript);\n  const hasMath = detection.has_math || false;\n  \n  // Adjust providers if math detected\n  let recommendedProviders = detection.recommended_providers;\n  if (hasMath) {\n    recommendedProviders = ['mathpix', ...(recommendedProviders || []).filter(p => p !== 'mathpix')];\n  } else if (!recommendedProviders) {\n    const providerMap = {\n      'hebrew': ['mistral', 'google_vision', 'tesseract'],\n      'arabic': ['google_vision', 'azure', 'mistral'],\n      'han': ['google_vision', 'azure', 'mistral'],\n      'latin': ['mistral', 'google_vision', 'tesseract']\n    };\n    recommendedProviders = providerMap[primaryScript] || ['mistral', 'google_vision', 'tesseract'];\n  }\n  \n  return {\n    success: true,\n    data: {\n      primary_script: primaryScript,\n      scripts: scripts,\n      is_rtl: isRtl,\n      has_diacritics: detection.has_diacritics || false,\n      has_math: hasMath,\n      recommended_providers: recommendedProviders,\n      sample_text: detection.sample_text || null\n    },\n    _trace: _trace,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n} catch (e) {\n  _trace.llm_response = `Parse error: ${e.message}`;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    success: false,\n    error: { code: 'PARSE_ERROR', message: e.message, http_status: 500 },\n    _trace: _trace,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}"
+      },
+      "id": "normalize-pdf",
+      "name": "Normalize PDF Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 500]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1340, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Switch Mode",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Mode": {
+      "main": [
+        [
+          {
+            "node": "Analyze Text (Unicode)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "OpenAI Vision (Image)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "OpenAI Vision (PDF)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Analyze Text (Unicode)": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Vision (Image)": {
+      "main": [
+        [
+          {
+            "node": "Normalize Image Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Vision (PDF)": {
+      "main": [
+        [
+          {
+            "node": "Normalize PDF Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize Image Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Normalize PDF Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP_-_Speaker_Identifier.json
+++ b/workflows/MCP_-_Speaker_Identifier.json
@@ -1,12 +1,22 @@
 {
-  "updatedAt": "2025-12-18T08:39:26.000Z",
-  "createdAt": "2025-12-18T08:39:17.990Z",
-  "id": "zp2f63S20SLgs22o",
   "name": "MCP - Speaker Identifier",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Speaker Identifier\n\n**Endpoint:** POST /webhook/speaker-identifier\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"data\", \"assemblyai_api_key\"],\n  \"properties\": {\n    \"data\": { \"type\": \"string\", \"description\": \"Audio URL or base64 encoded audio\" },\n    \"assemblyai_api_key\": { \"type\": \"string\", \"description\": \"AssemblyAI API key\" },\n    \"source\": { \"type\": \"string\", \"description\": \"'url' or 'base64' (default: url)\" },\n    \"options.speakers_expected\": { \"type\": \"number\", \"description\": \"Number of expected speakers\" },\n    \"options.language\": { \"type\": \"string\", \"description\": \"Language code or 'auto'\" },\n    \"options.include_transcription\": { \"type\": \"boolean\", \"description\": \"Include full transcript (default: true)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"data\": \"https://...\",\n    \"source\": \"url\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"assemblyai\": \"...\" }\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"speakers\": [...], \"utterances\": [...] },\n  \"meta\": { \"provider\": \"assemblyai\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** AssemblyAI Speaker Diarization",
+        "height": 620,
+        "width": 420,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        40,
+        -200
+      ]
+    },
     {
       "parameters": {
         "httpMethod": "POST",
@@ -26,30 +36,11 @@
     },
     {
       "parameters": {
-        "conditions": {
-          "options": {
-            "caseSensitive": true,
-            "leftValue": "",
-            "typeValidation": "strict"
-          },
-          "conditions": [
-            {
-              "id": "condition-data",
-              "leftValue": "={{ $json.body.data }}",
-              "rightValue": "",
-              "operator": {
-                "type": "string",
-                "operation": "exists"
-              }
-            }
-          ],
-          "combinator": "and"
-        },
-        "options": {}
+        "jsCode": "// ============================================\n// VALIDATION INPUT - RFC-014 Compatible\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Extract audio data ---\nconst data = ctx.data || body.data;\nconst source = ctx.source || body.source || 'url';\nconst options = ctx.options || body.options || {};\n\n// --- Extract API key ---\nconst assemblyaiKey = body.assemblyai_api_key \n  || ctx.assemblyai_api_key \n  || body.plugin_context?.api_keys?.assemblyai \n  || ctx.plugin_context?.api_keys?.assemblyai;\n\n// --- Validation (REQUIRED fields only) ---\nif (!data) errors.push('data (audio URL or base64) is required');\nif (!assemblyaiKey) errors.push('assemblyai_api_key is required');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  data: data,\n  source: source,\n  options: options,\n  assemblyai_api_key: assemblyaiKey,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
         460,
@@ -58,18 +49,71 @@
     },
     {
       "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        680,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR - with _trace\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        900,
+        480
+      ]
+    },
+    {
+      "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'INVALID_INPUT', message: 'Missing required field: data (URL or base64 audio)' } }) }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       },
-      "id": "error-invalid-input",
-      "name": "Error Invalid Input",
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
       "position": [
-        680,
+        1120,
         480
       ]
     },
@@ -84,7 +128,7 @@
           "conditions": [
             {
               "id": "condition-source",
-              "leftValue": "={{ $json.body.source }}",
+              "leftValue": "={{ $json.source }}",
               "rightValue": "base64",
               "operator": {
                 "type": "string",
@@ -101,21 +145,21 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        680,
-        300
+        900,
+        200
       ]
     },
     {
       "parameters": {
-        "jsCode": "// For base64 input, we need to upload to a temporary storage\nconst base64Data = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\nconst apiKey = $input.first().json.body.assemblyai_api_key;\n\n// Remove data URL prefix if present\nconst cleanBase64 = base64Data.replace(/^data:audio\\/[a-z]+;base64,/, '');\n\nreturn {\n  json: {\n    audioBase64: cleanBase64,\n    options: options,\n    needsUpload: true,\n    assemblyai_api_key: apiKey\n  }\n};"
+        "jsCode": "// For base64 input, we need to upload to a temporary storage\nconst prevData = $('Validate Input').first().json;\nconst base64Data = prevData.data;\nconst options = prevData.options || {};\nconst apiKey = prevData.assemblyai_api_key;\n\n// Remove data URL prefix if present\nconst cleanBase64 = base64Data.replace(/^data:audio\\/[a-z]+;base64,/, '');\n\nreturn {\n  json: {\n    audioBase64: cleanBase64,\n    options: options,\n    needsUpload: true,\n    assemblyai_api_key: apiKey,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request,\n    startTime: prevData.startTime\n  }\n};"
       },
       "id": "prepare-base64",
       "name": "Prepare Base64",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        900,
-        200
+        1120,
+        100
       ]
     },
     {
@@ -148,48 +192,48 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1120,
-        200
+        1340,
+        100
       ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// Prepare URL audio input\nconst audioUrl = $input.first().json.body.data;\nconst options = $input.first().json.body.options || {};\nconst apiKey = $input.first().json.body.assemblyai_api_key;\n\nreturn {\n  json: {\n    audioUrl: audioUrl,\n    options: options,\n    needsUpload: false,\n    assemblyai_api_key: apiKey\n  }\n};"
+        "jsCode": "// Prepare URL audio input\nconst prevData = $('Validate Input').first().json;\nconst audioUrl = prevData.data;\nconst options = prevData.options || {};\nconst apiKey = prevData.assemblyai_api_key;\n\nreturn {\n  json: {\n    audioUrl: audioUrl,\n    options: options,\n    needsUpload: false,\n    assemblyai_api_key: apiKey,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request,\n    startTime: prevData.startTime\n  }\n};"
       },
       "id": "prepare-url",
       "name": "Prepare URL",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        900,
-        400
+        1120,
+        300
       ]
     },
     {
       "parameters": {
-        "jsCode": "// Merge uploaded URL with options\nconst uploadResponse = $input.first().json;\nconst previousData = $('Prepare Base64').first().json;\n\nreturn {\n  json: {\n    audioUrl: uploadResponse.upload_url,\n    options: previousData.options,\n    assemblyai_api_key: previousData.assemblyai_api_key\n  }\n};"
+        "jsCode": "// Merge uploaded URL with options\nconst uploadResponse = $input.first().json;\nconst previousData = $('Prepare Base64').first().json;\n\nreturn {\n  json: {\n    audioUrl: uploadResponse.upload_url,\n    options: previousData.options,\n    assemblyai_api_key: previousData.assemblyai_api_key,\n    user_id: previousData.user_id,\n    guild_id: previousData.guild_id,\n    user_request: previousData.user_request,\n    startTime: previousData.startTime\n  }\n};"
       },
       "id": "merge-upload-result",
       "name": "Merge Upload Result",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1340,
-        200
+        1560,
+        100
       ]
     },
     {
       "parameters": {
-        "jsCode": "// Prepare AssemblyAI transcription request\nconst input = $input.first().json;\nconst options = input.options || {};\n\nconst requestBody = {\n  audio_url: input.audioUrl,\n  speaker_labels: true\n};\n\n// Add optional parameters\nif (options.speakers_expected) {\n  requestBody.speakers_expected = options.speakers_expected;\n}\n\nif (options.language && options.language !== 'auto') {\n  requestBody.language_code = options.language;\n}\n\nif (options.language === 'auto') {\n  requestBody.language_detection = true;\n}\n\nreturn {\n  json: {\n    requestBody: requestBody,\n    options: options,\n    assemblyai_api_key: input.assemblyai_api_key\n  }\n};"
+        "jsCode": "// Prepare AssemblyAI transcription request\nconst input = $input.first().json;\nconst options = input.options || {};\n\nconst requestBody = {\n  audio_url: input.audioUrl,\n  speaker_labels: true\n};\n\n// Add optional parameters\nif (options.speakers_expected) {\n  requestBody.speakers_expected = options.speakers_expected;\n}\n\nif (options.language && options.language !== 'auto') {\n  requestBody.language_code = options.language;\n}\n\nif (options.language === 'auto') {\n  requestBody.language_detection = true;\n}\n\nreturn {\n  json: {\n    requestBody: requestBody,\n    options: options,\n    assemblyai_api_key: input.assemblyai_api_key,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request,\n    startTime: input.startTime\n  }\n};"
       },
       "id": "prepare-transcription-request",
       "name": "Prepare Transcription Request",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        1560,
-        300
+        1780,
+        200
       ]
     },
     {
@@ -222,22 +266,22 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        1780,
-        300
+        2000,
+        200
       ],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// Store transcript ID and options for polling\nconst response = $input.first().json;\nconst previousData = $('Prepare Transcription Request').first().json;\n\nreturn {\n  json: {\n    transcriptId: response.id,\n    status: response.status,\n    options: previousData.options,\n    pollCount: 0,\n    startTime: Date.now(),\n    assemblyai_api_key: previousData.assemblyai_api_key\n  }\n};"
+        "jsCode": "// Store transcript ID and options for polling\nconst response = $input.first().json;\nconst previousData = $('Prepare Transcription Request').first().json;\n\nreturn {\n  json: {\n    transcriptId: response.id,\n    status: response.status,\n    options: previousData.options,\n    pollCount: 0,\n    startTime: previousData.startTime,\n    assemblyai_api_key: previousData.assemblyai_api_key,\n    user_id: previousData.user_id,\n    guild_id: previousData.guild_id,\n    user_request: previousData.user_request\n  }\n};"
       },
       "id": "store-transcript-id",
       "name": "Store Transcript ID",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2000,
-        300
+        2220,
+        200
       ]
     },
     {
@@ -263,8 +307,8 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [
-        2220,
-        300
+        2440,
+        200
       ],
       "onError": "continueRegularOutput"
     },
@@ -296,8 +340,8 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        2440,
-        300
+        2660,
+        200
       ]
     },
     {
@@ -328,38 +372,59 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
-        2660,
+        2880,
+        300
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD TRANSCRIPTION ERROR - with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'TRANSCRIPTION_ERROR',\n    message: input.error || 'Transcription failed',\n    http_status: 500\n  },\n  _trace: {\n    service_response: { \n      transcription_error: input.error || 'Transcription failed',\n      transcript_id: storedData.transcriptId\n    },\n    provider: 'assemblyai',\n    mode: 'error',\n    latency_ms: Date.now() - storedData.startTime,\n    user_id: storedData.user_id,\n    guild_id: storedData.guild_id,\n    user_request: storedData.user_request\n  },\n  user_id: storedData.user_id,\n  guild_id: storedData.guild_id,\n  user_request: storedData.user_request\n};"
+      },
+      "id": "build-transcription-error",
+      "name": "Build Transcription Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3100,
         400
       ]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ JSON.stringify({ success: false, error: { code: 'TRANSCRIPTION_ERROR', message: $json.error || 'Transcription failed' } }) }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 500
+          "responseCode": 500,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       },
-      "id": "error-transcription",
-      "name": "Error Transcription",
+      "id": "respond-transcription-error",
+      "name": "Respond Transcription Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
       "position": [
-        2880,
-        500
+        3320,
+        400
       ]
     },
     {
       "parameters": {
-        "jsCode": "// Increment poll count and prepare for next poll\nconst response = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\n\nconst pollCount = storedData.pollCount + 1;\nconst elapsedMs = Date.now() - storedData.startTime;\n\n// Timeout after 30 minutes\nif (elapsedMs > 30 * 60 * 1000) {\n  throw new Error('Transcription timeout after 30 minutes');\n}\n\nreturn {\n  json: {\n    transcriptId: storedData.transcriptId,\n    status: response.status,\n    options: storedData.options,\n    pollCount: pollCount,\n    startTime: storedData.startTime,\n    assemblyai_api_key: storedData.assemblyai_api_key\n  }\n};"
+        "jsCode": "// Increment poll count and prepare for next poll\nconst response = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\n\nconst pollCount = storedData.pollCount + 1;\nconst elapsedMs = Date.now() - storedData.startTime;\n\n// Timeout after 30 minutes\nif (elapsedMs > 30 * 60 * 1000) {\n  throw new Error('Transcription timeout after 30 minutes');\n}\n\nreturn {\n  json: {\n    transcriptId: storedData.transcriptId,\n    status: response.status,\n    options: storedData.options,\n    pollCount: pollCount,\n    startTime: storedData.startTime,\n    assemblyai_api_key: storedData.assemblyai_api_key,\n    user_id: storedData.user_id,\n    guild_id: storedData.guild_id,\n    user_request: storedData.user_request\n  }\n};"
       },
       "id": "prepare-next-poll",
       "name": "Prepare Next Poll",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2880,
-        300
+        3100,
+        200
       ]
     },
     {
@@ -372,21 +437,21 @@
       "type": "n8n-nodes-base.wait",
       "typeVersion": 1.1,
       "position": [
-        3100,
-        300
+        3320,
+        200
       ]
     },
     {
       "parameters": {
-        "jsCode": "// Format the final response with speaker identification\nconst transcript = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\nconst options = storedData.options || {};\nconst startTime = storedData.startTime;\n\n// Group utterances by speaker\nconst speakerStats = {};\nconst utterances = transcript.utterances || [];\n\nutterances.forEach(u => {\n  if (!speakerStats[u.speaker]) {\n    speakerStats[u.speaker] = {\n      id: u.speaker,\n      label: `Speaker ${u.speaker.replace('speaker_', '').toUpperCase()}`,\n      total_speaking_time_ms: 0,\n      utterance_count: 0\n    };\n  }\n  speakerStats[u.speaker].total_speaking_time_ms += (u.end - u.start);\n  speakerStats[u.speaker].utterance_count++;\n});\n\n// Calculate percentages\nconst totalSpeakingTime = Object.values(speakerStats).reduce((sum, s) => sum + s.total_speaking_time_ms, 0);\nconst speakers = Object.values(speakerStats).map(s => ({\n  ...s,\n  percentage: totalSpeakingTime > 0 ? Math.round((s.total_speaking_time_ms / totalSpeakingTime) * 100) : 0\n}));\n\n// Format utterances\nconst formattedUtterances = utterances.map(u => ({\n  speaker: u.speaker,\n  text: u.text,\n  start_ms: u.start,\n  end_ms: u.end,\n  confidence: u.confidence\n}));\n\n// Build full transcript with speaker labels\nconst transcriptFull = utterances.map(u => {\n  const label = speakerStats[u.speaker]?.label || u.speaker;\n  return `${label}: ${u.text}`;\n}).join('\\n');\n\nconst response = {\n  success: true,\n  data: {\n    speakers: speakers,\n    utterances: options.include_transcription !== false ? formattedUtterances : undefined,\n    transcript_full: options.include_transcription !== false ? transcriptFull : undefined,\n    audio_duration_ms: transcript.audio_duration * 1000,\n    num_speakers_detected: speakers.length,\n    language_detected: transcript.language_code\n  },\n  meta: {\n    provider: 'assemblyai',\n    execution_mode: 'online',\n    processing_time_ms: Date.now() - startTime,\n    transcript_id: transcript.id\n  }\n};\n\nreturn { json: response };"
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE - with _trace\n// ============================================\n\nconst transcript = $input.first().json;\nconst storedData = $('Store Transcript ID').first().json;\nconst options = storedData.options || {};\nconst startTime = storedData.startTime;\n\n// Group utterances by speaker\nconst speakerStats = {};\nconst utterances = transcript.utterances || [];\n\nutterances.forEach(u => {\n  if (!speakerStats[u.speaker]) {\n    speakerStats[u.speaker] = {\n      id: u.speaker,\n      label: `Speaker ${u.speaker.replace('speaker_', '').toUpperCase()}`,\n      total_speaking_time_ms: 0,\n      utterance_count: 0\n    };\n  }\n  speakerStats[u.speaker].total_speaking_time_ms += (u.end - u.start);\n  speakerStats[u.speaker].utterance_count++;\n});\n\n// Calculate percentages\nconst totalSpeakingTime = Object.values(speakerStats).reduce((sum, s) => sum + s.total_speaking_time_ms, 0);\nconst speakers = Object.values(speakerStats).map(s => ({\n  ...s,\n  percentage: totalSpeakingTime > 0 ? Math.round((s.total_speaking_time_ms / totalSpeakingTime) * 100) : 0\n}));\n\n// Format utterances\nconst formattedUtterances = utterances.map(u => ({\n  speaker: u.speaker,\n  text: u.text,\n  start_ms: u.start,\n  end_ms: u.end,\n  confidence: u.confidence\n}));\n\n// Build full transcript with speaker labels\nconst transcriptFull = utterances.map(u => {\n  const label = speakerStats[u.speaker]?.label || u.speaker;\n  return `${label}: ${u.text}`;\n}).join('\\n');\n\nconst latencyMs = Date.now() - startTime;\n\nconst response = {\n  success: true,\n  data: {\n    speakers: speakers,\n    utterances: options.include_transcription !== false ? formattedUtterances : undefined,\n    transcript_full: options.include_transcription !== false ? transcriptFull : undefined,\n    audio_duration_ms: transcript.audio_duration * 1000,\n    num_speakers_detected: speakers.length,\n    language_detected: transcript.language_code\n  },\n  meta: {\n    provider: 'assemblyai',\n    execution_mode: 'online',\n    processing_time_ms: latencyMs,\n    transcript_id: transcript.id\n  },\n  _trace: {\n    service_response: {\n      speakers_detected: speakers.length,\n      audio_duration_ms: transcript.audio_duration * 1000,\n      language_detected: transcript.language_code,\n      transcript_id: transcript.id\n    },\n    provider: 'assemblyai',\n    mode: 'speaker-identification',\n    latency_ms: latencyMs,\n    user_id: storedData.user_id,\n    guild_id: storedData.guild_id,\n    user_request: storedData.user_request\n  },\n  user_id: storedData.user_id,\n  guild_id: storedData.guild_id,\n  user_request: storedData.user_request\n};\n\nreturn { json: response };"
       },
       "id": "format-response",
       "name": "Format Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        2660,
-        200
+        2880,
+        100
       ]
     },
     {
@@ -410,25 +475,9 @@
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
       "position": [
-        2880,
-        200
+        3100,
+        100
       ]
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ],
-      "parameters": {
-        "color": 4,
-        "width": 550,
-        "height": 220,
-        "content": "## MCP - Speaker Identifier\n\n**Endpoint:** POST /webhook/speaker-identifier\n\n**Parameters:**\n- `data` (required): Audio URL or base64 encoded audio\n- `assemblyai_api_key` (required): AssemblyAI API key\n- `source` (optional): 'url' or 'base64' (default: url)\n- `options.speakers_expected` (optional): Number of expected speakers\n- `options.language` (optional): Language code or 'auto'\n- `options.include_transcription` (optional): Include full transcript (default: true)\n\n**Returns:** Speaker statistics, utterances with timestamps"
-      }
     }
   ],
   "connections": {
@@ -447,6 +496,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Is Base64?",
             "type": "main",
             "index": 0
@@ -454,7 +514,18 @@
         ],
         [
           {
-            "node": "Error Invalid Input",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -589,7 +660,7 @@
       "main": [
         [
           {
-            "node": "Error Transcription",
+            "node": "Build Transcription Error",
             "type": "main",
             "index": 0
           }
@@ -597,6 +668,17 @@
         [
           {
             "node": "Prepare Next Poll",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Transcription Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Transcription Error",
             "type": "main",
             "index": 0
           }
@@ -641,31 +723,5 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "fa173755-445e-4ed4-b402-c6f55b0693a4",
-  "activeVersionId": "fa173755-445e-4ed4-b402-c6f55b0693a4",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T08:39:17.996Z",
-      "createdAt": "2025-12-18T08:39:17.996Z",
-      "role": "workflow:owner",
-      "workflowId": "zp2f63S20SLgs22o",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }

--- a/workflows/MCP_-_Summarizer.json
+++ b/workflows/MCP_-_Summarizer.json
@@ -1,38 +1,44 @@
 {
-  "updatedAt": "2025-12-15T14:55:59.702Z",
-  "createdAt": "2025-12-15T14:55:53.312Z",
-  "id": "XNRFE2ch7KZDoRT1",
   "name": "MCP - Summarizer",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-summarizer",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
-      "webhookId": "summarizer-webhook",
+      "parameters": {
+        "content": "## MCP - Summarizer\n\n**Endpoint:** POST /webhook/summarizer\n\n**Description:** Summarizes text using Anthropic Claude.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\"],\n  \"properties\": {\n    \"text\": { \"type\": \"string\", \"description\": \"Text to summarize (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized summary\" },\n    \"style\": { \"type\": \"string\", \"description\": \"Summary style: brief, detailed, bullet-points\" },\n    \"max_length\": { \"type\": \"integer\", \"description\": \"Target word count\" },\n    \"language\": { \"type\": \"string\", \"description\": \"Output language\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 1024)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"summary\", \"original_length\", \"summary_length\", \"compression_ratio\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 560,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "summarizer",
         "responseMode": "responseNode",
         "options": {}
-      }
+      },
+      "id": "webhook-summarizer",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "summarizer-webhook"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Summarizer\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required field ---\nconst text = body.text || ctx.text;\nif (!text || typeof text !== 'string' || text.trim().length === 0) {\n  errors.push('text requis (chaine non vide)');\n}\n\n// --- Context fields for tracing ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst style = body.style || ctx.style || null;\nconst maxLength = body.max_length || ctx.max_length || null;\nconst language = body.language || ctx.language || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 1024);\nconst executionMode = body.execution_mode || ctx.execution_mode || 'online';\n\n// Validate style if provided\nconst validStyles = ['brief', 'detailed', 'bullet-points'];\nif (style && !validStyles.includes(style)) {\n  errors.push(`style invalide: ${style} (doit etre: ${validStyles.join(', ')})`);\n}\n\n// --- API Key from env or request ---\nconst anthropicKey = body.anthropic_api_key || body.plugin_context?.api_keys?.anthropic || $env.ANTHROPIC_API_KEY || '';\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text.trim(),\n  style: style,\n  max_length: maxLength,\n  language: language,\n  max_tokens: maxTokens,\n  execution_mode: executionMode,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  anthropicKey: anthropicKey,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
-      "position": [
-        460,
-        300
-      ],
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,155 +48,134 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-text",
-      "name": "Error: No Text",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: text\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"anthropic\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
-        }
-      }
-    },
-    {
-      "id": "anthropic-summarize",
-      "name": "Anthropic Summarize",
-      "type": "@n8n/n8n-nodes-langchain.lmChatAnthropic",
-      "typeVersion": 1.2,
-      "position": [
-        700,
-        200
-      ],
-      "parameters": {
-        "model": "claude-3-5-sonnet-20241022",
-        "options": {
-          "maxTokensToSample": 4096,
-          "temperature": 0.3
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       },
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-credentials",
-          "name": "Anthropic account"
-        }
-      }
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE PROMPT - Summarizer\n// ============================================\n\nconst data = $input.first().json;\n\nlet prompt = 'Summarize the following text';\n\nif (data.style) {\n  prompt += ` in a ${data.style} style`;\n}\nif (data.max_length) {\n  prompt += ` in approximately ${data.max_length} words`;\n}\nif (data.language) {\n  prompt += ` in ${data.language}`;\n}\nif (data.user_request) {\n  prompt += `. User context: ${data.user_request}`;\n}\n\nprompt += `:\\n\\n${data.text}\\n\\nProvide a clear, concise summary that captures the main points.`;\n\nreturn {\n  prompt: prompt,\n  original_length: data.text.length,\n  text: data.text,\n  style: data.style,\n  max_tokens: data.max_tokens,\n  execution_mode: data.execution_mode,\n  user_id: data.user_id,\n  guild_id: data.guild_id,\n  user_request: data.user_request,\n  anthropicKey: data.anthropicKey,\n  startTime: data.startTime\n};"
+      },
       "id": "prepare-prompt",
       "name": "Prepare Prompt",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        700,
-        100
-      ],
-      "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"prompt\": (\"Summarize the following text\" + ($json.body.style ? \" in a \" + $json.body.style + \" style\" : \"\") + ($json.body.max_length ? \" in approximately \" + $json.body.max_length + \" words\" : \"\") + ($json.body.language ? \" in \" + $json.body.language : \"\") + \":\\n\\n\" + $json.body.text + \"\\n\\nProvide a clear, concise summary that captures the main points.\"), \"original_length\": $json.body.text.length } }}"
-      }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 200]
     },
     {
-      "id": "call-anthropic",
-      "name": "Call Anthropic API",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        920,
-        200
-      ],
       "parameters": {
         "method": "POST",
         "url": "https://api.anthropic.com/v1/messages",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "anthropicApi",
+        "authentication": "none",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.anthropicKey }}"
+            },
             {
               "name": "anthropic-version",
               "value": "2023-06-01"
             },
             {
-              "name": "content-type",
+              "name": "Content-Type",
               "value": "application/json"
             }
           ]
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ { \"model\": \"claude-3-5-sonnet-20241022\", \"max_tokens\": $json.body.max_tokens || 1024, \"messages\": [ { \"role\": \"user\", \"content\": $('Prepare Prompt').first().json.prompt } ] } }}"
-      },
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-credentials",
-          "name": "Anthropic account"
+        "jsonBody": "={{ JSON.stringify({ model: 'claude-sonnet-4-20250514', max_tokens: $json.max_tokens || 1024, messages: [{ role: 'user', content: $json.prompt }] }) }}",
+        "options": {
+          "timeout": 60000
         }
-      }
+      },
+      "id": "call-anthropic",
+      "name": "Call Anthropic API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 200],
+      "onError": "continueRegularOutput"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OUTPUT - Summarizer\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Prompt').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error || input.type === 'error') {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error?.message || 'Anthropic API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'anthropic',\n      model: 'claude-sonnet-4-20250514',\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst summary = input.content?.[0]?.text || '';\nconst originalLength = prevData.original_length;\nconst summaryLength = summary.length;\nconst compressionRatio = originalLength > 0 ? Math.round((originalLength / summaryLength) * 100) / 100 : 0;\n\nconst _trace = {\n  llm_response: summary,\n  service_response: input,\n  provider: 'anthropic',\n  model: input.model || 'claude-sonnet-4-20250514',\n  tokens: {\n    input: input.usage?.input_tokens || 0,\n    output: input.usage?.output_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    summary: summary,\n    original_length: originalLength,\n    summary_length: summaryLength,\n    compression_ratio: compressionRatio\n  },\n  meta: {\n    provider: 'anthropic',\n    model: input.model || 'claude-sonnet-4-20250514',\n    execution_mode: prevData.execution_mode || 'online',\n    usage: {\n      input_tokens: input.usage?.input_tokens || 0,\n      output_tokens: input.usage?.output_tokens || 0\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
       "id": "format-output",
       "name": "Format Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        1140,
-        200
-      ],
-      "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"summary\": $json.content[0].text, \"original_length\": $('Prepare Prompt').first().json.original_length, \"summary_length\": $json.content[0].text.length, \"compression_ratio\": Math.round(($('Prepare Prompt').first().json.original_length / $json.content[0].text.length) * 100) / 100 }, \"meta\": { \"provider\": \"anthropic\", \"model\": \"claude-3-5-sonnet-20241022\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"input_tokens\": $json.usage.input_tokens, \"output_tokens\": $json.usage.output_tokens } } } }}"
-      }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1340, 200]
     },
     {
-      "id": "respond-success",
-      "name": "Respond Success",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1360,
-        200
-      ],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 550,
-        "height": 200,
-        "content": "## MCP - Summarizer\n\n**Endpoint:** POST /webhook/summarizer\n\n**Parameters:**\n- `text` (required): Text to summarize\n- `style` (optional): Summary style (brief, detailed, bullet-points)\n- `max_length` (optional): Target word count\n- `language` (optional): Output language\n- `execution_mode` (optional): online | offline\n\n**Returns:** Summary with compression ratio and token usage"
-      }
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1560, 200]
     }
   ],
   "connections": {
@@ -209,6 +194,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Prepare Prompt",
             "type": "main",
             "index": 0
@@ -216,7 +212,18 @@
         ],
         [
           {
-            "node": "Error: No Text",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -249,7 +256,7 @@
       "main": [
         [
           {
-            "node": "Respond Success",
+            "node": "Respond",
             "type": "main",
             "index": 0
           }
@@ -260,32 +267,6 @@
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "f163bc06-bba5-4ce3-b975-bef080c92d3e",
-  "activeVersionId": "f163bc06-bba5-4ce3-b975-bef080c92d3e",
-  "versionCounter": 384,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-15T14:55:53.316Z",
-      "createdAt": "2025-12-15T14:55:53.316Z",
-      "role": "workflow:owner",
-      "workflowId": "XNRFE2ch7KZDoRT1",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "availableInMCP": true
+  }
 }

--- a/workflows/MCP_-_Syllabus_Generator.json
+++ b/workflows/MCP_-_Syllabus_Generator.json
@@ -1,38 +1,44 @@
 {
-  "updatedAt": "2025-12-18T10:04:12.000Z",
-  "createdAt": "2025-12-18T10:03:46.689Z",
-  "id": "gUxqJkQubu3NGPOB",
   "name": "MCP - Syllabus Generator",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-syllabus",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
-      "webhookId": "syllabus-generator-webhook",
+      "parameters": {
+        "content": "## MCP - Syllabus Generator\n\n**Endpoint:** POST /webhook/syllabus-generator\n\n**Description:** Genere des syllabus educatifs complets avec modules, lecons, objectifs et evaluations.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"topic\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"topic\": { \"type\": \"string\", \"description\": \"Sujet/theme du cours\" },\n    \"context\": { \"type\": \"string\", \"description\": \"Contexte supplementaire\" },\n    \"options\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"level\": { \"type\": \"string\", \"enum\": [\"debutant\", \"intermediaire\", \"avance\"], \"default\": \"intermediaire\" },\n        \"duration_weeks\": { \"type\": \"integer\", \"default\": 8 },\n        \"hours_per_week\": { \"type\": \"integer\", \"default\": 4 },\n        \"language\": { \"type\": \"string\", \"default\": \"fr\" },\n        \"format\": { \"type\": \"string\", \"enum\": [\"theorique\", \"pratique\", \"hybride\"], \"default\": \"hybride\" }\n      }\n    }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"syllabus\", \"modules\", \"lessons\", \"metadata\"],\n  \"domain\": \"education\"\n}\n```",
+        "height": 680,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "syllabus-generator",
         "responseMode": "responseNode",
         "options": {}
-      }
+      },
+      "id": "webhook-syllabus",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "syllabus-generator-webhook"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Syllabus Generator\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Specific webhook parameters ---\nconst topic = body.topic || ctx.topic || null;\n\nif (!topic) {\n  errors.push('topic requis');\n}\n\n// Parse options with defaults\nconst options = body.options || ctx.options || {};\nconst level = options.level || 'intermediaire';\nconst durationWeeks = options.duration_weeks || 8;\nconst hoursPerWeek = options.hours_per_week || 4;\nconst language = options.language || 'fr';\nconst format = options.format || 'hybride';\nconst additionalContext = body.context_text || ctx.context_text || '';\n\n// Validate level enum\nif (!['debutant', 'intermediaire', 'avance'].includes(level)) {\n  errors.push('level doit etre debutant, intermediaire ou avance');\n}\n\n// Validate format enum\nif (!['theorique', 'pratique', 'hybride'].includes(format)) {\n  errors.push('format doit etre theorique, pratique ou hybride');\n}\n\n// --- API Keys passed from MCP Server ---\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key || body.plugin_context?.api_keys?.openai || '';\nconst model = body.model || ctx.model || 'gpt-4o';\n\nif (!openaiApiKey) {\n  errors.push('openai_api_key requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  topic: topic,\n  level: level,\n  duration_weeks: durationWeeks,\n  hours_per_week: hoursPerWeek,\n  language: language,\n  format: format,\n  context_text: additionalContext,\n  openaiApiKey: openaiApiKey,\n  model: model,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
-      "position": [
-        460,
-        300
-      ],
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,45 +48,58 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.topic }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-topic",
-      "name": "Error: No Topic",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: topic\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
-      "id": "openai-syllabus",
-      "name": "OpenAI Generate Syllabus",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/chat/completions",
@@ -90,7 +109,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.openai_api_key }}"
+              "value": "=Bearer {{ $json.openaiApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -100,56 +119,49 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"{{ $json.body.model || 'gpt-4o' }}\",\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un expert pédagogique spécialisé dans la conception de programmes de formation. Génère un syllabus détaillé et structuré.\\n\\nRègles:\\n1. Structure claire avec modules et leçons\\n2. Objectifs d'apprentissage SMART pour chaque module\\n3. Activités pratiques et évaluations\\n4. Ressources recommandées\\n5. Estimation du temps pour chaque élément\\n6. Prérequis clairement identifiés\\n\\nSchéma JSON attendu:\\n{\\n  \\\"syllabus\\\": {\\n    \\\"title\\\": \\\"string\\\",\\n    \\\"description\\\": \\\"string\\\",\\n    \\\"target_audience\\\": \\\"string\\\",\\n    \\\"prerequisites\\\": [\\\"string\\\"],\\n    \\\"learning_outcomes\\\": [\\\"string\\\"],\\n    \\\"duration\\\": {\\\"total_hours\\\": number, \\\"weeks\\\": number},\\n    \\\"modules\\\": [\\n      {\\n        \\\"id\\\": number,\\n        \\\"title\\\": \\\"string\\\",\\n        \\\"description\\\": \\\"string\\\",\\n        \\\"duration_hours\\\": number,\\n        \\\"objectives\\\": [\\\"string\\\"],\\n        \\\"lessons\\\": [\\n          {\\n            \\\"id\\\": \\\"string\\\",\\n            \\\"title\\\": \\\"string\\\",\\n            \\\"content\\\": \\\"string\\\",\\n            \\\"duration_minutes\\\": number,\\n            \\\"type\\\": \\\"lecture\\\" | \\\"practical\\\" | \\\"discussion\\\" | \\\"assessment\\\"\\n          }\\n        ],\\n        \\\"activities\\\": [\\\"string\\\"],\\n        \\\"assessment\\\": {\\\"type\\\": \\\"string\\\", \\\"description\\\": \\\"string\\\", \\\"weight\\\": number}\\n      }\\n    ],\\n    \\\"resources\\\": [\\n      {\\\"type\\\": \\\"book\\\" | \\\"article\\\" | \\\"video\\\" | \\\"tool\\\", \\\"title\\\": \\\"string\\\", \\\"url\\\": \\\"string\\\" | null}\\n    ],\\n    \\\"grading\\\": {\\\"method\\\": \\\"string\\\", \\\"breakdown\\\": [{\\\"component\\\": \\\"string\\\", \\\"weight\\\": number}]}\\n  }\\n}\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Génère un syllabus complet pour:\\n\\nSujet: {{ $json.body.topic }}\\n\\nNiveau: {{ $json.body.options?.level || 'intermédiaire' }}\\nDurée souhaitée: {{ $json.body.options?.duration_weeks || 8 }} semaines\\nHeures par semaine: {{ $json.body.options?.hours_per_week || 4 }}\\nLangue: {{ $json.body.options?.language || 'fr' }}\\nFormat: {{ $json.body.options?.format || 'hybride (théorie + pratique)' }}\\n\\nContexte supplémentaire: {{ $json.body.context || 'Aucun' }}\"\n    }\n  ],\n  \"temperature\": 0.7,\n  \"max_tokens\": 8192\n}",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const userRequest = data.user_request;\n  const topic = data.topic;\n  const level = data.level;\n  const durationWeeks = data.duration_weeks;\n  const hoursPerWeek = data.hours_per_week;\n  const language = data.language;\n  const format = data.format;\n  const contextText = data.context_text;\n  \n  const systemPrompt = `Tu es un expert pedagogique specialise dans la conception de programmes de formation. Genere un syllabus detaille et structure.\n\nRegles:\n1. Structure claire avec modules et lecons\n2. Objectifs d'apprentissage SMART pour chaque module\n3. Activites pratiques et evaluations\n4. Ressources recommandees\n5. Estimation du temps pour chaque element\n6. Prerequis clairement identifies\n\nSchema JSON attendu:\n{\n  \"syllabus\": {\n    \"title\": \"string\",\n    \"description\": \"string\",\n    \"target_audience\": \"string\",\n    \"prerequisites\": [\"string\"],\n    \"learning_outcomes\": [\"string\"],\n    \"duration\": {\"total_hours\": number, \"weeks\": number},\n    \"modules\": [\n      {\n        \"id\": number,\n        \"title\": \"string\",\n        \"description\": \"string\",\n        \"duration_hours\": number,\n        \"objectives\": [\"string\"],\n        \"lessons\": [\n          {\n            \"id\": \"string\",\n            \"title\": \"string\",\n            \"content\": \"string\",\n            \"duration_minutes\": number,\n            \"type\": \"lecture\" | \"practical\" | \"discussion\" | \"assessment\"\n          }\n        ],\n        \"activities\": [\"string\"],\n        \"assessment\": {\"type\": \"string\", \"description\": \"string\", \"weight\": number}\n      }\n    ],\n    \"resources\": [\n      {\"type\": \"book\" | \"article\" | \"video\" | \"tool\", \"title\": \"string\", \"url\": \"string\" | null}\n    ],\n    \"grading\": {\"method\": \"string\", \"breakdown\": [{\"component\": \"string\", \"weight\": number}]}\n  }\n}`;\n\n  const userPrompt = `**Demande utilisateur:** \"${userRequest}\"\n\nGenere un syllabus complet pour:\n\nSujet: ${topic}\n\nNiveau: ${level}\nDuree souhaitee: ${durationWeeks} semaines\nHeures par semaine: ${hoursPerWeek}\nLangue: ${language}\nFormat: ${format} (theorie + pratique)\n\nContexte supplementaire: ${contextText || 'Aucun'}`;\n\n  return JSON.stringify({\n    model: data.model,\n    response_format: { type: 'json_object' },\n    messages: [\n      { role: 'system', content: systemPrompt },\n      { role: 'user', content: userPrompt }\n    ],\n    temperature: 0.7,\n    max_tokens: 8192\n  });\n})() }}",
         "options": {
           "timeout": 180000
         }
       },
+      "id": "openai-syllabus",
+      "name": "OpenAI Generate Syllabus",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [940, 200],
       "onError": "continueRegularOutput"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// PARSE LLM RESPONSE - Syllabus Generator\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\nconst statusCode = input.statusCode || 200;\n\n// Initialize trace with llm_response format\nconst _trace = {\n  llm_response: null,\n  service_response: null,\n  provider: 'openai',\n  model: prevData.model || 'gpt-4o',\n  tokens: { input: 0, output: 0 },\n  latency_ms: 0,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\n// Handle API error\nif (statusCode >= 400 || input.error) {\n  const errorMsg = input.body?.error?.message || input.error?.message || 'OpenAI API error';\n  _trace.llm_response = `Error: ${errorMsg}`;\n  _trace.service_response = input.body || input;\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'LLM_ERROR',\n        message: errorMsg,\n        http_status: statusCode\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract response\nconst body = input.body || input;\nconst content = body.choices?.[0]?.message?.content || '';\nconst usage = body.usage || {};\n\n// Populate trace with LLM response\n_trace.llm_response = content;\n_trace.service_response = body;\n_trace.tokens = {\n  input: usage.prompt_tokens || 0,\n  output: usage.completion_tokens || 0\n};\n\n// Parse JSON from response\nlet parsed;\ntry {\n  // Handle markdown code blocks\n  let jsonStr = content;\n  const codeBlockMatch = content.match(/```(?:json)?\\s*([\\s\\S]*?)```/);\n  if (codeBlockMatch) {\n    jsonStr = codeBlockMatch[1].trim();\n  } else {\n    const rawMatch = content.match(/\\{[\\s\\S]*\\}/);\n    if (rawMatch) jsonStr = rawMatch[0];\n  }\n  \n  parsed = JSON.parse(jsonStr);\n} catch (e) {\n  _trace.latency_ms = Date.now() - startTime;\n  \n  return {\n    json: {\n      success: false,\n      error: {\n        code: 'PARSE_ERROR',\n        message: 'Failed to parse syllabus response: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      _trace: _trace\n    }\n  };\n}\n\n// Extract syllabus data\nconst syllabus = parsed.syllabus || parsed;\n\n// Calculate statistics\nconst stats = {\n  total_modules: syllabus.modules?.length || 0,\n  total_lessons: syllabus.modules?.reduce((sum, m) => sum + (m.lessons?.length || 0), 0) || 0,\n  total_hours: syllabus.duration?.total_hours || syllabus.modules?.reduce((sum, m) => sum + (m.duration_hours || 0), 0) || 0\n};\n\n_trace.latency_ms = Date.now() - startTime;\n\nreturn {\n  json: {\n    success: true,\n    data: {\n      ...parsed,\n      statistics: stats\n    },\n    meta: {\n      provider: 'openai',\n      model: prevData.model || 'gpt-4o',\n      topic: prevData.topic,\n      level: prevData.level,\n      language: prevData.language,\n      tokens_used: (usage.prompt_tokens || 0) + (usage.completion_tokens || 0),\n      processing_time_ms: Date.now() - startTime\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: _trace\n  }\n};"
+      },
       "id": "parse-response",
-      "name": "Parse Syllabus Response",
+      "name": "Parse LLM Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
-      "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\n\nconst results = items.map(item => {\n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'OpenAI API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          execution_mode: webhookData.body.execution_mode || 'online'\n        }\n      }\n    };\n  }\n\n  try {\n    const content = item.json.choices?.[0]?.message?.content || '{}';\n    const parsed = JSON.parse(content);\n    \n    // Calculate some statistics\n    const syllabus = parsed.syllabus || parsed;\n    const stats = {\n      total_modules: syllabus.modules?.length || 0,\n      total_lessons: syllabus.modules?.reduce((sum, m) => sum + (m.lessons?.length || 0), 0) || 0,\n      total_hours: syllabus.duration?.total_hours || syllabus.modules?.reduce((sum, m) => sum + (m.duration_hours || 0), 0) || 0\n    };\n    \n    return {\n      json: {\n        success: true,\n        data: {\n          ...parsed,\n          statistics: stats\n        },\n        meta: {\n          provider: 'openai',\n          model: item.json.model || webhookData.body.model || 'gpt-4o',\n          execution_mode: webhookData.body.execution_mode || 'online',\n          tokens_used: item.json.usage?.total_tokens || 0\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse syllabus response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          execution_mode: webhookData.body.execution_mode || 'online'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
-      }
+      "position": [1180, 200]
     },
     {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 650,
-        "height": 300,
-        "content": "## MCP - Syllabus Generator\n\n**Endpoint:** POST /webhook/syllabus-generator\n\n**Parameters:**\n- `topic` (required): Subject/course topic\n- `openai_api_key` (required): OpenAI API key\n- `model` (optional): gpt-4o, gpt-4o-mini (default: gpt-4o)\n- `context` (optional): Additional context or requirements\n- `options.level` (optional): debutant | intermediaire | avance (default: intermediaire)\n- `options.duration_weeks` (optional): Course duration in weeks (default: 8)\n- `options.hours_per_week` (optional): Hours per week (default: 4)\n- `options.language` (optional): fr | en (default: fr)\n- `options.format` (optional): theorique | pratique | hybride (default: hybride)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Complete syllabus with modules, lessons, objectives, assessments, resources"
-      }
+      "typeVersion": 1.1,
+      "position": [1420, 200]
     }
   ],
   "connections": {
@@ -168,6 +180,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI Generate Syllabus",
             "type": "main",
             "index": 0
@@ -175,7 +198,18 @@
         ],
         [
           {
-            "node": "Error: No Topic",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -186,14 +220,14 @@
       "main": [
         [
           {
-            "node": "Parse Syllabus Response",
+            "node": "Parse LLM Response",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Parse Syllabus Response": {
+    "Parse LLM Response": {
       "main": [
         [
           {
@@ -207,33 +241,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "3b3b62ad-0bc5-4984-9550-db7558d00983",
-  "activeVersionId": "3b3b62ad-0bc5-4984-9550-db7558d00983",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T10:03:46.691Z",
-      "createdAt": "2025-12-18T10:03:46.691Z",
-      "role": "workflow:owner",
-      "workflowId": "gUxqJkQubu3NGPOB",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Table_Extractor.json
+++ b/workflows/MCP_-_Table_Extractor.json
@@ -1,38 +1,53 @@
 {
-  "updatedAt": "2025-12-18T10:04:11.000Z",
-  "createdAt": "2025-12-18T10:03:54.483Z",
-  "id": "lciEMHKOrajRVIJm",
   "name": "MCP - Table Extractor",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-table",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
+      "parameters": {
+        "content": "## MCP - Table Extractor\n\n**Endpoint:** POST /webhook/table-extractor\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"data\", \"mistral_api_key\"],\n  \"properties\": {\n    \"data\": { \"type\": \"string\", \"description\": \"Image URL or base64 data\" },\n    \"source\": { \"type\": \"string\", \"enum\": [\"url\", \"base64\"], \"default\": \"url\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key\" },\n    \"execution_mode\": { \"type\": \"string\", \"enum\": [\"online\", \"offline\"], \"default\": \"online\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"data\": \"https://... or base64\",\n    \"source\": \"url\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"tables\": [...], \"raw_markdown\": \"...\", \"table_count\": 1 },\n  \"meta\": { \"provider\": \"mistral-ocr\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** Mistral Pixtral-12B (Vision OCR)",
+        "height": 620,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
       "position": [
-        240,
-        300
-      ],
-      "webhookId": "table-extractor-webhook",
+        -60,
+        -220
+      ]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "table-extractor",
         "responseMode": "responseNode",
         "options": {}
-      }
-    },
-    {
-      "id": "validate-input",
-      "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
+      },
+      "id": "webhook-table",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
       "position": [
-        460,
+        0,
         300
       ],
+      "webhookId": "table-extractor-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - RFC-014 Compatible\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Extract data (image URL or base64) ---\nconst dataRaw = ctx.data || body.data;\nconst source = ctx.source || body.source || 'url';\n\n// --- Extract API key ---\nconst mistralKey = body.mistral_api_key \n  || ctx.mistral_api_key \n  || body.plugin_context?.api_keys?.mistral \n  || ctx.plugin_context?.api_keys?.mistral;\n\n// --- Extract execution mode ---\nconst executionMode = ctx.execution_mode || body.execution_mode || 'online';\n\n// --- Validation ---\nconst hasData = !!dataRaw;\nconst hasMistralKey = !!mistralKey;\n\nif (!hasData) errors.push('data (URL ou base64) requis');\nif (!hasMistralKey) errors.push('mistral_api_key requis');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// --- Prepare image URL for Mistral ---\nlet imageUrl = '';\nif (source === 'base64') {\n  imageUrl = 'data:image/png;base64,' + dataRaw;\n} else {\n  imageUrl = dataRaw;\n}\n\nreturn {\n  valid: true,\n  imageUrl: imageUrl,\n  data: dataRaw,\n  source: source,\n  mistralApiKey: mistralKey,\n  executionMode: executionMode,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        220,
+        300
+      ]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,45 +57,29 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.data }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        440,
+        300
+      ]
     },
     {
-      "id": "error-no-data",
-      "name": "Error: No Data",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        500
-      ],
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: data (URL or base64)\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"mistral-ocr\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
-        "options": {
-          "responseCode": 400
-        }
-      }
-    },
-    {
-      "id": "mistral-ocr",
-      "name": "Mistral OCR",
-      "type": "n8n-nodes-base.httpRequest",
-      "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
       "parameters": {
         "method": "POST",
         "url": "https://api.mistral.ai/v1/chat/completions",
@@ -90,7 +89,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.mistral_api_key }}"
+              "value": "=Bearer {{ $json.mistralApiKey }}"
             },
             {
               "name": "Content-Type",
@@ -100,56 +99,101 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"pixtral-12b-2409\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"Extrais TOUS les tableaux de cette image/document. Pour chaque tableau, fournis un JSON structuré avec:\\n- id: numéro du tableau\\n- headers: liste des en-têtes de colonnes\\n- rows: liste des lignes (chaque ligne est une liste de valeurs)\\n- confidence: score de confiance (0-1)\\n\\nRéponds UNIQUEMENT en JSON valide avec cette structure:\\n{\\n  \\\"tables\\\": [\\n    {\\n      \\\"id\\\": 1,\\n      \\\"headers\\\": [...],\\n      \\\"rows\\\": [[...], [...], ...],\\n      \\\"confidence\\\": 0.95\\n    }\\n  ],\\n  \\\"table_count\\\": 1\\n}\\n\\nSi aucun tableau n'est trouvé, retourne: {\\\"tables\\\": [], \\\"table_count\\\": 0}\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"{{ $json.body.source === 'base64' ? 'data:image/png;base64,' + $json.body.data : $json.body.data }}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"max_tokens\": 4096,\n  \"temperature\": 0.1\n}",
+        "jsonBody": "={\n  \"model\": \"pixtral-12b-2409\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"Extrais TOUS les tableaux de cette image/document. Pour chaque tableau, fournis un JSON structuré avec:\\n- id: numéro du tableau\\n- headers: liste des en-têtes de colonnes\\n- rows: liste des lignes (chaque ligne est une liste de valeurs)\\n- confidence: score de confiance (0-1)\\n\\nRéponds UNIQUEMENT en JSON valide avec cette structure:\\n{\\n  \\\"tables\\\": [\\n    {\\n      \\\"id\\\": 1,\\n      \\\"headers\\\": [...],\\n      \\\"rows\\\": [[...], [...], ...],\\n      \\\"confidence\\\": 0.95\\n    }\\n  ],\\n  \\\"table_count\\\": 1\\n}\\n\\nSi aucun tableau n'est trouvé, retourne: {\\\"tables\\\": [], \\\"table_count\\\": 0}\"\n        },\n        {\n          \"type\": \"image_url\",\n          \"image_url\": {\n            \"url\": \"{{ $json.imageUrl }}\"\n          }\n        }\n      ]\n    }\n  ],\n  \"max_tokens\": 4096,\n  \"temperature\": 0.1\n}",
         "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
           "timeout": 120000
         }
       },
+      "id": "mistral-ocr",
+      "name": "Mistral OCR",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        660,
+        200
+      ],
       "onError": "continueRegularOutput"
     },
     {
-      "id": "parse-response",
-      "name": "Parse OCR Response",
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT SUCCESS/ERROR RESPONSE - with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime;\n\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// --- Check for API error ---\nif (statusCode >= 400 || input.error) {\n  const errorMessage = data.message || data.error?.message || input.error?.message || 'Mistral API error';\n  return {\n    success: false,\n    error: {\n      code: 'OCR_API_ERROR',\n      message: errorMessage,\n      http_status: statusCode >= 400 ? statusCode : 500\n    },\n    _trace: {\n      service_response: { error: errorMessage, http_status: statusCode },\n      provider: 'mistral-ocr',\n      model: 'pixtral-12b-2409',\n      mode: 'error',\n      latency_ms: Date.now() - startTime,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  };\n}\n\ntry {\n  const content = data.choices?.[0]?.message?.content || '{}';\n  \n  // Try to extract JSON from the response\n  let parsed;\n  const jsonMatch = content.match(/\\{[\\s\\S]*\\}/);\n  if (jsonMatch) {\n    parsed = JSON.parse(jsonMatch[0]);\n  } else {\n    parsed = { tables: [], table_count: 0 };\n  }\n\n  // Generate markdown representation\n  let rawMarkdown = '';\n  if (parsed.tables && parsed.tables.length > 0) {\n    parsed.tables.forEach((table, idx) => {\n      if (idx > 0) rawMarkdown += '\\n\\n';\n      // Header\n      if (table.headers && table.headers.length > 0) {\n        rawMarkdown += '| ' + table.headers.join(' | ') + ' |\\n';\n        rawMarkdown += '|' + table.headers.map(() => '---').join('|') + '|\\n';\n      }\n      // Rows\n      if (table.rows) {\n        table.rows.forEach(row => {\n          rawMarkdown += '| ' + row.join(' | ') + ' |\\n';\n        });\n      }\n    });\n  }\n\n  return {\n    success: true,\n    data: {\n      tables: parsed.tables || [],\n      raw_markdown: rawMarkdown || null,\n      table_count: parsed.table_count || parsed.tables?.length || 0\n    },\n    meta: {\n      provider: 'mistral-ocr',\n      model: 'pixtral-12b-2409',\n      execution_mode: prevData.executionMode,\n      usage: data.usage || {}\n    },\n    _trace: {\n      service_response: {\n        table_count: parsed.table_count || parsed.tables?.length || 0,\n        has_markdown: !!rawMarkdown\n      },\n      provider: 'mistral-ocr',\n      model: 'pixtral-12b-2409',\n      mode: 'table-extraction',\n      latency_ms: Date.now() - startTime,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  };\n} catch (e) {\n  return {\n    success: false,\n    error: {\n      code: 'PARSE_ERROR',\n      message: 'Failed to parse OCR response: ' + e.message,\n      http_status: 500\n    },\n    _trace: {\n      service_response: { error: e.message },\n      provider: 'mistral-ocr',\n      model: 'pixtral-12b-2409',\n      mode: 'error',\n      latency_ms: Date.now() - startTime,\n      user_id: prevData.user_id,\n      guild_id: prevData.guild_id,\n      user_request: prevData.user_request\n    },\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  };\n}"
+      },
+      "id": "format-response",
+      "name": "Format Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        920,
+        880,
         200
-      ],
-      "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\nconst startTime = Date.now();\n\nconst results = items.map(item => {\n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'Mistral API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'mistral-ocr',\n          execution_mode: webhookData.body.execution_mode || 'online'\n        }\n      }\n    };\n  }\n\n  try {\n    const content = item.json.choices?.[0]?.message?.content || '{}';\n    // Try to extract JSON from the response\n    let parsed;\n    const jsonMatch = content.match(/\\{[\\s\\S]*\\}/);\n    if (jsonMatch) {\n      parsed = JSON.parse(jsonMatch[0]);\n    } else {\n      parsed = { tables: [], table_count: 0 };\n    }\n\n    // Generate markdown representation\n    let rawMarkdown = '';\n    if (parsed.tables && parsed.tables.length > 0) {\n      parsed.tables.forEach((table, idx) => {\n        if (idx > 0) rawMarkdown += '\\n\\n';\n        // Header\n        if (table.headers && table.headers.length > 0) {\n          rawMarkdown += '| ' + table.headers.join(' | ') + ' |\\n';\n          rawMarkdown += '|' + table.headers.map(() => '---').join('|') + '|\\n';\n        }\n        // Rows\n        if (table.rows) {\n          table.rows.forEach(row => {\n            rawMarkdown += '| ' + row.join(' | ') + ' |\\n';\n          });\n        }\n      });\n    }\n\n    return {\n      json: {\n        success: true,\n        data: {\n          tables: parsed.tables || [],\n          raw_markdown: rawMarkdown || null,\n          table_count: parsed.table_count || parsed.tables?.length || 0\n        },\n        meta: {\n          provider: 'mistral-ocr',\n          model: 'pixtral-12b-2409',\n          execution_mode: webhookData.body.execution_mode || 'online',\n          timings: {\n            ocr_ms: Date.now() - startTime,\n            parse_ms: 10\n          }\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse OCR response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'mistral-ocr',\n          execution_mode: webhookData.body.execution_mode || 'online'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
-      }
+      ]
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR - with _trace\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        660,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
+      "typeVersion": 1.1,
       "position": [
-        1140,
+        1100,
         200
-      ],
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
+      ]
     },
     {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
       "parameters": {
-        "color": 6,
-        "width": 600,
-        "height": 280,
-        "content": "## MCP - Table Extractor (Mistral OCR)\n\n**Endpoint:** POST /webhook/table-extractor\n\n**Parameters:**\n- `data` (required): Image URL or base64 data\n- `source` (optional): url | base64 (default: url)\n- `mistral_api_key` (required): Mistral API key\n- `options.output_format` (optional): json | markdown | csv (default: json)\n- `options.detect_headers` (optional): boolean (default: true)\n- `options.merge_cells` (optional): boolean (default: true)\n- `options.confidence_threshold` (optional): 0-1 (default: 0.8)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Extracted tables with headers, rows, confidence scores\n\n**Model:** pixtral-12b-2409 (Mistral Vision)"
-      }
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        880,
+        400
+      ]
     }
   ],
   "connections": {
@@ -168,6 +212,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Mistral OCR",
             "type": "main",
             "index": 0
@@ -175,7 +230,7 @@
         ],
         [
           {
-            "node": "Error: No Data",
+            "node": "Build Error",
             "type": "main",
             "index": 0
           }
@@ -186,18 +241,29 @@
       "main": [
         [
           {
-            "node": "Parse OCR Response",
+            "node": "Format Response",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Parse OCR Response": {
+    "Format Response": {
       "main": [
         [
           {
             "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -209,31 +275,5 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "28afbeb9-24ca-4198-a1bc-b93bba248466",
-  "activeVersionId": "28afbeb9-24ca-4198-a1bc-b93bba248466",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T10:03:54.487Z",
-      "createdAt": "2025-12-18T10:03:54.487Z",
-      "role": "workflow:owner",
-      "workflowId": "lciEMHKOrajRVIJm",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }

--- a/workflows/MCP_-_Tenant_-_Resolve.json
+++ b/workflows/MCP_-_Tenant_-_Resolve.json
@@ -1,0 +1,345 @@
+{
+  "name": "MCP - Tenant - Resolve",
+  "nodes": [
+    {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80],
+      "parameters": {
+        "color": 6,
+        "width": 340,
+        "height": 480,
+        "content": "## MCP - Tenant - Resolve\n\n**Endpoint:** POST /webhook/tenant-resolve\n\n**Description:** Resolves Discord user_id to tenant_id via API backend.\n\n**InputSchema:**\n```json\n{\n  \"type\": \"object\",\n  \"required\": [\"action\", \"user_id\"],\n  \"properties\": {\n    \"action\": {\n      \"type\": \"string\",\n      \"enum\": [\"resolve\"],\n      \"description\": \"Action a effectuer\"\n    },\n    \"user_id\": {\n      \"type\": \"string\",\n      \"description\": \"Discord user ID\"\n    },\n    \"guild_id\": {\n      \"type\": \"string\",\n      \"description\": \"Discord guild ID (optionnel)\"\n    }\n  }\n}\n```\n\n**Returns:**\n- `tenant_id`: Resolved tenant identifier\n- `user_id`: Original Discord user ID\n- `subscription_status`: Subscription status\n- `_trace`: Traceability information\n\n**RFC:** RFC-049 Entity Storage Architecture"
+      }
+    },
+    {
+      "id": "webhook",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "tenant-resolve-webhook",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "tenant-resolve",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Tenant Resolve\n// RFC-049 Entity Storage Architecture\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED fields ---\nconst action = body.action || ctx.action;\nconst userId = body.user_id || ctx.user_id;\n\n// --- OPTIONAL fields ---\nconst guildId = body.guild_id || ctx.guild_id || null;\n\nif (!action) {\n  errors.push('action requis');\n} else if (action !== 'resolve') {\n  errors.push('action doit etre \"resolve\"');\n}\n\nif (!userId) {\n  errors.push('user_id requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId\n  };\n}\n\nreturn {\n  valid: true,\n  action: action,\n  user_id: userId,\n  guild_id: guildId,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "build-validation-error",
+      "name": "Build Validation Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'n8n',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', ')\n  }\n};"
+      }
+    },
+    {
+      "id": "respond-validation-error",
+      "name": "Respond Validation Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "call-api-backend",
+      "name": "Call API Backend",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [900, 200],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.N8N_API_URL }}/n8n/tenants/resolve",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            {
+              "name": "user_id",
+              "value": "={{ $json.user_id }}"
+            },
+            {
+              "name": "guild_id",
+              "value": "={{ $json.guild_id || '' }}"
+            }
+          ]
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.N8N_API_KEY }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "if-api-success",
+      "name": "API Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1140, 200],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-tenant-id",
+              "leftValue": "={{ $json.tenant_id }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "isNotEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "build-success-response",
+      "name": "Build Success Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 100],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD SUCCESS RESPONSE\n// RFC-049 Entity Storage Architecture\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst latencyMs = Date.now() - startTime;\n\nreturn {\n  success: true,\n  data: {\n    tenant_id: input.tenant_id,\n    user_id: prevData.user_id,\n    subscription_status: input.subscription_status || 'active'\n  },\n  _trace: {\n    service_response: input,\n    provider: 'api-backend',\n    mode: 'resolve',\n    latency_ms: latencyMs,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      }
+    },
+    {
+      "id": "build-not-found-error",
+      "name": "Build Not Found Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD NOT FOUND ERROR\n// RFC-049 Entity Storage Architecture\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst latencyMs = Date.now() - startTime;\n\nreturn {\n  success: false,\n  error: {\n    code: 'USER_NOT_FOUND',\n    message: `No tenant found for user_id ${prevData.user_id}`\n  },\n  _trace: {\n    service_response: input,\n    provider: 'api-backend',\n    mode: 'error',\n    latency_ms: latencyMs,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id\n  }\n};"
+      }
+    },
+    {
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1620, 100],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1620, 300],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 404,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Call API Backend",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Validation Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Validation Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Call API Backend": {
+      "main": [
+        [
+          {
+            "node": "API Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "API Success?": {
+      "main": [
+        [
+          {
+            "node": "Build Success Response",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Not Found Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Success Response": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Not Found Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP_-_Text_Embedder.json
+++ b/workflows/MCP_-_Text_Embedder.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2025-12-18T15:17:07.000Z",
-  "createdAt": "2025-12-18T15:15:19.726Z",
-  "id": "N3FpKoAubDMFrYRS",
   "name": "MCP - Text Embedder",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-embedder",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "text-embedder-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +18,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Text Embedder\n// RFC-014 Extraction with Optional Context Fields\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (extract for tracing, NO validation errors if missing) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required parameters specific to this webhook ---\nconst text = body.text || ctx.text;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key;\nconst model = body.model || ctx.model || 'text-embedding-3-small';\nconst dimensions = body.dimensions || ctx.dimensions || 1536;\n\nif (!text) {\n  errors.push('text requis (string ou array de strings)');\n}\n\nif (!openaiApiKey) {\n  errors.push('openai_api_key requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text,\n  openai_api_key: openaiApiKey,\n  model: model,\n  dimensions: dimensions,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +40,12 @@
           },
           "conditions": [
             {
-              "id": "condition-text",
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +55,34 @@
       }
     },
     {
-      "id": "error-no-text",
-      "name": "Error: No Text",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'openai',\n    model: 'text-embedding-3-small',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: text (string or array of strings)\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"model\": \"text-embedding-3-small\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,10 +91,7 @@
       "name": "OpenAI Embeddings",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
         "method": "POST",
         "url": "https://api.openai.com/v1/embeddings",
@@ -91,7 +101,7 @@
           "parameters": [
             {
               "name": "Authorization",
-              "value": "=Bearer {{ $json.body.openai_api_key }}"
+              "value": "=Bearer {{ $json.openai_api_key }}"
             },
             {
               "name": "Content-Type",
@@ -101,7 +111,7 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"model\": \"{{ $json.body.model || 'text-embedding-3-small' }}\",\n  \"input\": {{ Array.isArray($json.body.text) ? JSON.stringify($json.body.text) : JSON.stringify($json.body.text) }},\n  \"dimensions\": {{ $json.body.dimensions || 1536 }}\n}",
+        "jsonBody": "={\n  \"model\": \"{{ $json.model }}\",\n  \"input\": {{ Array.isArray($json.text) ? JSON.stringify($json.text) : JSON.stringify($json.text) }},\n  \"dimensions\": {{ $json.dimensions }}\n}",
         "options": {
           "timeout": 60000
         }
@@ -113,12 +123,9 @@
       "name": "Parse Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
-        "jsCode": "const items = $input.all();\nconst webhookData = $('Webhook').first().json;\n\nconst results = items.map(item => {\n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'OpenAI API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: webhookData.body.model || 'text-embedding-3-small'\n        }\n      }\n    };\n  }\n\n  try {\n    const data = item.json.data || [];\n    const embeddings = data.map(d => ({\n      index: d.index,\n      embedding: d.embedding,\n      dimensions: d.embedding?.length || 0\n    }));\n    \n    return {\n      json: {\n        success: true,\n        data: {\n          embeddings: embeddings,\n          count: embeddings.length,\n          model: item.json.model,\n          dimensions: embeddings[0]?.dimensions || 0\n        },\n        meta: {\n          provider: 'openai',\n          model: item.json.model || webhookData.body.model || 'text-embedding-3-small',\n          usage: item.json.usage || {}\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse embeddings response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: webhookData.body.model || 'text-embedding-3-small'\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
+        "jsCode": "// ============================================\n// PARSE RESPONSE - MCP Text Embedder\n// With _trace for analyzable webhooks\n// ============================================\n\nconst items = $input.all();\nconst validationData = $('Validate Input').first().json;\n\nconst results = items.map(item => {\n  const latencyMs = Date.now() - validationData.startTime;\n  \n  // Check for API errors\n  if (item.json.error) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: item.json.error.code || 500,\n          message: item.json.error.message || 'OpenAI API error',\n          status: 'API_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: validationData.model\n        },\n        user_id: validationData.user_id,\n        guild_id: validationData.guild_id,\n        user_request: validationData.user_request,\n        _trace: {\n          service_response: { error: item.json.error },\n          provider: 'openai',\n          model: validationData.model,\n          mode: 'error',\n          latency_ms: latencyMs,\n          user_id: validationData.user_id,\n          guild_id: validationData.guild_id,\n          user_request: validationData.user_request\n        }\n      }\n    };\n  }\n\n  try {\n    const data = item.json.data || [];\n    const embeddings = data.map(d => ({\n      index: d.index,\n      embedding: d.embedding,\n      dimensions: d.embedding?.length || 0\n    }));\n    \n    const responseData = {\n      embeddings: embeddings,\n      count: embeddings.length,\n      model: item.json.model,\n      dimensions: embeddings[0]?.dimensions || 0\n    };\n    \n    return {\n      json: {\n        success: true,\n        data: responseData,\n        meta: {\n          provider: 'openai',\n          model: item.json.model || validationData.model,\n          usage: item.json.usage || {}\n        },\n        user_id: validationData.user_id,\n        guild_id: validationData.guild_id,\n        user_request: validationData.user_request,\n        _trace: {\n          service_response: responseData,\n          provider: 'openai',\n          model: item.json.model || validationData.model,\n          mode: 'success',\n          latency_ms: latencyMs,\n          token_usage: item.json.usage || {},\n          user_id: validationData.user_id,\n          guild_id: validationData.guild_id,\n          user_request: validationData.user_request\n        }\n      }\n    };\n  } catch (e) {\n    return {\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to parse embeddings response: ' + e.message,\n          status: 'PARSE_ERROR'\n        },\n        meta: {\n          provider: 'openai',\n          model: validationData.model\n        },\n        user_id: validationData.user_id,\n        guild_id: validationData.guild_id,\n        user_request: validationData.user_request,\n        _trace: {\n          service_response: { parse_error: e.message },\n          provider: 'openai',\n          model: validationData.model,\n          mode: 'error',\n          latency_ms: latencyMs,\n          user_id: validationData.user_id,\n          guild_id: validationData.guild_id,\n          user_request: validationData.user_request\n        }\n      }\n    };\n  }\n});\n\nreturn results;"
       }
     },
     {
@@ -126,10 +133,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
+      "position": [1340, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -138,18 +142,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 650,
-        "height": 280,
-        "content": "## MCP - Text Embedder\n\n**Endpoint:** POST /webhook/text-embedder\n\n**Parameters:**\n- `text` (required): String or array of strings to embed\n- `openai_api_key` (required): OpenAI API key\n- `model` (optional): Embedding model (default: text-embedding-3-small)\n- `dimensions` (optional): Output dimensions (default: 1536)\n\n**Models:**\n- `text-embedding-3-small`: Fast, cost-effective (default)\n- `text-embedding-3-large`: Higher quality, more dimensions\n- `text-embedding-ada-002`: Legacy model\n\n**Returns:** Array of embeddings with dimensions"
+        "width": 340,
+        "height": 680,
+        "content": "## MCP - Text Embedder\n\n**Endpoint:** POST /webhook/text-embedder\n\n**Description:** Genere des embeddings de texte via l'API OpenAI pour une utilisation en RAG, recherche semantique, etc.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\", \"openai_api_key\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"text\": { \"type\": \"string|array\", \"description\": \"Texte(s) a encoder\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"Cle API OpenAI\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Modele (default: text-embedding-3-small)\" },\n    \"dimensions\": { \"type\": \"integer\", \"description\": \"Dimensions output (default: 1536)\" }\n  }\n}\n```\n\n**Modeles disponibles:**\n- `text-embedding-3-small` (default) - Rapide, economique\n- `text-embedding-3-large` - Haute qualite\n- `text-embedding-ada-002` - Legacy\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"embeddings\", \"dimensions\", \"count\"],\n  \"domain\": \"embedding\"\n}\n```\n\n**Note:** user_id, guild_id, user_request sont OPTIONNELS (utilises pour le tracing)."
       }
     }
   ],
@@ -169,6 +170,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI Embeddings",
             "type": "main",
             "index": 0
@@ -176,7 +188,18 @@
         ],
         [
           {
-            "node": "Error: No Text",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -208,33 +231,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "54b1f535-d6fb-4ceb-b317-aed9c1937770",
-  "activeVersionId": "54b1f535-d6fb-4ceb-b317-aed9c1937770",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:15:19.729Z",
-      "createdAt": "2025-12-18T15:15:19.729Z",
-      "role": "workflow:owner",
-      "workflowId": "N3FpKoAubDMFrYRS",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Text_Generator.json
+++ b/workflows/MCP_-_Text_Generator.json
@@ -1,38 +1,44 @@
 {
-  "updatedAt": "2025-12-15T15:01:02.630Z",
-  "createdAt": "2025-12-15T15:00:57.138Z",
-  "id": "RipM3vFw09xhPtXR",
   "name": "MCP - Text Generator",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
-      "id": "webhook-textgen",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
-      "webhookId": "text-generator-webhook",
+      "parameters": {
+        "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Description:** Generates text using OpenAI GPT models.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"prompt\"],\n  \"properties\": {\n    \"prompt\": { \"type\": \"string\", \"description\": \"Text generation prompt (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized generation\" },\n    \"system_prompt\": { \"type\": \"string\", \"description\": \"System instructions for the model\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Model: gpt-4o (default), gpt-4o-mini, gpt-4-turbo\" },\n    \"temperature\": { \"type\": \"number\", \"description\": \"Temperature 0-2 (default: 0.7)\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 2048)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"text\", \"model\", \"finish_reason\"],\n  \"domain\": \"nlp\"\n}\n```",
+        "height": 600,
+        "width": 400,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [60, 60]
+    },
+    {
       "parameters": {
         "httpMethod": "POST",
         "path": "text-generator",
         "responseMode": "responseNode",
         "options": {}
-      }
+      },
+      "id": "webhook-textgen",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "text-generator-webhook"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Text Generator\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required field ---\nconst prompt = body.prompt || ctx.prompt;\nif (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {\n  errors.push('prompt requis (chaine non vide)');\n}\n\n// --- Context fields for tracing ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst systemPrompt = body.system_prompt || ctx.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.';\nconst model = body.model || ctx.model || 'gpt-4o';\nconst temperature = parseFloat(body.temperature || ctx.temperature || 0.7);\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 2048);\n\n// Validate model\nconst validModels = ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo'];\nif (!validModels.includes(model)) {\n  errors.push(`model invalide: ${model} (doit etre: ${validModels.join(', ')})`);\n}\n\n// Validate temperature\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// Validate max_tokens\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 16384) {\n  errors.push('max_tokens doit etre entre 1 et 16384');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  prompt: prompt.trim(),\n  system_prompt: systemPrompt,\n  model: model,\n  temperature: temperature,\n  max_tokens: maxTokens,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      },
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2.2,
-      "position": [
-        460,
-        300
-      ],
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300]
+    },
+    {
       "parameters": {
         "conditions": {
           "options": {
@@ -42,117 +48,123 @@
           },
           "conditions": [
             {
-              "leftValue": "={{ $json.body.prompt }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "isNotEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      }
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300]
     },
     {
-      "id": "error-no-prompt",
-      "name": "Error: No Prompt",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
+    },
+    {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: prompt\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
-      }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 480]
     },
     {
-      "id": "openai-generate",
-      "name": "OpenAI Generate Text",
-      "type": "n8n-nodes-base.openAi",
-      "typeVersion": 1.8,
-      "position": [
-        700,
-        200
-      ],
       "parameters": {
-        "resource": "chat",
-        "operation": "message",
-        "model": "={{ $json.body.model || 'gpt-4o' }}",
-        "messages": {
-          "values": [
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "predefinedCredentialType",
+        "nodeCredentialType": "openAiApi",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
             {
-              "content": "={{ $json.body.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.' }}",
-              "role": "system"
-            },
-            {
-              "content": "={{ $json.body.prompt }}",
-              "role": "user"
+              "name": "Content-Type",
+              "value": "application/json"
             }
           ]
         },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  let userContent = data.prompt;\n  \n  // Inject user_request context if provided\n  if (data.user_request) {\n    userContent = `User context: ${data.user_request}\\n\\n${data.prompt}`;\n  }\n  \n  return JSON.stringify({\n    model: data.model,\n    messages: [\n      { role: 'system', content: data.system_prompt },\n      { role: 'user', content: userContent }\n    ],\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
         "options": {
-          "temperature": "={{ $json.body.temperature || 0.7 }}",
-          "maxTokens": "={{ $json.body.max_tokens || 2048 }}"
+          "timeout": 120000
         }
       },
+      "id": "openai-generate",
+      "name": "OpenAI Generate",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [920, 200],
       "credentials": {
         "openAiApi": {
           "id": "openai-credentials",
           "name": "OpenAI account"
         }
-      }
+      },
+      "onError": "continueRegularOutput"
     },
     {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nconst _trace = {\n  llm_response: text,\n  service_response: input,\n  provider: 'openai',\n  model: modelUsed,\n  tokens: {\n    input: input.usage?.prompt_tokens || 0,\n    output: input.usage?.completion_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'openai',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+      },
       "id": "format-output",
       "name": "Format Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        920,
-        200
-      ],
-      "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"text\": $json.message.content, \"model\": $json.model || $('Webhook').first().json.body.model || 'gpt-4o', \"finish_reason\": $json.finish_reason || 'stop' }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"usage\": { \"prompt_tokens\": $json.usage?.prompt_tokens || 0, \"completion_tokens\": $json.usage?.completion_tokens || 0, \"total_tokens\": $json.usage?.total_tokens || 0 } } } }}"
-      }
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1160, 200]
     },
     {
-      "id": "respond-success",
-      "name": "Respond Success",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        1140,
-        200
-      ],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      }
-    },
-    {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ],
-      "parameters": {
-        "color": 6,
-        "width": 550,
-        "height": 220,
-        "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Parameters:**\n- `prompt` (required): Text generation prompt\n- `system_prompt` (optional): System instructions\n- `model` (optional): gpt-4o, gpt-4o-mini, gpt-4-turbo (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.7)\n- `max_tokens` (optional): Max output tokens (default: 2048)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Generated text with usage stats"
-      }
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1400, 200]
     }
   ],
   "connections": {
@@ -171,21 +183,43 @@
       "main": [
         [
           {
-            "node": "OpenAI Generate Text",
-            "type": "main",
-            "index": 0
-          }
-        ],
-        [
-          {
-            "node": "Error: No Prompt",
+            "node": "Valid?",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "OpenAI Generate Text": {
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "OpenAI Generate",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Generate": {
       "main": [
         [
           {
@@ -200,7 +234,7 @@
       "main": [
         [
           {
-            "node": "Respond Success",
+            "node": "Respond",
             "type": "main",
             "index": 0
           }
@@ -211,32 +245,6 @@
   "settings": {
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "be07dd41-4219-4bf5-b268-0f6fcb0f98ff",
-  "activeVersionId": "be07dd41-4219-4bf5-b268-0f6fcb0f98ff",
-  "versionCounter": 383,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-15T15:00:57.145Z",
-      "createdAt": "2025-12-15T15:00:57.145Z",
-      "role": "workflow:owner",
-      "workflowId": "RipM3vFw09xhPtXR",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "availableInMCP": true
+  }
 }

--- a/workflows/MCP_-_Text_to_Speech.json
+++ b/workflows/MCP_-_Text_to_Speech.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2025-12-15T14:43:17.399Z",
-  "createdAt": "2025-12-15T14:43:17.295Z",
-  "id": "ygMdwJrg8sl5L0pG",
   "name": "MCP - Text to Speech",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-tts",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "text-to-speech-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +18,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Text to Speech\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, no validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Required parameters for TTS ---\nconst text = body.text || ctx.text;\n\nif (!text) {\n  errors.push('text is required');\n}\n\n// --- Optional parameters with defaults ---\nconst voice = body.voice || ctx.voice || 'alloy';\nconst model = body.model || ctx.model || 'tts-1';\nconst format = body.format || ctx.format || 'mp3';\nconst speed = body.speed || ctx.speed || 1;\nconst executionMode = body.execution_mode || ctx.execution_mode || 'online';\n\n// Validate voice option\nconst validVoices = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];\nif (voice && !validVoices.includes(voice)) {\n  errors.push(`Invalid voice. Must be one of: ${validVoices.join(', ')}`);\n}\n\n// Validate model option\nconst validModels = ['tts-1', 'tts-1-hd'];\nif (model && !validModels.includes(model)) {\n  errors.push(`Invalid model. Must be one of: ${validModels.join(', ')}`);\n}\n\n// Validate format option\nconst validFormats = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'];\nif (format && !validFormats.includes(format)) {\n  errors.push(`Invalid format. Must be one of: ${validFormats.join(', ')}`);\n}\n\n// Validate speed range\nif (speed < 0.25 || speed > 4.0) {\n  errors.push('Speed must be between 0.25 and 4.0');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text,\n  voice: voice,\n  model: model,\n  format: format,\n  speed: speed,\n  execution_mode: executionMode,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +40,12 @@
           },
           "conditions": [
             {
-              "id": "check-text",
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "notEmpty"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +55,34 @@
       }
     },
     {
-      "id": "error-no-text",
-      "name": "Error: No Text",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'openai-tts',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        680,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Text is required\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $json.body.execution_mode || \"online\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,19 +91,16 @@
       "name": "OpenAI TTS",
       "type": "n8n-nodes-base.openAi",
       "typeVersion": 1.8,
-      "position": [
-        680,
-        300
-      ],
+      "position": [900, 200],
       "parameters": {
         "resource": "audio",
         "operation": "generate",
-        "input": "={{ $json.body.text }}",
-        "voice": "={{ $json.body.voice || 'alloy' }}",
+        "input": "={{ $json.text }}",
+        "voice": "={{ $json.voice }}",
         "options": {
-          "model": "={{ $json.body.model || 'tts-1' }}",
-          "responseFormat": "={{ $json.body.format || 'mp3' }}",
-          "speed": "={{ $json.body.speed || 1 }}"
+          "model": "={{ $json.model }}",
+          "responseFormat": "={{ $json.format }}",
+          "speed": "={{ $json.speed }}"
         }
       },
       "credentials": {
@@ -103,15 +113,11 @@
     {
       "id": "format-output",
       "name": "Format Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        900,
-        300
-      ],
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1120, 200],
       "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": { \"audio_base64\": $json.data, \"format\": $('Webhook').first().json.body.format || 'mp3', \"voice\": $('Webhook').first().json.body.voice || 'alloy' }, \"meta\": { \"provider\": \"openai\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"model\": $('Webhook').first().json.body.model || 'tts-1' } } }}"
+        "jsCode": "// ============================================\n// FORMAT OUTPUT - MCP Text to Speech\n// ============================================\n\nconst prevData = $('Validate Input').first().json;\nconst ttsOutput = $input.first().json;\n\nconst result = {\n  audio_base64: ttsOutput.data,\n  format: prevData.format,\n  voice: prevData.voice,\n  model: prevData.model\n};\n\nreturn {\n  success: true,\n  data: result,\n  meta: {\n    provider: 'openai',\n    execution_mode: prevData.execution_mode,\n    model: prevData.model\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request,\n  _trace: {\n    service_response: result,\n    provider: 'openai-tts',\n    mode: 'success',\n    latency_ms: Date.now() - prevData.startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  }\n};"
       }
     },
     {
@@ -119,10 +125,7 @@
       "name": "Respond Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        1120,
-        300
-      ],
+      "position": [1340, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -131,18 +134,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 400,
-        "height": 180,
-        "content": "## MCP - Text to Speech\n\n**Endpoint:** POST /webhook/text-to-speech\n\n**Parameters:**\n- `text` (required): Text to convert\n- `voice`: alloy, echo, fable, onyx, nova, shimmer\n- `model`: tts-1 or tts-1-hd\n- `format`: mp3, opus, aac, flac\n- `speed`: 0.25 to 4.0"
+        "width": 380,
+        "height": 620,
+        "content": "## MCP - Text to Speech\n\n**Endpoint:** POST /webhook/text-to-speech\n\n**Description:** Convert text to speech audio using OpenAI TTS API.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Text to convert to speech (required)\" },\n    \"voice\": { \"type\": \"string\", \"enum\": [\"alloy\", \"echo\", \"fable\", \"onyx\", \"nova\", \"shimmer\"], \"default\": \"alloy\" },\n    \"model\": { \"type\": \"string\", \"enum\": [\"tts-1\", \"tts-1-hd\"], \"default\": \"tts-1\" },\n    \"format\": { \"type\": \"string\", \"enum\": [\"mp3\", \"opus\", \"aac\", \"flac\", \"wav\", \"pcm\"], \"default\": \"mp3\" },\n    \"speed\": { \"type\": \"number\", \"minimum\": 0.25, \"maximum\": 4.0, \"default\": 1 }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"audio_base64\", \"format\", \"voice\", \"model\"],\n  \"domain\": \"audio\"\n}\n```\n\n**Note:** user_id, guild_id, user_request are OPTIONAL for tracing purposes."
       }
     }
   ],
@@ -162,6 +162,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "OpenAI TTS",
             "type": "main",
             "index": 0
@@ -169,7 +180,18 @@
         ],
         [
           {
-            "node": "Error: No Text",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -201,33 +223,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "f97f054f-8fbb-42fb-9278-564d41105bb7",
-  "activeVersionId": "f97f054f-8fbb-42fb-9278-564d41105bb7",
-  "versionCounter": 385,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-15T14:43:17.305Z",
-      "createdAt": "2025-12-15T14:43:17.305Z",
-      "role": "workflow:owner",
-      "workflowId": "ygMdwJrg8sl5L0pG",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Tokenizer.json
+++ b/workflows/MCP_-_Tokenizer.json
@@ -1,21 +1,12 @@
 {
-  "updatedAt": "2025-12-18T15:17:05.000Z",
-  "createdAt": "2025-12-18T15:15:24.436Z",
-  "id": "hKjyL9mPtl8H8N0C",
   "name": "MCP - Tokenizer",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "id": "webhook-tokenizer",
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "tokenizer-webhook",
       "parameters": {
         "httpMethod": "POST",
@@ -27,12 +18,19 @@
     {
       "id": "validate-input",
       "name": "Validate Input",
-      "type": "n8n-nodes-base.if",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ],
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Tokenizer\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- Parametres specifiques au webhook ---\nconst text = body.text || ctx.text;\nconst model = body.model || ctx.model || 'gpt-4o';\n\nif (!text) {\n  errors.push('text requis');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  text: text,\n  model: model,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -42,12 +40,12 @@
           },
           "conditions": [
             {
-              "id": "condition-text",
-              "leftValue": "={{ $json.body.text }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -57,19 +55,34 @@
       }
     },
     {
-      "id": "error-no-text",
-      "name": "Error: No Text",
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'tokenizer',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
+    },
+    {
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
-      "typeVersion": 1,
-      "position": [
-        700,
-        460
-      ],
+      "typeVersion": 1.1,
+      "position": [1120, 460],
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { \"success\": false, \"error\": { \"code\": 400, \"message\": \"Missing required parameter: text\", \"status\": \"BAD_REQUEST\" }, \"meta\": { \"provider\": \"tokenizer\" } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       }
     },
@@ -78,12 +91,9 @@
       "name": "Count Tokens",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        700,
-        200
-      ],
+      "position": [900, 200],
       "parameters": {
-        "jsCode": "const body = $('Webhook').first().json.body;\nconst text = body.text;\nconst model = body.model || 'gpt-4o';\n\n// Approximate token counting based on model family\n// These are estimates - actual counts may vary slightly\n\n// Character-based estimation for different encodings\nconst estimateTokens = (text, encoding) => {\n  // GPT-4/3.5 use cl100k_base encoding (~4 chars per token for English)\n  // GPT-2 uses gpt2 encoding (~4 chars per token)\n  // Claude uses similar tokenization\n  \n  const charCount = text.length;\n  const wordCount = text.split(/\\s+/).filter(w => w.length > 0).length;\n  \n  // Different ratios for different content types\n  const hasCode = /[{}\\[\\]();=<>]/.test(text);\n  const hasCJK = /[\\u4e00-\\u9fff\\u3040-\\u309f\\u30a0-\\u30ff]/.test(text);\n  const hasEmoji = /[\\u{1F600}-\\u{1F64F}\\u{1F300}-\\u{1F5FF}]/u.test(text);\n  \n  let charsPerToken;\n  \n  if (hasCJK) {\n    // CJK characters are typically 1-2 tokens each\n    charsPerToken = 1.5;\n  } else if (hasCode) {\n    // Code tends to have more tokens per character\n    charsPerToken = 3;\n  } else {\n    // English text averages ~4 chars per token\n    charsPerToken = 4;\n  }\n  \n  const estimatedTokens = Math.ceil(charCount / charsPerToken);\n  \n  return {\n    estimated_tokens: estimatedTokens,\n    char_count: charCount,\n    word_count: wordCount,\n    avg_word_length: wordCount > 0 ? (charCount / wordCount).toFixed(2) : 0,\n    has_code: hasCode,\n    has_cjk: hasCJK,\n    has_emoji: hasEmoji,\n    chars_per_token_estimate: charsPerToken\n  };\n};\n\n// Model context limits\nconst MODEL_LIMITS = {\n  'gpt-4o': 128000,\n  'gpt-4o-mini': 128000,\n  'gpt-4-turbo': 128000,\n  'gpt-4': 8192,\n  'gpt-3.5-turbo': 16385,\n  'claude-3-opus': 200000,\n  'claude-3-sonnet': 200000,\n  'claude-3-haiku': 200000,\n  'claude-3.5-sonnet': 200000,\n  'mistral-large': 128000,\n  'mistral-small': 32000,\n  'gemini-1.5-pro': 1000000,\n  'gemini-1.5-flash': 1000000\n};\n\nconst analysis = estimateTokens(text, model);\nconst contextLimit = MODEL_LIMITS[model] || 128000;\nconst usagePercent = ((analysis.estimated_tokens / contextLimit) * 100).toFixed(2);\n\nreturn [{\n  json: {\n    success: true,\n    data: {\n      model: model,\n      estimated_tokens: analysis.estimated_tokens,\n      context_limit: contextLimit,\n      usage_percent: parseFloat(usagePercent),\n      fits_context: analysis.estimated_tokens < contextLimit,\n      remaining_tokens: Math.max(0, contextLimit - analysis.estimated_tokens),\n      statistics: {\n        char_count: analysis.char_count,\n        word_count: analysis.word_count,\n        avg_word_length: parseFloat(analysis.avg_word_length),\n        chars_per_token: analysis.chars_per_token_estimate\n      },\n      content_type: {\n        has_code: analysis.has_code,\n        has_cjk: analysis.has_cjk,\n        has_emoji: analysis.has_emoji\n      }\n    },\n    meta: {\n      provider: 'tokenizer',\n      note: 'Token counts are estimates. Actual counts may vary by ~5-10%.'\n    }\n  }\n}];"
+        "jsCode": "// ============================================\n// COUNT TOKENS - MCP Tokenizer\n// ============================================\n\nconst prevData = $('Validate Input').first().json;\nconst text = prevData.text;\nconst model = prevData.model;\n\n// Approximate token counting based on model family\n// These are estimates - actual counts may vary slightly\n\n// Character-based estimation for different encodings\nconst estimateTokens = (text, encoding) => {\n  // GPT-4/3.5 use cl100k_base encoding (~4 chars per token for English)\n  // GPT-2 uses gpt2 encoding (~4 chars per token)\n  // Claude uses similar tokenization\n  \n  const charCount = text.length;\n  const wordCount = text.split(/\\s+/).filter(w => w.length > 0).length;\n  \n  // Different ratios for different content types\n  const hasCode = /[{}\\[\\]();=<>]/.test(text);\n  const hasCJK = /[\\u4e00-\\u9fff\\u3040-\\u309f\\u30a0-\\u30ff]/.test(text);\n  const hasEmoji = /[\\u{1F600}-\\u{1F64F}\\u{1F300}-\\u{1F5FF}]/u.test(text);\n  \n  let charsPerToken;\n  \n  if (hasCJK) {\n    // CJK characters are typically 1-2 tokens each\n    charsPerToken = 1.5;\n  } else if (hasCode) {\n    // Code tends to have more tokens per character\n    charsPerToken = 3;\n  } else {\n    // English text averages ~4 chars per token\n    charsPerToken = 4;\n  }\n  \n  const estimatedTokens = Math.ceil(charCount / charsPerToken);\n  \n  return {\n    estimated_tokens: estimatedTokens,\n    char_count: charCount,\n    word_count: wordCount,\n    avg_word_length: wordCount > 0 ? (charCount / wordCount).toFixed(2) : 0,\n    has_code: hasCode,\n    has_cjk: hasCJK,\n    has_emoji: hasEmoji,\n    chars_per_token_estimate: charsPerToken\n  };\n};\n\n// Model context limits\nconst MODEL_LIMITS = {\n  'gpt-4o': 128000,\n  'gpt-4o-mini': 128000,\n  'gpt-4-turbo': 128000,\n  'gpt-4': 8192,\n  'gpt-3.5-turbo': 16385,\n  'claude-3-opus': 200000,\n  'claude-3-sonnet': 200000,\n  'claude-3-haiku': 200000,\n  'claude-3.5-sonnet': 200000,\n  'mistral-large': 128000,\n  'mistral-small': 32000,\n  'gemini-1.5-pro': 1000000,\n  'gemini-1.5-flash': 1000000\n};\n\nconst analysis = estimateTokens(text, model);\nconst contextLimit = MODEL_LIMITS[model] || 128000;\nconst usagePercent = ((analysis.estimated_tokens / contextLimit) * 100).toFixed(2);\n\nconst result = {\n  model: model,\n  estimated_tokens: analysis.estimated_tokens,\n  context_limit: contextLimit,\n  usage_percent: parseFloat(usagePercent),\n  fits_context: analysis.estimated_tokens < contextLimit,\n  remaining_tokens: Math.max(0, contextLimit - analysis.estimated_tokens),\n  statistics: {\n    char_count: analysis.char_count,\n    word_count: analysis.word_count,\n    avg_word_length: parseFloat(analysis.avg_word_length),\n    chars_per_token: analysis.chars_per_token_estimate\n  },\n  content_type: {\n    has_code: analysis.has_code,\n    has_cjk: analysis.has_cjk,\n    has_emoji: analysis.has_emoji\n  }\n};\n\nreturn {\n  success: true,\n  data: result,\n  meta: {\n    provider: 'tokenizer',\n    note: 'Token counts are estimates. Actual counts may vary by ~5-10%.'\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request,\n  _trace: {\n    service_response: result,\n    provider: 'tokenizer',\n    mode: 'success',\n    latency_ms: Date.now() - prevData.startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  }\n};"
       }
     },
     {
@@ -91,10 +101,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1,
-      "position": [
-        920,
-        200
-      ],
+      "position": [1120, 200],
       "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $json }}",
@@ -103,18 +110,15 @@
     },
     {
       "id": "sticky-note-doc",
-      "name": "API Documentation",
+      "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        240,
-        60
-      ],
+      "position": [-100, -80],
       "parameters": {
         "color": 6,
-        "width": 650,
-        "height": 300,
-        "content": "## MCP - Tokenizer\n\n**Endpoint:** POST /webhook/tokenizer\n\n**Parameters:**\n- `text` (required): Text to tokenize/count\n- `model` (optional): Model for context limit (default: gpt-4o)\n\n**Returns:**\n- `estimated_tokens`: Estimated token count\n- `context_limit`: Model's context window size\n- `usage_percent`: Percentage of context used\n- `fits_context`: Boolean if text fits in context\n- `remaining_tokens`: Tokens available\n- `statistics`: char_count, word_count, avg_word_length\n- `content_type`: has_code, has_cjk, has_emoji\n\n**Note:** Token counts are estimates (~5-10% variance).\nFor exact counts, use OpenAI's tiktoken library.\n\n**No API key required** - uses local estimation"
+        "width": 340,
+        "height": 620,
+        "content": "## MCP - Tokenizer\n\n**Endpoint:** POST /webhook/tokenizer\n\n**Description:** Estime le nombre de tokens pour un texte donne et calcule l'utilisation du contexte pour differents modeles LLM.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"text\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte a tokenizer\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Modele pour limite de contexte (default: gpt-4o)\" }\n  }\n}\n```\n\n**Modeles supportes:**\n- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4, gpt-3.5-turbo\n- Anthropic: claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet\n- Mistral: mistral-large, mistral-small\n- Google: gemini-1.5-pro, gemini-1.5-flash\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"estimated_tokens\", \"context_limit\", \"usage_percent\", \"statistics\"],\n  \"domain\": \"utility\"\n}\n```\n\n**Note:** Les comptes de tokens sont des estimations (~5-10% variance)."
       }
     }
   ],
@@ -134,6 +138,17 @@
       "main": [
         [
           {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
             "node": "Count Tokens",
             "type": "main",
             "index": 0
@@ -141,7 +156,18 @@
         ],
         [
           {
-            "node": "Error: No Text",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -162,33 +188,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "9c97acd9-dd35-48ce-b32f-c6114cc3c58c",
-  "activeVersionId": "9c97acd9-dd35-48ce-b32f-c6114cc3c58c",
-  "versionCounter": 369,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-18T15:15:24.438Z",
-      "createdAt": "2025-12-18T15:15:24.438Z",
-      "role": "workflow:owner",
-      "workflowId": "hKjyL9mPtl8H8N0C",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_-_Tools_Enricher.json
+++ b/workflows/MCP_-_Tools_Enricher.json
@@ -1,0 +1,1054 @@
+{
+  "name": "MCP - Tools Enricher",
+  "nodes": [
+    {
+      "id": "webhook-enricher",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        240,
+        400
+      ],
+      "webhookId": "tools-enricher",
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "tools-enricher",
+        "responseMode": "responseNode",
+        "options": {}
+      }
+    },
+    {
+      "id": "manual-trigger",
+      "name": "Manual Trigger",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [
+        240,
+        200
+      ]
+    },
+    {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        700,
+        300
+      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Tools Enricher\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required context fields ---\nconst userId = body.user_id || ctx.user_id;\nconst guildId = body.guild_id || ctx.guild_id;\nconst userRequest = body.user_request || ctx.user_request;\n\nif (!userId) {\n  errors.push('user_id requis');\n}\nif (!guildId) {\n  errors.push('guild_id requis');\n}\nif (!userRequest) {\n  errors.push('user_request requis');\n}\n\n// --- API keys from headers, body, or env ---\nconst anthropicKey = body.api_keys?.anthropic || ctx.api_keys?.anthropic || $env.ANTHROPIC_API_KEY;\nconst openaiKey = body.api_keys?.openai || ctx.api_keys?.openai || $env.OPENAI_API_KEY;\nconst n8nApiKey = headers['x-n8n-api-key'] || headers['X-N8N-API-KEY'] || body.n8n_api_key || ctx.n8n_api_key || $env.N8N_API_KEY;\n\n// Get models from env\nconst modelAnthropic = $env.MODEL_ANTHROPIC || 'claude-3-5-haiku-20241022';\nconst modelOpenai = $env.MODEL_OPENAI || 'gpt-4o-mini';\n\n// Qdrant config - use shared instance\nconst qdrantHost = body.qdrant_host || ctx.qdrant_host || $env.QDRANT_SHARED_1_HOST || 'host3.local';\nconst qdrantPort = body.qdrant_port || ctx.qdrant_port || $env.QDRANT_SHARED_1_PORT || '20001';\nconst qdrantApiKey = body.qdrant_api_key || ctx.qdrant_api_key || $env.QDRANT_SHARED_1_API_KEY || '';\nconst qdrantCollection = body.qdrant_collection || ctx.qdrant_collection || 'tools_index';\n\n// Options\nconst mode = body.mode || ctx.mode || 'full';\nconst workflowIds = body.workflow_ids || ctx.workflow_ids || [];\nconst dryRun = body.dry_run === true || ctx.dry_run === true;\nconst batchSize = body.batch_size || ctx.batch_size || 10;\n\n// Async callback pattern (RFC-040)\nconst callbackUrl = body.callback_url || ctx.callback_url || null;\n// Generate UUID without crypto (n8n doesn't support Node.js crypto module)\nconst generateUUID = () => 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {\n  const r = Math.random() * 16 | 0;\n  return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);\n});\nconst jobId = body.job_id || ctx.job_id || generateUUID();\n\n// Validate API keys only after required fields\nif (!anthropicKey) errors.push('Missing ANTHROPIC_API_KEY');\nif (!openaiKey) errors.push('Missing OPENAI_API_KEY');\nif (!n8nApiKey) errors.push('Missing N8N_API_KEY');\n\nconst now = new Date();\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      errors: errors,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest,\n      callbackUrl: callbackUrl,\n      jobId: jobId\n    }\n  }];\n}\n\n// Initialize static data for results tracking\nconst staticData = $getWorkflowStaticData('global');\nstaticData.results = [];\nstaticData.jobId = jobId;\nstaticData.startedAt = now.toISOString();\nstaticData.callbackUrl = callbackUrl;\nstaticData.userId = userId;\nstaticData.guildId = guildId;\nstaticData.userRequest = userRequest;\n\nreturn [{\n  json: {\n    valid: true,\n    config: {\n      jobId,\n      callbackUrl,\n      anthropicKey,\n      openaiKey,\n      n8nApiKey,\n      modelAnthropic,\n      modelOpenai,\n      qdrantUrl: `http://${qdrantHost}:${qdrantPort}`,\n      qdrantApiKey,\n      qdrantCollection,\n      mode,\n      workflowIds,\n      dryRun,\n      batchSize\n    },\n    stats: {\n      startedAt: now.toISOString()\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    startTime: Date.now()\n  }\n}];"
+      }
+    },
+    {
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        920,
+        300
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "check-callback",
+      "name": "Has Callback URL?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        1140,
+        200
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.config.callbackUrl }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "respond-accepted-async",
+      "name": "Respond Accepted (Async)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1380,
+        100
+      ],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, job_id: $json.config.jobId, status: 'processing', message: 'Enrichment started, results will be posted to callback URL' } }}",
+        "options": {
+          "responseCode": 202
+        }
+      }
+    },
+    {
+      "id": "respond-accepted-sync",
+      "name": "Respond Accepted (Sync)",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1380,
+        300
+      ],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ { success: true, message: 'Enrichment started', mode: $json.config.mode, dry_run: $json.config.dryRun } }}",
+        "options": {
+          "responseCode": 202
+        }
+      }
+    },
+    {
+      "id": "get-workflows",
+      "name": "Get Workflows",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1860,
+        200
+      ],
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.N8N_API_URL || 'http://pi6.local:5678/api/v1' }}/workflows?active=true&limit=250",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-N8N-API-KEY",
+              "value": "={{ $('Validate Input').first().json.config.n8nApiKey }}"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "get-indexed",
+      "name": "Get Indexed",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        2100,
+        200
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $('Validate Input').first().json.config.qdrantUrl }}/collections/{{ $('Validate Input').first().json.config.qdrantCollection }}/points/scroll",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "api-key",
+              "value": "={{ $('Validate Input').first().json.config.qdrantApiKey }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "{\"limit\": 500, \"with_payload\": {\"include\": [\"workflow_id\", \"source_updated_at\", \"keywords\", \"operations\", \"use_cases\"]}, \"with_vector\": false}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "filter-workflows",
+      "name": "Filter Workflows",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2340,
+        200
+      ],
+      "parameters": {
+        "jsCode": "const n8nData = $('Get Workflows').first().json;\nconst qdrantData = $input.first().json;\nconst config = $('Validate Input').first().json.config;\n\nif (n8nData.error) {\n  return [];\n}\n\n// Get already indexed workflow_ids with their metadata\nconst indexedMap = new Map();\nif (qdrantData.result?.points) {\n  for (const p of qdrantData.result.points) {\n    indexedMap.set(p.payload.workflow_id, {\n      source_updated_at: p.payload.source_updated_at,\n      keywords: p.payload.keywords || [],\n      operations: p.payload.operations || [],\n      use_cases: p.payload.use_cases || []\n    });\n  }\n}\nconsole.log(`[Enricher] Found ${indexedMap.size} already indexed workflows`);\n\n// Helper: check if metadata is empty/incomplete\nfunction hasEmptyMetadata(indexed) {\n  if (!indexed) return true;\n  const noKeywords = !indexed.keywords || indexed.keywords.length === 0;\n  const noOperations = !indexed.operations || indexed.operations.length === 0;\n  const noUseCases = !indexed.use_cases || indexed.use_cases.length === 0;\n  return noKeywords || noOperations || noUseCases;\n}\n\nconst allWorkflows = n8nData.data || [];\n\n// Filter: has webhook, not Registry/System workflows\nlet workflows = allWorkflows.filter(w => {\n  if (!w.active) return false;\n  if (w.name.includes('Registry')) return false;\n  if (w.name.includes('Enricher')) return false;\n  const hasWebhook = w.nodes?.some(n => n.type === 'n8n-nodes-base.webhook');\n  return hasWebhook;\n});\n\n// Mode: specific - force update specified IDs\nif (config.mode === 'specific' && config.workflowIds.length > 0) {\n  workflows = workflows.filter(w => config.workflowIds.includes(w.id));\n  console.log(`[Enricher] Specific: ${workflows.length} workflows to process`);\n}\n\n// Mode: incremental - exclude already indexed (unless updated OR metadata empty)\nif (config.mode === 'incremental') {\n  workflows = workflows.filter(w => {\n    const indexed = indexedMap.get(w.id);\n    if (!indexed) return true; // Not indexed yet\n    // Re-index if metadata is empty\n    if (hasEmptyMetadata(indexed)) {\n      console.log(`[Enricher] Re-indexing ${w.name}: empty metadata`);\n      return true;\n    }\n    // Re-index if workflow was updated after last indexing\n    return new Date(w.updatedAt) > new Date(indexed.source_updated_at);\n  });\n  console.log(`[Enricher] Incremental: ${workflows.length} new/updated/empty workflows to process`);\n}\n\n// Return items for SplitInBatches\nreturn workflows.map(w => {\n  const webhookNode = w.nodes?.find(n => n.type === 'n8n-nodes-base.webhook');\n  const stickyNote = w.nodes?.find(n => n.type === 'n8n-nodes-base.stickyNote');\n  const codeNodes = w.nodes?.filter(n => n.type === 'n8n-nodes-base.code') || [];\n  const httpNodes = w.nodes?.filter(n => n.type === 'n8n-nodes-base.httpRequest') || [];\n  const nodeTypes = [...new Set(w.nodes?.map(n => n.type.replace('n8n-nodes-base.', '')) || [])];\n  const codeSnippets = codeNodes.slice(0, 3).map(n => (n.parameters?.jsCode || '').substring(0, 500));\n  const httpUrls = httpNodes.map(n => n.parameters?.url || '').filter(u => u);\n  \n  console.log(`[Enricher] Queued: ${w.name}`);\n  \n  return {\n    json: {\n      workflow_id: w.id,\n      name: w.name,\n      webhook_path: webhookNode?.parameters?.path || webhookNode?.webhookId || '',\n      webhook_method: webhookNode?.parameters?.httpMethod || 'POST',\n      sticky_content: stickyNote?.parameters?.content || '',\n      node_types: nodeTypes,\n      node_count: w.nodes?.length || 0,\n      code_snippets: codeSnippets,\n      http_urls: httpUrls,\n      updated_at: w.updatedAt,\n      config\n    }\n  };\n});"
+      }
+    },
+    {
+      "id": "split-batches",
+      "name": "Split Batches",
+      "type": "n8n-nodes-base.splitInBatches",
+      "typeVersion": 3,
+      "position": [
+        2580,
+        200
+      ],
+      "parameters": {
+        "batchSize": 1,
+        "options": {}
+      }
+    },
+    {
+      "id": "process-workflow",
+      "name": "Process Workflow",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2820,
+        200
+      ],
+      "parameters": {
+        "jsCode": "const workflow = $input.first().json;\nconst config = workflow.config;\nconst validateData = $('Validate Input').first().json;\nconst userRequest = validateData.user_request || '';\n\n// Sanitize text for JSON (remove problematic chars)\nfunction sanitize(text, maxLen = 500) {\n  if (!text) return '';\n  return String(text)\n    .substring(0, maxLen)\n    .replace(/[\\x00-\\x1F\\x7F]/g, ' ')\n    .replace(/\\\\/g, '\\\\\\\\')\n    .replace(/\"/g, '\\\\\"')\n    .trim();\n}\n\n// Build context\nconst context = {\n  name: workflow.name,\n  webhook_path: workflow.webhook_path,\n  webhook_method: workflow.webhook_method,\n  node_types: workflow.node_types.join(', '),\n  node_count: workflow.node_count,\n  existing_doc: sanitize(workflow.sticky_content, 400),\n  code_samples: sanitize(workflow.code_snippets.join(' --- '), 600),\n  http_endpoints: workflow.http_urls.join(', ')\n};\n\n// Build Claude request body with user_request context\nconst claudeBody = {\n  model: config.modelAnthropic,\n  max_tokens: 2000,\n  tools: [{\n    name: 'enrich_tool_metadata',\n    description: 'Generate structured metadata for an n8n workflow tool',\n    input_schema: {\n      type: 'object',\n      required: ['description', 'category', 'keywords', 'use_cases', 'operations'],\n      properties: {\n        description: { type: 'string', description: 'Concise description (max 100 chars), verb infinitive' },\n        category: { type: 'string', enum: ['recherche', 'traduction', 'media', 'documents', 'email', 'calendar', 'database', 'ai', 'communication', 'finance', 'torah', 'autre'] },\n        keywords: { type: 'array', items: { type: 'string' }, description: '5-15 keywords FR and EN' },\n        use_cases: { type: 'array', items: { type: 'string' }, description: '2-5 concrete examples' },\n        operations: {\n          type: 'array',\n          items: {\n            type: 'object',\n            required: ['id', 'type', 'verbs_fr', 'verbs_en'],\n            properties: {\n              id: { type: 'string' },\n              type: { type: 'string', enum: ['READ', 'WRITE'] },\n              verbs_fr: { type: 'array', items: { type: 'string' } },\n              verbs_en: { type: 'array', items: { type: 'string' } }\n            }\n          },\n          description: 'Operations with READ/WRITE type and associated verbs'\n        }\n      }\n    }\n  }],\n  tool_choice: { type: 'tool', name: 'enrich_tool_metadata' },\n  messages: [{\n    role: 'user',\n    content: `**Demande utilisateur:** ${userRequest}\n\nAnalyse ce workflow n8n et genere des metadonnees structurees.\n\nWORKFLOW:\n- Nom: ${context.name}\n- Webhook: ${context.webhook_method} /${context.webhook_path}\n- Nodes (${context.node_count}): ${context.node_types}\n- Documentation: ${context.existing_doc}\n- Code: ${context.code_samples}\n- HTTP endpoints: ${context.http_endpoints}\n\nREGLES:\n- description: max 100 chars, verbe infinitif\n- keywords: FR et EN, synonymes inclus\n- use_cases: commencer par un verbe\n- operations: identifier TOUTES les actions (READ=consulter/lire, WRITE=creer/envoyer/modifier)\n\nUtilise l'outil enrich_tool_metadata.`\n  }]\n};\n\nreturn [{\n  json: {\n    ...workflow,\n    context,\n    claudeBody,\n    user_id: validateData.user_id,\n    guild_id: validateData.guild_id,\n    user_request: userRequest\n  }\n}];"
+      }
+    },
+    {
+      "id": "call-claude",
+      "name": "Claude Generate",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3060,
+        200
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.config.anthropicKey }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.claudeBody) }}",
+        "options": {
+          "timeout": 60000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "parse-claude",
+      "name": "Parse Claude",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3300,
+        200
+      ],
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst prevData = $('Process Workflow').first().json;\n\nif (input.error) {\n  return [{\n    json: {\n      ...prevData,\n      claude_result: null,\n      claude_error: input.error.message || 'Claude API error',\n      status: 'claude_failed'\n    }\n  }];\n}\n\ntry {\n  // Extract tool use result\n  const toolUse = input.content?.find(c => c.type === 'tool_use');\n  if (!toolUse || !toolUse.input) {\n    return [{\n      json: {\n        ...prevData,\n        claude_result: null,\n        claude_error: 'No tool_use in response',\n        status: 'claude_failed'\n      }\n    }];\n  }\n  \n  return [{\n    json: {\n      ...prevData,\n      claude_result: toolUse.input,\n      claude_usage: input.usage || {},\n      status: 'claude_ok'\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      ...prevData,\n      claude_result: null,\n      claude_error: 'Parse error: ' + e.message,\n      status: 'claude_failed'\n    }\n  }];\n}"
+      }
+    },
+    {
+      "id": "check-claude-ok",
+      "name": "Claude OK?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        3540,
+        200
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.status }}",
+              "rightValue": "claude_ok",
+              "operator": {
+                "type": "string",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "call-gpt-validate",
+      "name": "GPT Validate",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        3780,
+        100
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.config.openaiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"{{ $json.config.modelOpenai }}\",\n  \"temperature\": 0.3,\n  \"response_format\": { \"type\": \"json_object\" },\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"Tu es un validateur de métadonnées. Vérifie et corrige si nécessaire. Réponds en JSON avec: { \\\"valid\\\": true/false, \\\"score\\\": 0.0-1.0, \\\"corrections\\\": {...} ou null, \\\"issues\\\": [...] }\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Valide ces métadonnées pour le workflow '{{ $json.name }}':\\n\\n{{ JSON.stringify($json.claude_result) }}\\n\\nVérifie:\\n1. description < 100 chars et verbe infinitif\\n2. keywords contient FR et EN\\n3. operations a les bons types READ/WRITE\\n4. cohérence globale\"\n    }\n  ]\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "parse-gpt",
+      "name": "Parse GPT",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        4020,
+        100
+      ],
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst prevData = $('Parse Claude').first().json;\n\nif (input.error) {\n  // GPT failed, use Claude result as-is\n  return [{\n    json: {\n      ...prevData,\n      gpt_validation: { valid: true, score: 0.7, note: 'GPT validation skipped' },\n      final_metadata: prevData.claude_result,\n      status: 'gpt_skipped'\n    }\n  }];\n}\n\ntry {\n  const content = input.choices?.[0]?.message?.content;\n  const validation = JSON.parse(content);\n  \n  // Apply corrections if any\n  let finalMetadata = prevData.claude_result;\n  if (validation.corrections) {\n    finalMetadata = { ...prevData.claude_result, ...validation.corrections };\n  }\n  \n  return [{\n    json: {\n      ...prevData,\n      gpt_validation: validation,\n      final_metadata: finalMetadata,\n      status: validation.valid ? 'validated' : 'corrected'\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      ...prevData,\n      gpt_validation: { valid: true, score: 0.7, note: 'Parse error, using Claude' },\n      final_metadata: prevData.claude_result,\n      status: 'gpt_parse_error'\n    }\n  }];\n}"
+      }
+    },
+    {
+      "id": "generate-embedding",
+      "name": "Generate Embedding",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4260,
+        100
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/embeddings",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.config.openaiKey }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"model\": \"text-embedding-3-small\",\n  \"input\": \"{{ $json.final_metadata.description }} | {{ $json.final_metadata.keywords.join(', ') }} | {{ $json.final_metadata.use_cases.join('. ') }} | {{ $json.final_metadata.operations.map(op => op.id + ': ' + op.verbs_fr.join(', ')).join('; ') }}\"\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "prepare-qdrant",
+      "name": "Prepare Qdrant",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        4500,
+        100
+      ],
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst prevData = $('Parse GPT').first().json;\n\n// Use workflow_id directly as point_id (Qdrant accepts string IDs)\nfunction workflowToPointId(workflowId) {\n  // Convert workflow_id to a valid UUID using a simple deterministic method\n  // Pad the workflow_id and convert to hex-like format\n  const padded = (workflowId + '0000000000000000').substring(0, 16);\n  let hex = '';\n  for (let i = 0; i < padded.length; i++) {\n    hex += padded.charCodeAt(i).toString(16).padStart(2, '0');\n  }\n  // Format: 8-4-4-4-12 (total 32 hex chars)\n  return `${hex.substring(0,8)}-${hex.substring(8,12)}-4${hex.substring(12,15)}-a${hex.substring(15,18)}-${hex.substring(18,30)}`;\n}\n\nconst embedding = input.data?.[0]?.embedding;\n\nif (!embedding) {\n  return [{\n    json: {\n      ...prevData,\n      embedding: null,\n      embedding_error: 'No embedding generated',\n      status: 'embedding_failed'\n    }\n  }];\n}\n\n// Deterministic point_id based on workflow_id\nconst pointId = workflowToPointId(prevData.workflow_id);\n\n// Build Qdrant payload\nconst payload = {\n  workflow_id: prevData.workflow_id,\n  webhook_path: prevData.webhook_path,\n  webhook_url: `http://pi6.local:5678/webhook/${prevData.webhook_path}`,\n  webhook_method: prevData.webhook_method,\n  name: prevData.name,\n  description: prevData.final_metadata.description,\n  category: prevData.final_metadata.category,\n  keywords: prevData.final_metadata.keywords,\n  use_cases: prevData.final_metadata.use_cases,\n  operations: prevData.final_metadata.operations,\n  enrichment_score: prevData.gpt_validation?.score || 0.7,\n  enriched_at: new Date().toISOString(),\n  enricher_version: '1.0',\n  source_updated_at: prevData.updated_at,\n  active: true,\n  scope: 'user'\n};\n\nconsole.log(`[Enricher] Preparing: ${prevData.name} (${prevData.workflow_id})`);\n\nreturn [{\n  json: {\n    ...prevData,\n    embedding,\n    point_id: pointId,\n    qdrant_payload: payload,\n    status: 'ready_to_store'\n  }\n}];"
+      }
+    },
+    {
+      "id": "check-dry-run",
+      "name": "Dry Run?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        4740,
+        100
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.config.dryRun }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "store-qdrant",
+      "name": "Store in Qdrant",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        4980,
+        0
+      ],
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $json.config.qdrantUrl }}/collections/{{ $json.config.qdrantCollection }}/points",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "api-key",
+              "value": "={{ $json.config.qdrantApiKey }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"points\": [{\n    \"id\": \"{{ $json.point_id }}\",\n    \"vector\": {{ JSON.stringify($json.embedding) }},\n    \"payload\": {{ JSON.stringify($json.qdrant_payload) }}\n  }]\n}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "skip-store",
+      "name": "Skip Store (Dry Run)",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        4980,
+        200
+      ]
+    },
+    {
+      "id": "track-result",
+      "name": "Track Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        5460,
+        100
+      ],
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst prevData = $('Prepare Qdrant').first().json;\nconst config = $('Validate Input').first().json.config;\n\nlet status = 'enriched';\nif (config.dryRun) {\n  status = 'dry_run';\n} else if (input.error) {\n  status = 'qdrant_failed';\n}\n\nconst result = {\n  workflow_id: prevData.workflow_id,\n  name: prevData.name,\n  webhook_path: prevData.webhook_path,\n  status,\n  enrichment_score: prevData.gpt_validation?.score || 0.7,\n  point_id: prevData.point_id,\n  timestamp: new Date().toISOString(),\n  error: input.error?.message || null\n};\n\n// Log progress\nconst staticData = $getWorkflowStaticData('global');\nstaticData.results.push(result);\nconst count = staticData.results.length;\nconsole.log(`[Enricher] ${count}. ${status.toUpperCase()}: ${prevData.name}`);\n\nreturn [{ json: result }];"
+      }
+    },
+    {
+      "id": "mark-failed",
+      "name": "Mark Failed",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        3780,
+        300
+      ],
+      "parameters": {
+        "jsCode": "const prevData = $input.first().json;\n\nconst result = {\n  workflow_id: prevData.workflow_id,\n  name: prevData.name,\n  webhook_path: prevData.webhook_path,\n  status: 'failed',\n  error: prevData.claude_error || 'Unknown error',\n  timestamp: new Date().toISOString()\n};\n\n// Log failure\nconst staticData = $getWorkflowStaticData('global');\nstaticData.results.push(result);\nconst count = staticData.results.length;\nconsole.log(`[Enricher] ${count}. FAILED: ${prevData.name} - ${result.error}`);\n\nreturn [{ json: result }];"
+      }
+    },
+    {
+      "id": "aggregate-stats",
+      "name": "Aggregate Stats",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        5940,
+        200
+      ],
+      "parameters": {
+        "jsCode": "const config = $('Validate Input').first().json.config;\nconst validateData = $('Validate Input').first().json;\nconst staticData = $getWorkflowStaticData('global');\nconst results = staticData.results || [];\nconst startedAt = staticData.startedAt;\n\n// Context fields\nconst userId = staticData.userId || validateData.user_id;\nconst guildId = staticData.guildId || validateData.guild_id;\nconst userRequest = staticData.userRequest || validateData.user_request;\n\n// Calculate stats\nconst enriched = results.filter(r => r.status === 'enriched').length;\nconst dryRunCount = results.filter(r => r.status === 'dry_run').length;\nconst failed = results.filter(r => r.status === 'failed' || r.status === 'qdrant_failed').length;\nconst errorList = results.filter(r => r.status === 'failed' || r.status === 'qdrant_failed');\n\nconst latencyMs = Date.now() - new Date(startedAt).getTime();\n\nconst stats = {\n  job_id: staticData.jobId,\n  mode: config.mode,\n  dry_run: config.dryRun,\n  total: results.length,\n  enriched,\n  dry_run_count: dryRunCount,\n  failed,\n  duration_ms: latencyMs,\n  collection: config.qdrantCollection\n};\n\n// Build _trace for Langfuse\nconst _trace = {\n  service_response: stats,\n  provider: 'anthropic+openai',\n  mode: config.mode,\n  latency_ms: latencyMs,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nconst responseBody = {\n  success: failed === 0,\n  job_id: staticData.jobId,\n  status: 'completed',\n  message: failed === 0\n    ? `Enrichment completed: ${enriched} tools indexed.`\n    : `Enrichment completed with ${failed} errors.`,\n  stats,\n  errors: errorList.length > 0 ? errorList : null,\n  results: results,\n  _trace: _trace,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn [{\n  json: {\n    responseBody,\n    callbackUrl: staticData.callbackUrl\n  }\n}];"
+      }
+    },
+    {
+      "id": "check-has-callback",
+      "name": "Has Callback?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [
+        6180,
+        200
+      ],
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose"
+          },
+          "conditions": [
+            {
+              "leftValue": "={{ $json.callbackUrl }}",
+              "rightValue": "",
+              "operator": {
+                "type": "string",
+                "operation": "notEmpty"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      }
+    },
+    {
+      "id": "prepare-callback",
+      "name": "Prepare Callback",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6420,
+        100
+      ],
+      "parameters": {
+        "jsCode": "const crypto = require('crypto');\nconst input = $input.first().json;\n\nconst callbackUrl = input.callbackUrl;\nconst body = input.responseBody;\nconst payload = JSON.stringify(body);\n\n// RFC-040: HMAC signature - sign body only, output hex WITHOUT prefix\nconst secret = $env.N8N_WEBHOOK_SECRET || 'default-secret';\nconst signature = crypto.createHmac('sha256', secret).update(payload).digest('hex');\n\nconsole.log(`[Enricher] Sending callback to ${callbackUrl}`);\n\nreturn [{\n  json: {\n    callbackUrl,\n    payload,\n    signature\n  }\n}];"
+      }
+    },
+    {
+      "id": "send-callback",
+      "name": "Send Callback",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        6660,
+        100
+      ],
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.callbackUrl }}",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-N8N-Signature",
+              "value": "={{ $json.signature }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "string",
+        "body": "={{ $json.payload }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "id": "callback-result",
+      "name": "Callback Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        6900,
+        100
+      ],
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\nconst prevData = $('Prepare Callback').first().json;\n\nif (input.error) {\n  console.log(`[Enricher] Callback failed: ${input.error.message}`);\n  return [{\n    json: {\n      callback_sent: false,\n      callback_error: input.error.message,\n      callback_url: prevData.callbackUrl\n    }\n  }];\n}\n\nconsole.log(`[Enricher] Callback sent successfully to ${prevData.callbackUrl}`);\nreturn [{\n  json: {\n    callback_sent: true,\n    callback_url: prevData.callbackUrl,\n    callback_response: input\n  }\n}];"
+      }
+    },
+    {
+      "id": "no-callback",
+      "name": "No Callback (Sync)",
+      "type": "n8n-nodes-base.noOp",
+      "typeVersion": 1,
+      "position": [
+        6420,
+        300
+      ]
+    },
+    {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        240,
+        0
+      ],
+      "parameters": {
+        "color": 4,
+        "width": 600,
+        "height": 720,
+        "content": "## MCP - Tools Enricher (RFC-032 + RFC-040)\n\n**Endpoint:** POST /webhook/tools-enricher\n\n**Description:** Enrichir automatiquement les metadonnees des tools n8n et les indexer dans Qdrant\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"mode\": { \"type\": \"string\", \"enum\": [\"full\", \"incremental\", \"specific\"], \"default\": \"full\", \"description\": \"Mode d'enrichissement\" },\n    \"workflow_ids\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"description\": \"Liste d'IDs specifiques (mode specific)\" },\n    \"dry_run\": { \"type\": \"boolean\", \"default\": false, \"description\": \"Test sans ecriture Qdrant\" },\n    \"batch_size\": { \"type\": \"integer\", \"default\": 10, \"description\": \"Taille des batches\" },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL callback async (RFC-040)\" },\n    \"job_id\": { \"type\": \"string\", \"description\": \"ID job personnalise\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"stats\", \"results\", \"errors\"],\n  \"domain\": \"ai\"\n}\n```\n\n**Category:** ai\n**Keywords:** tools, enrichment, metadata, qdrant, embeddings, indexation, semantic"
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request,\n  callbackUrl: input.callbackUrl,\n  jobId: input.jobId\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1140,
+        560
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1380,
+        560
+      ]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Manual Trigger": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Has Callback URL?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Callback URL?": {
+      "main": [
+        [
+          {
+            "node": "Respond Accepted (Async)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Accepted (Sync)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond Accepted (Async)": {
+      "main": [
+        [
+          {
+            "node": "Get Workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Respond Accepted (Sync)": {
+      "main": [
+        [
+          {
+            "node": "Get Workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Workflows": {
+      "main": [
+        [
+          {
+            "node": "Get Indexed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Indexed": {
+      "main": [
+        [
+          {
+            "node": "Filter Workflows",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter Workflows": {
+      "main": [
+        [
+          {
+            "node": "Split Batches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Batches": {
+      "main": [
+        [
+          {
+            "node": "Aggregate Stats",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Process Workflow",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Workflow": {
+      "main": [
+        [
+          {
+            "node": "Claude Generate",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude Generate": {
+      "main": [
+        [
+          {
+            "node": "Parse Claude",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Claude": {
+      "main": [
+        [
+          {
+            "node": "Claude OK?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Claude OK?": {
+      "main": [
+        [
+          {
+            "node": "GPT Validate",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Mark Failed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "GPT Validate": {
+      "main": [
+        [
+          {
+            "node": "Parse GPT",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse GPT": {
+      "main": [
+        [
+          {
+            "node": "Generate Embedding",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Embedding": {
+      "main": [
+        [
+          {
+            "node": "Prepare Qdrant",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Qdrant": {
+      "main": [
+        [
+          {
+            "node": "Dry Run?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Dry Run?": {
+      "main": [
+        [
+          {
+            "node": "Skip Store (Dry Run)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Store in Qdrant",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Store in Qdrant": {
+      "main": [
+        [
+          {
+            "node": "Track Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Skip Store (Dry Run)": {
+      "main": [
+        [
+          {
+            "node": "Track Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Track Result": {
+      "main": [
+        [
+          {
+            "node": "Split Batches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mark Failed": {
+      "main": [
+        [
+          {
+            "node": "Split Batches",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate Stats": {
+      "main": [
+        [
+          {
+            "node": "Has Callback?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Callback?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Callback",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Callback (Sync)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Callback": {
+      "main": [
+        [
+          {
+            "node": "Send Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Send Callback": {
+      "main": [
+        [
+          {
+            "node": "Callback Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  }
+}

--- a/workflows/MCP_-_Transcriber.json
+++ b/workflows/MCP_-_Transcriber.json
@@ -1,12 +1,22 @@
 {
-  "updatedAt": "2025-12-16T11:40:44.008Z",
-  "createdAt": "2025-12-16T11:40:39.349Z",
-  "id": "prG9VSsc5cxACJFj",
   "name": "MCP - Transcriber",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP - Transcriber\n\n**Endpoint:** POST /webhook/video-transcription\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"videoUrl OR videoBase64\"],\n  \"properties\": {\n    \"videoUrl\": { \"type\": \"string\", \"description\": \"URL of video to transcribe\" },\n    \"videoBase64\": { \"type\": \"string\", \"description\": \"Base64-encoded video\" },\n    \"videoMimeType\": { \"type\": \"string\", \"description\": \"MIME type for base64 video\", \"default\": \"video/mp4\" },\n    \"operation\": { \"type\": \"string\", \"description\": \"Operation type\", \"default\": \"transcribe\" },\n    \"language\": { \"type\": \"string\", \"description\": \"Output language\", \"default\": \"auto\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Model to use\", \"default\": \"gemini-2.5-flash\" },\n    \"enableChunking\": { \"type\": \"boolean\", \"description\": \"Enable chunking\", \"default\": false },\n    \"chunkDuration\": { \"type\": \"number\", \"description\": \"Chunk duration in seconds\", \"default\": 10 },\n    \"videoDuration\": { \"type\": \"number\", \"description\": \"Video duration\", \"default\": 0 },\n    \"customInstructions\": { \"type\": \"string\", \"description\": \"Custom instructions\" },\n    \"startTime\": { \"type\": \"string\", \"description\": \"Start time\" },\n    \"endTime\": { \"type\": \"string\", \"description\": \"End time\" },\n    \"execution_mode\": { \"type\": \"string\", \"description\": \"Execution mode\", \"default\": \"online\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"videoUrl\": \"https://...\"\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { ... },\n  \"meta\": { \"provider\": \"gemini\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** Google Vertex AI (Gemini)",
+        "height": 700,
+        "width": 450,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [
+        -60,
+        -200
+      ]
+    },
     {
       "parameters": {
         "httpMethod": "POST",
@@ -19,10 +29,23 @@
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
       "position": [
-        240,
+        0,
         300
       ],
       "webhookId": "video-transcription-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - RFC-014 Compatible\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing only, NO validation errors) ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Extract video source ---\nconst videoUrl_raw = ctx.videoUrl || ctx.video_url || body.videoUrl || body.video_url;\nconst videoBase64_raw = ctx.videoBase64 || ctx.video_base64 || body.videoBase64 || body.video_base64;\nconst videoMimeType = ctx.videoMimeType || ctx.video_mime_type || body.videoMimeType || body.video_mime_type || 'video/mp4';\n\n// --- Extract operation parameters ---\nconst operation = ctx.operation || body.operation || 'transcribe';\nconst outputLanguage = ctx.language || body.language || 'auto';\nconst enableChunking = (ctx.enableChunking || body.enableChunking) === true || (ctx.enableChunking || body.enableChunking) === 'true';\nconst chunkDuration = ctx.chunkDuration || body.chunkDuration || 10;\nconst videoDuration = ctx.videoDuration || body.videoDuration || 0;\nconst model = ctx.model || body.model || 'gemini-2.5-flash';\nconst customInstructions = ctx.customInstructions || body.customInstructions || '';\nconst startTime = ctx.startTime || body.startTime || '';\nconst endTime = ctx.endTime || body.endTime || '';\nconst executionMode = ctx.execution_mode || body.execution_mode || 'online';\n\n// --- Validation ---\nconst hasVideo = !!(videoUrl_raw || videoBase64_raw);\n\nif (!hasVideo) errors.push('videoUrl or videoBase64 required');\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// --- Determine video source type ---\nconst hasBase64 = !!videoBase64_raw;\nconst videoSource = hasBase64 ? 'base64' : 'url';\n\nconst result = {\n  valid: true,\n  videoSource,\n  operation,\n  outputLanguage,\n  enableChunking,\n  chunkDuration,\n  videoDuration,\n  model,\n  customInstructions,\n  startTime,\n  endTime,\n  executionMode,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime_ms: Date.now()\n};\n\nif (hasBase64) {\n  result.videoBase64 = videoBase64_raw;\n  result.videoMimeType = videoMimeType;\n} else {\n  result.videoUrl = videoUrl_raw;\n}\n\nreturn result;"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        220,
+        300
+      ]
     },
     {
       "parameters": {
@@ -34,12 +57,12 @@
           },
           "conditions": [
             {
-              "id": "condition-url",
-              "leftValue": "={{ $json.body.videoUrl || $json.body.videoBase64 }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
@@ -47,39 +70,13 @@
         },
         "options": {}
       },
-      "id": "check-video-url",
-      "name": "Has video?",
+      "id": "if-valid",
+      "name": "Valid?",
       "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
+      "typeVersion": 2.2,
       "position": [
-        460,
+        440,
         300
-      ]
-    },
-    {
-      "parameters": {
-        "errorMessage": "={{ \"No video provided. Please send videoUrl or videoBase64 in the request body\" }}"
-      },
-      "id": "error-no-video",
-      "name": "Error: No Video",
-      "type": "n8n-nodes-base.stopAndError",
-      "typeVersion": 1,
-      "position": [
-        680,
-        420
-      ]
-    },
-    {
-      "parameters": {
-        "jsCode": "// Prepare data for Video Transcription node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: transcribe)\nconst operation = body.operation || 'transcribe';\n\n// Determine video source type\nconst hasBase64 = !!body.videoBase64;\nconst videoSource = hasBase64 ? 'base64' : 'url';\n\n// Get optional parameters\nconst outputLanguage = body.language || 'auto';\nconst enableChunking = body.enableChunking === true || body.enableChunking === 'true';\nconst chunkDuration = body.chunkDuration || 10;\nconst videoDuration = body.videoDuration || 0;\nconst model = body.model || 'gemini-2.5-flash';\nconst customInstructions = body.customInstructions || '';\nconst startTime = body.startTime || '';\nconst endTime = body.endTime || '';\n\nconst result = {\n  videoSource,\n  operation,\n  outputLanguage,\n  enableChunking,\n  chunkDuration,\n  videoDuration,\n  model,\n  customInstructions,\n  startTime,\n  endTime,\n  originalRequest: { ...body, videoBase64: body.videoBase64 ? '<base64_data>' : undefined }\n};\n\nif (hasBase64) {\n  result.videoBase64 = body.videoBase64;\n  result.videoMimeType = body.videoMimeType || 'video/mp4';\n} else {\n  result.videoUrl = body.videoUrl;\n}\n\nreturn [{ json: result }];"
-      },
-      "id": "prepare-config",
-      "name": "Prepare Config",
-      "type": "n8n-nodes-base.code",
-      "typeVersion": 2,
-      "position": [
-        680,
-        180
       ]
     },
     {
@@ -107,8 +104,8 @@
       "type": "n8n-nodes-video-transcription.videoTranscription",
       "typeVersion": 1,
       "position": [
-        900,
-        180
+        660,
+        200
       ],
       "credentials": {
         "googleVertexAiApi": {
@@ -118,49 +115,80 @@
       }
     },
     {
-      "id": "format-output",
-      "name": "Format Output",
-      "type": "n8n-nodes-base.set",
-      "typeVersion": 3.4,
-      "position": [
-        1100,
-        180
-      ],
       "parameters": {
-        "mode": "raw",
-        "jsonOutput": "={{ { \"success\": true, \"data\": $json, \"meta\": { \"provider\": \"gemini\", \"execution_mode\": $('Webhook').first().json.body.execution_mode || \"online\", \"operation\": $('Webhook').first().json.body.operation || \"transcribe\", \"model\": $('Webhook').first().json.body.model || \"gemini-2.5-flash\" } } }}"
-      }
+        "jsCode": "// ============================================\n// FORMAT SUCCESS RESPONSE - with _trace\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime_ms;\n\nreturn {\n  success: true,\n  data: input,\n  meta: {\n    provider: 'gemini',\n    execution_mode: prevData.executionMode,\n    operation: prevData.operation,\n    model: prevData.model\n  },\n  _trace: {\n    service_response: {\n      operation: prevData.operation,\n      model: prevData.model,\n      has_transcription: !!input.transcription\n    },\n    provider: 'gemini',\n    mode: prevData.operation,\n    latency_ms: Date.now() - startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  },\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request\n};"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        880,
+        200
+      ]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       },
       "id": "respond-success",
-      "name": "Respond Success",
+      "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
       "position": [
-        1300,
-        180
+        1100,
+        200
       ]
     },
     {
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ],
       "parameters": {
-        "color": 4,
-        "width": 500,
-        "height": 180,
-        "content": "## MCP - Transcriber\n\n**Endpoint:** POST /webhook/video-transcription\n\n**Parameters:**\n- `videoUrl` (required*): URL of video to transcribe\n- `videoBase64` (required*): Base64 encoded video\n- `language` (optional): Output language\n- `model` (optional): gemini-2.5-flash (default)\n- `execution_mode` (optional): online | offline"
-      }
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR - with _trace\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        660,
+        400
+      ]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        880,
+        400
+      ]
     }
   ],
   "connections": {
@@ -168,36 +196,36 @@
       "main": [
         [
           {
-            "node": "Has video?",
+            "node": "Validate Input",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Has video?": {
+    "Validate Input": {
       "main": [
         [
           {
-            "node": "Prepare Config",
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Video Transcription",
             "type": "main",
             "index": 0
           }
         ],
         [
           {
-            "node": "Error: No Video",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Prepare Config": {
-      "main": [
-        [
-          {
-            "node": "Video Transcription",
+            "node": "Build Error",
             "type": "main",
             "index": 0
           }
@@ -208,18 +236,29 @@
       "main": [
         [
           {
-            "node": "Format Output",
+            "node": "Format Response",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Format Output": {
+    "Format Response": {
       "main": [
         [
           {
-            "node": "Respond Success",
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -231,31 +270,5 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "93b4e1eb-8afa-4c17-895e-a9cad4a7c6ac",
-  "activeVersionId": "93b4e1eb-8afa-4c17-895e-a9cad4a7c6ac",
-  "versionCounter": 380,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-16T11:40:39.357Z",
-      "createdAt": "2025-12-16T11:40:39.357Z",
-      "role": "workflow:owner",
-      "workflowId": "prG9VSsc5cxACJFj",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }

--- a/workflows/MCP_Gemini_Image.json
+++ b/workflows/MCP_Gemini_Image.json
@@ -1,30 +1,49 @@
 {
-  "updatedAt": "2025-12-27T23:45:22.000Z",
-  "createdAt": "2025-12-19T15:38:18.404Z",
-  "id": "De6a7Mdnj7z9hTlP",
   "name": "MCP Gemini Image",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
     {
+      "id": "sticky-note-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-100, -80],
+      "parameters": {
+        "color": 6,
+        "width": 380,
+        "height": 780,
+        "content": "## MCP Gemini Image\n\n**Endpoint:** POST /webhook/gemini-image\n\n**Description:** Generateur d'images IA via Google Gemini/Vertex AI avec support multi-operations (generate, extractCharacter, createCharacterSheet, composeScene).\n\n**InputSchema:**\n```json\n{\n  \"required\": [],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"operation\": { \"type\": \"string\", \"description\": \"Operation: generate, extractCharacter, createCharacterSheet, composeScene (default: generate)\" },\n    \"prompt\": { \"type\": \"string\", \"description\": \"Prompt de generation (operation: generate)\" },\n    \"sourceImage\": { \"type\": \"string\", \"description\": \"Image source base64/URL (operations: extractCharacter, createCharacterSheet)\" },\n    \"scenePrompt\": { \"type\": \"string\", \"description\": \"Description de scene (operation: composeScene)\" },\n    \"referenceImages\": { \"type\": \"array\", \"description\": \"Images de reference (operation: composeScene)\" },\n    \"aspectRatio\": { \"type\": \"string\", \"description\": \"Ratio (default: 16:9)\" },\n    \"outputFormat\": { \"type\": \"string\", \"description\": \"Format sortie (default: png)\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Modele Gemini\" },\n    \"uploadToGcs\": { \"type\": \"boolean\", \"description\": \"Upload vers GCS\" },\n    \"gcsBucket\": { \"type\": \"string\", \"description\": \"Bucket GCS\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"image\", \"gcs\", \"textFeedback\", \"metadata\"],\n  \"domain\": \"image-generation\"\n}\n```\n\n**Note:** user_id, guild_id, user_request sont optionnels (tracing uniquement)."
+      }
+    },
+    {
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [240, 300],
+      "webhookId": "gemini-image-webhook",
       "parameters": {
         "httpMethod": "POST",
         "path": "gemini-image",
         "responseMode": "responseNode",
         "options": {}
-      },
-      "id": "webhook-trigger",
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "typeVersion": 2,
-      "position": [
-        240,
-        304
-      ],
-      "webhookId": "gemini-image-webhook"
+      }
     },
     {
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [460, 300],
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Gemini Image\n// RFC-014: Extract context fields for tracing\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Tracing context fields (OPTIONAL - no validation errors) ---\nconst userId = body.user_id || ctx.user_id || body.userId || '';\nconst guildId = body.guild_id || ctx.guild_id || '';\nconst userRequest = body.user_request || ctx.user_request || '';\n\n// --- Operation detection ---\nconst operation = body.operation || ctx.operation || 'generate';\n\n// --- Operation-specific validation ---\nconst hasPrompt = !!(body.prompt || ctx.prompt);\nconst hasSourceImage = !!(body.sourceImage || ctx.sourceImage);\nconst hasScenePrompt = !!(body.scenePrompt || ctx.scenePrompt);\nconst hasReferenceImages = !!(body.referenceImages || ctx.referenceImages);\n\n// Validate based on operation\nswitch (operation) {\n  case 'generate':\n    if (!hasPrompt) {\n      errors.push('prompt requis pour operation generate');\n    }\n    break;\n    \n  case 'extractCharacter':\n  case 'createCharacterSheet':\n    if (!hasSourceImage) {\n      errors.push('sourceImage requis pour operation ' + operation);\n    }\n    break;\n    \n  case 'composeScene':\n    if (!hasScenePrompt) {\n      errors.push('scenePrompt requis pour operation composeScene');\n    }\n    break;\n    \n  default:\n    // For unknown operations, require at least one input\n    if (!hasPrompt && !hasSourceImage && !hasScenePrompt) {\n      errors.push('Au moins un input requis: prompt, sourceImage, ou scenePrompt');\n    }\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    operation: operation\n  };\n}\n\n// --- Extract all parameters ---\nconst aspectRatio = body.aspectRatio || ctx.aspectRatio || '16:9';\nconst outputFormat = body.outputFormat || ctx.outputFormat || 'png';\nconst model = body.model || ctx.model || 'gemini-2.5-flash-preview-native-audio-dialog';\nconst includeTextFeedback = body.includeTextFeedback === true || body.includeTextFeedback === 'true';\n\n// GCS upload parameters\nconst uploadToGcs = body.uploadToGcs === true || body.uploadToGcs === 'true';\nconst gcsBucket = body.gcsBucket || ctx.gcsBucket || '';\nconst gcsPathPrefix = body.gcsPathPrefix || ctx.gcsPathPrefix || 'gemini-images';\nconst signedUrlExpirationHours = body.signedUrlExpirationHours || ctx.signedUrlExpirationHours || 24;\n\nreturn {\n  valid: true,\n  operation: operation,\n  // Generate params\n  prompt: body.prompt || ctx.prompt || '',\n  // Extract/Sheet params\n  sourceImage: body.sourceImage || ctx.sourceImage || '',\n  sourceImageMimeType: body.sourceImageMimeType || ctx.sourceImageMimeType || 'image/png',\n  characterDescription: body.characterDescription || ctx.characterDescription || 'the main character',\n  views: body.views || ctx.views || ['front', 'back'],\n  // Compose params\n  referenceImages: body.referenceImages || ctx.referenceImages || [],\n  scenePrompt: body.scenePrompt || ctx.scenePrompt || '',\n  // Common params\n  aspectRatio: aspectRatio,\n  outputFormat: outputFormat,\n  model: model,\n  includeTextFeedback: includeTextFeedback,\n  uploadToGcs: uploadToGcs,\n  gcsBucket: gcsBucket,\n  gcsPathPrefix: gcsPathPrefix,\n  signedUrlExpirationHours: signedUrlExpirationHours,\n  // Tracing context\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now(),\n  originalRequest: { ...body }\n};"
+      }
+    },
+    {
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [680, 300],
       "parameters": {
         "conditions": {
           "options": {
@@ -34,55 +53,64 @@
           },
           "conditions": [
             {
-              "id": "condition-input",
-              "leftValue": "={{ $json.body.prompt || $json.body.sourceImage || $json.body.scenePrompt }}",
-              "rightValue": "",
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
               "operator": {
-                "type": "string",
-                "operation": "exists"
+                "type": "boolean",
+                "operation": "equals"
               }
             }
           ],
           "combinator": "and"
         },
         "options": {}
-      },
-      "id": "check-input",
-      "name": "Has input?",
-      "type": "n8n-nodes-base.if",
-      "typeVersion": 2,
-      "position": [
-        464,
-        304
-      ]
+      }
     },
     {
-      "parameters": {
-        "errorMessage": "={{ \"No input provided. Please send prompt (for generate), sourceImage (for extract/sheet), or scenePrompt (for compose) in the request body\" }}"
-      },
-      "id": "error-no-input",
-      "name": "Error: No Input",
-      "type": "n8n-nodes-base.stopAndError",
-      "typeVersion": 1,
-      "position": [
-        688,
-        432
-      ]
-    },
-    {
-      "parameters": {
-        "jsCode": "// Prepare data for Gemini Image node\nconst input = $('Webhook').first().json;\nconst body = input.body || input;\n\n// Get operation from request (default: generate)\nconst operation = body.operation || 'generate';\n\n// Common parameters\nconst aspectRatio = body.aspectRatio || '16:9';\nconst outputFormat = body.outputFormat || 'png';\nconst model = body.model || 'gemini-2.5-flash-preview-native-audio-dialog';\nconst includeTextFeedback = body.includeTextFeedback === true || body.includeTextFeedback === 'true';\n\n// GCS upload parameters\nconst uploadToGcs = body.uploadToGcs === true || body.uploadToGcs === 'true';\nconst gcsBucket = body.gcsBucket || '';\nconst gcsPathPrefix = body.gcsPathPrefix || 'gemini-images';\nconst signedUrlExpirationHours = body.signedUrlExpirationHours || 24;\nconst userId = body.userId || '';\n\n// Operation-specific parameters\nconst result = {\n  operation,\n  aspectRatio,\n  outputFormat,\n  model,\n  includeTextFeedback,\n  uploadToGcs,\n  gcsBucket,\n  gcsPathPrefix,\n  signedUrlExpirationHours,\n  userId,\n  originalRequest: { ...body }\n};\n\nswitch (operation) {\n  case 'generate':\n    result.prompt = body.prompt || '';\n    break;\n    \n  case 'extractCharacter':\n    result.sourceImage = body.sourceImage || '';\n    result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n    result.characterDescription = body.characterDescription || 'the main character';\n    break;\n    \n  case 'createCharacterSheet':\n    result.sourceImage = body.sourceImage || '';\n    result.sourceImageMimeType = body.sourceImageMimeType || 'image/png';\n    result.views = body.views || ['front', 'back'];\n    break;\n    \n  case 'composeScene':\n    result.referenceImages = body.referenceImages || [];\n    result.scenePrompt = body.scenePrompt || '';\n    break;\n}\n\nreturn [{ json: result }];"
-      },
-      "id": "prepare-config",
-      "name": "Prepare Config",
+      "id": "build-error",
+      "name": "Build Error",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        688,
-        192
-      ]
+      "position": [900, 460],
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'gemini-image',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  operation: input.operation,\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      }
     },
     {
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1120, 460],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "gemini-image",
+      "name": "Gemini Image",
+      "type": "n8n-nodes-gemini-image.geminiImage",
+      "typeVersion": 1,
+      "position": [900, 200],
+      "credentials": {
+        "googleVertexAiApi": {
+          "id": "Yis7YQJ8FMrvHGzl",
+          "name": "Google Vertex AI account"
+        }
+      },
       "parameters": {
         "operation": "={{ $json.operation }}",
         "credentialType": "vertexai",
@@ -104,51 +132,31 @@
           "gcsBucket": "={{ $json.gcsBucket }}",
           "gcsPathPrefix": "={{ $json.gcsPathPrefix }}",
           "signedUrlExpirationHours": "={{ $json.signedUrlExpirationHours }}",
-          "userId": "={{ $json.userId }}"
-        }
-      },
-      "id": "gemini-image",
-      "name": "Gemini Image",
-      "type": "n8n-nodes-gemini-image.geminiImage",
-      "typeVersion": 1,
-      "position": [
-        912,
-        192
-      ],
-      "credentials": {
-        "googleVertexAiApi": {
-          "id": "Yis7YQJ8FMrvHGzl",
-          "name": "Google Vertex AI account"
+          "userId": "={{ $json.user_id }}"
         }
       }
     },
     {
-      "parameters": {
-        "jsCode": "// Format response\nconst input = $input.first().json;\nconst binary = $input.first().binary;\n\nconst response = {\n  success: true,\n  operation: input.operation,\n  image: {\n    base64: input.imageBase64,\n    mimeType: input.mimeType,\n    format: input.mimeType.split('/')[1]\n  },\n  model: input.model,\n  textFeedback: input.textFeedback || null,\n  metadata: input.metadata\n};\n\n// Add GCS info if present\nif (input.gcs) {\n  response.gcs = input.gcs;\n}\n\nreturn [{ json: response }];"
-      },
       "id": "format-response",
       "name": "Format Response",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1120,
-        192
-      ]
+      "position": [1120, 200],
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT RESPONSE - MCP Gemini Image\n// ============================================\n\nconst prevData = $('Validate Input').first().json;\nconst input = $input.first().json;\n\nconst response = {\n  success: true,\n  operation: input.operation || prevData.operation,\n  image: {\n    base64: input.imageBase64,\n    mimeType: input.mimeType,\n    format: input.mimeType ? input.mimeType.split('/')[1] : 'png'\n  },\n  model: input.model || prevData.model,\n  textFeedback: input.textFeedback || null,\n  metadata: input.metadata || {},\n  user_id: prevData.user_id,\n  guild_id: prevData.guild_id,\n  user_request: prevData.user_request,\n  _trace: {\n    service_response: {\n      operation: input.operation || prevData.operation,\n      model: input.model || prevData.model,\n      has_image: !!input.imageBase64,\n      has_gcs: !!input.gcs\n    },\n    provider: 'gemini-image',\n    mode: 'success',\n    latency_ms: Date.now() - prevData.startTime,\n    user_id: prevData.user_id,\n    guild_id: prevData.guild_id,\n    user_request: prevData.user_request\n  }\n};\n\n// Add GCS info if present\nif (input.gcs) {\n  response.gcs = input.gcs;\n}\n\nreturn response;"
+      }
     },
     {
-      "parameters": {
-        "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
-      },
       "id": "respond-success",
       "name": "Respond Success",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1344,
-        192
-      ]
+      "position": [1340, 200],
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      }
     }
   ],
   "connections": {
@@ -156,36 +164,47 @@
       "main": [
         [
           {
-            "node": "Has input?",
+            "node": "Validate Input",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Has input?": {
+    "Validate Input": {
       "main": [
         [
           {
-            "node": "Prepare Config",
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Gemini Image",
             "type": "main",
             "index": 0
           }
         ],
         [
           {
-            "node": "Error: No Input",
+            "node": "Build Error",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Prepare Config": {
+    "Build Error": {
       "main": [
         [
           {
-            "node": "Gemini Image",
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -217,33 +236,6 @@
   },
   "settings": {
     "executionOrder": "v1",
-    "callerPolicy": "workflowsFromSameOwner",
-    "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "b297771f-9ce4-4c1c-8848-f8f276acab1e",
-  "activeVersionId": "b297771f-9ce4-4c1c-8848-f8f276acab1e",
-  "versionCounter": 361,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2025-12-19T15:38:18.410Z",
-      "createdAt": "2025-12-19T15:38:18.410Z",
-      "role": "workflow:owner",
-      "workflowId": "De6a7Mdnj7z9hTlP",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+    "callerPolicy": "workflowsFromSameOwner"
+  }
 }

--- a/workflows/MCP_Qdrant_-_Save.json
+++ b/workflows/MCP_Qdrant_-_Save.json
@@ -1,12 +1,19 @@
 {
-  "updatedAt": "2026-01-20T19:34:14.000Z",
-  "createdAt": "2026-01-07T11:14:58.273Z",
-  "id": "deFTjJpRp8ulaj3H",
   "name": "MCP Qdrant - Save",
-  "description": null,
-  "active": true,
-  "isArchived": false,
   "nodes": [
+    {
+      "parameters": {
+        "content": "## MCP Qdrant - Save\n\n**Endpoint:** POST /webhook/qdrant-save\n\n**Description:** Saves entity data with optional Qdrant vector embedding storage.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"entity_type\", \"data\", \"qdrant_host\", \"qdrant_port\", \"qdrant_collection\", \"openai_api_key\"],\n  \"properties\": {\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type of entity being saved\" },\n    \"data\": { \"type\": \"object\", \"description\": \"Entity data to save (title, description, tags, etc.)\" },\n    \"qdrant_host\": { \"type\": \"string\", \"description\": \"Qdrant server hostname\" },\n    \"qdrant_port\": { \"type\": \"integer\", \"description\": \"Qdrant server port\" },\n    \"qdrant_collection\": { \"type\": \"string\", \"description\": \"Qdrant collection name\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"OpenAI API key for embeddings\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Original user request (optional, for tracing)\" },\n    \"store_embedding\": { \"type\": \"boolean\", \"description\": \"Whether to store embedding in Qdrant\", \"default\": true },\n    \"llm_metadata\": { \"type\": \"object\", \"description\": \"LLM provider metadata (optional)\" }\n  }\n}\n```\n\n**Note:** user_id, guild_id, user_request are OPTIONAL - extracted for tracing only.",
+        "height": 520,
+        "width": 380,
+        "color": 6
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 80]
+    },
     {
       "parameters": {
         "httpMethod": "POST",
@@ -18,24 +25,18 @@
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        304
-      ],
+      "position": [240, 304],
       "webhookId": "recipes-save-webhook"
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const body = input.body || input;\n\n  const errors = [];\n\n  if (!body.entity_type) {\n    errors.push('Missing required parameter: entity_type');\n  }\n  if (!body.data) {\n    errors.push('Missing required parameter: data');\n  }\n  if (!body.user_id && !body.discord_user_id) {\n    errors.push('Missing required parameter: user_id or discord_user_id');\n  }\n  if (!body.qdrant_host) {\n    errors.push('Missing required parameter: qdrant_host');\n  }\n  if (!body.qdrant_port) {\n    errors.push('Missing required parameter: qdrant_port');\n  }\n  if (!body.qdrant_collection) {\n    errors.push('Missing required parameter: qdrant_collection');\n  }\n  if (!body.openai_api_key) {\n    errors.push('Missing required parameter: openai_api_key');\n  }\n\n  if (errors.length > 0) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: errors.join(', '),\n          status: 'BAD_REQUEST'\n        }\n      }\n    }];\n  }\n\n  const data = body.data;\n\n  // Build text for embedding (generic)\n  const embeddingText = [\n    data.title || '',\n    data.description || '',\n    (data.tags || []).join(' '),\n    (data.ingredients || []).map(i => typeof i === 'string' ? i : i.name).join(' '),\n    data.content || ''\n  ].join(' ').trim();\n\n  const qdrantUrl = `http://${body.qdrant_host}:${body.qdrant_port}`;\n\n  return [{\n    json: {\n      valid: true,\n      entity_type: body.entity_type,\n      data,\n      embedding_text: embeddingText,\n      user_id: body.user_id || body.discord_user_id,\n      store_embedding: body.store_embedding !== false,\n      llm_metadata: body.llm_metadata || {},\n      qdrant_url: qdrantUrl,\n      qdrant_collection: body.qdrant_collection,\n      openai_api_key: body.openai_api_key\n    }\n  }];"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - MCP Qdrant Save\n// RFC-014 Extraction Pattern\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- OPTIONAL context fields (for tracing, NO validation errors if missing) ---\nconst userId = body.user_id || ctx.user_id || body.discord_user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- REQUIRED webhook parameters ---\nconst entityType = body.entity_type || ctx.entity_type;\nconst data = body.data || ctx.data;\nconst qdrantHost = body.qdrant_host || ctx.qdrant_host;\nconst qdrantPort = body.qdrant_port || ctx.qdrant_port;\nconst qdrantCollection = body.qdrant_collection || ctx.qdrant_collection;\nconst openaiApiKey = body.openai_api_key || ctx.openai_api_key;\n\nif (!entityType) {\n  errors.push('entity_type requis');\n}\nif (!data) {\n  errors.push('data requis');\n}\nif (!qdrantHost) {\n  errors.push('qdrant_host requis');\n}\nif (!qdrantPort) {\n  errors.push('qdrant_port requis');\n}\nif (!qdrantCollection) {\n  errors.push('qdrant_collection requis');\n}\nif (!openaiApiKey) {\n  errors.push('openai_api_key requis');\n}\n\n// Optional parameters\nconst storeEmbedding = body.store_embedding !== false;\nconst llmMetadata = body.llm_metadata || ctx.llm_metadata || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// Build text for embedding (generic)\nconst embeddingText = [\n  data.title || '',\n  data.description || '',\n  (data.tags || []).join(' '),\n  (data.ingredients || []).map(i => typeof i === 'string' ? i : i.name).join(' '),\n  data.content || ''\n].join(' ').trim();\n\nconst qdrantUrl = `http://${qdrantHost}:${qdrantPort}`;\n\nreturn {\n  valid: true,\n  entity_type: entityType,\n  data: data,\n  embedding_text: embeddingText,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  store_embedding: storeEmbedding,\n  llm_metadata: llmMetadata,\n  qdrant_url: qdrantUrl,\n  qdrant_collection: qdrantCollection,\n  openai_api_key: openaiApiKey,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        464,
-        304
-      ]
+      "position": [460, 304]
     },
     {
       "parameters": {
@@ -47,6 +48,7 @@
           },
           "conditions": [
             {
+              "id": "check-valid",
               "leftValue": "={{ $json.valid }}",
               "rightValue": true,
               "operator": {
@@ -63,27 +65,39 @@
       "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        688,
-        304
-      ]
+      "position": [680, 304]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [900, 480]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ { success: false, error: $json.error, meta: { provider: 'recipes-save' } } }}",
+        "responseBody": "={{ JSON.stringify($json) }}",
         "options": {
-          "responseCode": 400
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
         }
       },
-      "id": "error-validation",
-      "name": "Error: Validation",
+      "id": "respond-error",
+      "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        912,
-        464
-      ]
+      "position": [1120, 480]
     },
     {
       "parameters": {
@@ -113,10 +127,7 @@
       "name": "Generate Embedding",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        912,
-        208
-      ],
+      "position": [912, 208],
       "onError": "continueRegularOutput"
     },
     {
@@ -127,10 +138,7 @@
       "name": "Prepare Qdrant",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1152,
-        208
-      ]
+      "position": [1152, 208]
     },
     {
       "parameters": {
@@ -171,10 +179,7 @@
       "name": "Store Embedding?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        1392,
-        208
-      ]
+      "position": [1392, 208]
     },
     {
       "parameters": {
@@ -204,10 +209,7 @@
       "name": "Store in Qdrant",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        1632,
-        112
-      ],
+      "position": [1632, 112],
       "onError": "continueRegularOutput"
     },
     {
@@ -216,10 +218,7 @@
       "name": "Skip Qdrant",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [
-        1632,
-        304
-      ]
+      "position": [1632, 304]
     },
     {
       "parameters": {},
@@ -227,10 +226,7 @@
       "name": "Merge",
       "type": "n8n-nodes-base.merge",
       "typeVersion": 3,
-      "position": [
-        1872,
-        208
-      ]
+      "position": [1872, 208]
     },
     {
       "parameters": {
@@ -256,55 +252,40 @@
       "name": "Save to API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        2256,
-        208
-      ],
+      "position": [2256, 208],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "  const input = $input.first().json;\n  const prevData = $('Validate Input').first().json;\n  const qdrantData = $('Prepare Qdrant').first().json;\n\n  try {\n    if (input.error) {\n      return [{\n        json: {\n          success: false,\n          error: {\n            code: input.error.status || 500,\n            message: input.error.message || 'API save failed',\n            status: 'API_ERROR'\n          },\n          meta: { provider: 'api' }\n        }\n      }];\n    }\n\n    return [{\n      json: {\n        success: true,\n        data: {\n          entity_id: input.data?.id || input.id,\n          entity_type: prevData.entity_type,\n          stored_in_qdrant: !!qdrantData.embedding,\n          qdrant_point_id: qdrantData.point_id || null,\n          entity: prevData.data\n        },\n        meta: {\n          provider: 'api+qdrant',\n          api_response: input\n        }\n      }\n    }];\n  } catch (e) {\n    return [{\n      json: {\n        success: false,\n        error: {\n          code: 500,\n          message: 'Failed to process save: ' + e.message,\n          status: 'PROCESS_ERROR'\n        },\n        meta: { provider: 'api' }\n      }\n    }];\n  }"
+        "jsCode": "// ============================================\n// FORMAT OUTPUT - MCP Qdrant Save\n// With _trace for RFC-014 compliance\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst qdrantData = $('Prepare Qdrant').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// --- Context fields for traceability ---\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\ntry {\n  if (input.error) {\n    return [{\n      json: {\n        success: false,\n        _trace: {\n          service_response: input,\n          provider: 'api',\n          mode: 'error',\n          latency_ms: Date.now() - startTime,\n          user_id: userId,\n          guild_id: guildId,\n          user_request: userRequest\n        },\n        error: {\n          code: 'API_ERROR',\n          message: input.error.message || 'API save failed',\n          http_status: input.error.status || 500\n        },\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest\n      }\n    }];\n  }\n\n  return [{\n    json: {\n      success: true,\n      data: {\n        entity_id: input.data?.id || input.id,\n        entity_type: prevData.entity_type,\n        stored_in_qdrant: !!qdrantData.embedding,\n        qdrant_point_id: qdrantData.point_id || null,\n        entity: prevData.data\n      },\n      _trace: {\n        service_response: { api: input, qdrant: qdrantData.embedding ? 'stored' : 'skipped' },\n        provider: 'api+qdrant',\n        mode: 'success',\n        latency_ms: Date.now() - startTime,\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  }];\n} catch (e) {\n  return [{\n    json: {\n      success: false,\n      _trace: {\n        service_response: { error: e.message },\n        provider: 'api',\n        mode: 'error',\n        latency_ms: Date.now() - startTime,\n        user_id: userId,\n        guild_id: guildId,\n        user_request: userRequest\n      },\n      error: {\n        code: 'PROCESS_ERROR',\n        message: 'Failed to process save: ' + e.message,\n        http_status: 500\n      },\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  }];\n}"
       },
       "id": "format-output",
       "name": "Format Output",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        2496,
-        208
-      ]
+      "position": [2496, 208]
     },
     {
       "parameters": {
         "respondWith": "json",
-        "responseBody": "={{ $json }}",
-        "options": {}
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
       },
       "id": "respond-success",
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        2736,
-        208
-      ]
-    },
-    {
-      "parameters": {
-        "content": "## Recipes - Save\n\n**Endpoint:** POST /webhook/recipes-save\n\n**Parameters:**\n- `recipe` (required): Full recipe object\n- `user_id` or `discord_user_id` (required): User identifier\n- `store_embedding` (optional): Store in Qdrant (default: true)\n- `llm_metadata` (optional): Provider info for tracking\n\n**Actions:** Generates embedding → Stores in Qdrant → Saves to API",
-        "height": 180,
-        "width": 550,
-        "color": 4
-      },
-      "id": "sticky-note-doc",
-      "name": "API Documentation",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [
-        240,
-        80
-      ]
+      "position": [2736, 208]
     },
     {
       "parameters": {
@@ -312,10 +293,7 @@
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        2048,
-        208
-      ],
+      "position": [2048, 208],
       "id": "3d15bfbd-98da-4453-8922-44f420eef961",
       "name": "Parse json"
     }
@@ -354,7 +332,18 @@
         ],
         [
           {
-            "node": "Error: Validation",
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
             "type": "main",
             "index": 0
           }
@@ -472,31 +461,5 @@
     "executionOrder": "v1",
     "callerPolicy": "workflowsFromSameOwner",
     "availableInMCP": false
-  },
-  "staticData": null,
-  "meta": null,
-  "pinData": {},
-  "versionId": "cfdd3ddf-4764-48c5-a23e-169ebafea295",
-  "activeVersionId": "cfdd3ddf-4764-48c5-a23e-169ebafea295",
-  "versionCounter": 78,
-  "triggerCount": 1,
-  "tags": [],
-  "shared": [
-    {
-      "updatedAt": "2026-01-07T11:14:58.278Z",
-      "createdAt": "2026-01-07T11:14:58.278Z",
-      "role": "workflow:owner",
-      "workflowId": "deFTjJpRp8ulaj3H",
-      "projectId": "rkp1YaKKlE3ExOIx",
-      "project": {
-        "updatedAt": "2025-12-03T16:40:05.384Z",
-        "createdAt": "2025-12-03T14:59:10.085Z",
-        "id": "rkp1YaKKlE3ExOIx",
-        "name": "Franck Sebbah <franck.sebbah@gmail.com>",
-        "type": "personal",
-        "icon": null,
-        "description": null
-      }
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

Implémentation de RFC-049 : Architecture de stockage des entités unifiant MongoDB, PostgreSQL et Qdrant.

### Nouveaux webhooks créés

| Webhook | Description |
|---------|-------------|
| **MCP - Tenant - Resolve** | Résout Discord user_id → tenant_id |
| **MCP - Entity - Save** | Sauvegarde MongoDB + Qdrant (remplace MCP Qdrant - Save) |
| **MCP - Entity - Search** | Recherche Qdrant + enrichissement MongoDB (remplace MCP Qdrant - Search) |
| **MCP - Entity - Rating** | Notes 1-5 (PostgreSQL) |
| **MCP - Entity - Comment** | Commentaires (PostgreSQL) |

### Documentation

- `docs/rfc/RFC-049-ENTITY-STORAGE-ARCHITECTURE.md` - Architecture complète
- `docs/issues/ISSUE-014-RFC049-IMPLEMENTATION-PLAN.md` - Plan d'implémentation
- `docs/RFC-049-MIGRATION-GUIDE.md` - Guide de migration pour les équipes
- `docs/issues/ISSUE-013-ITEMS-RATING-COMMENT-WEBHOOKS.md` - Marqué SUPERSEDED

### Changements clés

- **tenant_id obligatoire** via header `X-Tenant-ID`
- **Même UUID** pour entity_id (MongoDB) et qdrant_point_id (Qdrant)
- **Multi-tenant Qdrant** avec filtrage automatique par tenant_id
- **Endpoint batch** pour enrichissement performant

### Prérequis

Les endpoints API Backend définis dans RFC-049 doivent être implémentés avant utilisation en production.

### Cohabitation

Les anciens webhooks `MCP Qdrant - Save` et `MCP Qdrant - Search` restent fonctionnels (deprecated).

## Test plan

- [ ] Importer les 5 workflows dans n8n
- [ ] Vérifier les InputSchema dans le registry MCP
- [ ] Tester avec API Backend mockée
- [ ] Valider le guide de migration avec chatbot-core

🤖 Generated with [Claude Code](https://claude.com/claude-code)