### PR TITLE
feat(n8n): RFC-061 Discord group channels workflows

### DIFF
--- a/workflows/GUILD_-_Category_Create.json
+++ b/workflows/GUILD_-_Category_Create.json
@@ -1,0 +1,128 @@
+{
+  "name": "GUILD - Category Create",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord/category/create",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "discord-category-create"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://discord.com/api/v10/guilds/{{ $json.body.guild_id }}/channels",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"name\": \"{{ $json.body.name }}\",\n  \"type\": 4\n}",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "discord-api",
+      "name": "Create Category (Discord)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const discordResponse = $input.first().json;\n\nif (discordResponse.id) {\n  return {\n    success: true,\n    category_id: discordResponse.id,\n    name: discordResponse.name\n  };\n} else {\n  return {\n    success: false,\n    error: discordResponse.message || 'Unknown error',\n    code: discordResponse.code\n  };\n}"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Create Category (Discord)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Category (Discord)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    }
+  ]
+}

--- a/workflows/GUILD_-_Channel_Create.json
+++ b/workflows/GUILD_-_Channel_Create.json
@@ -1,0 +1,260 @@
+{
+  "name": "GUILD - Channel Create",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord/channel/create",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "discord-channel-create"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body;\n\n// Build permission_overwrites for private channel\nconst permissionOverwrites = [];\nif (body.private) {\n  permissionOverwrites.push({\n    id: body.guild_id,\n    type: 0,\n    deny: \"1024\"  // VIEW_CHANNEL\n  });\n}\n\nreturn {\n  guild_id: body.guild_id,\n  category_id: body.category_id,\n  name: body.name,\n  topic: body.topic || '',\n  private: body.private || false,\n  create_invite: body.create_invite || false,\n  invite_max_age: body.invite_max_age || 604800,\n  permission_overwrites: permissionOverwrites\n};"
+      },
+      "id": "prepare-data",
+      "name": "Prepare Channel Data",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [470, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://discord.com/api/v10/guilds/{{ $json.guild_id }}/channels",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"name\": \"{{ $json.name }}\",\n  \"type\": 0,\n  \"parent_id\": {{ $json.category_id ? '\"' + $json.category_id + '\"' : 'null' }},\n  \"topic\": \"{{ $json.topic }}\",\n  \"permission_overwrites\": {{ JSON.stringify($json.permission_overwrites) }}\n}",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "create-channel",
+      "name": "Create Channel (Discord)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [690, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-invite",
+              "leftValue": "={{ $('Prepare Channel Data').item.json.create_invite }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-create-invite",
+      "name": "Create Invite?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [910, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://discord.com/api/v10/channels/{{ $('Create Channel (Discord)').item.json.id }}/invites",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"max_age\": {{ $('Prepare Channel Data').item.json.invite_max_age }},\n  \"max_uses\": 0,\n  \"temporary\": false\n}",
+        "options": {}
+      },
+      "id": "create-invite",
+      "name": "Create Invite (Discord)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1130, 200],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const channelData = $('Create Channel (Discord)').item.json;\nconst inviteData = $input.first().json;\nconst maxAge = $('Prepare Channel Data').item.json.invite_max_age;\n\n// Calculate expiration date\nconst expiresAt = new Date(Date.now() + maxAge * 1000).toISOString();\n\nreturn {\n  success: true,\n  channel_id: channelData.id,\n  channel_name: channelData.name,\n  invite_url: `https://discord.gg/${inviteData.code}`,\n  invite_expires_at: expiresAt\n};"
+      },
+      "id": "format-with-invite",
+      "name": "Format Response (with invite)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1350, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "const channelData = $('Create Channel (Discord)').item.json;\n\nreturn {\n  success: true,\n  channel_id: channelData.id,\n  channel_name: channelData.name,\n  invite_url: null,\n  invite_expires_at: null\n};"
+      },
+      "id": "format-without-invite",
+      "name": "Format Response (no invite)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1130, 400]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1570, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Prepare Channel Data",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Channel Data": {
+      "main": [
+        [
+          {
+            "node": "Create Channel (Discord)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Channel (Discord)": {
+      "main": [
+        [
+          {
+            "node": "Create Invite?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Invite?": {
+      "main": [
+        [
+          {
+            "node": "Create Invite (Discord)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format Response (no invite)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Invite (Discord)": {
+      "main": [
+        [
+          {
+            "node": "Format Response (with invite)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response (with invite)": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response (no invite)": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    }
+  ]
+}

--- a/workflows/GUILD_-_Channel_Delete.json
+++ b/workflows/GUILD_-_Channel_Delete.json
@@ -1,0 +1,116 @@
+{
+  "name": "GUILD - Channel Delete",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord/channel/delete",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "discord-channel-delete"
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "=https://discord.com/api/v10/channels/{{ $json.body.channel_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "delete-channel",
+      "name": "Delete Channel (Discord)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const discordResponse = $input.first().json;\n\n// Discord returns the deleted channel object on success\nif (discordResponse.id) {\n  return {\n    success: true,\n    channel_id: discordResponse.id,\n    channel_name: discordResponse.name\n  };\n} else {\n  return {\n    success: false,\n    error: discordResponse.message || 'Unknown error',\n    code: discordResponse.code\n  };\n}"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Delete Channel (Discord)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Delete Channel (Discord)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    }
+  ]
+}

--- a/workflows/GUILD_-_Invite_Renew.json
+++ b/workflows/GUILD_-_Invite_Renew.json
@@ -1,0 +1,128 @@
+{
+  "name": "GUILD - Invite Renew",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord/invite/renew",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "discord-invite-renew"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://discord.com/api/v10/channels/{{ $json.body.channel_id }}/invites",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"max_age\": {{ $json.body.max_age || 604800 }},\n  \"max_uses\": 0,\n  \"temporary\": false\n}",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "create-invite",
+      "name": "Create Invite (Discord)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const inviteData = $input.first().json;\nconst maxAge = $('Webhook').item.json.body.max_age || 604800;\n\nif (inviteData.code) {\n  const expiresAt = new Date(Date.now() + maxAge * 1000).toISOString();\n  \n  return {\n    success: true,\n    invite_url: `https://discord.gg/${inviteData.code}`,\n    invite_code: inviteData.code,\n    invite_expires_at: expiresAt,\n    max_age: maxAge\n  };\n} else {\n  return {\n    success: false,\n    error: inviteData.message || 'Unknown error',\n    code: inviteData.code\n  };\n}"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Create Invite (Discord)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Invite (Discord)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    }
+  ]
+}

--- a/workflows/GUILD_-_Invite_Renew_Cron.json
+++ b/workflows/GUILD_-_Invite_Renew_Cron.json
@@ -1,0 +1,376 @@
+{
+  "name": "GUILD - Invite Renew Cron",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "triggerAtHour": 3
+            }
+          ]
+        }
+      },
+      "id": "cron-trigger",
+      "name": "Daily 3AM",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [250, 300]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_URL }}/api/discord/admin/guilds/cron/renew-expiring-invites",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "get-expiring-invites",
+      "name": "Get Expiring Invites (Backend)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "backend-api",
+          "name": "Backend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-groups",
+              "leftValue": "={{ $json.groups?.length > 0 }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-groups-to-renew",
+      "name": "Groups to Renew?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "jsCode": "// No groups to renew\nreturn {\n  success: true,\n  renewed: 0,\n  message: 'No expiring invites found'\n};"
+      },
+      "id": "no-groups",
+      "name": "No Groups",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [910, 450]
+    },
+    {
+      "parameters": {
+        "fieldToSplitOut": "groups",
+        "options": {}
+      },
+      "id": "split-groups",
+      "name": "Split Groups",
+      "type": "n8n-nodes-base.splitOut",
+      "typeVersion": 1,
+      "position": [910, 150]
+    },
+    {
+      "parameters": {
+        "amount": 1,
+        "unit": "seconds"
+      },
+      "id": "wait-rate-limit",
+      "name": "Wait (Rate Limit)",
+      "type": "n8n-nodes-base.wait",
+      "typeVersion": 1.1,
+      "position": [1130, 150]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://discord.com/api/v10/channels/{{ $json.discord_channel_id }}/invites",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"max_age\": {{ $json.invite_max_age || 604800 }},\n  \"max_uses\": 0,\n  \"temporary\": false\n}",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "create-invite",
+      "name": "Create New Invite (Discord)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1350, 150],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const group = $('Split Groups').item.json;\nconst inviteData = $input.first().json;\nconst maxAge = group.invite_max_age || 604800;\n\nif (inviteData.code) {\n  return {\n    group_id: group.id,\n    guild_id: group.guild_id,\n    invite_url: `https://discord.gg/${inviteData.code}`,\n    invite_expires_at: new Date(Date.now() + maxAge * 1000).toISOString(),\n    success: true\n  };\n} else {\n  return {\n    group_id: group.id,\n    guild_id: group.guild_id,\n    error: inviteData.message || 'Unknown error',\n    success: false\n  };\n}"
+      },
+      "id": "format-invite-result",
+      "name": "Format Invite Result",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1570, 150]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-invite-success",
+      "name": "Invite Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1790, 150]
+    },
+    {
+      "parameters": {
+        "method": "PATCH",
+        "url": "={{ $env.BACKEND_URL }}/api/ecommerce/admin/guilds/{{ $json.guild_id }}/groups/{{ $json.group_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"discord_invite_url\": \"{{ $json.invite_url }}\",\n  \"discord_invite_expires_at\": \"{{ $json.invite_expires_at }}\"\n}",
+        "options": {}
+      },
+      "id": "update-group",
+      "name": "Update Group (Backend)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2010, 50],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "backend-api",
+          "name": "Backend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "aggregate": "aggregateAllItemData",
+        "options": {}
+      },
+      "id": "aggregate-results",
+      "name": "Aggregate Results",
+      "type": "n8n-nodes-base.aggregate",
+      "typeVersion": 1,
+      "position": [2230, 150]
+    },
+    {
+      "parameters": {
+        "jsCode": "const results = $input.first().json.data || [];\nconst renewed = results.filter(r => r.success !== false).length;\nconst failed = results.filter(r => r.success === false).length;\n\nreturn {\n  success: true,\n  renewed: renewed,\n  failed: failed,\n  total: results.length,\n  timestamp: new Date().toISOString()\n};"
+      },
+      "id": "summary",
+      "name": "Summary",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2450, 150]
+    }
+  ],
+  "connections": {
+    "Daily 3AM": {
+      "main": [
+        [
+          {
+            "node": "Get Expiring Invites (Backend)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Expiring Invites (Backend)": {
+      "main": [
+        [
+          {
+            "node": "Groups to Renew?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Groups to Renew?": {
+      "main": [
+        [
+          {
+            "node": "Split Groups",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "No Groups",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Groups": {
+      "main": [
+        [
+          {
+            "node": "Wait (Rate Limit)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Wait (Rate Limit)": {
+      "main": [
+        [
+          {
+            "node": "Create New Invite (Discord)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create New Invite (Discord)": {
+      "main": [
+        [
+          {
+            "node": "Format Invite Result",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Invite Result": {
+      "main": [
+        [
+          {
+            "node": "Invite Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Invite Success?": {
+      "main": [
+        [
+          {
+            "node": "Update Group (Backend)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Aggregate Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Update Group (Backend)": {
+      "main": [
+        [
+          {
+            "node": "Aggregate Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Aggregate Results": {
+      "main": [
+        [
+          {
+            "node": "Summary",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    },
+    {
+      "name": "cron"
+    }
+  ]
+}

--- a/workflows/GUILD_-_Student_Verify.json
+++ b/workflows/GUILD_-_Student_Verify.json
@@ -1,0 +1,454 @@
+{
+  "name": "GUILD - Student Verify",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord/student/verify",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "discord-student-verify"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_URL }}/api/discord/webhook/student-verify",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"guild_id\": \"{{ $json.body.guild_id }}\",\n  \"email\": \"{{ $json.body.email }}\"\n}",
+        "options": {}
+      },
+      "id": "lookup-student",
+      "name": "Lookup Student (Backend)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "backend-api",
+          "name": "Backend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-success",
+              "leftValue": "={{ $json.success }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-student-found",
+      "name": "Student Found?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={\n  \"success\": false,\n  \"error\": \"email_not_found\",\n  \"message\": \"Aucun eleve avec cet email\"\n}",
+        "options": {}
+      },
+      "id": "respond-not-found",
+      "name": "Respond Not Found",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 450]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "=https://discord.com/api/v10/channels/{{ $json.group.discord_channel_id }}/permissions/{{ $('Webhook').item.json.body.discord_user_id }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"allow\": \"68608\",\n  \"type\": 1\n}",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "add-to-group-channel",
+      "name": "Add to Group Channel",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [910, 150],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-personal-enabled",
+              "leftValue": "={{ $('Lookup Student (Backend)').item.json.group.personal_channels_enabled }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-personal-channel",
+      "name": "Personal Channel Enabled?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [1130, 150]
+    },
+    {
+      "parameters": {
+        "jsCode": "const studentData = $('Lookup Student (Backend)').item.json;\nconst discordUserId = $('Webhook').item.json.body.discord_user_id;\nconst guildId = $('Webhook').item.json.body.guild_id;\n\nconst permissionOverwrites = [\n  {\n    id: guildId,\n    type: 0,\n    deny: \"1024\"  // VIEW_CHANNEL denied for @everyone\n  },\n  {\n    id: discordUserId,\n    type: 1,\n    allow: \"68608\"  // VIEW + SEND + HISTORY for student\n  }\n];\n\n// Add profs role if configured\nif (studentData.group.profs_role_discord_id) {\n  permissionOverwrites.push({\n    id: studentData.group.profs_role_discord_id,\n    type: 0,\n    allow: \"68608\"  // VIEW + SEND + HISTORY for profs\n  });\n}\n\nreturn {\n  guild_id: guildId,\n  channel_name: studentData.group.channel_name,\n  parent_id: studentData.group.personal_channel_category_discord_id,\n  permission_overwrites: permissionOverwrites\n};"
+      },
+      "id": "prepare-personal-channel",
+      "name": "Prepare Personal Channel",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1350, 50]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://discord.com/api/v10/guilds/{{ $json.guild_id }}/channels",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"name\": \"{{ $json.channel_name }}\",\n  \"type\": 0,\n  \"parent_id\": {{ $json.parent_id ? '\"' + $json.parent_id + '\"' : 'null' }},\n  \"permission_overwrites\": {{ JSON.stringify($json.permission_overwrites) }}\n}",
+        "options": {
+          "retry": {
+            "maxTries": 3,
+            "retryInterval": 1000,
+            "retryIntervalExponential": true
+          }
+        }
+      },
+      "id": "create-personal-channel",
+      "name": "Create Personal Channel",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1570, 50],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "discord-bot-token",
+          "name": "Discord Bot Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_URL }}/api/discord/webhook/student-join-callback",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"student_id\": \"{{ $('Lookup Student (Backend)').item.json.student.id }}\",\n  \"discord_user_id\": \"{{ $('Webhook').item.json.body.discord_user_id }}\",\n  \"discord_channel_id\": \"{{ $json.id || null }}\"\n}",
+        "options": {}
+      },
+      "id": "callback-backend-with-channel",
+      "name": "Callback Backend (with channel)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1790, 50],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "backend-api",
+          "name": "Backend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.BACKEND_URL }}/api/discord/webhook/student-join-callback",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"student_id\": \"{{ $('Lookup Student (Backend)').item.json.student.id }}\",\n  \"discord_user_id\": \"{{ $('Webhook').item.json.body.discord_user_id }}\",\n  \"discord_channel_id\": null\n}",
+        "options": {}
+      },
+      "id": "callback-backend-no-channel",
+      "name": "Callback Backend (no channel)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1350, 250],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "backend-api",
+          "name": "Backend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const studentData = $('Lookup Student (Backend)').item.json;\nconst personalChannelId = $('Create Personal Channel')?.item?.json?.id || null;\n\nreturn {\n  success: true,\n  student: {\n    id: studentData.student.id,\n    firstname: studentData.student.firstname,\n    lastname: studentData.student.lastname,\n    group_name: studentData.group.name\n  },\n  actions_performed: {\n    added_to_group_channel: true,\n    personal_channel_created: personalChannelId !== null,\n    personal_channel_id: personalChannelId\n  }\n};"
+      },
+      "id": "format-success-with-channel",
+      "name": "Format Success (with channel)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2010, 50]
+    },
+    {
+      "parameters": {
+        "jsCode": "const studentData = $('Lookup Student (Backend)').item.json;\n\nreturn {\n  success: true,\n  student: {\n    id: studentData.student.id,\n    firstname: studentData.student.firstname,\n    lastname: studentData.student.lastname,\n    group_name: studentData.group.name\n  },\n  actions_performed: {\n    added_to_group_channel: true,\n    personal_channel_created: false,\n    personal_channel_id: null\n  }\n};"
+      },
+      "id": "format-success-no-channel",
+      "name": "Format Success (no channel)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1570, 250]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-success",
+      "name": "Respond Success",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2230, 150]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Lookup Student (Backend)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Lookup Student (Backend)": {
+      "main": [
+        [
+          {
+            "node": "Student Found?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Student Found?": {
+      "main": [
+        [
+          {
+            "node": "Add to Group Channel",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Not Found",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Add to Group Channel": {
+      "main": [
+        [
+          {
+            "node": "Personal Channel Enabled?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Personal Channel Enabled?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Personal Channel",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Callback Backend (no channel)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Personal Channel": {
+      "main": [
+        [
+          {
+            "node": "Create Personal Channel",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Create Personal Channel": {
+      "main": [
+        [
+          {
+            "node": "Callback Backend (with channel)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Callback Backend (with channel)": {
+      "main": [
+        [
+          {
+            "node": "Format Success (with channel)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Callback Backend (no channel)": {
+      "main": [
+        [
+          {
+            "node": "Format Success (no channel)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success (with channel)": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Success (no channel)": {
+      "main": [
+        [
+          {
+            "node": "Respond Success",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    }
+  ]
+}

--- a/workflows/GUILD_-_Tenant_Settings.json
+++ b/workflows/GUILD_-_Tenant_Settings.json
@@ -1,0 +1,110 @@
+{
+  "name": "GUILD - Tenant Settings",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "discord/tenant/settings",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [250, 300],
+      "webhookId": "discord-tenant-settings"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.BACKEND_URL }}/api/ecommerce/admin/guilds/{{ $json.body.guild_id }}/discord-settings",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {}
+      },
+      "id": "get-settings",
+      "name": "Get Discord Settings (Backend)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [470, 300],
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "backend-api",
+          "name": "Backend API"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "jsCode": "const settings = $input.first().json;\n\n// Return settings in format expected by chatbot-core\nreturn {\n  verification_enabled: settings.verification_enabled || false,\n  verification_method: settings.verification_method || 'button',\n  verification_channel_id: settings.verification_channel_id || null,\n  welcome_enabled: settings.welcome_enabled !== false,\n  welcome_title: settings.welcome_title || 'Bienvenue !',\n  welcome_message: settings.welcome_message || 'Pour finaliser ton inscription, entre ton email.',\n  welcome_color: settings.welcome_color || 5865426,\n  welcome_thumbnail_url: settings.welcome_thumbnail_url || null,\n  welcome_footer_text: settings.welcome_footer_text || 'Reponds directement a ce message',\n  verification_success_message: settings.verification_success_message || '✅ Email verifie ! Tu as maintenant acces a tes channels.',\n  verification_error_message: settings.verification_error_message || '❌ Email non reconnu. Verifie et reessaie.',\n  verification_retry_message: settings.verification_retry_message || '🔄 Reessaie avec ton email exact.',\n  verification_timeout_hours: settings.verification_timeout_hours || 24,\n  verification_reminder_hours: settings.verification_reminder_hours || 6,\n  timeout_action: settings.timeout_action || 'remind'\n};"
+      },
+      "id": "format-settings",
+      "name": "Format Settings",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [690, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $json }}",
+        "options": {}
+      },
+      "id": "respond-webhook",
+      "name": "Respond to Webhook",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [910, 300]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Get Discord Settings (Backend)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Discord Settings (Backend)": {
+      "main": [
+        [
+          {
+            "node": "Format Settings",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Settings": {
+      "main": [
+        [
+          {
+            "node": "Respond to Webhook",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "staticData": null,
+  "tags": [
+    {
+      "name": "guild"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "rfc-061"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implementation des 7 workflows n8n pour RFC-061 (Discord Group Channels).

## Workflows créés

| Workflow | Type | Path | Description |
|----------|------|------|-------------|
| `GUILD - Category Create` | Webhook | `discord/category/create` | Créer catégorie Discord |
| `GUILD - Channel Create` | Webhook | `discord/channel/create` | Créer channel + invitation |
| `GUILD - Channel Delete` | Webhook | `discord/channel/delete` | Supprimer channel (cascade) |
| `GUILD - Invite Renew` | Webhook | `discord/invite/renew` | Renouveler invitation |
| `GUILD - Student Verify` | Webhook | `discord/student/verify` | Vérifier email + permissions |
| `GUILD - Tenant Settings` | Webhook | `discord/tenant/settings` | Récupérer branding (chatbot-core) |
| `GUILD - Invite Renew Cron` | Cron | - | Renouvellement quotidien 3h |

## Features

- Rate limiting : retry + exponential backoff natif
- Debounce : Wait node (1s) pour batch operations
- Callback backend après vérification étudiant
- Support channels personnels par étudiant
- Gestion `profs_role_discord_id` pour permissions

## Credentials requis

- `discord-bot-token` : Header Auth pour Discord API
- `backend-api` : Header Auth pour Backend API

## Test plan

- [ ] Configurer credentials dans n8n
- [ ] Activer les 7 workflows
- [ ] Tester webhook `category-create`
- [ ] Tester webhook `channel-create` avec invite
- [ ] Tester flow complet `student-verify`
- [ ] Vérifier cron `invite-renew` (exécution manuelle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)