### PR TITLE
feat(torah): add corpus catalog webhooks

### DIFF
--- a/docs/guides/TORAH_WEBHOOKS_V2.md
+++ b/docs/guides/TORAH_WEBHOOKS_V2.md
@@ -379,6 +379,157 @@ GET /webhook/torah-sources
 
 ---
 
+## 8. GET /webhook/torah-corpus (NOUVEAU v2)
+
+Liste des corpus du catalogue (9 corpus seedes).
+
+### Request
+
+```
+GET /webhook/torah-corpus
+```
+
+Pas de parametres.
+
+### Response
+
+```json
+{
+  "success": true,
+  "corpus": [
+    {
+      "id": "uuid",
+      "name": "Bavli",
+      "hebrew_name": "בבלי",
+      "aliases": {
+        "sefaria": ["Talmud/Bavli", "Babylonian Talmud"],
+        "french": ["Talmud de Babylone", "Talmud Bavli"],
+        "variants": ["Talmud Babli", "Gemara"]
+      }
+    },
+    {
+      "id": "uuid",
+      "name": "Yerushalmi",
+      "hebrew_name": "ירושלמי",
+      "aliases": {
+        "sefaria": ["Talmud/Yerushalmi", "Jerusalem Talmud"],
+        "french": ["Talmud de Jerusalem"],
+        "variants": []
+      }
+    }
+  ],
+  "count": 9
+}
+```
+
+**Usage:** Alimenter un menu deroulant pour selection du corpus.
+
+---
+
+## 9. GET /webhook/torah-corpus-sedarim (NOUVEAU v2)
+
+Liste des sedarim d'un corpus.
+
+### Request
+
+```
+GET /webhook/torah-corpus-sedarim?corpus=Bavli
+```
+
+| Param | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `corpus` | string | Oui | Nom canonique ou alias du corpus |
+
+### Response (succes)
+
+```json
+{
+  "success": true,
+  "corpus": "Bavli",
+  "sedarim": [
+    {
+      "id": "uuid",
+      "name": "Zeraim",
+      "hebrew_name": "זרעים",
+      "aliases": {}
+    },
+    {
+      "id": "uuid",
+      "name": "Moed",
+      "hebrew_name": "מועד",
+      "aliases": {}
+    }
+  ],
+  "count": 6
+}
+```
+
+### Response (erreur 404)
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 404,
+    "message": "Corpus not found: 'XYZ'",
+    "status": "NOT_FOUND"
+  }
+}
+```
+
+---
+
+## 10. GET /webhook/torah-corpus-traites (NOUVEAU v2)
+
+Liste des traites et pages d'un seder.
+
+### Request
+
+```
+GET /webhook/torah-corpus-traites?corpus=Bavli&seder=Zeraim
+```
+
+| Param | Type | Requis | Description |
+|-------|------|--------|-------------|
+| `corpus` | string | Oui | Nom canonique ou alias du corpus |
+| `seder` | string | Oui | Nom canonique ou alias du seder |
+
+### Response (succes)
+
+```json
+{
+  "success": true,
+  "corpus": "Bavli",
+  "seder": "Zeraim",
+  "traites": [
+    {
+      "id": "uuid-project",
+      "name": "Berakhot",
+      "pages": ["2a", "2b", "3a", "3b", "..."],
+      "pages_count": 127
+    }
+  ],
+  "count": 1
+}
+```
+
+### Response (erreur 404)
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": 404,
+    "message": "Seder not found: 'XYZ' in corpus 'Bavli'",
+    "status": "NOT_FOUND"
+  }
+}
+```
+
+**Usage:** Construire un picker hierarchique `Corpus → Seder → Traite → Page`
+
+---
+
 ## Gestion des erreurs
 
 ### AmbiguousReferenceError (HTTP 400)
@@ -455,6 +606,9 @@ Les workflows acceptent temporairement les deux formats:
 | torah-router | qPhg64qfExkYEMsI | Active |
 | torah-vocalization | 8SzNofDdhn4J16Zq | Active |
 | torah-sources | (a verifier) | Active |
+| torah-corpus | AfTOoUOzRD2fF5cG | Active |
+| torah-corpus-sedarim | p3I65tQo5eoYndum | Active |
+| torah-corpus-traites | ILoUSDjcNOZBxmYs | Active |
 
 ---
 

--- a/workflows/Torah_Corpus.json
+++ b/workflows/Torah_Corpus.json
@@ -1,0 +1,123 @@
+{
+  "name": "Torah Corpus",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Corpus\n\n**Endpoint:** GET /webhook/torah-corpus\n\n**Description:** Liste des 9 corpus du catalogue Torah.\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"corpus\": [\n    {\n      \"id\": \"uuid\",\n      \"name\": \"Bavli\",\n      \"hebrew_name\": \"בבלי\",\n      \"aliases\": {...}\n    }\n  ],\n  \"count\": 9\n}\n```",
+        "height": 350,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [64, 64]
+    },
+    {
+      "parameters": {
+        "path": "torah-corpus",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-corpus"
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.API_URL }}/api/corpus",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "get-corpus-api",
+      "name": "Get Corpus (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [620, 300],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format API response\nconst input = $input.first().json;\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// API error\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.detail?.message || data.message || 'Erreur API',\n        status: statusCode === 404 ? 'NOT_FOUND' : 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Success response\nreturn [{\n  json: {\n    success: true,\n    ...data\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? ($json.error.code || 500) : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-webhook",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 300]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Get Corpus (API)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Corpus (API)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah_Corpus_Sedarim.json
+++ b/workflows/Torah_Corpus_Sedarim.json
@@ -1,0 +1,213 @@
+{
+  "name": "Torah Corpus Sedarim",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Corpus Sedarim\n\n**Endpoint:** GET /webhook/torah-corpus-sedarim\n\n**Query:**\n- `corpus`: Nom du corpus (ex: Bavli)\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"corpus\": \"Bavli\",\n  \"sedarim\": [\n    {\n      \"id\": \"uuid\",\n      \"name\": \"Zeraim\",\n      \"hebrew_name\": \"זרעים\"\n    }\n  ],\n  \"count\": 6\n}\n```\n\n**Erreur 404:** Corpus non trouve",
+        "height": 400,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [64, 64]
+    },
+    {
+      "parameters": {
+        "path": "torah-corpus-sedarim",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-corpus-sedarim"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse and validate parameters\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst corpus = query.corpus || null;\n\n// Validation\nif (!corpus) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: 'Le parametre \"corpus\" est requis',\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    corpus: corpus\n  }\n}];"
+      },
+      "id": "parse-params",
+      "name": "Parse Parameters",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.API_URL }}/api/corpus/{{ encodeURIComponent($json.corpus) }}/sedarim",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "get-sedarim-api",
+      "name": "Get Sedarim (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format API response\nconst input = $input.first().json;\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// 404 - Corpus not found\nif (statusCode === 404) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: data.detail?.message || data.detail || 'Corpus non trouve',\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Other API error\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.detail?.message || data.message || 'Erreur API',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Success response\nreturn [{\n  json: {\n    success: true,\n    ...data\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? ($json.error.code || 500) : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1500, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Parameters": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Sedarim (API)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Sedarim (API)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "staticData": null,
+  "tags": []
+}

--- a/workflows/Torah_Corpus_Traites.json
+++ b/workflows/Torah_Corpus_Traites.json
@@ -1,0 +1,213 @@
+{
+  "name": "Torah Corpus Traites",
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Torah Corpus Traites\n\n**Endpoint:** GET /webhook/torah-corpus-traites\n\n**Query:**\n- `corpus`: Nom du corpus (ex: Bavli)\n- `seder`: Nom du seder (ex: Zeraim)\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"corpus\": \"Bavli\",\n  \"seder\": \"Zeraim\",\n  \"traites\": [\n    {\n      \"id\": \"uuid\",\n      \"name\": \"Berakhot\",\n      \"pages\": [\"2a\", \"2b\", ...],\n      \"pages_count\": 127\n    }\n  ],\n  \"count\": 1\n}\n```\n\n**Erreur 404:** Corpus ou seder non trouve",
+        "height": 450,
+        "width": 320,
+        "color": 5
+      },
+      "id": "sticky-doc",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [64, 64]
+    },
+    {
+      "parameters": {
+        "path": "torah-corpus-traites",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-trigger",
+      "name": "Webhook Trigger",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [400, 300],
+      "webhookId": "torah-corpus-traites"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Parse and validate parameters\nconst input = $input.first().json;\nconst query = input.query || {};\n\nconst corpus = query.corpus || null;\nconst seder = query.seder || null;\n\n// Validation\nconst errors = [];\nif (!corpus) errors.push('Le parametre \"corpus\" est requis');\nif (!seder) errors.push('Le parametre \"seder\" est requis');\n\nif (errors.length > 0) {\n  return [{\n    json: {\n      valid: false,\n      error: {\n        code: 400,\n        message: errors.join(', '),\n        status: 'BAD_REQUEST'\n      }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    corpus: corpus,\n    seder: seder\n  }\n}];"
+      },
+      "id": "parse-params",
+      "name": "Parse Parameters",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [620, 300]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "check-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [840, 300]
+    },
+    {
+      "parameters": {
+        "url": "={{ $env.API_URL }}/api/corpus/{{ encodeURIComponent($json.corpus) }}/sedarim/{{ encodeURIComponent($json.seder) }}",
+        "options": {
+          "response": {
+            "response": {
+              "fullResponse": true
+            }
+          },
+          "timeout": 30000
+        }
+      },
+      "id": "get-traites-api",
+      "name": "Get Traites (API)",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1060, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Format API response\nconst input = $input.first().json;\nconst data = input.body || input;\nconst statusCode = input.statusCode || 200;\n\n// 404 - Corpus or seder not found\nif (statusCode === 404) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: 404,\n        message: data.detail?.message || data.detail || 'Corpus ou seder non trouve',\n        status: 'NOT_FOUND'\n      }\n    }\n  }];\n}\n\n// Other API error\nif (statusCode >= 400) {\n  return [{\n    json: {\n      success: false,\n      error: {\n        code: statusCode,\n        message: data.detail?.message || data.message || 'Erreur API',\n        status: 'API_ERROR'\n      }\n    }\n  }];\n}\n\n// Success response\nreturn [{\n  json: {\n    success: true,\n    ...data\n  }\n}];"
+      },
+      "id": "format-response",
+      "name": "Format Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1280, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error ? ($json.error.code || 500) : 200 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1500, 200]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.error?.code || 400 }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1060, 400]
+    }
+  ],
+  "connections": {
+    "Webhook Trigger": {
+      "main": [
+        [
+          {
+            "node": "Parse Parameters",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse Parameters": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Get Traites (API)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Traites (API)": {
+      "main": [
+        [
+          {
+            "node": "Format Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Response": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "staticData": null,
+  "tags": []
+}


### PR DESCRIPTION
## Summary

Add 3 new webhooks for hierarchical corpus navigation (picker Corpus → Seder → Traite → Page).

## New Webhooks

| Webhook | Workflow ID | Endpoint API |
|---------|-------------|--------------|
| `torah-corpus` | AfTOoUOzRD2fF5cG | `GET /api/corpus` |
| `torah-corpus-sedarim` | p3I65tQo5eoYndum | `GET /api/corpus/{corpus}/sedarim` |
| `torah-corpus-traites` | ILoUSDjcNOZBxmYs | `GET /api/corpus/{corpus}/sedarim/{seder}` |

## Usage

```
GET /webhook/torah-corpus
GET /webhook/torah-corpus-sedarim?corpus=Bavli
GET /webhook/torah-corpus-traites?corpus=Bavli&seder=Zeraim
```

## Documentation

Updated `docs/guides/TORAH_WEBHOOKS_V2.md` with sections 8, 9, 10.

## Test plan

- [ ] Test torah-corpus returns list of 9 corpus
- [ ] Test torah-corpus-sedarim with valid corpus
- [ ] Test torah-corpus-sedarim with invalid corpus (404)
- [ ] Test torah-corpus-traites with valid corpus/seder
- [ ] Test torah-corpus-traites with invalid seder (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)