### PR TITLE
fix(classroom): correct custom node type format

### DIFF
--- a/custom-nodes/package.json
+++ b/custom-nodes/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "n8n-nodes-calendar-dynamic": "file:./n8n-nodes-calendar-dynamic",
+    "n8n-nodes-classroom-dynamic": "file:./n8n-nodes-classroom-dynamic",
     "n8n-nodes-contacts-dynamic": "file:./n8n-nodes-contacts-dynamic",
     "n8n-nodes-drive-dynamic": "file:./n8n-nodes-drive-dynamic",
     "n8n-nodes-gemini-image": "file:./n8n-nodes-gemini-image",

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,10 @@ services:
     ports:
       - "5678:5678"
     env_file:
-      - .env.local
+      - ../.env.local
+    environment:
+      # Custom nodes path (required for n8n to load them)
+      - N8N_CUSTOM_EXTENSIONS=/home/node/.n8n/nodes
 
     volumes:
       # Données persistantes n8n (fichiers binaires, logs, cache)

--- a/workflows/MCP_-_Google_Classroom_Server.json
+++ b/workflows/MCP_-_Google_Classroom_Server.json
@@ -431,7 +431,7 @@
     {
       "id": "course-create-001",
       "name": "course_create",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 100],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -448,7 +448,7 @@
     {
       "id": "course-get-001",
       "name": "course_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 160],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -461,7 +461,7 @@
     {
       "id": "course-getAll-001",
       "name": "course_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 220],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -476,7 +476,7 @@
     {
       "id": "course-update-001",
       "name": "course_update",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 280],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -494,7 +494,7 @@
     {
       "id": "course-delete-001",
       "name": "course_delete",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 340],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -507,7 +507,7 @@
     {
       "id": "course-archive-001",
       "name": "course_archive",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 400],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -520,7 +520,7 @@
     {
       "id": "courseWork-create-001",
       "name": "courseWork_create",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 480],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -541,7 +541,7 @@
     {
       "id": "courseWork-get-001",
       "name": "courseWork_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 540],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -555,7 +555,7 @@
     {
       "id": "courseWork-getAll-001",
       "name": "courseWork_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 600],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -570,7 +570,7 @@
     {
       "id": "courseWork-update-001",
       "name": "courseWork_update",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 660],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -591,7 +591,7 @@
     {
       "id": "courseWork-delete-001",
       "name": "courseWork_delete",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 720],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -605,7 +605,7 @@
     {
       "id": "studentSubmission-get-001",
       "name": "studentSubmission_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 800],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -620,7 +620,7 @@
     {
       "id": "studentSubmission-getAll-001",
       "name": "studentSubmission_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 860],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -636,7 +636,7 @@
     {
       "id": "studentSubmission-grade-001",
       "name": "studentSubmission_grade",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 920],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -653,7 +653,7 @@
     {
       "id": "studentSubmission-return-001",
       "name": "studentSubmission_return",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 980],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -668,7 +668,7 @@
     {
       "id": "student-create-001",
       "name": "student_create",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1060],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -682,7 +682,7 @@
     {
       "id": "student-get-001",
       "name": "student_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1120],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -696,7 +696,7 @@
     {
       "id": "student-getAll-001",
       "name": "student_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1180],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -711,7 +711,7 @@
     {
       "id": "student-delete-001",
       "name": "student_delete",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1240],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -725,7 +725,7 @@
     {
       "id": "teacher-create-001",
       "name": "teacher_create",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1320],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -739,7 +739,7 @@
     {
       "id": "teacher-get-001",
       "name": "teacher_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1380],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -753,7 +753,7 @@
     {
       "id": "teacher-getAll-001",
       "name": "teacher_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1440],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -768,7 +768,7 @@
     {
       "id": "teacher-delete-001",
       "name": "teacher_delete",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1500],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -782,7 +782,7 @@
     {
       "id": "announcement-create-001",
       "name": "announcement_create",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1580],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -798,7 +798,7 @@
     {
       "id": "announcement-get-001",
       "name": "announcement_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1640],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -812,7 +812,7 @@
     {
       "id": "announcement-getAll-001",
       "name": "announcement_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1700],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -827,7 +827,7 @@
     {
       "id": "announcement-update-001",
       "name": "announcement_update",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1760],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -844,7 +844,7 @@
     {
       "id": "announcement-delete-001",
       "name": "announcement_delete",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1820],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -858,7 +858,7 @@
     {
       "id": "topic-create-001",
       "name": "topic_create",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1900],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -872,7 +872,7 @@
     {
       "id": "topic-get-001",
       "name": "topic_get",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 1960],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -886,7 +886,7 @@
     {
       "id": "topic-getAll-001",
       "name": "topic_getAll",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 2020],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -901,7 +901,7 @@
     {
       "id": "topic-update-001",
       "name": "topic_update",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 2080],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",
@@ -916,7 +916,7 @@
     {
       "id": "topic-delete-001",
       "name": "topic_delete",
-      "type": "n8n-nodes-classroom-dynamic.classroomToolDynamic",
+      "type": "CUSTOM.classroomToolDynamic",
       "position": [760, 2140],
       "parameters": {
         "accessToken": "={{ $json.body.access_token }}",


### PR DESCRIPTION
## Summary
- Fix node type format from `n8n-nodes-classroom-dynamic.classroomToolDynamic` to `CUSTOM.classroomToolDynamic` (33 occurrences)
- Add `N8N_CUSTOM_EXTENSIONS` environment variable in docker-compose.yml
- Fix `.env.local` path to reference parent directory (`../.env.local`)
- Register `n8n-nodes-classroom-dynamic` in `custom-nodes/package.json`

## Problem
The MCP - Google Classroom Server workflow was failing with:
```
Unrecognized node type: n8n-nodes-classroom-dynamic.classroomToolDynamic
```

## Root Cause
n8n requires custom nodes to use the `CUSTOM.` prefix format, not the npm package name format.

| Format | Status |
|--------|--------|
| `CUSTOM.classroomToolDynamic` | ✅ Works |
| `n8n-nodes-classroom-dynamic.classroomToolDynamic` | ❌ Fails |

## Test plan
- [x] Verify workflow imports successfully in n8n
- [x] Verify workflow activates without errors
- [x] Confirm `CUSTOM.classroomToolDynamic` nodes are recognized

## Related
- RFC-083: MCP Google Classroom Server
- PR #346 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)