### PR TITLE
feat(webhooks): Multi-provider BYOT pattern for LLM webhooks

### DIFF
--- a/workflows/LLM_-_Call_Messages.json
+++ b/workflows/LLM_-_Call_Messages.json
@@ -1,0 +1,516 @@
+{
+  "name": "LLM - Call Messages",
+  "description": "Multi-provider LLM webhook (BYOT pattern) - Supports Anthropic, OpenAI, Mistral",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## LLM - Call Messages (Multi-Provider BYOT)\n\n**Endpoint:** POST /webhook/llm-call-messages\n\n**Description:** Appel LLM synchrone multi-provider avec pattern BYOT (Bring Your Own Token).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"provider\", \"model\", \"api_key\", \"messages\"],\n  \"properties\": {\n    \"provider\": { \"type\": \"string\", \"enum\": [\"anthropic\", \"openai\", \"mistral\"] },\n    \"model\": { \"type\": \"string\", \"description\": \"Model ID (ex: claude-sonnet-4-20250514, gpt-4o)\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"API key for the provider (REQUIRED, no fallback)\" },\n    \"system\": { \"type\": \"string\", \"description\": \"System prompt\" },\n    \"messages\": { \"type\": \"array\", \"description\": \"Messages array [{role, content}]\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 4096 },\n    \"temperature\": { \"type\": \"number\", \"default\": 0.7, \"minimum\": 0, \"maximum\": 2 },\n    \"metadata\": { \"type\": \"object\", \"description\": \"Passthrough metadata\" }\n  }\n}\n```\n\n**Providers supportes:**\n- `anthropic` → Claude (claude-sonnet-4-20250514, claude-haiku-4-5-20251001, etc.)\n- `openai` → GPT (gpt-4o, gpt-4o-mini, etc.)\n- `mistral` → Mistral (mistral-large-latest, mistral-medium, etc.)\n\n**BYOT Pattern:** api_key est OBLIGATOIRE. Aucun fallback sur les variables d'environnement.",
+        "height": 700,
+        "width": 450,
+        "color": 4
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "llm-call-messages",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-llm",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [260, 340],
+      "webhookId": "llm-call-messages-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Call Messages (BYOT)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider} (doit etre: ${validProviders.join(', ')})`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string' || model.trim().length === 0) {\n  errors.push('model requis (ex: claude-sonnet-4-20250514, gpt-4o)');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length === 0) {\n  errors.push('api_key requis (BYOT pattern - aucun fallback sur env)');\n}\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis (array non vide)');\n}\n\n// --- Optional: system prompt ---\nconst system = body.system || ctx.system || null;\n\n// --- Optional: max_tokens ---\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 4096);\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 200000) {\n  errors.push('max_tokens doit etre entre 1 et 200000');\n}\n\n// --- Optional: temperature ---\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// --- Passthrough metadata ---\nconst metadata = body.metadata || ctx.metadata || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    metadata: metadata\n  };\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  temperature: temperature,\n  metadata: metadata,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 340]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [700, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  metadata: input.metadata,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0\n  }\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 520]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 520]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "anthropic",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "anthropic"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "openai",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "openai"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "mistral",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "mistral"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-provider",
+      "name": "Switch Provider",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [920, 240]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const body = {\n    model: data.model,\n    max_tokens: data.max_tokens,\n    temperature: data.temperature,\n    messages: data.messages\n  };\n  if (data.system) {\n    body.system = data.system;\n  }\n  return JSON.stringify(body);\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-anthropic",
+      "name": "Anthropic API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 80],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const messages = [];\n  if (data.system) {\n    messages.push({ role: 'system', content: data.system });\n  }\n  messages.push(...data.messages);\n  return JSON.stringify({\n    model: data.model,\n    messages: messages,\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-openai",
+      "name": "OpenAI API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 240],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.mistral.ai/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const messages = [];\n  if (data.system) {\n    messages.push({ role: 'system', content: data.system });\n  }\n  messages.push(...data.messages);\n  return JSON.stringify({\n    model: data.model,\n    messages: messages,\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-mistral",
+      "name": "Mistral API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 400],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ANTHROPIC RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: input.error.type || 'ANTHROPIC_ERROR',\n      message: input.error.message || 'Anthropic API error',\n      http_status: 500\n    },\n    metadata: prevData.metadata,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'anthropic',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: latencyMs\n    }\n  };\n}\n\nconst text = input.content?.[0]?.text || '';\nconst stopReason = input.stop_reason || 'end_turn';\nconst modelUsed = input.model || prevData.model;\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: stopReason\n  },\n  meta: {\n    provider: 'anthropic',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.input_tokens || 0,\n      completion_tokens: input.usage?.output_tokens || 0,\n      total_tokens: (input.usage?.input_tokens || 0) + (input.usage?.output_tokens || 0)\n    }\n  },\n  metadata: prevData.metadata,\n  _trace: {\n    llm_response: text,\n    service_response: input,\n    provider: 'anthropic',\n    model: modelUsed,\n    tokens: {\n      input: input.usage?.input_tokens || 0,\n      output: input.usage?.output_tokens || 0\n    },\n    latency_ms: latencyMs\n  }\n};"
+      },
+      "id": "format-anthropic",
+      "name": "Format Anthropic",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 80]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: input.error.code || 'OPENAI_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    metadata: prevData.metadata,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: latencyMs\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'openai',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  metadata: prevData.metadata,\n  _trace: {\n    llm_response: text,\n    service_response: input,\n    provider: 'openai',\n    model: modelUsed,\n    tokens: {\n      input: input.usage?.prompt_tokens || 0,\n      output: input.usage?.completion_tokens || 0\n    },\n    latency_ms: latencyMs\n  }\n};"
+      },
+      "id": "format-openai",
+      "name": "Format OpenAI",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 240]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT MISTRAL RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Handle error response\nif (input.error || input.message) {\n  return {\n    success: false,\n    error: {\n      code: 'MISTRAL_ERROR',\n      message: input.message || input.error?.message || 'Mistral API error',\n      http_status: 500\n    },\n    metadata: prevData.metadata,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'mistral',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: latencyMs\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'mistral',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  metadata: prevData.metadata,\n  _trace: {\n    llm_response: text,\n    service_response: input,\n    provider: 'mistral',\n    model: modelUsed,\n    tokens: {\n      input: input.usage?.prompt_tokens || 0,\n      output: input.usage?.completion_tokens || 0\n    },\n    latency_ms: latencyMs\n  }\n};"
+      },
+      "id": "format-mistral",
+      "name": "Format Mistral",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 400]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "mergeByFields": {
+          "values": []
+        },
+        "options": {}
+      },
+      "id": "merge-responses",
+      "name": "Merge",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1620, 240]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1860, 240]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Switch Provider",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Provider": {
+      "main": [
+        [
+          {
+            "node": "Anthropic API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "OpenAI API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Mistral API",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Anthropic API": {
+      "main": [
+        [
+          {
+            "node": "Format Anthropic",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI API": {
+      "main": [
+        [
+          {
+            "node": "Format OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mistral API": {
+      "main": [
+        [
+          {
+            "node": "Format Mistral",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Anthropic": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Mistral": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  },
+  "staticData": null,
+  "tags": ["llm", "multi-provider", "byot"]
+}

--- a/workflows/MCP_-_Text_Generator.json
+++ b/workflows/MCP_-_Text_Generator.json
@@ -1,27 +1,20 @@
 {
-  "updatedAt": "2026-03-24T20:22:38.555Z",
-  "createdAt": "2025-12-15T15:00:57.138Z",
-  "id": "RipM3vFw09xhPtXR",
   "name": "MCP - Text Generator",
-  "description": null,
+  "description": "Multi-provider text generation webhook (BYOT pattern) - Supports Anthropic, OpenAI, Mistral",
   "active": true,
-  "isArchived": false,
   "nodes": [
     {
       "parameters": {
-        "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Description:** Generates text using OpenAI GPT models.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"prompt\"],\n  \"properties\": {\n    \"prompt\": { \"type\": \"string\", \"description\": \"Text generation prompt (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized generation\" },\n    \"system_prompt\": { \"type\": \"string\", \"description\": \"System instructions for the model\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Model: gpt-4o (default), gpt-4o-mini, gpt-4-turbo\" },\n    \"temperature\": { \"type\": \"number\", \"description\": \"Temperature 0-2 (default: 0.7)\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 2048)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"text\", \"model\", \"finish_reason\"],\n  \"domain\": \"nlp\"\n}\n```",
-        "height": 600,
-        "width": 400,
+        "content": "## MCP - Text Generator (Multi-Provider BYOT)\n\n**Endpoint:** POST /webhook/text-generator\n\n**Description:** Generation de texte multi-provider avec pattern BYOT.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"provider\", \"model\", \"api_key\", \"prompt\"],\n  \"properties\": {\n    \"provider\": { \"type\": \"string\", \"enum\": [\"anthropic\", \"openai\", \"mistral\"] },\n    \"model\": { \"type\": \"string\", \"description\": \"Model ID\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"API key (REQUIRED, no fallback)\" },\n    \"prompt\": { \"type\": \"string\", \"description\": \"Text generation prompt\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User context\" },\n    \"system_prompt\": { \"type\": \"string\", \"description\": \"System instructions\" },\n    \"temperature\": { \"type\": \"number\", \"default\": 0.7 },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 2048 },\n    \"user_id\": { \"type\": \"string\" },\n    \"guild_id\": { \"type\": \"string\" }\n  }\n}\n```\n\n**BYOT Pattern:** api_key OBLIGATOIRE, aucun fallback env.",
+        "height": 580,
+        "width": 420,
         "color": 6
       },
       "id": "doc-sticky",
       "name": "Documentation",
       "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [
-        60,
-        60
-      ]
+      "position": [60, 60]
     },
     {
       "parameters": {
@@ -34,24 +27,18 @@
       "name": "Webhook",
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 2,
-      "position": [
-        240,
-        300
-      ],
+      "position": [240, 300],
       "webhookId": "text-generator-webhook"
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// VALIDATION INPUT - Text Generator\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required field ---\nconst prompt = body.prompt || ctx.prompt;\nif (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {\n  errors.push('prompt requis (chaine non vide)');\n}\n\n// --- Context fields for tracing ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst systemPrompt = body.system_prompt || ctx.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.';\nconst model = body.model || ctx.model || 'gpt-4o';\nconst temperature = parseFloat(body.temperature || ctx.temperature || 0.7);\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 2048);\n\n// Validate model\nconst validModels = ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo'];\nif (!validModels.includes(model)) {\n  errors.push(`model invalide: ${model} (doit etre: ${validModels.join(', ')})`);\n}\n\n// Validate temperature\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// Validate max_tokens\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 16384) {\n  errors.push('max_tokens doit etre entre 1 et 16384');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  prompt: prompt.trim(),\n  system_prompt: systemPrompt,\n  model: model,\n  temperature: temperature,\n  max_tokens: maxTokens,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Text Generator (BYOT Multi-Provider)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider} (doit etre: ${validProviders.join(', ')})`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string' || model.trim().length === 0) {\n  errors.push('model requis');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length === 0) {\n  errors.push('api_key requis (BYOT pattern - aucun fallback sur env)');\n}\n\n// --- REQUIRED: prompt ---\nconst prompt = body.prompt || ctx.prompt;\nif (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {\n  errors.push('prompt requis (chaine non vide)');\n}\n\n// --- Context fields for tracing ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst systemPrompt = body.system_prompt || ctx.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.';\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 2048);\n\n// Validate temperature\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// Validate max_tokens\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 200000) {\n  errors.push('max_tokens doit etre entre 1 et 200000');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\n// Build user content with context\nlet userContent = prompt.trim();\nif (userRequest) {\n  userContent = `User context: ${userRequest}\\n\\n${userContent}`;\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  prompt: prompt.trim(),\n  user_content: userContent,\n  system_prompt: systemPrompt,\n  temperature: temperature,\n  max_tokens: maxTokens,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        460,
-        300
-      ]
+      "position": [460, 300]
     },
     {
       "parameters": {
@@ -80,10 +67,7 @@
       "name": "Valid?",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
-      "position": [
-        680,
-        300
-      ]
+      "position": [680, 300]
     },
     {
       "parameters": {
@@ -93,10 +77,7 @@
       "name": "Build Error",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        900,
-        480
-      ]
+      "position": [900, 480]
     },
     {
       "parameters": {
@@ -118,20 +99,105 @@
       "name": "Respond Error",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1120,
-        480
-      ]
+      "position": [1120, 480]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "anthropic",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "anthropic"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "openai",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "openai"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "mistral",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "mistral"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-provider",
+      "name": "Switch Provider",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [900, 200]
     },
     {
       "parameters": {
         "method": "POST",
-        "url": "https://api.openai.com/v1/chat/completions",
-        "authentication": "predefinedCredentialType",
-        "nodeCredentialType": "openAiApi",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
             {
               "name": "Content-Type",
               "value": "application/json"
@@ -140,39 +206,127 @@
         },
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ (() => {\n  const data = $json;\n  let userContent = data.prompt;\n  \n  // Inject user_request context if provided\n  if (data.user_request) {\n    userContent = `User context: ${data.user_request}\\n\\n${data.prompt}`;\n  }\n  \n  return JSON.stringify({\n    model: data.model,\n    messages: [\n      { role: 'system', content: data.system_prompt },\n      { role: 'user', content: userContent }\n    ],\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  return JSON.stringify({\n    model: data.model,\n    system: data.system_prompt,\n    messages: [{ role: 'user', content: data.user_content }],\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
         "options": {
           "timeout": 120000
         }
       },
-      "id": "openai-generate",
-      "name": "OpenAI Generate",
+      "id": "http-anthropic",
+      "name": "Anthropic API",
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
-      "position": [
-        920,
-        200
-      ],
-      "credentials": {
-        "openAiApi": {
-          "id": "openai-credentials",
-          "name": "OpenAI account"
-        }
-      },
+      "position": [1120, 40],
       "onError": "continueRegularOutput"
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nconst _trace = {\n  llm_response: text,\n  service_response: input,\n  provider: 'openai',\n  model: modelUsed,\n  tokens: {\n    input: input.usage?.prompt_tokens || 0,\n    output: input.usage?.completion_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'openai',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  return JSON.stringify({\n    model: data.model,\n    messages: [\n      { role: 'system', content: data.system_prompt },\n      { role: 'user', content: data.user_content }\n    ],\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
       },
-      "id": "format-output",
-      "name": "Format Output",
+      "id": "http-openai",
+      "name": "OpenAI API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 200],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.mistral.ai/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  return JSON.stringify({\n    model: data.model,\n    messages: [\n      { role: 'system', content: data.system_prompt },\n      { role: 'user', content: data.user_content }\n    ],\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "http-mistral",
+      "name": "Mistral API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1120, 360],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT ANTHROPIC RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: input.error.type || 'ANTHROPIC_ERROR',\n      message: input.error.message || 'Anthropic API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'anthropic',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: latencyMs,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst text = input.content?.[0]?.text || '';\nconst stopReason = input.stop_reason || 'end_turn';\nconst modelUsed = input.model || prevData.model;\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: stopReason\n  },\n  meta: {\n    provider: 'anthropic',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.input_tokens || 0,\n      completion_tokens: input.usage?.output_tokens || 0,\n      total_tokens: (input.usage?.input_tokens || 0) + (input.usage?.output_tokens || 0)\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: {\n    llm_response: text,\n    service_response: input,\n    provider: 'anthropic',\n    model: modelUsed,\n    tokens: {\n      input: input.usage?.input_tokens || 0,\n      output: input.usage?.output_tokens || 0\n    },\n    latency_ms: latencyMs,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  }\n};"
+      },
+      "id": "format-anthropic",
+      "name": "Format Anthropic",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1160,
-        200
-      ]
+      "position": [1360, 40]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: input.error.code || 'OPENAI_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: latencyMs,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'openai',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: {\n    llm_response: text,\n    service_response: input,\n    provider: 'openai',\n    model: modelUsed,\n    tokens: {\n      input: input.usage?.prompt_tokens || 0,\n      output: input.usage?.completion_tokens || 0\n    },\n    latency_ms: latencyMs,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  }\n};"
+      },
+      "id": "format-openai",
+      "name": "Format OpenAI",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1360, 200]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT MISTRAL RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error || input.message) {\n  return {\n    success: false,\n    error: {\n      code: 'MISTRAL_ERROR',\n      message: input.message || input.error?.message || 'Mistral API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'mistral',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: latencyMs,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'mistral',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: {\n    llm_response: text,\n    service_response: input,\n    provider: 'mistral',\n    model: modelUsed,\n    tokens: {\n      input: input.usage?.prompt_tokens || 0,\n      output: input.usage?.completion_tokens || 0\n    },\n    latency_ms: latencyMs,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  }\n};"
+      },
+      "id": "format-mistral",
+      "name": "Format Mistral",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1360, 360]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "mergeByFields": {
+          "values": []
+        },
+        "options": {}
+      },
+      "id": "merge-responses",
+      "name": "Merge",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1600, 200]
     },
     {
       "parameters": {
@@ -194,10 +348,7 @@
       "name": "Respond",
       "type": "n8n-nodes-base.respondToWebhook",
       "typeVersion": 1.1,
-      "position": [
-        1400,
-        200
-      ]
+      "position": [1840, 200]
     }
   ],
   "connections": {
@@ -227,7 +378,7 @@
       "main": [
         [
           {
-            "node": "OpenAI Generate",
+            "node": "Switch Provider",
             "type": "main",
             "index": 0
           }
@@ -252,18 +403,98 @@
         ]
       ]
     },
-    "OpenAI Generate": {
+    "Switch Provider": {
       "main": [
         [
           {
-            "node": "Format Output",
+            "node": "Anthropic API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "OpenAI API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Mistral API",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Format Output": {
+    "Anthropic API": {
+      "main": [
+        [
+          {
+            "node": "Format Anthropic",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI API": {
+      "main": [
+        [
+          {
+            "node": "Format OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mistral API": {
+      "main": [
+        [
+          {
+            "node": "Format Mistral",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Anthropic": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Mistral": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge": {
       "main": [
         [
           {
@@ -281,342 +512,5 @@
     "availableInMCP": true
   },
   "staticData": null,
-  "meta": null,
-  "pinData": null,
-  "versionId": "9900d374-97dc-4672-9de1-6fd6a5814afb",
-  "activeVersionId": "9900d374-97dc-4672-9de1-6fd6a5814afb",
-  "versionCounter": 448,
-  "triggerCount": 1,
-  "shared": [
-    {
-      "updatedAt": "2026-02-02T17:55:15.060Z",
-      "createdAt": "2026-02-02T17:55:15.060Z",
-      "role": "workflow:owner",
-      "workflowId": "RipM3vFw09xhPtXR",
-      "projectId": "U3cZjxLpPGVohw1b",
-      "project": {
-        "updatedAt": "2026-02-02T18:03:13.881Z",
-        "createdAt": "2026-02-02T17:54:12.365Z",
-        "id": "U3cZjxLpPGVohw1b",
-        "name": "Sebbah fsebbah@azy.solutions <fsebbah@azy.solutions>",
-        "type": "personal",
-        "icon": null,
-        "description": null,
-        "projectRelations": [
-          {
-            "updatedAt": "2026-02-02T17:54:12.365Z",
-            "createdAt": "2026-02-02T17:54:12.365Z",
-            "userId": "af142d6e-919f-4345-b234-759caa50a7bb",
-            "projectId": "U3cZjxLpPGVohw1b",
-            "user": {
-              "updatedAt": "2026-04-09T12:42:54.002Z",
-              "createdAt": "2026-02-02T17:54:09.643Z",
-              "id": "af142d6e-919f-4345-b234-759caa50a7bb",
-              "email": "fsebbah@azy.solutions",
-              "firstName": "Sebbah",
-              "lastName": "fsebbah@azy.solutions",
-              "personalizationAnswers": {
-                "version": "v4",
-                "personalization_survey_submitted_at": "2026-02-02T18:03:20.553Z",
-                "personalization_survey_n8n_version": "2.6.3"
-              },
-              "settings": {
-                "userActivated": true,
-                "firstSuccessfulWorkflowId": "zFOKwZABmUlo7tg6",
-                "userActivatedAt": 1770062456227,
-                "npsSurvey": {
-                  "waitingForResponse": true,
-                  "ignoredCount": 1,
-                  "lastShownAt": 1771441113942
-                }
-              },
-              "disabled": false,
-              "mfaEnabled": false,
-              "lastActiveAt": "2026-04-09",
-              "isPending": false
-            }
-          }
-        ]
-      }
-    }
-  ],
-  "tags": [],
-  "activeVersion": {
-    "updatedAt": "2026-03-24T20:22:34.516Z",
-    "createdAt": "2026-03-24T20:22:34.516Z",
-    "versionId": "9900d374-97dc-4672-9de1-6fd6a5814afb",
-    "workflowId": "RipM3vFw09xhPtXR",
-    "nodes": [
-      {
-        "parameters": {
-          "content": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Description:** Generates text using OpenAI GPT models.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"prompt\"],\n  \"properties\": {\n    \"prompt\": { \"type\": \"string\", \"description\": \"Text generation prompt (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized generation\" },\n    \"system_prompt\": { \"type\": \"string\", \"description\": \"System instructions for the model\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Model: gpt-4o (default), gpt-4o-mini, gpt-4-turbo\" },\n    \"temperature\": { \"type\": \"number\", \"description\": \"Temperature 0-2 (default: 0.7)\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 2048)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"text\", \"model\", \"finish_reason\"],\n  \"domain\": \"nlp\"\n}\n```",
-          "height": 600,
-          "width": 400,
-          "color": 6
-        },
-        "id": "doc-sticky",
-        "name": "Documentation",
-        "type": "n8n-nodes-base.stickyNote",
-        "typeVersion": 1,
-        "position": [
-          60,
-          60
-        ]
-      },
-      {
-        "parameters": {
-          "httpMethod": "POST",
-          "path": "text-generator",
-          "responseMode": "responseNode",
-          "options": {}
-        },
-        "id": "webhook-textgen",
-        "name": "Webhook",
-        "type": "n8n-nodes-base.webhook",
-        "typeVersion": 2,
-        "position": [
-          240,
-          300
-        ],
-        "webhookId": "text-generator-webhook"
-      },
-      {
-        "parameters": {
-          "jsCode": "// ============================================\n// VALIDATION INPUT - Text Generator\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\n\n// Support RFC-014: data in context.* with fallback to root level\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- Required field ---\nconst prompt = body.prompt || ctx.prompt;\nif (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {\n  errors.push('prompt requis (chaine non vide)');\n}\n\n// --- Context fields for tracing ---\nconst userId = body.user_id || ctx.user_id || null;\nconst guildId = body.guild_id || ctx.guild_id || null;\nconst userRequest = body.user_request || ctx.user_request || null;\n\n// --- Optional parameters ---\nconst systemPrompt = body.system_prompt || ctx.system_prompt || 'You are a helpful assistant that generates high-quality text based on user instructions.';\nconst model = body.model || ctx.model || 'gpt-4o';\nconst temperature = parseFloat(body.temperature || ctx.temperature || 0.7);\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 2048);\n\n// Validate model\nconst validModels = ['gpt-4o', 'gpt-4o-mini', 'gpt-4-turbo', 'gpt-3.5-turbo'];\nif (!validModels.includes(model)) {\n  errors.push(`model invalide: ${model} (doit etre: ${validModels.join(', ')})`);\n}\n\n// Validate temperature\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// Validate max_tokens\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 16384) {\n  errors.push('max_tokens doit etre entre 1 et 16384');\n}\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest\n  };\n}\n\nreturn {\n  valid: true,\n  prompt: prompt.trim(),\n  system_prompt: systemPrompt,\n  model: model,\n  temperature: temperature,\n  max_tokens: maxTokens,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  startTime: Date.now()\n};"
-        },
-        "id": "validate-input",
-        "name": "Validate Input",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          460,
-          300
-        ]
-      },
-      {
-        "parameters": {
-          "conditions": {
-            "options": {
-              "caseSensitive": true,
-              "leftValue": "",
-              "typeValidation": "strict"
-            },
-            "conditions": [
-              {
-                "id": "check-valid",
-                "leftValue": "={{ $json.valid }}",
-                "rightValue": true,
-                "operator": {
-                  "type": "boolean",
-                  "operation": "equals"
-                }
-              }
-            ],
-            "combinator": "and"
-          },
-          "options": {}
-        },
-        "id": "if-valid",
-        "name": "Valid?",
-        "type": "n8n-nodes-base.if",
-        "typeVersion": 2.2,
-        "position": [
-          680,
-          300
-        ]
-      },
-      {
-        "parameters": {
-          "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  _trace: {\n    service_response: { validation_errors: input.errors },\n    provider: 'none',\n    mode: 'error',\n    latency_ms: 0,\n    user_id: input.user_id,\n    guild_id: input.guild_id,\n    user_request: input.user_request\n  },\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  user_id: input.user_id,\n  guild_id: input.guild_id,\n  user_request: input.user_request\n};"
-        },
-        "id": "build-error",
-        "name": "Build Error",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          900,
-          480
-        ]
-      },
-      {
-        "parameters": {
-          "respondWith": "json",
-          "responseBody": "={{ JSON.stringify($json) }}",
-          "options": {
-            "responseCode": 400,
-            "responseHeaders": {
-              "entries": [
-                {
-                  "name": "Content-Type",
-                  "value": "application/json"
-                }
-              ]
-            }
-          }
-        },
-        "id": "respond-error",
-        "name": "Respond Error",
-        "type": "n8n-nodes-base.respondToWebhook",
-        "typeVersion": 1.1,
-        "position": [
-          1120,
-          480
-        ]
-      },
-      {
-        "parameters": {
-          "method": "POST",
-          "url": "https://api.openai.com/v1/chat/completions",
-          "authentication": "predefinedCredentialType",
-          "nodeCredentialType": "openAiApi",
-          "sendHeaders": true,
-          "headerParameters": {
-            "parameters": [
-              {
-                "name": "Content-Type",
-                "value": "application/json"
-              }
-            ]
-          },
-          "sendBody": true,
-          "specifyBody": "json",
-          "jsonBody": "={{ (() => {\n  const data = $json;\n  let userContent = data.prompt;\n  \n  // Inject user_request context if provided\n  if (data.user_request) {\n    userContent = `User context: ${data.user_request}\\n\\n${data.prompt}`;\n  }\n  \n  return JSON.stringify({\n    model: data.model,\n    messages: [\n      { role: 'system', content: data.system_prompt },\n      { role: 'user', content: userContent }\n    ],\n    max_tokens: data.max_tokens,\n    temperature: data.temperature\n  });\n})() }}",
-          "options": {
-            "timeout": 120000
-          }
-        },
-        "id": "openai-generate",
-        "name": "OpenAI Generate",
-        "type": "n8n-nodes-base.httpRequest",
-        "typeVersion": 4.2,
-        "position": [
-          920,
-          200
-        ],
-        "credentials": {
-          "openAiApi": {
-            "id": "openai-credentials",
-            "name": "OpenAI account"
-          }
-        },
-        "onError": "continueRegularOutput"
-      },
-      {
-        "parameters": {
-          "jsCode": "// ============================================\n// FORMAT OPENAI RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\nconst userId = prevData.user_id;\nconst guildId = prevData.guild_id;\nconst userRequest = prevData.user_request;\n\n// Handle error response\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: 'LLM_ERROR',\n      message: input.error.message || 'OpenAI API error',\n      http_status: 500\n    },\n    user_id: userId,\n    guild_id: guildId,\n    user_request: userRequest,\n    _trace: {\n      llm_response: null,\n      service_response: input,\n      provider: 'openai',\n      model: prevData.model,\n      tokens: { input: 0, output: 0 },\n      latency_ms: Date.now() - startTime,\n      user_id: userId,\n      guild_id: guildId,\n      user_request: userRequest\n    }\n  };\n}\n\nconst text = input.choices?.[0]?.message?.content || '';\nconst finishReason = input.choices?.[0]?.finish_reason || 'stop';\nconst modelUsed = input.model || prevData.model;\n\nconst _trace = {\n  llm_response: text,\n  service_response: input,\n  provider: 'openai',\n  model: modelUsed,\n  tokens: {\n    input: input.usage?.prompt_tokens || 0,\n    output: input.usage?.completion_tokens || 0\n  },\n  latency_ms: Date.now() - startTime,\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest\n};\n\nreturn {\n  success: true,\n  data: {\n    text: text,\n    model: modelUsed,\n    finish_reason: finishReason\n  },\n  meta: {\n    provider: 'openai',\n    model: modelUsed,\n    usage: {\n      prompt_tokens: input.usage?.prompt_tokens || 0,\n      completion_tokens: input.usage?.completion_tokens || 0,\n      total_tokens: input.usage?.total_tokens || 0\n    }\n  },\n  user_id: userId,\n  guild_id: guildId,\n  user_request: userRequest,\n  _trace: _trace\n};"
-        },
-        "id": "format-output",
-        "name": "Format Output",
-        "type": "n8n-nodes-base.code",
-        "typeVersion": 2,
-        "position": [
-          1160,
-          200
-        ]
-      },
-      {
-        "parameters": {
-          "respondWith": "json",
-          "responseBody": "={{ JSON.stringify($json) }}",
-          "options": {
-            "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
-            "responseHeaders": {
-              "entries": [
-                {
-                  "name": "Content-Type",
-                  "value": "application/json"
-                }
-              ]
-            }
-          }
-        },
-        "id": "respond-success",
-        "name": "Respond",
-        "type": "n8n-nodes-base.respondToWebhook",
-        "typeVersion": 1.1,
-        "position": [
-          1400,
-          200
-        ]
-      }
-    ],
-    "connections": {
-      "Webhook": {
-        "main": [
-          [
-            {
-              "node": "Validate Input",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Validate Input": {
-        "main": [
-          [
-            {
-              "node": "Valid?",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Valid?": {
-        "main": [
-          [
-            {
-              "node": "OpenAI Generate",
-              "type": "main",
-              "index": 0
-            }
-          ],
-          [
-            {
-              "node": "Build Error",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Build Error": {
-        "main": [
-          [
-            {
-              "node": "Respond Error",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "OpenAI Generate": {
-        "main": [
-          [
-            {
-              "node": "Format Output",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      },
-      "Format Output": {
-        "main": [
-          [
-            {
-              "node": "Respond",
-              "type": "main",
-              "index": 0
-            }
-          ]
-        ]
-      }
-    },
-    "authors": "Sebbah fsebbah@azy.solutions",
-    "name": null,
-    "description": null
-  }
+  "tags": ["llm", "multi-provider", "byot", "mcp"]
 }


### PR DESCRIPTION
## Summary

- **Add new webhook `llm-call-messages`** - Multi-provider LLM synchrone avec pattern BYOT (Bring Your Own Token)
- **Update `text-generator` to multi-provider** - Breaking change: requiert maintenant `provider`, `model`, `api_key`
- **Support 3 providers**: Anthropic, OpenAI, Mistral avec routing via Switch node

## Breaking Changes ⚠️

Le webhook `text-generator` requiert maintenant les paramètres obligatoires suivants :
- `provider` : `anthropic` | `openai` | `mistral`
- `model` : ID du modèle (ex: `claude-sonnet-4-20250514`, `gpt-4o`)
- `api_key` : Clé API du provider (OBLIGATOIRE, aucun fallback sur env)

## New Webhook: `llm-call-messages`

```bash
POST /webhook/llm-call-messages
{
  "provider": "anthropic",
  "model": "claude-sonnet-4-20250514", 
  "api_key": "sk-ant-...",
  "system": "Tu es un assistant utile.",
  "messages": [{"role": "user", "content": "Bonjour"}],
  "max_tokens": 4096,
  "temperature": 0.7
}
```

## Architecture

```
Webhook → Validate Input → Valid? 
                            ├─ Yes → Switch Provider
                            │         ├─ anthropic → Anthropic API → Format
                            │         ├─ openai → OpenAI API → Format
                            │         └─ mistral → Mistral API → Format
                            │                              ↓
                            │                           Merge → Respond (200)
                            └─ No → Build Error → Respond Error (400)
```

## Test plan

- [ ] Tester `llm-call-messages` avec provider `anthropic`
- [ ] Tester `llm-call-messages` avec provider `openai`
- [ ] Tester `llm-call-messages` avec provider `mistral`
- [ ] Tester `text-generator` avec les 3 providers
- [ ] Vérifier erreur 400 si `api_key` manquant
- [ ] Vérifier erreur 400 si `provider` invalide
- [ ] Importer les workflows dans n8n et activer

## Related Documentation

- RFC-085 section 7.4.3 (multi-provider pattern)
- RFC-086 section 5.1 (streaming multi-provider)
- `docs/guides/skills-n8n-anthropic-contract.md` v2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)