### PR TITLE
feat(webhooks): Streaming and Skills webhooks (RFC-086)

### DIFF
--- a/workflows/Claude_-_Call_Stream_With_Skills.json
+++ b/workflows/Claude_-_Call_Stream_With_Skills.json
@@ -1,0 +1,319 @@
+{
+  "name": "Claude - Call Stream With Skills",
+  "description": "Anthropic-only streaming webhook with Files API for generating .docx, .xlsx files",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Claude - Call Stream With Skills\n\n**Endpoint:** POST /webhook/claude-call-stream-with-skills\n\n**Description:** Streaming Claude avec Files API - le plus complexe des 4 webhooks.\nCombine streaming par paquets + génération de fichiers.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"api_key\", \"model\", \"messages\", \"container\", \"callback_url\", \"correlation_id\"],\n  \"properties\": {\n    \"api_key\": { \"type\": \"string\" },\n    \"model\": { \"type\": \"string\" },\n    \"betas\": { \"type\": \"array\", \"default\": [\"files-api-2025-04-14\"] },\n    \"system\": { \"type\": \"string\" },\n    \"messages\": { \"type\": \"array\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 16000 },\n    \"container\": { \"skills\": [...] },\n    \"callback_url\": { \"type\": \"string\" },\n    \"correlation_id\": { \"type\": \"string\" },\n    \"stream_config\": {...},\n    \"metadata\": { \"type\": \"object\" }\n  }\n}\n```\n\n**Output (immediate):** { status: 'streaming', correlation_id }\n**Callbacks:** Packets to callback_url, final packet includes files",
+        "height": 620,
+        "width": 450,
+        "color": 2
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "claude-call-stream-with-skills",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-stream-skills",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [260, 340],
+      "webhookId": "claude-call-stream-with-skills-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Claude Stream With Skills\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: api_key ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string') {\n  errors.push('api_key requis');\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model || 'claude-sonnet-4-20250514';\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis');\n}\n\n// --- REQUIRED: container with skills ---\nconst container = body.container || ctx.container;\nif (!container || !container.skills || container.skills.length === 0) {\n  errors.push('container.skills requis');\n}\n\n// --- REQUIRED: callback_url ---\nconst callbackUrl = body.callback_url || ctx.callback_url;\nif (!callbackUrl || typeof callbackUrl !== 'string') {\n  errors.push('callback_url requis');\n}\n\n// --- REQUIRED: correlation_id ---\nconst correlationId = body.correlation_id || ctx.correlation_id;\nif (!correlationId || typeof correlationId !== 'string') {\n  errors.push('correlation_id requis');\n}\n\n// --- Optional ---\nconst betas = body.betas || ctx.betas || ['files-api-2025-04-14'];\nconst system = body.system || ctx.system || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 16000);\nconst tools = body.tools || ctx.tools || [];\nconst metadata = body.metadata || ctx.metadata || {};\n\nconst streamConfig = {\n  flush_timeout_ms: body.stream_config?.flush_timeout_ms || 500,\n  flush_token_count: body.stream_config?.flush_token_count || 20,\n  flush_size_bytes: body.stream_config?.flush_size_bytes || 4096\n};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    correlation_id: correlationId,\n    metadata: metadata\n  };\n}\n\nreturn {\n  valid: true,\n  api_key: apiKey.trim(),\n  model: model,\n  betas: betas,\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  container: container,\n  tools: tools,\n  callback_url: callbackUrl,\n  correlation_id: correlationId,\n  stream_config: streamConfig,\n  metadata: metadata,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 340]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [700, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first().json;\n\nreturn {\n  success: false,\n  status: 'error',\n  correlation_id: input.correlation_id,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  metadata: input.metadata\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 520]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 520]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE STREAM REQUEST\n// ============================================\n\nconst data = $json;\n\nreturn {\n  immediate_response: {\n    success: true,\n    status: 'streaming',\n    correlation_id: data.correlation_id,\n    message: 'Stream with skills initiated. Packets will be sent to callback_url.'\n  },\n  stream_request: data\n};"
+      },
+      "id": "prepare-stream",
+      "name": "Prepare Stream",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 240]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json.immediate_response) }}",
+        "options": {
+          "responseCode": 202,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-streaming",
+      "name": "Respond Streaming",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 160]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.stream_request.api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "anthropic-beta",
+              "value": "={{ $json.stream_request.betas.join(',') }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const req = $json.stream_request;\n  const body = {\n    model: req.model,\n    max_tokens: req.max_tokens,\n    messages: req.messages,\n    container: req.container,\n    stream: true\n  };\n  if (req.system) body.system = req.system;\n  if (req.tools && req.tools.length > 0) body.tools = req.tools;\n  return JSON.stringify(body);\n})() }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "http-anthropic-stream-skills",
+      "name": "Anthropic Stream Skills",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 320],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS RESPONSE & EXTRACT FILES\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Stream').first().json;\nconst req = prevData.stream_request;\nconst startTime = req.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Extract text content\nlet textContent = '';\nconst fileRefs = [];\n\nif (input.content) {\n  for (const block of input.content) {\n    if (block.type === 'text') {\n      textContent += block.text;\n    }\n    // Check for file artifacts\n    if (block.type === 'tool_result' && block.output?.file_id) {\n      fileRefs.push({\n        file_id: block.output.file_id,\n        name: block.output.name || 'document',\n        mime_type: block.output.mime_type\n      });\n    }\n  }\n}\n\n// Check container_result for files\nif (input.container_result?.files) {\n  for (const file of input.container_result.files) {\n    fileRefs.push({\n      file_id: file.file_id,\n      name: file.name,\n      mime_type: file.mime_type\n    });\n  }\n}\n\n// Build final packet with files\nconst finalPacket = {\n  correlation_id: req.correlation_id,\n  sequence: 1,\n  events: [\n    { type: 'content_block_delta', delta: { text: textContent } },\n    { type: 'message_stop' }\n  ],\n  final: true,\n  cumulative_tokens: (input.usage?.input_tokens || 0) + (input.usage?.output_tokens || 0),\n  usage: input.usage || { input_tokens: 0, output_tokens: 0 },\n  provider: 'anthropic',\n  model: req.model,\n  duration_ms: latencyMs,\n  timestamp: new Date().toISOString(),\n  metadata: req.metadata,\n  // Files are included in final packet for Skills\n  files: fileRefs.map(f => ({\n    file_id: f.file_id,\n    name: f.name,\n    mime_type: f.mime_type,\n    download_url: `https://api.anthropic.com/v1/files/${f.file_id}/content`\n  }))\n};\n\nreturn {\n  callback_url: req.callback_url,\n  packet: finalPacket,\n  api_key: req.api_key\n};"
+      },
+      "id": "process-response",
+      "name": "Process Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 320]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.callback_url }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Correlation-ID",
+              "value": "={{ $json.packet.correlation_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.packet) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "send-callback",
+      "name": "Send to Callback",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1620, 320],
+      "onError": "continueRegularOutput"
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Stream",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Stream": {
+      "main": [
+        [
+          {
+            "node": "Respond Streaming",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Anthropic Stream Skills",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Anthropic Stream Skills": {
+      "main": [
+        [
+          {
+            "node": "Process Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Response": {
+      "main": [
+        [
+          {
+            "node": "Send to Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  },
+  "staticData": null,
+  "tags": ["llm", "anthropic", "skills", "files-api", "streaming"]
+}

--- a/workflows/Claude_-_Call_With_Skills.json
+++ b/workflows/Claude_-_Call_With_Skills.json
@@ -1,0 +1,374 @@
+{
+  "name": "Claude - Call With Skills",
+  "description": "Anthropic-only webhook with Files API for generating .docx, .xlsx files",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## Claude - Call With Skills (Anthropic Files API)\n\n**Endpoint:** POST /webhook/claude-call-with-skills\n\n**Description:** Appel Claude avec Files API pour générer des documents (.docx, .xlsx, etc.)\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"api_key\", \"model\", \"messages\", \"container\"],\n  \"properties\": {\n    \"api_key\": { \"type\": \"string\", \"description\": \"Anthropic API key (REQUIRED)\" },\n    \"model\": { \"type\": \"string\", \"default\": \"claude-sonnet-4-20250514\" },\n    \"betas\": { \"type\": \"array\", \"default\": [\"files-api-2025-04-14\"] },\n    \"system\": { \"type\": \"string\" },\n    \"messages\": { \"type\": \"array\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 16000 },\n    \"container\": {\n      \"skills\": [{ \"type\": \"anthropic\", \"skill_id\": \"docx|xlsx|...\" }]\n    },\n    \"tools\": { \"type\": \"array\" },\n    \"metadata\": { \"type\": \"object\" }\n  }\n}\n```\n\n**Skills disponibles:**\n- `docx` : Génère .docx (Word)\n- `xlsx` : Génère .xlsx (Excel)\n- `code_sandbox` : Exécution code Python\n- `artifact_file` : Fichiers arbitraires\n\n**ANTHROPIC ONLY** - Les Skills sont spécifiques à Anthropic.",
+        "height": 680,
+        "width": 450,
+        "color": 3
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "claude-call-with-skills",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-skills",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [260, 340],
+      "webhookId": "claude-call-with-skills-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - Claude Call With Skills\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: api_key ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string') {\n  errors.push('api_key requis (Anthropic key)');\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model || 'claude-sonnet-4-20250514';\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis');\n}\n\n// --- REQUIRED: container with skills ---\nconst container = body.container || ctx.container;\nif (!container || !container.skills || container.skills.length === 0) {\n  errors.push('container.skills requis (ex: [{ type: \"anthropic\", skill_id: \"docx\" }])');\n}\n\n// --- Optional ---\nconst betas = body.betas || ctx.betas || ['files-api-2025-04-14'];\nconst system = body.system || ctx.system || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 16000);\nconst tools = body.tools || ctx.tools || [];\nconst metadata = body.metadata || ctx.metadata || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    metadata: metadata\n  };\n}\n\nreturn {\n  valid: true,\n  api_key: apiKey.trim(),\n  model: model,\n  betas: betas,\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  container: container,\n  tools: tools,\n  metadata: metadata,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 340]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [700, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  },\n  metadata: input.metadata\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 520]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 520]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "anthropic-beta",
+              "value": "={{ $json.betas.join(',') }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const body = {\n    model: data.model,\n    max_tokens: data.max_tokens,\n    messages: data.messages,\n    container: data.container\n  };\n  if (data.system) body.system = data.system;\n  if (data.tools && data.tools.length > 0) body.tools = data.tools;\n  return JSON.stringify(body);\n})() }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "http-anthropic-skills",
+      "name": "Anthropic Skills API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [920, 240],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// EXTRACT FILE IDs FROM RESPONSE\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\n\n// Handle API error\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: input.error.type || 'ANTHROPIC_ERROR',\n      message: input.error.message || 'Anthropic Skills API error',\n      http_status: 500\n    },\n    metadata: prevData.metadata,\n    api_key: prevData.api_key\n  };\n}\n\n// Extract text content and file references\nconst textContent = [];\nconst fileRefs = [];\n\nfor (const block of (input.content || [])) {\n  if (block.type === 'text') {\n    textContent.push(block.text);\n  }\n  // Check for tool_use blocks that might contain file references\n  if (block.type === 'tool_use' && block.name === 'create_document') {\n    // The file_id will be in the subsequent tool_result\n    // or in the container's file output\n  }\n}\n\n// Check for files in container output\nif (input.container_result?.files) {\n  for (const file of input.container_result.files) {\n    fileRefs.push({\n      file_id: file.file_id,\n      name: file.name,\n      mime_type: file.mime_type,\n      size: file.size\n    });\n  }\n}\n\n// Alternative: Check content blocks for file artifacts\nfor (const block of (input.content || [])) {\n  if (block.type === 'tool_result' && block.output?.file_id) {\n    fileRefs.push({\n      file_id: block.output.file_id,\n      name: block.output.name || 'document',\n      mime_type: block.output.mime_type || 'application/octet-stream'\n    });\n  }\n}\n\nreturn {\n  success: true,\n  has_files: fileRefs.length > 0,\n  file_refs: fileRefs,\n  text_content: textContent.join('\\n'),\n  raw_response: input,\n  model: input.model || prevData.model,\n  usage: input.usage || { input_tokens: 0, output_tokens: 0 },\n  stop_reason: input.stop_reason || 'end_turn',\n  metadata: prevData.metadata,\n  api_key: prevData.api_key,\n  startTime: startTime\n};"
+      },
+      "id": "extract-files",
+      "name": "Extract File IDs",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1140, 240]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "has-files",
+              "leftValue": "={{ $json.has_files }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-has-files",
+      "name": "Has Files?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1360, 240]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// DOWNLOAD FILES FROM ANTHROPIC FILES API\n// Note: This is a simplified version\n// Real implementation needs to iterate over file_refs\n// ============================================\n\nconst data = $json;\nconst files = [];\n\n// For each file reference, download the file content\n// Using the Anthropic Files API: GET /v1/files/{file_id}/content\nfor (const fileRef of data.file_refs) {\n  try {\n    const fileUrl = `https://api.anthropic.com/v1/files/${fileRef.file_id}/content`;\n    \n    // Note: In a real implementation, you would make an HTTP request here\n    // For now, we store the file reference with download URL\n    files.push({\n      file_id: fileRef.file_id,\n      name: fileRef.name,\n      mime_type: fileRef.mime_type,\n      download_url: fileUrl,\n      // base64_content would be populated after download\n      base64_content: null,\n      download_headers: {\n        'x-api-key': data.api_key,\n        'anthropic-version': '2023-06-01'\n      }\n    });\n  } catch (error) {\n    files.push({\n      file_id: fileRef.file_id,\n      error: error.message\n    });\n  }\n}\n\nconst latencyMs = Date.now() - (data.startTime || Date.now());\n\nreturn {\n  success: true,\n  content: [\n    {\n      type: 'text',\n      text: data.text_content\n    }\n  ],\n  files: files,\n  provider: 'anthropic',\n  model: data.model,\n  usage: data.usage,\n  stop_reason: data.stop_reason,\n  metadata: data.metadata,\n  _trace: {\n    provider: 'anthropic',\n    model: data.model,\n    latency_ms: latencyMs,\n    files_count: files.length\n  }\n};"
+      },
+      "id": "download-files",
+      "name": "Download Files",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1580, 160]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT RESPONSE WITHOUT FILES\n// ============================================\n\nconst data = $json;\nconst latencyMs = Date.now() - (data.startTime || Date.now());\n\nreturn {\n  success: data.success !== false,\n  content: [\n    {\n      type: 'text',\n      text: data.text_content || ''\n    }\n  ],\n  files: [],\n  provider: 'anthropic',\n  model: data.model,\n  usage: data.usage || { input_tokens: 0, output_tokens: 0 },\n  stop_reason: data.stop_reason || 'end_turn',\n  metadata: data.metadata,\n  error: data.error || null,\n  _trace: {\n    provider: 'anthropic',\n    model: data.model,\n    latency_ms: latencyMs,\n    files_count: 0\n  }\n};"
+      },
+      "id": "format-no-files",
+      "name": "Format (No Files)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1580, 320]
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "mergeByFields": {
+          "values": []
+        },
+        "options": {}
+      },
+      "id": "merge-responses",
+      "name": "Merge",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3,
+      "position": [1800, 240]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.success ? 200 : ($json.error?.http_status || 500) }}",
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-success",
+      "name": "Respond",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2020, 240]
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Anthropic Skills API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Anthropic Skills API": {
+      "main": [
+        [
+          {
+            "node": "Extract File IDs",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract File IDs": {
+      "main": [
+        [
+          {
+            "node": "Has Files?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Files?": {
+      "main": [
+        [
+          {
+            "node": "Download Files",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Format (No Files)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download Files": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format (No Files)": {
+      "main": [
+        [
+          {
+            "node": "Merge",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Merge": {
+      "main": [
+        [
+          {
+            "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  },
+  "staticData": null,
+  "tags": ["llm", "anthropic", "skills", "files-api"]
+}

--- a/workflows/LLM_-_Call_Stream.json
+++ b/workflows/LLM_-_Call_Stream.json
@@ -1,0 +1,508 @@
+{
+  "name": "LLM - Call Stream",
+  "description": "Multi-provider LLM streaming webhook (BYOT pattern) - Async callback architecture",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "content": "## LLM - Call Stream (Multi-Provider BYOT)\n\n**Endpoint:** POST /webhook/llm-call-stream\n\n**Description:** Streaming LLM multi-provider avec pattern callback asynchrone.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"provider\", \"model\", \"api_key\", \"messages\", \"callback_url\", \"correlation_id\"],\n  \"properties\": {\n    \"provider\": { \"enum\": [\"anthropic\", \"openai\", \"mistral\"] },\n    \"model\": { \"type\": \"string\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"REQUIRED, no fallback\" },\n    \"system\": { \"type\": \"string\" },\n    \"messages\": { \"type\": \"array\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 4096 },\n    \"temperature\": { \"type\": \"number\", \"default\": 0.7 },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL for async packet delivery\" },\n    \"correlation_id\": { \"type\": \"string\" },\n    \"stream_config\": {\n      \"flush_timeout_ms\": 500,\n      \"flush_token_count\": 20,\n      \"flush_size_bytes\": 4096\n    },\n    \"metadata\": { \"type\": \"object\" }\n  }\n}\n```\n\n**Output (immediate):**\n```json\n{ \"status\": \"streaming\", \"correlation_id\": \"...\" }\n```\n\n**Callbacks:** POST to callback_url with chunk packets",
+        "height": 680,
+        "width": 450,
+        "color": 5
+      },
+      "id": "doc-sticky",
+      "name": "Documentation",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [40, 40]
+    },
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "llm-call-stream",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "id": "webhook-stream",
+      "name": "Webhook",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [260, 340],
+      "webhookId": "llm-call-stream-webhook"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Call Stream (BYOT)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider}`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string') {\n  errors.push('model requis');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string') {\n  errors.push('api_key requis (BYOT - aucun fallback)');\n}\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis (array non vide)');\n}\n\n// --- REQUIRED: callback_url ---\nconst callbackUrl = body.callback_url || ctx.callback_url;\nif (!callbackUrl || typeof callbackUrl !== 'string') {\n  errors.push('callback_url requis pour recevoir les paquets');\n}\n\n// --- REQUIRED: correlation_id ---\nconst correlationId = body.correlation_id || ctx.correlation_id;\nif (!correlationId || typeof correlationId !== 'string') {\n  errors.push('correlation_id requis pour le tracking');\n}\n\n// --- Optional ---\nconst system = body.system || ctx.system || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 4096);\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nconst metadata = body.metadata || ctx.metadata || {};\n\n// Stream config with defaults\nconst streamConfig = {\n  flush_timeout_ms: body.stream_config?.flush_timeout_ms || 500,\n  flush_token_count: body.stream_config?.flush_token_count || 20,\n  flush_size_bytes: body.stream_config?.flush_size_bytes || 4096\n};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    correlation_id: correlationId\n  };\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  temperature: temperature,\n  callback_url: callbackUrl,\n  correlation_id: correlationId,\n  stream_config: streamConfig,\n  metadata: metadata,\n  startTime: Date.now()\n};"
+      },
+      "id": "validate-input",
+      "name": "Validate Input",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 340]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-valid",
+              "leftValue": "={{ $json.valid }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-valid",
+      "name": "Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [700, 340]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// BUILD VALIDATION ERROR\n// ============================================\n\nconst input = $input.first().json;\n\nreturn {\n  success: false,\n  status: 'error',\n  correlation_id: input.correlation_id || null,\n  error: {\n    code: 'VALIDATION_ERROR',\n    message: input.errors.join(', '),\n    http_status: 400\n  }\n};"
+      },
+      "id": "build-error",
+      "name": "Build Error",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 520]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 400,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-error",
+      "name": "Respond Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 520]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PREPARE STREAM REQUEST\n// Retourne immédiatement { status: 'streaming' }\n// puis déclenche le streaming asynchrone\n// ============================================\n\nconst data = $json;\n\n// Préparer la configuration pour le streaming\nconst streamRequest = {\n  provider: data.provider,\n  model: data.model,\n  api_key: data.api_key,\n  system: data.system,\n  messages: data.messages,\n  max_tokens: data.max_tokens,\n  temperature: data.temperature,\n  callback_url: data.callback_url,\n  correlation_id: data.correlation_id,\n  stream_config: data.stream_config,\n  metadata: data.metadata,\n  startTime: data.startTime\n};\n\n// Pour le moment, on passe les données au prochain node\n// Le streaming réel nécessite un custom node ou script externe\nreturn {\n  immediate_response: {\n    success: true,\n    status: 'streaming',\n    correlation_id: data.correlation_id,\n    message: 'Stream initiated. Packets will be sent to callback_url.'\n  },\n  stream_request: streamRequest\n};"
+      },
+      "id": "prepare-stream",
+      "name": "Prepare Stream",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [920, 240]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json.immediate_response) }}",
+        "options": {
+          "responseCode": 202,
+          "responseHeaders": {
+            "entries": [
+              {
+                "name": "Content-Type",
+                "value": "application/json"
+              }
+            ]
+          }
+        }
+      },
+      "id": "respond-streaming",
+      "name": "Respond Streaming",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1140, 160]
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.stream_request.provider }}",
+                    "rightValue": "anthropic",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "anthropic"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.stream_request.provider }}",
+                    "rightValue": "openai",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "openai"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.stream_request.provider }}",
+                    "rightValue": "mistral",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "mistral"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "id": "switch-provider",
+      "name": "Switch Provider",
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [1140, 320]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.anthropic.com/v1/messages",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-api-key",
+              "value": "={{ $json.stream_request.api_key }}"
+            },
+            {
+              "name": "anthropic-version",
+              "value": "2023-06-01"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const req = $json.stream_request;\n  const body = {\n    model: req.model,\n    max_tokens: req.max_tokens,\n    temperature: req.temperature,\n    messages: req.messages,\n    stream: true\n  };\n  if (req.system) body.system = req.system;\n  return JSON.stringify(body);\n})() }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "http-anthropic-stream",
+      "name": "Anthropic Stream",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 160],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.stream_request.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const req = $json.stream_request;\n  const messages = [];\n  if (req.system) messages.push({ role: 'system', content: req.system });\n  messages.push(...req.messages);\n  return JSON.stringify({\n    model: req.model,\n    messages: messages,\n    max_tokens: req.max_tokens,\n    temperature: req.temperature,\n    stream: true\n  });\n})() }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "http-openai-stream",
+      "name": "OpenAI Stream",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 320],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "https://api.mistral.ai/v1/chat/completions",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Authorization",
+              "value": "=Bearer {{ $json.stream_request.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const req = $json.stream_request;\n  const messages = [];\n  if (req.system) messages.push({ role: 'system', content: req.system });\n  messages.push(...req.messages);\n  return JSON.stringify({\n    model: req.model,\n    messages: messages,\n    max_tokens: req.max_tokens,\n    temperature: req.temperature,\n    stream: true\n  });\n})() }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "http-mistral-stream",
+      "name": "Mistral Stream",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1380, 480],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PROCESS STREAM RESPONSE & SEND TO CALLBACK\n// Note: n8n HTTP Request ne supporte pas le streaming SSE natif\n// La réponse est reçue en entier (non-streamé)\n// Pour un vrai streaming, utiliser un custom node ou script externe\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Stream').first().json;\nconst req = prevData.stream_request;\nconst startTime = req.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Déterminer le provider depuis le flux\nlet provider = req.provider;\nlet text = '';\nlet usage = { input_tokens: 0, output_tokens: 0 };\nlet finishReason = 'stop';\n\n// Parser selon le provider\nif (provider === 'anthropic') {\n  text = input.content?.[0]?.text || '';\n  usage = {\n    input_tokens: input.usage?.input_tokens || 0,\n    output_tokens: input.usage?.output_tokens || 0\n  };\n  finishReason = input.stop_reason || 'end_turn';\n} else {\n  // OpenAI / Mistral format\n  text = input.choices?.[0]?.message?.content || '';\n  usage = {\n    input_tokens: input.usage?.prompt_tokens || 0,\n    output_tokens: input.usage?.completion_tokens || 0\n  };\n  finishReason = input.choices?.[0]?.finish_reason || 'stop';\n}\n\n// Construire le paquet final\nconst finalPacket = {\n  correlation_id: req.correlation_id,\n  sequence: 1,\n  events: [\n    { type: 'content_block_delta', delta: { text: text } },\n    { type: 'message_stop' }\n  ],\n  final: true,\n  cumulative_tokens: usage.input_tokens + usage.output_tokens,\n  usage: usage,\n  provider: provider,\n  model: req.model,\n  duration_ms: latencyMs,\n  timestamp: new Date().toISOString(),\n  metadata: req.metadata\n};\n\nreturn {\n  callback_url: req.callback_url,\n  packet: finalPacket\n};"
+      },
+      "id": "process-response",
+      "name": "Process Response",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1620, 320]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $json.callback_url }}",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            },
+            {
+              "name": "X-Correlation-ID",
+              "value": "={{ $json.packet.correlation_id }}"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify($json.packet) }}",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "send-callback",
+      "name": "Send to Callback",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1860, 320],
+      "onError": "continueRegularOutput"
+    }
+  ],
+  "connections": {
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate Input": {
+      "main": [
+        [
+          {
+            "node": "Valid?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Valid?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Stream",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Build Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Build Error": {
+      "main": [
+        [
+          {
+            "node": "Respond Error",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Stream": {
+      "main": [
+        [
+          {
+            "node": "Respond Streaming",
+            "type": "main",
+            "index": 0
+          },
+          {
+            "node": "Switch Provider",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Switch Provider": {
+      "main": [
+        [
+          {
+            "node": "Anthropic Stream",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "OpenAI Stream",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Mistral Stream",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Anthropic Stream": {
+      "main": [
+        [
+          {
+            "node": "Process Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI Stream": {
+      "main": [
+        [
+          {
+            "node": "Process Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mistral Stream": {
+      "main": [
+        [
+          {
+            "node": "Process Response",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Process Response": {
+      "main": [
+        [
+          {
+            "node": "Send to Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner",
+    "availableInMCP": true
+  },
+  "staticData": null,
+  "tags": ["llm", "multi-provider", "byot", "streaming"]
+}


### PR DESCRIPTION
## Summary

- **Add `llm-call-stream`** - Multi-provider streaming webhook with async callback pattern
- **Add `claude-call-with-skills`** - Anthropic Files API for .docx/.xlsx generation
- **Add `claude-call-stream-with-skills`** - Combined streaming + Files API (most complex)

## New Webhooks

| Webhook | Provider | Features |
|---------|----------|----------|
| `llm-call-stream` | Multi (anthropic, openai, mistral) | Streaming via callback_url |
| `claude-call-with-skills` | Anthropic only | Files API (.docx, .xlsx) |
| `claude-call-stream-with-skills` | Anthropic only | Streaming + Files API |

## Architecture Notes

### Streaming Pattern (per RFC-086)
```
Client → Webhook → Immediate 202 Response
                ↓
        n8n calls LLM API (stream: true)
                ↓
        Accumulate tokens by packets
                ↓
        POST packets to callback_url
```

### Skills/Files API
```
Request with container.skills → Anthropic API
                              ↓
                    Extract file_ids from response
                              ↓
                    Return with download URLs
```

## Limitations

⚠️ **True SSE streaming** requires:
- Custom n8n node with fetch/stream support, OR
- External script called via Execute Command

Current implementation receives full response (non-streamed) and sends as single packet. For true per-token streaming, additional infrastructure is needed.

## Test plan

- [ ] Test `llm-call-stream` with anthropic provider
- [ ] Test `llm-call-stream` with openai provider  
- [ ] Test `claude-call-with-skills` with docx skill
- [ ] Test `claude-call-stream-with-skills` with docx skill
- [ ] Verify callback_url receives packets
- [ ] Verify 400 error if api_key missing

## Related

- RFC-086 LLM Streaming Architecture
- PR #349 (llm-call-messages, text-generator multi-provider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)