### PR TITLE
fix(deploy): Docker image cleanup + fix network label warning

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -210,7 +210,11 @@ do_deploy_services() {
         fi
 
         # Build et démarrage avec docker compose
-        docker compose -f docker-compose.redis-xadd.yml up -d --build
+        docker compose -f docker-compose.redis-xadd.yml up -d --build --remove-orphans
+
+        # Nettoyer les anciennes images (dangling)
+        log_info "Nettoyage des anciennes images Docker..."
+        docker image prune -f --filter "dangling=true" 2>/dev/null || true
 
         log_success "Redis XADD Service déployé via Docker"
     else

--- a/services/docker-compose.redis-xadd.yml
+++ b/services/docker-compose.redis-xadd.yml
@@ -52,9 +52,9 @@ services:
 
 networks:
   n8n-network:
-    # Créer le réseau s'il n'existe pas, ou utiliser un existant
+    # Utiliser le réseau existant (créé par deploy.sh ou n8n)
+    external: true
     name: ${DOCKER_NETWORK:-n8n-network}
-    driver: bridge
 
 # volumes:
 #   redis-data:


### PR DESCRIPTION
## Summary
- Ajoute le nettoyage automatique des images Docker "dangling" après chaque build
- Corrige le warning "network was found but has incorrect label" en utilisant `external: true`
- Ajoute `--remove-orphans` pour nettoyer les conteneurs orphelins

## Test plan
- [ ] Déployer avec `./deploy.sh --services --docker`
- [ ] Vérifier qu'il n'y a plus de warning sur le label du réseau
- [ ] Vérifier que `docker images` ne contient pas d'images `<none>` accumulées

🤖 Generated with [Claude Code](https://claude.com/claude-code)