### PR TITLE
feat(redis-xadd): add key endpoints and migrate CHANNELS---Private-Recovery

### DIFF
--- a/docs/guides/redis-xadd-service.md
+++ b/docs/guides/redis-xadd-service.md
@@ -1,0 +1,236 @@
+# Guide : Utilisation du Redis XADD Service dans n8n
+
+**Date:** 2026-05-20
+**Version:** 1.1.0
+
+---
+
+## Introduction
+
+Le **Redis XADD Service** est un micro-service HTTP qui permet à n8n d'interagir avec Redis sans utiliser le node `ExecuteCommand` (désactivé depuis n8n 2.0).
+
+Ce guide explique comment utiliser ce service dans vos workflows n8n.
+
+---
+
+## Prérequis
+
+1. Le service `redis-xadd-service` doit être démarré (Docker ou PM2)
+2. La variable d'environnement `REDIS_XADD_SERVICE_URL` doit être configurée dans n8n
+3. Le service doit pouvoir accéder à Redis
+
+---
+
+## Cas d'usage
+
+### 1. Stocker des données temporaires (remplace les fichiers)
+
+**Problème :** Vous utilisiez un fichier pour stocker des données entre exécutions.
+
+**Solution :** Utiliser une clé Redis via HTTP Request.
+
+#### Écrire des données
+
+```
+Node: HTTP Request
+Method: PUT
+URL: {{ $env.REDIS_XADD_SERVICE_URL }}/key/mon:namespace:ma_cle
+Body (JSON):
+{
+  "value": "{{ $json.data }}",
+  "ttl": 3600
+}
+```
+
+#### Lire des données
+
+```
+Node: HTTP Request
+Method: GET
+URL: {{ $env.REDIS_XADD_SERVICE_URL }}/key/mon:namespace:ma_cle
+```
+
+Réponse :
+```json
+{
+  "success": true,
+  "key": "mon:namespace:ma_cle",
+  "value": "mes données",
+  "exists": true
+}
+```
+
+#### Supprimer des données
+
+```
+Node: HTTP Request
+Method: DELETE
+URL: {{ $env.REDIS_XADD_SERVICE_URL }}/key/mon:namespace:ma_cle
+```
+
+---
+
+### 2. Publier des événements (Redis Streams)
+
+**Problème :** Vous voulez notifier d'autres services qu'une action s'est produite.
+
+**Solution :** Utiliser XADD pour publier dans un stream Redis.
+
+```
+Node: HTTP Request
+Method: POST
+URL: {{ $env.REDIS_XADD_SERVICE_URL }}/xadd
+Body (JSON):
+{
+  "stream": "mon:stream:events",
+  "fields": {
+    "event": "user_created",
+    "user_id": "{{ $json.user_id }}",
+    "timestamp": "{{ $now.toISO() }}"
+  },
+  "max_len": 1000
+}
+```
+
+---
+
+### 3. Notifier les outils MCP
+
+**Problème :** Vous avez mis à jour un workflow et voulez notifier le système MCP.
+
+**Solution :** Utiliser l'endpoint `/tools/notify`.
+
+```
+Node: HTTP Request
+Method: POST
+URL: {{ $env.REDIS_XADD_SERVICE_URL }}/tools/notify
+Body (JSON):
+{
+  "action": "workflow_updated",
+  "workflow_name": "Mon Workflow"
+}
+```
+
+---
+
+## Bonnes pratiques
+
+### Nommage des clés
+
+Utilisez des namespaces pour organiser vos clés :
+
+```
+n8n:workflow_name:purpose
+```
+
+Exemples :
+- `n8n:channels:pending` - Channels en attente de traitement
+- `n8n:cache:api_response` - Cache de réponse API
+- `n8n:state:last_run` - État de la dernière exécution
+
+### TTL (Time-To-Live)
+
+Définissez toujours un TTL pour les données temporaires :
+
+```json
+{
+  "value": "données",
+  "ttl": 86400  // 24 heures
+}
+```
+
+### Gestion des erreurs
+
+Ajoutez `onError: "continueRegularOutput"` pour gérer les cas où le service est indisponible :
+
+```json
+{
+  "onError": "continueRegularOutput"
+}
+```
+
+Puis vérifiez dans le code suivant :
+
+```javascript
+const response = $input.first().json;
+
+if (response.error || !response.success) {
+  // Gérer l'erreur
+  return { error: true, message: 'Redis service unavailable' };
+}
+```
+
+---
+
+## Exemples de workflows
+
+### Workflow : Recovery avec Redis
+
+Voir `workflows/CHANNELS---Private-Recovery.json` pour un exemple complet de migration depuis ExecuteCommand vers HTTP Request.
+
+**Architecture :**
+```
+Schedule Trigger
+      │
+      ▼
+GET /key/n8n:pending_channels  ──► Parse JSONL
+      │
+      ▼
+Process entries...
+      │
+      ├─► All success? ──► DELETE /key/n8n:pending_channels
+      │
+      └─► Some failed? ──► PUT /key/n8n:pending_channels (failures only)
+```
+
+---
+
+## Dépannage
+
+### Le service ne répond pas
+
+1. Vérifier que le container/process est en cours d'exécution :
+   ```bash
+   docker ps | grep redis-xadd
+   # ou
+   pm2 list | grep redis-xadd
+   ```
+
+2. Tester le health check :
+   ```bash
+   curl http://localhost:8765/health
+   ```
+
+### Variable d'environnement non définie
+
+**Symptôme :** `Invalid URL: /key/...`
+
+**Solution :** Vérifier que `REDIS_XADD_SERVICE_URL` est définie :
+```bash
+# Docker
+docker exec n8n env | grep REDIS_XADD
+
+# PM2
+pm2 env <n8n_id> | grep REDIS_XADD
+```
+
+### Clé non trouvée
+
+**Symptôme :** `"exists": false` dans la réponse
+
+C'est un comportement normal si la clé n'a jamais été créée ou a expiré (TTL). Gérez ce cas dans votre code :
+
+```javascript
+if (!response.exists) {
+  // Initialiser avec une valeur par défaut
+  return { data: [] };
+}
+```
+
+---
+
+## Références
+
+- [Documentation complète](../n8n/REDIS_XADD_SERVICE.md)
+- [Limitations Redis dans n8n](../n8n/REDIS_LIMITATIONS.md)
+- [Code source](../../services/redis_xadd_service.py)

--- a/docs/n8n/REDIS_XADD_SERVICE.md
+++ b/docs/n8n/REDIS_XADD_SERVICE.md
@@ -1,7 +1,8 @@
 # Redis XADD Micro-Service pour n8n
 
 **Date:** 2026-05-15
-**Dernière mise à jour:** 2026-05-15
+**Dernière mise à jour:** 2026-05-20
+**Version:** 1.1.0
 **Référence:** RFC-089, RFC-090
 **Fichier:** `services/redis_xadd_service.py`
 
@@ -63,6 +64,9 @@ services/redis_xadd_service.py
 | `/xadd` | POST | XADD générique sur n'importe quel stream |
 | `/tools/notify` | POST | Endpoint spécifique pour MCP Tools Notify |
 | `/events/publish` | POST | Endpoint générique pour publier des événements |
+| `/key/{key}` | GET | Lire une clé Redis (remplace `cat file`) |
+| `/key/{key}` | PUT | Écrire une clé Redis (remplace `echo > file`) |
+| `/key/{key}` | DELETE | Supprimer une clé Redis (remplace `rm file`) |
 
 ### 2.3 Configuration
 
@@ -113,6 +117,66 @@ curl -X POST http://localhost:8765/tools/notify \
     "action": "workflow_updated",
     "workflow_name": "My Workflow"
   }'
+```
+
+#### Lire une clé (GET /key/{key})
+```bash
+curl http://localhost:8765/key/n8n:pending_channels
+```
+
+Réponse (clé existe) :
+```json
+{
+  "success": true,
+  "key": "n8n:pending_channels",
+  "value": "{\"channel_id\":\"123\"}\n{\"channel_id\":\"456\"}",
+  "exists": true
+}
+```
+
+Réponse (clé n'existe pas) :
+```json
+{
+  "success": true,
+  "key": "n8n:pending_channels",
+  "value": null,
+  "exists": false
+}
+```
+
+#### Écrire une clé (PUT /key/{key})
+```bash
+curl -X PUT http://localhost:8765/key/n8n:pending_channels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "value": "{\"channel_id\":\"123\"}\n{\"channel_id\":\"456\"}",
+    "ttl": 86400
+  }'
+```
+
+Réponse :
+```json
+{
+  "success": true,
+  "key": "n8n:pending_channels",
+  "value": "{\"channel_id\":\"123\"}\n{\"channel_id\":\"456\"}"
+}
+```
+
+> **Note:** Le paramètre `ttl` est optionnel (en secondes). Sans TTL, la clé n'expire jamais.
+
+#### Supprimer une clé (DELETE /key/{key})
+```bash
+curl -X DELETE http://localhost:8765/key/n8n:pending_channels
+```
+
+Réponse :
+```json
+{
+  "success": true,
+  "key": "n8n:pending_channels",
+  "exists": true
+}
 ```
 
 ---
@@ -522,7 +586,59 @@ async def xadd(request: XAddRequest):
 
 ---
 
-## 8. Références
+## 8. Migration ExecuteCommand → HTTP Request
+
+### 8.1 Contexte
+
+Depuis n8n 2.0, le node `ExecuteCommand` est désactivé par défaut. Les workflows qui utilisaient des commandes shell pour lire/écrire des fichiers doivent être migrés vers des appels HTTP au service Redis XADD.
+
+### 8.2 Exemple : CHANNELS---Private-Recovery
+
+Ce workflow a été migré de fichiers locaux vers Redis :
+
+| Ancien (ExecuteCommand) | Nouveau (HTTP Request) |
+|-------------------------|------------------------|
+| `cat /var/log/n8n/pending_channels.log` | `GET /key/n8n:pending_channels` |
+| `rm /var/log/n8n/pending_channels.log` | `DELETE /key/n8n:pending_channels` |
+| `echo '...' > /var/log/n8n/pending_channels.log` | `PUT /key/n8n:pending_channels` |
+
+### 8.3 Avantages de la migration
+
+1. **Compatibilité n8n 2.0+** : Pas besoin de réactiver ExecuteCommand
+2. **Persistance** : Redis est plus robuste qu'un fichier local
+3. **Scalabilité** : Fonctionne en environnement distribué (Docker, Kubernetes)
+4. **Observabilité** : Les clés Redis sont inspectables avec redis-cli
+
+### 8.4 Configuration n8n dans le workflow
+
+Utiliser la variable d'environnement dans les URLs :
+
+```
+{{ $env.REDIS_XADD_SERVICE_URL }}/key/n8n:pending_channels
+```
+
+### 8.5 Adaptation du code JavaScript
+
+**Avant (lecture fichier):**
+```javascript
+const output = $input.first().json.stdout || '';
+if (!output.trim()) {
+  return { has_entries: false };
+}
+```
+
+**Après (lecture Redis):**
+```javascript
+const response = $input.first().json;
+if (!response.exists || !response.value) {
+  return { has_entries: false };
+}
+const content = response.value;
+```
+
+---
+
+## 9. Références
 
 - [REDIS_LIMITATIONS.md](./REDIS_LIMITATIONS.md) - Limitations Redis dans n8n
 - [RFC-089](../rfc/) - Skills API Architecture

--- a/services/redis_xadd_service.py
+++ b/services/redis_xadd_service.py
@@ -39,8 +39,8 @@ redis_client = redis.Redis(
 
 app = FastAPI(
     title="Redis XADD Service",
-    description="Micro-service pour Redis Streams XADD - Remplace Execute Command dans n8n 2.0",
-    version="1.0.0"
+    description="Micro-service pour Redis Streams XADD et clés simples - Remplace Execute Command dans n8n 2.0",
+    version="1.1.0"
 )
 
 
@@ -73,6 +73,109 @@ class HealthResponse(BaseModel):
     redis_host: str
     redis_port: int
     redis_db: int
+
+
+class KeyValue(BaseModel):
+    """Valeur pour une clé Redis"""
+    value: str = Field(..., description="Valeur à stocker")
+    ttl: Optional[int] = Field(None, description="Time-to-live en secondes (optionnel)")
+
+
+class KeyResponse(BaseModel):
+    """Réponse pour les opérations sur clés"""
+    success: bool
+    key: str
+    value: Optional[str] = None
+    exists: Optional[bool] = None
+
+
+# ============================================
+# ENDPOINTS POUR CLÉS SIMPLES (GET/SET/DELETE)
+# Remplace les ExecuteCommand qui lisent/écrivent des fichiers
+# ============================================
+
+@app.get("/key/{key:path}", response_model=KeyResponse)
+async def get_key(key: str):
+    """
+    Lit la valeur d'une clé Redis.
+
+    Équivalent de: cat /path/to/file
+    Remplace: ExecuteCommand avec 'cat file'
+
+    Retourne success=true et value si la clé existe,
+    success=true et value=null si la clé n'existe pas.
+    """
+    try:
+        value = redis_client.get(key)
+
+        return KeyResponse(
+            success=True,
+            key=key,
+            value=value,
+            exists=value is not None
+        )
+
+    except redis.RedisError as e:
+        logger.error(f"Redis error in get_key: {e}")
+        raise HTTPException(status_code=500, detail=f"Redis error: {str(e)}")
+
+
+@app.put("/key/{key:path}", response_model=KeyResponse)
+async def set_key(key: str, data: KeyValue):
+    """
+    Écrit une valeur dans une clé Redis.
+
+    Équivalent de: echo 'value' > /path/to/file
+    Remplace: ExecuteCommand avec 'echo > file'
+
+    Paramètres:
+    - key: Nom de la clé (peut contenir des / pour simuler des chemins)
+    - value: Valeur à stocker
+    - ttl: Durée de vie en secondes (optionnel)
+    """
+    try:
+        if data.ttl:
+            redis_client.setex(key, data.ttl, data.value)
+        else:
+            redis_client.set(key, data.value)
+
+        logger.info(f"SET {key} (ttl={data.ttl})")
+
+        return KeyResponse(
+            success=True,
+            key=key,
+            value=data.value
+        )
+
+    except redis.RedisError as e:
+        logger.error(f"Redis error in set_key: {e}")
+        raise HTTPException(status_code=500, detail=f"Redis error: {str(e)}")
+
+
+@app.delete("/key/{key:path}", response_model=KeyResponse)
+async def delete_key(key: str):
+    """
+    Supprime une clé Redis.
+
+    Équivalent de: rm /path/to/file
+    Remplace: ExecuteCommand avec 'rm file'
+
+    Retourne success=true même si la clé n'existait pas.
+    """
+    try:
+        deleted = redis_client.delete(key)
+
+        logger.info(f"DEL {key} (deleted={deleted})")
+
+        return KeyResponse(
+            success=True,
+            key=key,
+            exists=deleted > 0
+        )
+
+    except redis.RedisError as e:
+        logger.error(f"Redis error in delete_key: {e}")
+        raise HTTPException(status_code=500, detail=f"Redis error: {str(e)}")
 
 
 @app.get("/health", response_model=HealthResponse)

--- a/workflows/CHANNELS---Private-Recovery.json
+++ b/workflows/CHANNELS---Private-Recovery.json
@@ -1,0 +1,378 @@
+{
+  "name": "CHANNELS---Private-Recovery",
+  "description": "Retry failed channel registrations stored in Redis (migrated from file-based ExecuteCommand)",
+  "active": true,
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [
+            {
+              "field": "minutes",
+              "minutesInterval": 15
+            }
+          ]
+        }
+      },
+      "id": "channel-recovery-0001",
+      "name": "Schedule Trigger",
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.2,
+      "position": [
+        0,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.REDIS_XADD_SERVICE_URL }}/key/n8n:pending_channels",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "channel-recovery-0002",
+      "name": "Read Pending Channels",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        224,
+        304
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// PARSE PENDING CHANNELS FROM REDIS\n// Migrated from file-based JSONL to Redis key\n// ============================================\n\nconst response = $input.first().json;\n\n// Check if key exists and has value\nif (!response.exists || !response.value) {\n  return {\n    has_entries: false,\n    entries: [],\n    message: 'No pending channels to process'\n  };\n}\n\nconst content = response.value;\n\n// Parse JSONL (one JSON per line)\nconst lines = content.trim().split('\\n').filter(line => line.trim());\nconst entries = [];\n\nfor (const line of lines) {\n  try {\n    const entry = JSON.parse(line);\n    entries.push(entry);\n  } catch (e) {\n    // Skip invalid JSON lines\n    console.log('Invalid JSON line:', line);\n  }\n}\n\nreturn {\n  has_entries: entries.length > 0,\n  entries: entries,\n  count: entries.length\n};"
+      },
+      "id": "channel-recovery-0003",
+      "name": "Parse JSONL",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        448,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-has-entries",
+              "leftValue": "={{ $json.has_entries }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "channel-recovery-0004",
+      "name": "Has Entries?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        672,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// SPLIT ENTRIES FOR PROCESSING\n// ============================================\n\nconst data = $input.first().json;\nconst entries = data.entries || [];\n\n// Return each entry as separate item for loop processing\nreturn entries.map(entry => ({ entry }));"
+      },
+      "id": "channel-recovery-0005",
+      "name": "Split Entries",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        880,
+        208
+      ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.API_URL }}/api/channels/private",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Project-ID",
+              "value": "={{ $json.entry.project_id }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"guild_id\": {{ JSON.stringify($json.entry.guild_id) }},\n  \"discord_user_id\": {{ JSON.stringify($json.entry.user_id) }},\n  \"channel_id\": {{ JSON.stringify($json.entry.channel_id) }},\n  \"channel_type\": {{ JSON.stringify($json.entry.type) }},\n  \"channel_name\": {{ JSON.stringify($json.entry.name) }}\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "id": "channel-recovery-0006",
+      "name": "Retry Register Channel",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1104,
+        208
+      ],
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// COLLECT RESULTS\n// ============================================\n\nconst items = $input.all();\nconst results = {\n  processed: 0,\n  success: 0,\n  failed: 0,\n  failures: []\n};\n\nfor (const item of items) {\n  results.processed++;\n  if (item.json.success) {\n    results.success++;\n  } else {\n    results.failed++;\n    results.failures.push({\n      channel_id: item.json.entry?.channel_id,\n      error: item.json.error || 'Unknown error'\n    });\n  }\n}\n\nreturn results;"
+      },
+      "id": "channel-recovery-0007",
+      "name": "Collect Results",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1328,
+        208
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "check-all-success",
+              "leftValue": "={{ $json.failed }}",
+              "rightValue": 0,
+              "operator": {
+                "type": "number",
+                "operation": "equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "channel-recovery-0008",
+      "name": "All Success?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1552,
+        208
+      ]
+    },
+    {
+      "parameters": {
+        "method": "DELETE",
+        "url": "={{ $env.REDIS_XADD_SERVICE_URL }}/key/n8n:pending_channels",
+        "options": {
+          "timeout": 5000
+        }
+      },
+      "id": "channel-recovery-0009",
+      "name": "Clear Pending Channels",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1792,
+        256
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// REWRITE LOG WITH FAILURES ONLY\n// ============================================\n\nconst results = $('Collect Results').first().json;\nconst originalEntries = $('Parse JSONL').first().json.entries || [];\n\n// Keep only entries that failed\nconst failedChannelIds = results.failures.map(f => f.channel_id);\nconst entriesToKeep = originalEntries.filter(e => \n  failedChannelIds.includes(e.channel_id)\n);\n\n// Convert back to JSONL\nconst newLogContent = entriesToKeep\n  .map(e => JSON.stringify(e))\n  .join('\\n');\n\nreturn {\n  new_log_content: newLogContent,\n  entries_kept: entriesToKeep.length,\n  results: results\n};"
+      },
+      "id": "channel-recovery-0010",
+      "name": "Prepare Updated Log",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1760,
+        80
+      ]
+    },
+    {
+      "parameters": {
+        "method": "PUT",
+        "url": "={{ $env.REDIS_XADD_SERVICE_URL }}/key/n8n:pending_channels",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ $json.new_log_content ? JSON.stringify({ value: $json.new_log_content }) : JSON.stringify({ value: '' }) }}"
+      },
+      "id": "channel-recovery-0011",
+      "name": "Update Pending Channels",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1984,
+        80
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// NO ENTRIES - NOTHING TO DO\n// ============================================\n\nreturn {\n  message: 'No pending channels to process',\n  processed: 0\n};"
+      },
+      "id": "channel-recovery-0012",
+      "name": "No Entries",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        880,
+        400
+      ]
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": {
+      "main": [
+        [
+          {
+            "node": "Read Pending Channels",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Read Pending Channels": {
+      "main": [
+        [
+          {
+            "node": "Parse JSONL",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Parse JSONL": {
+      "main": [
+        [
+          {
+            "node": "Has Entries?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Has Entries?": {
+      "main": [
+        [
+          {
+            "node": "No Entries",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Split Entries",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Split Entries": {
+      "main": [
+        [
+          {
+            "node": "Retry Register Channel",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Retry Register Channel": {
+      "main": [
+        [
+          {
+            "node": "Collect Results",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Collect Results": {
+      "main": [
+        [
+          {
+            "node": "All Success?",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "All Success?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Updated Log",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Clear Pending Channels",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Prepare Updated Log": {
+      "main": [
+        [
+          {
+            "node": "Update Pending Channels",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1",
+    "callerPolicy": "workflowsFromSameOwner"
+  },
+  "staticData": null,
+  "tags": [
+    "channels",
+    "recovery",
+    "discord"
+  ]
+}

--- a/workflows/Claude_-_Batch_Poller.json
+++ b/workflows/Claude_-_Batch_Poller.json
@@ -422,14 +422,14 @@
       "main": [
         [
           {
-            "node": "Send Callback",
+            "node": "Publish to Redis",
             "type": "main",
             "index": 0
           }
         ]
       ]
     },
-    "Send Callback": {
+    "Publish to Redis": {
       "main": [
         [
           {


### PR DESCRIPTION
## Summary

- Add GET/PUT/DELETE `/key/{key}` endpoints to redis-xadd-service (v1.1.0)
- Migrate `CHANNELS---Private-Recovery` workflow from ExecuteCommand to HTTP Request
- Fix `Claude - Batch Poller` connection: `Process Results` → `Publish to Redis`
- Update documentation with new endpoints and usage guide

## Changes

| File | Description |
|------|-------------|
| `services/redis_xadd_service.py` | New endpoints for simple Redis keys |
| `workflows/CHANNELS---Private-Recovery.json` | Migrated to use HTTP Request |
| `workflows/Claude_-_Batch_Poller.json` | Fixed broken connection |
| `docs/n8n/REDIS_XADD_SERVICE.md` | Updated with new endpoints |
| `docs/guides/redis-xadd-service.md` | New usage guide |

## Why?

Since n8n 2.0, `ExecuteCommand` is disabled by default. This PR provides an HTTP-based alternative for workflows that need to read/write data persistently.

## Test plan

- [ ] Rebuild `n8n-redis-xadd` Docker image on host2
- [ ] Restart `redis-xadd-service` container
- [ ] Test GET/PUT/DELETE endpoints manually
- [ ] Import `CHANNELS---Private-Recovery.json` and verify it activates without error
- [ ] Verify `Claude - Batch Poller` processes batches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)