### PR TITLE
docs: add RFC-095, RFC-096 et briefing équipes

### DIFF
--- a/docs/issues/2026-05-27-briefing-equipes-n8n-mcp-plugin.md
+++ b/docs/issues/2026-05-27-briefing-equipes-n8n-mcp-plugin.md
@@ -1,0 +1,88 @@
+# Briefing équipes — n8n / MCP / plugin Discord (RFC-095 + RFC-096)
+
+> Date : 2026-05-27 · Émetteur : back · But : donner à chaque équipe **ce qu'elle doit lire, ses tasks pressenties, les décisions qu'elle doit rendre**, pour chiffrer et se prononcer avant le runtime DM (Phase 1) et l'extension pédagogique.
+> Contexte global : `docs/issues/2026-05-27-personae-roadmap-phases.md`.
+
+## Socle déjà figé (commun aux 3 équipes)
+- **Identité élève = `discord_user_id`** (snowflake, string). Pas de Firebase UID. `guild_id → tenant_id` via l'existant `GET /api/n8n/tenants/resolve`.
+- **Contrat runtime figé** : `docs/guides/RFC-095-API-CONTRACTS.md` §3.1 (`resolve-dm`, discriminateur `status`).
+- **B3 (`resolve-dm`) est en cours de build** côté back. Le contrat ne bougera pas ; seules restent ouvertes les décisions listées plus bas (additives).
+
+---
+
+## 1. Équipe n8n / chatbot-core
+
+### À lire
+`RFC-095-API-CONTRACTS.md` §0 + §3.1 · `RFC-095-DM-IDENTITY-RESOLUTION.md` §7 (flux cible) + §11 · `RFC-095-PERSONAE-MULTI-LEVELS.md` §9bis.1.
+
+### Tes tasks pressenties
+1. **Flux DM en 2 appels** :
+   - `GET /api/n8n/tenants/resolve?guild_id=G&user_id=D` → `{tenant_id, package, models}` *(existant)*.
+   - `GET /api/n8n/personae/resolve-dm?user_id=D&question=Q` + header `X-Tenant-ID: T` → `ResolveDmResponse` *(B3)*.
+2. **Brancher selon `status`** :
+   - `resolved` → dispatch LLM avec `personae.system_prompt` + `llm_params` + `rag_source_ids` + `models`.
+   - `out_of_scope` → afficher le message de décline (pas d'appel LLM sur le fond).
+   - `needs_clarification` → relayer la demande de précision (liste `clarification_candidates`), puis re-appeler `resolve-dm`.
+3. Rester « bête » : **le routing/classification est fait côté back**, pas dans n8n.
+
+### Décisions à rendre
+- Le contrat `resolve-dm` §3.1 te convient-il tel quel ? (params, 3 statuts, payload).
+- OK pour la séquence 2 appels (tenant puis personae) ? Ou tu préfères un endpoint « fat » unique `(guild_id, discord_user_id, question)` ?
+- Charge estimée.
+
+---
+
+## 2. Équipe MCP / azy-mcp
+
+### À lire
+`RFC-095-PERSONAE-MULTI-LEVELS.md` §9bis.3 + Q5bis · `RFC-096-PERSONAE-PEDAGOGIQUE.md` §4 (RAG par mode), §6 (LLM judge), §3.3.4 (corpus typé), §15.2 (seed Eduscol).
+
+### Tes tasks pressenties
+1. **RFC-095 — classification du routing (Q5bis)** : `resolve-dm` appelle un **classifieur LLM cheap via MCP** (`MCPHTTPDispatch.post_dispatch`). Nouvelle catégorie d'appel courte : 1 question + N matières candidates → `specialty_id` + confiance. À cadrer : **modèle** (Haiku-class par défaut), **quota**, **audit**.
+2. **RFC-096 — RAG piloté par mode pédagogique** (§4) : le retrieval Qdrant pondéré par le mode actif (types de chunks). Extension du grain de scoping.
+3. **RFC-096 — split IA Discipline/Niveau** (P3) : appel LLM « Histoire 3ème » → `{discipline, level}`.
+4. **RFC-096 — LLM judge / golden dataset** (§6, post-V1) : évaluation pédagogique automatisée.
+
+### Décisions à rendre
+- **Q5bis** : la classification passe bien par MCP (cohérent « tout LLM via MCP ») ? Modèle / quota / audit pour cette catégorie ?
+- Le filtrage RAG par mode (§4) est-il réaliste sur votre stack Qdrant actuelle ?
+- Charge estimée (classification V1 vs RAG-par-mode + judge plus tard).
+
+---
+
+## 3. Équipe plugin Discord
+
+### À lire
+`RFC-095-PERSONAE-MULTI-LEVELS.md` §9bis.2 · `RFC-095-DM-IDENTITY-RESOLUTION.md` §7 + §8 + §9 · `RFC-096-PERSONAE-PEDAGOGIQUE.md` §5.3 (transparence routage).
+
+### Tes tasks pressenties
+1. **Captation DM** : récupérer `(guild_id, discord_user_id, question)` et déclencher le flux n8n.
+2. **Rendu des 3 statuts** : réponse normale (`resolved`) · message de décline (`out_of_scope`) · **demande de précision** (`needs_clarification`) — potentiellement des **boutons** Discord pour choisir la matière.
+3. **Transparence routage (RFC-096 §5.3)** : afficher *« Matière détectée : X »* avec un bouton **[Changer]** (correction en 1 clic) — améliore le routing + pédagogique.
+4. **Inscription élève** : UX pour qu'un élève s'inscrive à ses matières (commande slash ? menu ?) **OU** inscription pilotée par l'admin (déjà dispo back : `GET /api/owner/students`, `GET/PUT/DELETE /students/{id}/enrollments`). À trancher : voie élève, voie admin, ou les deux.
+5. **Élève inconnu / non inscrit** : `resolve-dm` renvoie `out_of_scope` → inviter à s'inscrire / se vérifier (RFC-067).
+
+### Décisions à rendre
+- UX inscription : élève (Discord) et/ou admin ? Quel mécanisme Discord (commande, menu, réaction) ?
+- OK pour gérer les boutons de précision + le « [Changer] matière » ?
+- Charge estimée.
+
+---
+
+## 4. Décisions back encore ouvertes qui vous impactent (additives)
+
+Ces choix par défaut ont été pris pour ne pas bloquer le build B3 ; ils sont **additifs** (révisables sans casser le contrat). Donnez votre avis :
+
+| Sujet | Défaut back V1 | Impacte |
+|---|---|---|
+| **Mono-bot vs multi-bot** | Mono-tuteur : l'expert est dérivé de la matière routée (`expert_specialties`). | plugin + n8n (faut-il passer un `bot_application_id` ?) |
+| **Élève non vérifié** | `out_of_scope` (décline) ; l'invite à se vérifier est côté plugin. | plugin |
+| **Q5bis classification** | via MCP (`MCPHTTPDispatch`). | MCP |
+
+## 5. Grille de sign-off
+
+| Équipe | Position (✅ OK / ⚠️ réserves / ❌ bloquant) | Charge estimée | Remarques |
+|---|---|---|---|
+| n8n / chatbot-core | ⏳ | | |
+| MCP / azy-mcp | ⏳ | | |
+| plugin Discord | ⏳ | | |

--- a/docs/rfc/RFC-095-PERSONAE-MULTI-LEVELS.md
+++ b/docs/rfc/RFC-095-PERSONAE-MULTI-LEVELS.md
@@ -1,0 +1,451 @@
+# RFC-095 — Assistant DM par élève : inscription matières + routing contraint
+
+> Statut : Draft v2 2026-05-24 · Owner : product · Co-auteurs : front + back
+> Référence amont : RFC-081 v4.1 (personae bot) + audit Discord 2026-05-21 (`docs/issues/2026-05-21-discord-simplification-audience-personae.md`)
+> Audience : back, front, plugin Discord, n8n
+>
+> **v2 (2026-05-24)** — Refonte complète du modèle suite à l'analyse design (cf. §13 changelog). La v1 proposait une « audience statique attachée à un groupe » résolue par appartenance. Elle s'effondrait sur le cas d'usage réel (**DM 1:1 élève↔bot, élève multi-matières**) : un élève en 3 spécialités appartenait à 3 groupes → soit 3 bots dédiés (≈15 bots/classe, ingérable), soit un chevauchement systématique d'audiences en DM. La v2 reconstruit autour de **1 assistant DM par élève + inscription aux matières + routing sémantique contraint au périmètre inscrit**.
+
+## 1. Contexte et motivation
+
+RFC-081 v4.1 a livré le **Personae bot** (Expert + Spécialité + Style + Brique + Modèles, scopé par Canal). Le résolveur compose un system_prompt qui décrit **qui est l'assistant**.
+
+Manque : **à qui l'assistant s'adresse**, et surtout **comment un même élève multi-matières interagit avec l'assistant**.
+
+### 1.1 Le cas d'usage cible (tranché 2026-05-24)
+
+- **Canal = DM 1:1** entre l'élève et **un seul assistant**. *(Décision : pas de bot dans un salon « classe » — l'échange privé est jugé plus pertinent.)*
+- L'élève suit **plusieurs matières** (ex. Première : spé Histoire + spé Maths + spé SVT, plus le tronc commun → potentiellement ~15 matières).
+- **Anti-pattern rejeté** : 1 bot dédié par matière → l'élève jonglerait entre 15 DM, l'admin configurerait 15 bots/classe. Ingérable.
+
+### 1.2 La clé du modèle : l'inscription comme périmètre
+
+> *Mots du user (2026-05-24) : « Il faudra qu'on sache à l'avance quelles sont les matières auxquelles l'élève est enregistré. Soit il a une audience large, soit il s'inscrit à x matières, et le routing sémantique devra en tenir compte. »*
+
+> *Précision user (2026-05-24) : « Import ENT/Pronote → à oublier. Ce sera une inscription : il faut prévoir l'enregistrement en base et passer les informations au bot — le "comment" reste à voir. »*
+
+**Décisions actées** : l'inscription est un **acte explicite persisté en base** (table `student_subject_enrollment`, §4.2) — **pas** un import depuis un SI externe (ENT/Pronote). Reste à préciser : (a) l'acteur de l'inscription (admin ? flux dédié ?) et (b) le mécanisme de transmission du périmètre + audiences au bot au runtime (cf. §4.6 + Q5).
+
+L'élève est **inscrit** à un ensemble de matières. Cette inscription définit son **périmètre** : l'assistant ne route les questions que **dans ce sous-ensemble**, pas dans tout le catalogue.
+
+```
+Élève Marie inscrite à :  [Histoire — avancé] · [Maths — moyen] · [SVT — débutant]
+                              ↑ son périmètre (3 specialties + 3 audiences)
+
+Question « explique le logarithme »
+   → routing sémantique classe DANS {Histoire, Maths, SVT}  (3 candidats, pas 15)
+   → "Maths"
+   → bot      = Specialty Maths (RFC-081)
+   → audience = celle de l'inscription Maths de Marie (niveau moyen)
+```
+
+## 2. Modèle conceptuel
+
+### 2.1 Les 3 niveaux (revisités v2)
+
+| Niveau | Question | Porté par | Statut |
+|---|---|---|---|
+| **1 — bot** | « Qui je suis ? » | Specialty + Style + Models (RFC-081) | ✅ livré |
+| **2 — audience** | « À qui je parle, et à quel niveau ? » | `audience_personae` (catalogue) consommée **via l'inscription élève** | 📝 cette RFC |
+| **3 — routing** | « De quoi me parle l'élève, là, maintenant ? » | classifieur sémantique **contraint au périmètre inscrit** | 📝 cette RFC |
+
+> Note v2 : la v1 séparait « audience groupe » (niveau 2) et « audience user » (niveau 3). La v2 **fusionne** ces notions : l'audience est cataloguée (réutilisable), et l'**inscription** `(élève × matière → audience)` fournit l'effet « par-user » sans créer une audience par user. Le 3ᵉ niveau devient le **routing** (la dimension dynamique), pas un 3ᵉ type d'audience.
+
+### 2.2 Composition runtime
+
+```
+À chaque message de l'élève en DM :
+
+  1. ROUTING    question → specialty ∈ périmètre_inscrit(élève)   (ou fallback)
+  2. BOT        charge Specialty + Style + Models (RFC-081)
+  3. AUDIENCE   charge audience_personae de l'inscription (élève, specialty)
+  4. COMPOSE    system_prompt =
+                  Expert.base_prompt
+                + Specialty.context_prompt
+                + Style.prompt_modifier
+                + "[Audience]\n" + audience.description
+                + audience.style.prompt_modifier   (si style)
+```
+
+### 2.3 Pas d'entité « Personae » persistée (inchangé RFC-081 §16/§19)
+
+Le « Personae effectif » reste une **résolution runtime**. La v2 ajoute juste 2 entrées persistées : le **catalogue audience** + l'**inscription élève**.
+
+## 3. Niveau 1 — Personae bot (RFC-081, livré — pour mémoire)
+
+4 entités catalogue (Expert étendu + Specialty + Style + Brique) + `channel_bindings` + résolveur + 8 perms `personae:{specialty,style,binding,brick}:{read,write}`. Entièrement livré (PR1→PR5 + hotfixes). La v2 **réutilise** Specialty/Style sans les modifier.
+
+## 4. Niveau 2 — Audience + inscription (cette RFC)
+
+### 4.1 Catalogue `audience_personae`
+
+Une **audience** = une caractérisation réutilisable d'un public-cible : qui ils sont, ce qu'ils attendent, le ton qui leur convient.
+
+Exemples :
+- *« Niveau avancé — vise 16+ au bac. Vocabulaire technique attendu, démonstrations rigoureuses. Ton stimulant. »*
+- *« Niveau débutant — découverte. Reformuler, multiplier les exemples concrets, vérifier la compréhension. Ton rassurant. »*
+
+| Champ | Type | Rôle |
+|---|---|---|
+| `id` | UUID PK | |
+| `name` | VARCHAR(255) | Nom affiché (« Niveau avancé bac », « Découverte ») |
+| `description` | TEXT | Texte libre injecté au runtime |
+| `style_id` | UUID nullable FK styles(id) | Réutilise le catalogue Styles RFC-081 (optionnel) — cf. Q1 |
+| `is_draft` + `parent_id` | bool + UUID | Draft/Publish aligné RFC-081 §14.6 |
+| `is_active` + `set_by` + `set_at` + `updated_at` | meta | Audit |
+
+Pas de `tenant_id` (scope via search_path, cohérent RFC-081 §19.1 Q2).
+
+### 4.2 Inscription élève `student_subject_enrollment`
+
+L'inscription lie un **élève** à une **matière (Specialty)** avec l'**audience** qui le caractérise dans cette matière.
+
+```sql
+CREATE TABLE {schema}.student_subject_enrollment (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       VARCHAR(255) NOT NULL,             -- discord_user_id (snowflake Discord) — identité pivot élève, PAS un Firebase UID (cf. §4.2bis + RFC-095-DM-IDENTITY-RESOLUTION §11)
+  specialty_id  UUID NOT NULL REFERENCES {schema}.specialties(id) ON DELETE CASCADE,
+  audience_personae_id UUID NULLABLE
+                  REFERENCES {schema}.audience_personae(id) ON DELETE SET NULL,
+  set_by        VARCHAR(255) NULL,
+  set_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (user_id, specialty_id)                   -- 1 inscription par (élève, matière)
+);
+
+CREATE INDEX ix_enrollment_user ON {schema}.student_subject_enrollment (user_id);
+CREATE INDEX ix_enrollment_specialty ON {schema}.student_subject_enrollment (specialty_id);
+```
+
+Lecture :
+- Le **périmètre** d'un élève = `SELECT specialty_id FROM student_subject_enrollment WHERE user_id = :uid`.
+- L'**audience** pour `(élève, matière)` = la ligne correspondante.
+- `audience_personae_id` nullable → si NULL, l'élève est inscrit à la matière mais sans audience spécifique → **bot seul pour cette matière** (pas de couche audience, cf. §4.4).
+
+#### 4.2bis — `user_id` = `discord_user_id` (décision 2026-05-26)
+
+`user_id` contient le **`discord_user_id`** (snowflake Discord, chaîne) — **pas** un Firebase UID. Justification :
+
+- C'est déjà l'identité élève **partout** sur la plateforme : ecommerce (`UserCredit` PK `(guild_id, discord_user_id)`, `orders`, `addresses`…), training (`/api/training/enrollments/user/{discord_id}`).
+- Il n'existe **pas** de table `discord_students` ni de mapping fiable `discord ↔ firebase` ; exiger un compte Firebase par élève Discord est irréaliste.
+- En DM, le bot a déjà `discord_user_id` → **le « pont d'identité » `discord_user_id → user_id` s'effondre** (l'identité *est* le `discord_user_id`). Seul `guild_id → tenant_id` reste à résoudre (existant : `GET /api/n8n/tenants/resolve`).
+- Le `VARCHAR(255)` accueille le snowflake sans migration.
+
+Source des élèves connus d'un tenant (pour l'UI admin) : table publique `discord_user_mappings`, listable via `GET /api/owner/students`. Détail complet : `docs/guides/RFC-095-DM-IDENTITY-RESOLUTION.md` §11.
+
+### 4.3 Routing sémantique contraint (niveau 3)
+
+> **Décision (2026-05-24)** : routing par **classifieur LLM cheap** (Haiku-class), pas embeddings. Justif : robustesse sur les questions ambiguës ; le périmètre étant petit (3-15 matières), le prompt de classification reste court et peu coûteux. Embeddings cosine gardés comme optimisation V2 éventuelle si volume/coût le justifie.
+
+À chaque message, classifier la question **uniquement dans le périmètre inscrit** :
+
+```python
+async def route_subject(question: str, enrolled: list[Specialty]) -> Specialty | None:
+    if not enrolled:
+        return None                       # élève sans inscription → fallback large
+    if len(enrolled) == 1:
+        return enrolled[0]                # pas de routing nécessaire (économie d'1 appel)
+    # Classification LLM cheap contrainte aux N matières inscrites (N : 3-15).
+    # Prompt : "Parmi ces matières {names+descriptions}, laquelle correspond
+    # à la question ? Réponds par l'id, ou 'aucune'." → parse + seuil confiance.
+    return await classify_llm_cheap(question, candidates=enrolled)
+```
+
+**Bénéfices du périmètre contraint** :
+- **Accuracy** ↑ — classer parmi 3-15 candidats, pas tout le catalogue.
+- **Coût** ↓ — prompt court (peu de candidats) + modèle cheap.
+- **Court-circuit** : 1 seule matière inscrite → pas d'appel de classification.
+- **Traçable** : logger la matière retenue + la raison (debug/observabilité).
+
+### 4.4 Comportement hors-périmètre ou ambigu
+
+> **Décision (2026-05-24)** : l'assistant est **restreint aux matières inscrites**. Pas de notion d'« audience large » ni d'assistant généraliste de repli — une question hors inscription est **déclinée**.
+
+| Cas | Comportement |
+|---|---|
+| Question **hors des matières inscrites** | **Décline** : « Cette matière n'est pas dans ton inscription. » Pas de réponse LLM sur le fond. |
+| Élève **sans aucune inscription** | Décline de même (rien à router). À traiter en amont côté UX : inviter à s'inscrire. |
+| Routing **peu confiant** (score < seuil) | Demander à l'élève de préciser (« Tu poses une question de Maths ou d'Histoire ? ») — choix restreint à son périmètre |
+| Inscription **sans `audience_personae_id`** | Bot seul pour cette matière (pas de couche audience) — l'élève est bien inscrit, juste sans audience configurée |
+
+### 4.5 Résolveur runtime
+
+```python
+async def resolve_personae_dm(user_id: str, question: str) -> EffectivePersonae:
+    enrolled = await list_enrolled_specialties(user_id)        # périmètre
+    specialty = await route_subject(question, enrolled)        # niveau 3 routing
+
+    if specialty is None:
+        # Hors périmètre / pas d'inscription → on décline, PAS de fallback
+        # vers un assistant généraliste (cf. §4.4).
+        return EffectivePersonae(out_of_scope=True)
+
+    bot = await resolve_bot(specialty)                          # RFC-081 (specialty/style/models)
+    enrollment = await get_enrollment(user_id, specialty.id)
+    audience = (
+        await load_audience(enrollment.audience_personae_id)
+        if enrollment and enrollment.audience_personae_id else None
+    )
+    return EffectivePersonae(bot=bot, audience=audience)
+```
+
+`EffectivePersonae` étend la sortie RFC-081 avec un bloc `audience` optionnel.
+
+### 4.6 Endpoints HTTP
+
+```
+# Catalogue audience (pattern aligné RFC-081 §14.9)
+GET    /api/owner/audience-personae[?include_drafts=true]
+GET    /api/owner/audience-personae/{id}
+POST   /api/owner/audience-personae                          # → draft
+PATCH  /api/owner/audience-personae/{id}
+POST   /api/owner/audience-personae/{id}/duplicate-as-draft
+POST   /api/owner/audience-personae/{id}/publish
+DELETE /api/owner/audience-personae/{id}
+
+# Inscription élève
+GET    /api/owner/students/{user_id}/enrollments              # périmètre d'un élève
+PUT    /api/owner/students/{user_id}/enrollments              # full-replace atomique
+       body: [{ specialty_id, audience_personae_id? }, ...]
+DELETE /api/owner/students/{user_id}/enrollments/{specialty_id}
+
+# Inverse lookups
+GET    /api/owner/audience-personae/{id}/students             # élèves utilisant cette audience
+GET    /api/owner/specialties/{id}/students                   # élèves inscrits à une matière
+
+# Runtime (n8n / chatbot-core) — résolveur DM
+GET    /api/n8n/personae/resolve-dm?user_id=&question=        # route + compose
+```
+
+> Note : `resolve-dm` prend la `question` pour le routing. Alternative discutée : un endpoint qui retourne le périmètre + audiences, et le routing fait côté n8n. Cf. Q6.
+
+### 4.7 RBAC
+
+2 nouvelles permissions atomiques tenant-scoped :
+
+| Permission | Couvre |
+|---|---|
+| `personae:audience:read` | List/get audience personae + inscriptions + inverse lookups |
+| `personae:audience:write` | CRUD audience personae + PUT/DELETE inscriptions élève |
+
+→ **10 perms total**. Bundle UI `PERSONAE_MANAGER_BUNDLE` étendu à 10. Mappées owner+admin via migration publique (modèle RFC-081 §14.7 + fix `rfc081_v4_personae_perms_fix_001`).
+
+## 5. Routing — choix technique (à benchmarker)
+
+| Approche | Coût/latence | Accuracy | Note |
+|---|---|---|---|
+| **Embeddings cosine** (question vs `Specialty.context_prompt`) | ~0 (vecteurs pré-calculés) | Bonne sur périmètre contraint | Reco par défaut V1 |
+| **LLM cheap classifier** (Haiku) | 1 appel court/message | Excellente, gère l'ambiguïté | Si embeddings insuffisants |
+| **Sélecteur explicite élève** (« /maths ») | 0 | Parfaite | Friction ; fallback quand routing incertain |
+
+**Décision (2026-05-24) : LLM cheap classifier en V1** (Haiku-class), contraint au périmètre inscrit. Embeddings cosine = optimisation V2 si volume/coût le justifient. Sélecteur explicite élève = fallback UX quand la confiance du classifieur est faible.
+
+## 6. Niveau « audience user » individuel — hors scope V1
+
+Le besoin « chaque user a son personae perso » (prénom, préférences) est **absorbé par l'inscription** : l'audience par `(user, matière)` capture déjà la personnalisation utile. Une personnalisation fine par-user (au-delà de la matière) reste hors scope V1.
+
+### 6.1 Extension future — le « niveau » comme dimension de l'audience (V2+)
+
+Piste validée user (2026-05-24) : l'audience d'une inscription peut encoder un **niveau** (débutant / intermédiaire / avancé), et ce niveau pourrait être :
+
+- **Déclaré par l'élève** lui-même à l'inscription (« je me sens avancé en Maths »).
+- **Déterminé par un quiz** de positionnement à l'entrée dans une matière.
+- **Tracé dans le temps** pour suivre la **progression souhaitée** (l'élève vise un niveau cible ; l'audience évolue à mesure qu'il progresse).
+
+Implications schéma (à concevoir en V2) : `student_subject_enrollment` pourrait porter un `level` (enum/int) + un `target_level`, et l'audience injectée serait modulée par ce niveau (ex. même Specialty Maths, mais consignes adaptées débutant vs avancé). Le quiz + le tracking de progression sont une **feature à part entière** (hors RFC-095 V1) mais le modèle de données est compatible : ajouter des colonnes nullables à `student_subject_enrollment` sans casse.
+
+**V1 ne modélise PAS le niveau** : l'inscription = `(élève, matière, audience?)`, 1 ligne par couple. Le niveau, le quiz et la progression sont notés ici comme cap produit, pas comme livrable V1.
+
+## 7. Cohabitation et migration
+
+### 7.1 Pas d'impact RFC-081
+
+Le niveau 1 (bot) est inchangé. Les bindings canal existants continuent. La v2 ajoute un **chemin DM** parallèle.
+
+### 7.2 Migration alembic tenant (additive)
+
+- `CREATE TABLE audience_personae` (cf. §4.1)
+- `CREATE TABLE student_subject_enrollment` (cf. §4.2)
+- UNIQUE partial `audience_personae(name) WHERE is_draft = FALSE`
+- Migration publique : 2 perms `personae:audience:*` → owner+admin (pattern search_path-aware, cf. `rfc081_v4_personae_perms_fix_001` — **ne pas refaire le bug `"{schema}".roles`**).
+
+⚠️ **Vérif pré-FK cross-tenant** (leçon du fix RBAC #2415) : confirmer que `specialties` existe + type PK cohérent sur tous les tenants avant de poser les FK `student_subject_enrollment.specialty_id`.
+
+## 8. Plan d'implémentation — découpage PR (back)
+
+4 PRs séquentielles (B2 dépend de B1, B3 de B1+B2, B4 de B3). Chaque PR
+livre code **+ tests** (pas de PR « tests » séparée — tests dans chaque PR).
+
+### Leçons RFC-081 à respecter impérativement (toutes PRs)
+
+- **Migrations RBAC search_path-aware** : utiliser le pattern de
+  `rfc081_v4_personae_perms_fix_001` (`SET search_path TO "{schema}", public`
+  + refs non-qualifiées). **NE PAS** refaire `"{schema}".roles` (les roles
+  sont en `public`, les perms+role_permissions en tenant — cf. fix #2415).
+- **Types FK cohérents** : vérifier le type PK réel avant de poser une FK
+  (leçon `rag_source_id` VARCHAR vs UUID). `specialties.id` = UUID,
+  `audience_personae.id` = UUID → OK. `user_id` = VARCHAR (**`discord_user_id`**,
+  pas de FK vers users — cf. §4.2bis).
+- **Tables tenant vs public** : `audience_personae` + `student_subject_enrollment`
+  sont **per-tenant** (comme specialties). Vérifier que `specialties` existe
+  bien dans le schéma cible avant la FK.
+- **Pydantic `extra="forbid"`** partout + perms 3-segments (validateur OK
+  depuis #2414).
+- **Idempotence migrations** : `NOT EXISTS` / `IF NOT EXISTS` + skip public
+  pour les tables tenant.
+
+### PR B1 — Catalogue `audience_personae` (~1j)
+
+| Livrable | Détail |
+|---|---|
+| Migration tenant | `audience_personae` (UUID PK, name, description, style_id? FK styles ON DELETE SET NULL, is_draft+parent_id, is_active, set_by/set_at/updated_at) + UNIQUE partial `name WHERE NOT is_draft` + index parent_id |
+| Migration publique RBAC | 2 perms `personae:audience:{read,write}` → owner+admin, **pattern search_path-aware** |
+| RBAC code | `PermissionDomain.PERSONAE_AUDIENCE` + 2 entries `STANDARD_PERMISSIONS` |
+| Model | `AudiencePersonae` (mirror `Specialty`/`Style`) |
+| Schemas | `AudienceCreateRequest`/`UpdateRequest`/`Response`/`ListResponse` (extra=forbid) |
+| Service | `AudiencePersonaeService` — CRUD + Draft/Publish (mirror `SpecialtyService` : create_draft, update_draft, duplicate_as_draft, publish_draft, delete_draft + exceptions typées) |
+| Routes | `/api/owner/audience-personae` — 7 routes (list/get/create/update/duplicate-as-draft/publish/delete) + register `app/api.py` |
+| Tests | service (CRUD+draft/publish) + routes (happy/error + RBAC bypass + extra=forbid 422) |
+| Dépendances | **aucune** (catalogue standalone) — peut démarrer immédiatement |
+
+### PR B2 — Inscription `student_subject_enrollment` (~0.8j)
+
+| Livrable | Détail |
+|---|---|
+| Migration tenant | `student_subject_enrollment` (UUID PK, user_id VARCHAR, specialty_id FK CASCADE, audience_personae_id? FK SET NULL, UNIQUE(user_id,specialty_id), index user+specialty) |
+| Model | `StudentSubjectEnrollment` |
+| Schemas | `EnrollmentItem`, `EnrollmentSetRequest` (list), `EnrollmentListResponse` (extra=forbid) |
+| Service | `EnrollmentService` — list_for_student, set_enrollments (full-replace atomique diff add/remove), delete_one, inverse (students_for_audience, students_for_specialty) |
+| Routes | `GET/PUT/DELETE /api/owner/students/{user_id}/enrollments` + 2 inverse lookups |
+| RBAC | réutilise `personae:audience:{read,write}` |
+| Tests | service (set diff, inverse) + routes |
+| Dépendances | **B1** (FK `audience_personae_id`) |
+
+### PR B3 — Routing + résolveur DM (~1.2j)
+
+| Livrable | Détail |
+|---|---|
+| Settings | env vars : modèle classifieur cheap (`PERSONAE_ROUTER_MODEL`, défaut Haiku-class), seuil de confiance |
+| Routing | `route_subject(question, enrolled)` — court-circuit si 1 matière ; sinon classifieur **LLM cheap** contraint au périmètre + parse + seuil |
+| Helpers | `list_enrolled_specialties(user_id)`, `get_enrollment(user_id, specialty_id)` |
+| Résolveur | `resolve_personae_dm(user_id, question)` → compose bot (RFC-081) + audience (inscription) ; fallbacks (no enrollment / hors-scope / faible confiance) |
+| Endpoint | `GET /api/n8n/personae/resolve-dm?user_id=&question=` (X-Service-Token, search_path scopé — pattern RFC-094 `_get_n8n_db`) |
+| Schémas | étendre `EffectivePersonaeResponse` avec bloc `audience` + `routed_specialty_id` + `routing_confidence` |
+| Tests | routing (LLM mocké : haute/basse confiance, hors-scope) + résolveur + endpoint (happy + fallbacks) |
+| Dépendances | **B1 + B2 + RFC-081** (specialty/style resolver) |
+
+### PR B4 — Doc compagnon + smoke E2E (~0.7j)
+
+| Livrable | Détail |
+|---|---|
+| Doc front | §14 « Audience personae + inscription » dans `FRONTEND-RFC-081-V4-PERSONAE.md` (endpoints catalogue + inscription + RBAC 10 perms) |
+| Doc n8n | contrat `resolve-dm` (params, réponse, fallbacks) pour chatbot-core |
+| Smoke E2E | golden path DM multi-matières sous `INTEGRATION=1` (inscrire élève 3 matières → resolve-dm sur 2 questions de matières ≠ → vérifier routing + audience correcte) |
+| Dépendances | **B3** |
+
+**Total back : ~3.7j**, séquentiel B1→B2→B3→B4.
+
+### Front (hors périmètre back, ~3j à affiner)
+
+Catalogue audience (vue `/admin/personae/audiences` + `AudiencePersonaeFormDialog`) + UI inscription élève (dépend de Q2 — flux Discord élève vs admin) + carte hub. **B1 front peut démarrer dès B1 back mergé.**
+
+### Ordre de merge recommandé
+
+```
+B1 (catalogue)  ─→ B2 (inscription)  ─→ B3 (routing+resolve-dm)  ─→ B4 (doc+E2E)
+   front B1 ────────────────────────────────────────────────────→ front intégrations
+```
+
+B1 back + front B1 peuvent démarrer en parallèle immédiatement (ne dépendent pas de Q2). B3 attend la confirmation du contrat `resolve-dm` avec n8n. Le flux d'inscription Discord (Q2) ne bloque que le front, pas le back B1/B2.
+
+## 9. Questions ouvertes (à arbitrer avant code)
+
+| # | Question | Arbitre |
+|---|---|---|
+| ~~1~~ | ✅ **Tranché (2026-05-24, front+back alignés)** : `style_id` **réutilise le catalogue Styles RFC-081** (cohérence, pas de catalogue en double). FK `styles(id) ON DELETE SET NULL`. | back |
+| 2 | Inscription = acte explicite en base (~~ENT/Pronote abandonné~~). **Direction actée (2026-05-24)** : **double voie** — auto-inscription élève côté **Discord** + inscription manuelle **admin**. Reste à détailler les 2 flux UX. | produit |
+| ~~2bis~~ | ✅ **Tranché (2026-05-24)** : routing + composition **côté back** via `resolve-dm` (prend la `question`, renvoie le prompt composé). n8n reste bête. Cohérent pattern `/api/n8n/personae/resolve`. | back |
+| ~~3~~ | ✅ **Tranché (2026-05-24, front+back alignés)** : `/api/owner/audience-personae` (cohérent `/personae-bricks`). | back |
+| ~~4~~ | ✅ **Clos (2026-05-24)** : non-question. L'inscription = 1 ligne par `(élève, matière)` (UNIQUE), pas de notion de « niveau » en V1. Le « niveau » (déclaré / quiz / progression) est une **extension future** notée §6.1, hors V1. |
+| ~~5~~ | ✅ **Tranché (2026-05-24)** : **LLM cheap** (Haiku-class) contraint au périmètre inscrit. Embeddings = optimisation V2 éventuelle. | back |
+| ~~6~~ | ✅ **Tranché** = Q2bis : routing côté back (`resolve-dm`). | back |
+| **5bis** | ⏳ **L'appel LLM de classification du routing passe-t-il par MCP** (cohérent « tout LLM via MCP », chat.api n'a pas de client d'inférence direct) ou par un mini-client cheap dédié dans chat.api ? | back + **MCP** |
+| ~~7~~ | ✅ **Clos (2026-05-24)** : **pas** d'« audience large ». L'assistant est restreint aux matières inscrites ; une question hors périmètre est **déclinée** (§4.4). Aucune entité par défaut à créer. |
+
+## 9bis. Impacts équipes — chaque équipe doit se prononcer
+
+> Cette section liste l'impact pressenti par le back sur chaque équipe. **Chaque équipe renseigne sa colonne « Position »** (✅ OK / ⚠️ réserves / ❌ bloquant) + charge estimée + remarques, avant le démarrage de la PR B3 (runtime). Tant qu'une ligne est ⏳, l'intégration runtime n'est pas figée.
+
+### 9bis.1 — n8n / chatbot-core
+
+| Item | Détail | Position | Charge | Remarques |
+|---|---|---|---|---|
+| Câblage `resolve-dm` | Nouveau `GET /api/n8n/personae/resolve-dm?user_id=&question=` à appeler pour le flux DM élève (en plus de `/resolve` RFC-081 par canal). | ⏳ à évaluer | | |
+| Gestion `out_of_scope` | Si réponse `out_of_scope=true` → afficher le message de décline (matière hors inscription). | ⏳ à évaluer | | |
+| Gestion faible confiance | Si le back renvoie une demande de précision (« Maths ou Histoire ? ») → la relayer à l'élève. | ⏳ à évaluer | | |
+| Auth service-to-service | Réutilise `X-Service-Token` + `X-Tenant-ID` (pattern existant). | ⏳ à évaluer | | |
+
+### 9bis.2 — plugin Discord
+
+| Item | Détail | Position | Charge | Remarques |
+|---|---|---|---|---|
+| UX inscription élève | **Nouveau** : permettre à l'élève de s'inscrire à ses matières (commande slash ? menu select ? réaction ?). Q2 « double voie », volet Discord. | ⏳ à évaluer | | |
+| Flux DM 1:1 | Router les messages DM élève↔bot vers le pipeline resolve-dm. | ⏳ à évaluer | | |
+| UX décline / précision | Afficher le message hors-scope ; si demande de précision, potentiellement des boutons Discord. | ⏳ à évaluer | | |
+
+### 9bis.3 — MCP
+
+| Item | Détail | Position | Charge | Remarques |
+|---|---|---|---|---|
+| Appel LLM de classification (Q5bis) | Le routing `resolve-dm` doit classer la question via un LLM cheap. chat.api **n'a pas de client d'inférence direct** → l'appel transiterait par MCP (`MCPHTTPDispatch`). À cadrer : modèle utilisé, quota, audit. | ⏳ à évaluer | | |
+| Alternative client direct | Donner à chat.api un mini-client cheap dédié (contourne MCP, casse le principe « tout LLM via MCP »). | ⏳ à évaluer | | |
+| Skills / notebooks | Résolveur renvoie `skill_ids`/`notebook_ids` (RFC-081, déjà existant) — additif, **a priori pas d'impact MCP**. À confirmer. | ⏳ à évaluer | | |
+
+### 9bis.4 — front (rappel)
+
+| Item | Détail | Position | Charge | Remarques |
+|---|---|---|---|---|
+| UI catalogue audience | CRUD `/api/owner/audience-personae` (Draft/Publish, mirror Specialty/Style). | ⏳ à évaluer | | |
+| UI inscription (admin) | Gérer les inscriptions élève×matière côté owner (`/api/owner/students/{user_id}/enrollments`). | ⏳ à évaluer | | |
+
+> Les contrats d'endpoints (params, payload in/out, codes d'erreur) sont produits en **PR B0** (doc-first, cf. plan d'action `docs/issues/2026-05-24-rfc-095-plan-action-back.md`) **avant** tout code, pour que chaque équipe se prononce sur une base figée.
+
+## 10. Hors scope V1
+
+- Personnalisation fine par-user au-delà de la matière (§6).
+- Templates d'audience cross-tenant prédéfinis (« Niveau bac », « Découverte »).
+- Audience analytics (conversations par matière/niveau).
+- Routing multi-tours (mémoire du sujet courant dans la conversation pour éviter de reclasser chaque message) — optimisation V2.
+
+## 11. Schéma récapitulatif
+
+```
+                       ┌─────────────────────────────┐
+   Catalogue (owner)   │ audience_personae            │  ← réutilisable tenant-wide
+                       │  (name, description, style?)  │
+                       └──────────────┬──────────────┘
+                                      │ référencée par
+                       ┌──────────────┴──────────────┐
+   Inscription élève   │ student_subject_enrollment   │
+                       │  (user_id, specialty_id,      │
+                       │   audience_personae_id?)      │
+                       └──────────────┬──────────────┘
+                                      │ périmètre + audience
+   Runtime DM 1:1                     ▼
+   élève ──question──► route_subject(question, périmètre) ──► specialty
+                                      │
+                                      ├─► bot      = RFC-081 resolve(specialty)
+                                      └─► audience = enrollment(user, specialty).audience
+                                      ▼
+                              system_prompt composé
+```
+
+## 12. Changelog
+
+- **2026-05-26 (v2.5)** — Ajout §9bis « Impacts équipes » (n8n / plugin Discord / MCP / front), chaque équipe doit renseigner sa position avant B3. Ajout Q5bis (chemin de l'appel LLM de classification : via MCP ou client direct ?). Plan d'action : ajout d'une **PR B0 doc-first** (contrats endpoints + payloads in/out) en tête de séquence.
+- **2026-05-24 (v2.4)** — Q4 + Q7 clos. Q4 : pas de « niveau » en V1 (mon erreur de framing) — 1 ligne par (élève, matière) ; le niveau (déclaré/quiz/progression) devient une **extension future §6.1**. Q7 : pas d'« audience large » — hors-périmètre = décline (§4.4). Résolveur §4.5 corrigé (`out_of_scope` au lieu de `broad_default`). **Toutes les questions ouvertes sont désormais tranchées** — spec prête à coder.
+- **2026-05-24 (v2.3)** — Q1 (style_id réutilise catalogue Styles) + Q3 (naming `/api/owner/audience-personae`) tranchées, front+back alignés. §5 reco routing corrigée (LLM cheap, plus « embeddings d'abord »).
+- **2026-05-24 (v2.2)** — Décisions tranchées : routing = **LLM cheap** contraint au périmètre (Q5) ; routing + composition **côté back** via `resolve-dm` (Q2bis/Q6) ; inscription **double voie Discord élève + admin** (Q2, flux UX à détailler).
+- **2026-05-24 (v2.1)** — Précision inscription : import ENT/Pronote abandonné, l'inscription est un acte explicite persisté en base. Reste ouvert : l'acteur de l'inscription (Q2) + le mécanisme de transmission au bot (Q2bis/Q6).
+- **2026-05-24 (v2)** — Refonte autour de « DM 1:1 + inscription matières + routing contraint ». Abandon du modèle v1 « audience statique par groupe » qui ne tenait pas sur le cas DM multi-matières (chevauchement systématique / explosion du nombre de bots). Fusion des anciens niveaux 2/3 : l'audience est cataloguée + consommée via l'inscription ; le « niveau 3 » devient le routing dynamique.
+- **2026-05-21 (v1)** — Draft initial 3 niveaux (bot / audience groupe / audience user), suite à l'audit Discord.

--- a/docs/rfc/RFC-096-PERSONAE-PEDAGOGIQUE.md
+++ b/docs/rfc/RFC-096-PERSONAE-PEDAGOGIQUE.md
@@ -1,0 +1,942 @@
+# RFC-096 — Extension pédagogique du modèle Personae (Assistant pédagogique)
+
+| Champ | Valeur |
+|-------|--------|
+| Statut | Draft |
+| Version | 0.2 (fusion v1 interne + avis externe) |
+| Auteur | Franck |
+| Date | 2026-05-27 |
+| Étend | **RFC-081** (Personae 3-axes : Expert × Specialty × Style × Binding), **RFC-095** (inscription matières + audience + routing DM, *livré* B1/B2) |
+| Dépend de | **RFC-082** (programmes experts / Google Classroom) pour l'objet Référentiel ; capacités RAG multi-bot + chaîne multi-intent (numéros RFC **à attribuer**) |
+| Liés | Travaux Progression Pédagogique (STMG SGN 2026-2027) |
+
+> ⚠️ **Recalage numérotation (2026-05-27)** : ce document était nommé `RFC-095-personae-pedagogique-v2`, or RFC-095 est **déjà** le modèle *inscription + audience* (livré). C'est donc une **nouvelle RFC (RFC-096)** qui *étend* RFC-081 et RFC-095, pas une v2 de RFC-095.
+>
+> ⚠️ **xrefs du draft initial à recaler** : « RFC-053 (RAG scoping) », « RFC-054 (multi-intent) », « RFC-059 (gamification mastery) » **ne correspondent pas** à l'index de ce repo (ici RFC-053 = *Discord bot server management*, RFC-054 = *inexistante*, RFC-059 = *Guild credit allocation*). Les vrais numéros pour le scoping RAG / la chaîne multi-intent sont **à attribuer**. Delta back + état du livré : `docs/issues/2026-05-27-rfc-096-pedagogique-delta-back.md`.
+
+---
+
+## 1. Résumé exécutif
+
+Le modèle Personae actuel — composé de **Rôle, Spécialité, Style, Audience, Canal** — est solide pour les usages génériques (marketing, support, formation entreprise) mais présente plusieurs angles morts pour l'usage scolaire :
+
+1. Le **Niveau** est noyé dans la Spécialité, ce qui interdit la mutualisation par cycle et empêche le raisonnement sur la progression.
+2. Le **Référentiel** officiel (BO, Eduscol) est traité comme un simple document du corpus, alors qu'il définit ce qui *doit* être couvert.
+3. Les **Compétences** ne sont pas représentées comme objets pilotables et réutilisables entre niveaux.
+4. Le **Mode pédagogique** (acte pédagogique) est confondu avec le Style (ton).
+5. La **Politique de réponse** (scaffolding) est implicite.
+6. La **temporalité** (progression dans l'année) n'est pas représentée.
+7. Le **routage matière** dans le cas multi-matières repose sur une classification silencieuse.
+8. Aucune **mesure de qualité** n'est attachée au Personae.
+
+Cette RFC propose une **extension scolaire optionnelle** du modèle Personae, structurée autour de sept nouveaux objets ou dimensions :
+
+```
+Assistant pédagogique = Personae générique
+                      + pedagogical_extension {
+                            Discipline
+                          + Niveau
+                          + Référentiel
+                          + Compétences
+                          + Corpus typé
+                          + Mode pédagogique
+                          + Politique de réponse
+                          + Progression
+                          + Santé
+                        }
+```
+
+L'extension est **strictement additive** : les personae existants (marketing, support, coaching) ne sont pas touchés ; leur `pedagogical_extension` reste à `null`.
+
+**Priorisation** : (1) Niveau + Référentiel + Compétence, (2) Mode pédagogique, (3) Politique de réponse, (4) Progression, (5) Routage robuste, (6) Santé.
+
+---
+
+## 2. Contexte
+
+### 2.1 Modèle Personae actuel
+
+| Objet | Rôle |
+|-------|------|
+| Rôle | Fonction de l'assistant (Professeur, Coach…) |
+| Spécialité | Domaine + sources documentaires |
+| Style | Ton, registre, format |
+| Audience | Public visé |
+| Brique | Spécialité + Style réutilisable |
+| Canal | Lieu d'activation (Discord, Web, Classroom) |
+| Binding | Rattachement personae × canal |
+| Inscription | Matières d'un élève |
+
+### 2.2 Vertus du modèle actuel
+
+- Évite le bot monolithique.
+- Sépare proprement **savoir** / **médiation** / **public**, ce qui correspond implicitement au triangle didactique.
+- Réutilisable via Brique, déclinable via Audience.
+- Vue matricielle des bindings opérationnelle.
+
+### 2.3 Limites pour le scolaire
+
+Au-delà des huit angles morts résumés en §1, deux limites structurelles méritent d'être nommées :
+
+**Duplication par niveau.** "Maths 3ème" et "Maths 4ème" sont aujourd'hui deux Spécialités distinctes alors que ~70% du corpus cycle 4 est commun. À l'échelle multi-tenant, la duplication devient ingérable.
+
+**Impossibilité de raisonner sur la couverture.** Sans représentation explicite du programme officiel, on ne peut pas répondre à *« ce personae couvre-t-il toutes les compétences attendues en 3ème ? »*.
+
+---
+
+## 3. Modèle cible
+
+### 3.1 Vue conceptuelle
+
+```
+Assistant pédagogique
+├── Identité (Rôle, nom affiché)
+├── Domaine scolaire
+│   ├── Discipline
+│   ├── Niveau (+ cycle)
+│   ├── Référentiel
+│   └── Compétences couvertes
+├── Ressources
+│   └── Corpus typé (cours, exercices, corrections, erreurs, méthodes)
+├── Adaptation pédagogique
+│   ├── Audience
+│   ├── Style
+│   ├── Mode pédagogique (acte par défaut + autorisés)
+│   ├── Politique de réponse (catalogue de règles)
+│   └── Progression active
+├── Activation
+│   └── Canal + binding + inscriptions
+└── Qualité
+    └── Santé du personae
+```
+
+### 3.2 Responsabilités par objet
+
+| Objet | Question | Exemple |
+|-------|----------|---------|
+| Rôle | Qui parle ? | Professeur, Tuteur, Conseiller |
+| Discipline | De quelle matière ? | Mathématiques, Histoire-Géo |
+| Niveau | À quel niveau scolaire ? | 3ème, 1ère STMG |
+| Référentiel | Qu'est-ce qui est attendu officiellement ? | BO cycle 4 maths |
+| Compétence | Quelle unité pédagogique pilotable ? | Résoudre une équation du 1er degré |
+| Corpus | Sur quelles ressources s'appuie-t-on ? | Cours, exercices, annales |
+| Audience | À quel type d'élève s'adresse-t-on ? | Soutien, standard, visée mention |
+| Style | Comment s'exprime-t-on ? | Rassurant, rigoureux, ludique |
+| Mode pédagogique | Quel acte est en cours ? | Explication, aide guidée, correction |
+| Politique de réponse | Quelles règles de scaffolding ? | Indice avant solution, refus devoir clef en main |
+| Progression | Où en est la classe / l'élève ? | Période 2, chapitre courant |
+| Canal | Où intervient l'assistant ? | Discord, Web, Classroom |
+| Santé | Est-il fiable et couvrant ? | Indicateurs §3.3.9 |
+
+### 3.3 Objets nouveaux ou recadrés
+
+#### 3.3.1 Discipline + Niveau (split de la Spécialité)
+
+La Spécialité *« Maths 3ème »* est éclatée :
+
+```json
+{
+  "discipline_id": "mathematiques",
+  "level_id": "3eme",
+  "cycle": "cycle_4"
+}
+```
+
+Le libellé court *« Maths 3ème »* est conservé côté UI (les profs raisonnent ainsi). Côté données, le couple est explicite, indexable, et permet la mutualisation par cycle.
+
+#### 3.3.2 Référentiel
+
+Le Référentiel matérialise un programme officiel sous forme exploitable, pas comme un PDF du corpus :
+
+```json
+{
+  "referential_id": "bo_maths_cycle4_3eme",
+  "source": "BO n°31 du 30 juillet 2020",
+  "discipline_id": "mathematiques",
+  "level_id": "3eme",
+  "cycle": "cycle_4",
+  "competency_ids": [
+    "eq_1er_degre",
+    "fonctions_affines",
+    "theoreme_thales",
+    "proportionnalite_avancee"
+  ],
+  "version": "2020-07-30",
+  "limits": [
+    "ne pas introduire les équations du second degré",
+    "trigonométrie limitée au triangle rectangle"
+  ]
+}
+```
+
+Le Référentiel sert simultanément à filtrer le retrieval Qdrant (extension du grain RFC-053), évaluer la couverture, détecter le hors-périmètre, borner le golden dataset et identifier les prérequis manquants.
+
+#### 3.3.3 Compétence (nouveau, objet distinct)
+
+La Compétence est l'**unité pédagogique pilotable**. Elle est un objet de première classe, **partagé entre référentiels** (une même compétence peut apparaître à plusieurs niveaux avec des attendus différents) :
+
+```json
+{
+  "competency_id": "proportionnalite",
+  "label": "Proportionnalité",
+  "discipline_id": "mathematiques",
+  "level_variants": [
+    {
+      "level_id": "cm2",
+      "expected": "résoudre des problèmes simples avec tableaux",
+      "prerequisites": ["multiplication", "division"]
+    },
+    {
+      "level_id": "3eme",
+      "expected": "mobiliser dans des problèmes complexes, pourcentages, fonctions linéaires",
+      "prerequisites": ["calcul_litteral", "fonctions_lineaires"]
+    }
+  ]
+}
+```
+
+**Pourquoi un objet distinct du Référentiel** : une notion comme la proportionnalité traverse CM2, 6ème, 5ème, 4ème, 3ème avec des exigences progressives mais des prérequis partiellement communs. Modéliser la Compétence à part permet de capturer ces continuités, de mutualiser, et de raisonner sur les prérequis transversaux (essentiel pour le mode `remediation`).
+
+Le Référentiel devient alors une **liste de `competency_ids`** plutôt qu'un container monolithique des compétences.
+
+#### 3.3.4 Corpus typé
+
+Le Corpus reste rattaché à `(Discipline, Niveau)` mais ses chunks Qdrant portent un `type` qui pilote le filtrage RAG (cf. §4) :
+
+| Type | Contenu | Mode pédagogique principal |
+|------|---------|----------------------------|
+| `cours` | Leçons, définitions, démonstrations | `explication` |
+| `exercice` | Énoncés et corrigés gradués | `entrainement` |
+| `methode` | Stratégies de résolution typées | `aide_guidee` |
+| `correction` | Productions d'élèves corrigées | `correction` |
+| `erreur_classique` | Erreurs récurrentes commentées | `remediation` |
+| `referentiel` | Compétences BO | bornage / refus |
+
+Métadonnées par chunk :
+
+```json
+{
+  "discipline_id": "mathematiques",
+  "level_id": "3eme",
+  "cycle": "cycle_4",
+  "referential_id": "bo_maths_cycle4_3eme",
+  "competency_ids": ["eq_1er_degre"],
+  "type": "cours",
+  "difficulty": "standard",
+  "source_type": "support_enseignant",
+  "validated_by": "teacher",
+  "periods": ["periode_2"]
+}
+```
+
+#### 3.3.5 Mode pédagogique (nouveau, distinct du Style)
+
+Le Style décrit *comment on parle*. Le Mode pédagogique décrit *l'acte pédagogique en cours*. Deux axes orthogonaux.
+
+| Mode | Objectif |
+|------|----------|
+| `explication` | Faire comprendre une notion |
+| `aide_guidee` | Accompagner sans donner la solution |
+| `correction` | Corriger une production d'élève (copie, étape) |
+| `entrainement` | Proposer des exercices progressifs |
+| `revision` | Synthèse + quiz avant évaluation |
+| `evaluation` | Tester les acquis |
+| `remediation` | Reprendre les prérequis ou lacunes |
+
+Cette liste est volontairement opérationnelle : elle correspond aux **usages réels d'un enseignant**, pas à des catégories didactiques abstraites (socratique, magistrale…) qui mélangeraient posture et acte.
+
+Un Personae a un mode par défaut et une liste de modes autorisés :
+
+```json
+{
+  "default_pedagogical_mode": "aide_guidee",
+  "allowed_pedagogical_modes": [
+    "explication", "aide_guidee", "correction",
+    "entrainement", "revision", "remediation"
+  ]
+}
+```
+
+Le mode actif d'un échange peut être :
+- détecté automatiquement par classification d'intention,
+- choisi par l'enseignant via une commande,
+- demandé explicitement par l'élève ("aide-moi à corriger ma copie").
+
+#### 3.3.6 Politique de réponse (nouveau, catalogue)
+
+La Politique de réponse est un **catalogue de règles nommées** qu'on combine pour piloter le scaffolding. C'est plus modulaire et plus utilisable côté UI qu'un objet à champs booléens.
+
+| Politique | Effet |
+|-----------|-------|
+| `indice_avant_solution` | Donner un indice avant toute résolution complète |
+| `solution_par_etapes` | Découper la réponse en étapes successives |
+| `questionner_avant_aider` | Demander à l'élève ce qu'il a déjà tenté |
+| `correction_sans_faire_a_la_place` | Corriger la démarche sans produire le devoir |
+| `solution_complete_autorisee_en_revision` | Autoriser une solution complète dans un contexte de révision |
+| `refus_devoir_clef_en_main` | Refuser de faire un devoir entier sans participation |
+| `rappeler_prerequis_si_bloque` | Remonter aux prérequis si l'élève est bloqué |
+| `verbalisation_obligatoire` | Demander à l'élève de reformuler ce qu'il comprend |
+
+Application :
+
+```json
+{
+  "response_policies": [
+    "indice_avant_solution",
+    "correction_sans_faire_a_la_place",
+    "refus_devoir_clef_en_main",
+    "rappeler_prerequis_si_bloque"
+  ]
+}
+```
+
+**Cadrage produit important** : ce n'est pas une politique « anti-triche ». C'est une politique de **scaffolding pour l'apprentissage**. Le framing matter dans la communication aux profs, élèves et familles.
+
+Des **presets** peuvent être proposés côté UI : *« Soutien scolaire »*, *« Préparation examen »*, *« Coaching méthode »*, etc.
+
+#### 3.3.7 Progression
+
+Plug-in direct sur l'objet **Progression Pédagogique existant** (cf. travaux STMG SGN 2026-2027). Le Personae connaît à tout instant la position de la classe ou de l'élève :
+
+```json
+{
+  "progression_binding": {
+    "scope": "class_group",
+    "progression_id": "maths_3eme_2026_2027_classe_3A"
+  }
+}
+```
+
+Structure d'une Progression :
+
+```json
+{
+  "progression_id": "maths_3eme_2026_2027_classe_3A",
+  "scope": "class_group",
+  "etablissement": "college_xxx",
+  "periode_active": {
+    "numero": 2,
+    "debut": "2026-11-04",
+    "fin": "2026-12-19"
+  },
+  "competencies_vues": ["calcul_litteral", "equations_simples"],
+  "competencies_en_cours": ["theoreme_thales"],
+  "competencies_a_venir": ["fonctions_affines", "trigonometrie"]
+}
+```
+
+Comportement attendu : si la question porte sur une compétence `a_venir`, le Personae le signale et propose deux options (découverte simple ou remédiation des prérequis) plutôt que de répondre comme si la notion avait été enseignée.
+
+**C'est probablement le différenciant le plus fort par rapport à un GPT générique.** Aucun chatbot grand public ne sait *où* en est une classe à un instant t.
+
+#### 3.3.8 Santé du personae
+
+Indicateur agrégé affiché dans la matrice (cf. RFC-095) :
+
+| Indicateur | Calcul |
+|------------|--------|
+| Couverture référentiel | % de compétences avec ≥ N chunks pertinents |
+| Hors-périmètre | % de questions sortant du couple `(discipline, niveau)` |
+| Qualité réponses | Score LLM judge azy-mcp sur le golden dataset |
+| Respect du mode pédagogique | % de réponses conformes au mode actif |
+| Respect des politiques | % de réponses conformes aux politiques activées |
+| Qualité du routage matière | Taux d'acceptation des matières détectées |
+| Fraîcheur corpus | Date du dernier ajout |
+| Satisfaction enseignant | Retours manuels et validations |
+
+Alimentation :
+- LLM judge azy-mcp sur le golden dataset (batch hebdomadaire, modèle Haiku pour le coût).
+- Traces de conversation classifiées.
+- Corrections explicites des élèves sur le routage matière (§5.3).
+- Retours enseignants.
+
+---
+
+## 4. RAG et filtrage par mode pédagogique
+
+### 4.1 Principe
+
+Le retrieval Qdrant n'est plus une simple recherche sémantique sur un corpus monolithique : il est **piloté par le Mode pédagogique actif**. Le type de chunks privilégié change selon l'acte en cours.
+
+| Mode actif | Types de chunks privilégiés |
+|------------|------------------------------|
+| `explication` | `cours`, `methode`, `exemple` |
+| `aide_guidee` | `methode`, `exercice`, `erreur_classique` |
+| `correction` | `correction`, `erreur_classique`, `bareme` |
+| `entrainement` | `exercice` (filtré par difficulté) |
+| `revision` | `cours` (synthèses), `exercice` (representatifs) |
+| `remediation` | `cours` (prérequis), `erreur_classique`, `methode` |
+
+### 4.2 Ordre de filtrage recommandé
+
+```
+1. Tenant / établissement
+2. Élève / groupe / classe (si applicable)
+3. Discipline
+4. Niveau
+5. Référentiel
+6. Progression active (vu / en cours / non vu)
+7. Compétence ou notion détectée dans la question
+8. Type de ressource selon le mode pédagogique
+9. Difficulté (selon audience)
+```
+
+Le filtrage 1–7 borne le retrieval ; le filtrage 8–9 le pondère.
+
+### 4.3 Extension du grain RFC-053
+
+RFC-053 introduisait un scoping `(guild_id, bot_id)` pour Qdrant. L'extension scolaire ajoute :
+
+```
+(tenant_id, persona_id, discipline_id, level_id, referential_id, competency_id, type, difficulty)
+```
+
+Tous indexés. Le scoping reste rétro-compatible : un personae non-scolaire utilise le grain RFC-053 d'origine.
+
+---
+
+## 5. Cas particulier : un élève, plusieurs matières
+
+### 5.1 Tuteur personnel comme orchestrateur
+
+Conformément au cas prévu dans le guide actuel, l'élève voit un **Tuteur personnel** unique. Derrière, l'orchestrateur sélectionne le personae interne pertinent (Maths 3ème, Histoire 3ème…) selon :
+
+1. Inscription de l'élève (périmètre autorisé).
+2. Classification de la matière depuis la question.
+3. Classification de l'intention pédagogique (→ mode actif).
+4. Audience associée à l'élève.
+5. Progression de la classe / de l'élève.
+
+### 5.2 Cas qui cassent le routage
+
+| Cas | Exemple | Risque |
+|-----|---------|--------|
+| Question transversale | "Je ne comprends pas la moyenne dans notre expérience" | Maths ou SVT |
+| Question implicite | "Et pour l'autre formule ?" | Perte de contexte |
+| Question hors inscription | "Explique le logarithme" en CM2 | Hors-périmètre |
+| Question ambiguë | "Je ne comprends pas les fonctions" | Maths / programmation / économie |
+| Suite conversationnelle | Matière claire 3 messages avant | Mauvais routage isolé |
+
+### 5.3 Transparence à l'élève (UX)
+
+La matière détectée doit être **affichée** et **corrigible** en un clic :
+
+```
+Matière détectée : Mathématiques
+[ Changer : SVT | Physique | Géographie ]
+```
+
+Bénéfices :
+- Correction immédiate des erreurs de routage.
+- Trace utilisable pour améliorer le classifieur.
+- Bénéfice pédagogique direct : oblige l'élève à conceptualiser sa question.
+- Confiance utilisateur (pas de boîte noire).
+
+### 5.4 Implémentation orchestrateur
+
+Étend RFC-054 (multi-intent chain dans azy-mcp) :
+
+```
+Message élève
+  → identification utilisateur
+  → chargement profil (niveau, inscriptions, audience, progression)
+  → classification matière + intention → mode pédagogique
+  → si confiance < seuil : confirmation utilisateur
+  → sélection personae interne
+  → retrieval Qdrant filtré (cf. §4.2)
+  → application style + mode + politiques de réponse
+  → génération réponse
+  → trace de progression (compétence abordée, intention, satisfaction)
+```
+
+---
+
+## 6. Évaluation
+
+### 6.1 Golden dataset par référentiel
+
+Pour chaque Référentiel, un golden dataset minimal :
+
+```
+20 questions d'explication
+20 demandes d'aide guidée
+20 corrections d'erreurs fréquentes
+10 questions hors programme
+10 questions ambiguës multi-matières
+10 cas de devoir à ne pas faire à la place de l'élève
+```
+
+Chaque question est rattachée à un ou plusieurs `competency_ids`, ce qui permet le calcul de couverture par compétence.
+
+Stockage : collection Qdrant dédiée par référentiel, taguée `golden_dataset=true`.
+
+### 6.2 LLM judge (extension azy-mcp)
+
+Critères de notation pondérés :
+
+1. Exactitude disciplinaire.
+2. Adéquation au niveau (vocabulaire, complexité).
+3. Conformité au mode pédagogique actif.
+4. Conformité aux politiques de réponse activées.
+5. Respect du format attendu pour le canal.
+6. Refus correct du hors-périmètre.
+7. Cohérence avec la progression active (notion vue / non vue).
+
+Le juge LLM **ne remplace pas l'enseignant**. Il permet un premier contrôle automatique, la détection de dérives, la comparaison entre versions de prompts, la mesure de non-régression, et l'aide à la validation avant publication.
+
+### 6.3 Boucle d'amélioration
+
+Annotation des cas litigieux via le pipeline n8n existant → ré-injection dans le golden dataset → re-évaluation hebdomadaire. Cohérent avec l'architecture LangChain human-in-the-loop déjà mappée sur l'infra (Qdrant golden datasets + Discord annotation queue).
+
+---
+
+## 7. Migration depuis le modèle actuel
+
+### 7.1 Compatibilité ascendante via `pedagogical_extension`
+
+L'extension est **strictement optionnelle**. Un personae non-scolaire reste inchangé :
+
+```json
+{
+  "id": "coach_marketing_b2b",
+  "role_id": "coach",
+  "style_id": "encourageant",
+  "audience_id": "junior",
+  "channels": [...],
+  "pedagogical_extension": null
+}
+```
+
+Un personae scolaire l'utilise :
+
+```json
+{
+  "id": "persona_maths_3eme_soutien",
+  "role_id": "teacher",
+  "style_id": "rassurant_concret",
+  "audience_id": "remise_a_niveau",
+  "channels": [...],
+  "pedagogical_extension": {
+    "discipline_id": "mathematiques",
+    "level_id": "3eme",
+    "cycle": "cycle_4",
+    "referential_id": "bo_maths_cycle4_3eme",
+    "competency_ids": ["..."],
+    "corpus_collections": ["..."],
+    "default_pedagogical_mode": "aide_guidee",
+    "allowed_pedagogical_modes": ["..."],
+    "response_policies": ["..."],
+    "progression_binding": {...},
+    "health": {...}
+  }
+}
+```
+
+Aucun champ scolaire ne pollue le schéma générique.
+
+### 7.2 Étapes
+
+| # | Étape | Effort | Impact |
+|---|-------|--------|--------|
+| 1 | Schéma `pedagogical_extension` + objets Level, CurriculumReference, Competency | Moyen | Élevé (déverrouille tout le reste) |
+| 2 | Migration des Spécialités existantes (split Discipline/Niveau inféré) | Moyen | Élevé |
+| 3 | Catalogue des Modes pédagogiques + prompts par mode | Moyen | Élevé |
+| 4 | Catalogue des Politiques de réponse + presets | Faible | Élevé |
+| 5 | Connexion Progression existante | Moyen | Différenciant fort |
+| 6 | Transparence routage matière | Faible | Robustesse |
+| 7 | Santé du personae dans matrice + LLM judge | Élevé | Pilotage à l'échelle |
+
+### 7.3 Sourcing des Référentiels et Compétences
+
+Trois options :
+
+- **Constitution manuelle** par les profs (1 référentiel = 1 à 2 jours-homme).
+- **Extraction LLM** depuis les BO Eduscol publics (à valider qualitativement).
+- **Mutualisation** entre tenants (§8.3).
+
+Recommandation : seed initial par extraction LLM sur 3 à 5 référentiels prioritaires (Maths/Histoire/SVT collège), revue humaine, puis itération.
+
+### 7.4 POC de validation
+
+**Cible** : Maths 3ème + Référentiel BO cycle 4 + Progression existante.
+
+Justification : le travail STMG SGN 2026-2027 fournit déjà un template de Progression complet, transposable en quelques jours sur un autre niveau. Le BO cycle 4 maths est bien documenté. Et le segment "maths collège" est la demande tutorat dominante identifiée.
+
+Critères de succès du POC :
+- Couverture référentiel ≥ 80%.
+- Taux hors-périmètre ≤ 5%.
+- Score LLM judge ≥ 0,85 sur le golden dataset initial (50 questions).
+- Au moins 3 modes pédagogiques opérationnels (explication, aide_guidee, correction).
+- Validation par 2 enseignants externes.
+
+---
+
+## 8. Décisions ouvertes
+
+### 8.1 Nommage « Personae » vs « Assistant spécialisé »
+
+Le terme « Personae » entre en collision avec l'usage marketing classique de **persona = profil client**. Or le modèle a déjà `Audience` qui *est* le profil. Risque de confusion pour les profs et directions formation.
+
+**Recommandation** : *« Assistant spécialisé »* (ou *« Assistant pédagogique »* pour la variante scolaire) côté UI ; *« Personae »* conservé comme terme technique interne et dans l'API (`POST /personae`).
+
+| Interne | Interface |
+|---------|-----------|
+| Personae | Assistant spécialisé |
+| Personae pédagogique | Assistant pédagogique |
+| Audience | Public cible |
+| Binding | Activation |
+| Spécialité | Discipline / Domaine |
+
+### 8.2 Granularité du Niveau
+
+**Recommandation** : grain principal = classe (5ème, 4ème, 3ème), métadonnée héritée = cycle, pour mutualiser le corpus quand pertinent.
+
+### 8.3 Mutualisation des Référentiels et Compétences
+
+Le programme BO est public.
+
+**Recommandation** : Référentiel et Compétences maîtres mutualisés entre tenants + surcharges locales possibles par tenant (ex. compétences spécifiques au projet pédagogique d'un établissement).
+
+### 8.4 Choix du Mode pédagogique : automatique ou manuel ?
+
+Trois options :
+- Classification automatique d'intention.
+- Choix explicite par l'élève (commande, menu).
+- Choix par l'enseignant (mode imposé sur un canal).
+
+**Recommandation** : automatique par défaut, override possible par l'élève via commande Discord ou bouton UI, override possible par l'enseignant au niveau du Personae (ex. *« ce salon est en mode `revision` uniquement »*).
+
+### 8.5 Validation enseignante avant publication
+
+Faut-il bloquer l'activation d'un Personae pédagogique si la Santé est trop faible ?
+
+**Recommandation** : ne pas bloquer, mais afficher un statut *« À compléter »* dans la matrice et exiger une validation explicite *« Je publie quand même »*. La validation pédagogique humaine reste souveraine.
+
+### 8.6 Partage de Briques entre profs / établissements
+
+Levier de valeur potentiel : marketplace interne de Briques calibrées. **Hors-périmètre de cette RFC**, à garder comme roadmap.
+
+### 8.7 Routage : corrections élèves comme dataset d'entraînement
+
+Les corrections de matière par les élèves peuvent-elles servir à entraîner un routeur interne ?
+
+**Recommandation** : oui, sous réserve de consentement et d'anonymisation. À traiter dans une RFC dédiée au classifieur.
+
+---
+
+## 9. Non-objectifs
+
+Cette RFC ne vise pas à :
+
+- Remplacer le modèle Personae existant.
+- Imposer cette extension aux assistants non scolaires.
+- Définir tous les programmes officiels en une fois.
+- Construire immédiatement tous les golden datasets.
+- Fine-tuner un modèle LLM.
+- **Remplacer la validation enseignante** : le juge LLM est une aide, pas un arbitre final.
+
+Le fine-tuning reste hors-périmètre immédiat. La priorité reste : **RAG structuré + prompts par mode + politiques de réponse + évaluation**.
+
+---
+
+## 10. Risques et mitigations
+
+| Risque | Impact | Mitigation |
+|--------|--------|-----------|
+| Modèle trop complexe pour l'interface | Adoption faible | Parcours guidé existant + valeurs par défaut + presets + Briques pré-faites |
+| Confusion entre Style, Audience, Mode et Politique | Mauvaise configuration | Exemples concrets + aide à la configuration intégrée + presets nommés |
+| Routage matière incorrect | Réponses hors-contexte | Transparence + correction utilisateur (§5.3) + seuil de confiance |
+| Référentiel incomplet | Mauvaise couverture | Indicateur de couverture dans la Santé |
+| Progression trop rigide | Frustration élève | Autoriser découverte contrôlée hors progression avec signalement |
+| Sur-coût d'évaluation (LLM judge sur N×M personae) | Coût opérationnel | Batch hebdomadaire hors-pointe + modèle Haiku pour le judge |
+| Mode pédagogique mal respecté par le LLM | Dérive pédagogique | Politiques explicites en system prompt + ajout à la grille du judge + auto-correction par re-prompt |
+| LLM judge trop confiant | Faux sentiment de qualité | Combiner juge LLM + revue enseignante + jeux de tests humains |
+| Maintenance des Référentiels (BO évoluent) | Obsolescence | Versionnage du Référentiel + alerte à la mise à jour BO |
+| Confusion vocabulaire Personae / Persona | UX dégradée | Renommage UI (§8.1) |
+
+---
+
+## 11. Glossaire mis à jour
+
+| Terme | Définition |
+|-------|------------|
+| Personae | Assistant configuré (terme technique interne) |
+| Assistant spécialisé | Idem, libellé côté UI |
+| Assistant pédagogique | Personae avec `pedagogical_extension` non nulle |
+| Discipline | Matière (Mathématiques, Histoire-Géographie…) |
+| Niveau | Classe scolaire (CM2, 3ème, 1ère…) |
+| Cycle | Regroupement officiel de niveaux (cycle 3, cycle 4…) |
+| Référentiel | Représentation structurée d'un programme officiel |
+| Compétence | Unité pédagogique pilotable, partageable entre référentiels |
+| Corpus | Documents pédagogiques typés rattachés à `(Discipline, Niveau)` |
+| Audience | Profil du public visé (soutien, standard, visée mention) |
+| Style | Registre, ton, format d'expression |
+| Mode pédagogique | Acte pédagogique en cours (explication, aide guidée, correction…) |
+| Politique de réponse | Règle nommée de scaffolding |
+| Progression | Position temporelle dans le programme annuel |
+| Brique | Composition réutilisable (Discipline + Niveau + Style + Mode par défaut) |
+| Santé | Indicateur agrégé de fiabilité du personae |
+| `pedagogical_extension` | Bloc optionnel d'un Personae portant les attributs scolaires |
+
+---
+
+## 12. Annexes
+
+### A. Mapping ancien → nouveau modèle
+
+| Ancien (RFC-081/095) | Nouveau (cette RFC) |
+|----------------------|---------------------|
+| Rôle | Inchangé |
+| Spécialité | `pedagogical_extension`: Discipline + Niveau + Référentiel + Compétences + Corpus typé |
+| Style | Inchangé (recadré : registre + format uniquement) |
+| Audience | Inchangé |
+| Canal | Inchangé |
+| Brique = Spécialité + Style | Brique = Discipline + Niveau + Style + Mode pédagogique par défaut |
+| — | Mode pédagogique (nouveau) |
+| — | Politique de réponse (nouveau) |
+| — | Progression (nouveau, branchée sur l'existant) |
+| — | Santé (nouveau, indicateur) |
+
+### B. Schéma JSON complet d'un Assistant pédagogique
+
+```json
+{
+  "id": "persona_maths_3eme_soutien",
+  "display_name": "Prof de Maths 3ème — Soutien",
+  "role_id": "teacher",
+  "style_id": "rassurant_concret",
+  "audience_id": "remise_a_niveau",
+  "channels": [
+    {
+      "type": "discord",
+      "target": "salon_maths_3eme_3A"
+    }
+  ],
+  "pedagogical_extension": {
+    "discipline_id": "mathematiques",
+    "level_id": "3eme",
+    "cycle": "cycle_4",
+    "referential_id": "bo_maths_cycle4_3eme",
+    "competency_ids": [
+      "eq_1er_degre",
+      "fonctions_affines",
+      "proportionnalite",
+      "theoreme_thales"
+    ],
+    "corpus_collections": [
+      "maths_cycle4_cours",
+      "maths_3eme_exercices",
+      "maths_3eme_corrections",
+      "maths_3eme_erreurs_classiques",
+      "maths_3eme_methodes"
+    ],
+    "default_pedagogical_mode": "aide_guidee",
+    "allowed_pedagogical_modes": [
+      "explication",
+      "aide_guidee",
+      "correction",
+      "entrainement",
+      "revision",
+      "remediation"
+    ],
+    "response_policies": [
+      "indice_avant_solution",
+      "correction_sans_faire_a_la_place",
+      "refus_devoir_clef_en_main",
+      "rappeler_prerequis_si_bloque"
+    ],
+    "progression_binding": {
+      "scope": "class_group",
+      "progression_id": "maths_3eme_2026_2027_classe_3A"
+    },
+    "health": {
+      "status": "warning",
+      "coverage_referentiel": 0.74,
+      "off_scope_rate": 0.04,
+      "response_quality": 0.87,
+      "policy_compliance": 0.91,
+      "routing_quality": 0.88,
+      "last_eval": "2026-05-24T03:12:00Z"
+    }
+  }
+}
+```
+
+### C. Convergence des avis sources
+
+Trois analyses indépendantes ont convergé sur les axes principaux de cette RFC :
+
+| Axe | Avis interne (produit) | Avis externe | Méta-revue |
+|-----|------------------------|--------------|------------|
+| Niveau comme objet distinct | ✓ | ✓ | ✓ |
+| Référentiel comme objet de première classe | ✓ | ✓ | ✓ |
+| Compétence comme objet distinct du Référentiel | — | ✓ | ✓ |
+| Mode pédagogique séparé du Style | ✓ | ✓ | ✓ |
+| Politique de réponse comme catalogue nommé | — | ✓ | ✓ |
+| Progression comme dimension | ✓ | ✓ | ✓ |
+| Transparence du routage matière | ✓ | ✓ | ✓ |
+| Santé du personae dans la matrice | ✓ | ✓ | ✓ |
+| Renommage UI « Assistant spécialisé » | — | ✓ | ✓ |
+| Évaluation par LLM judge + golden dataset | ✓ | ✓ | ✓ |
+| Compatibilité via extension optionnelle | — | ✓ | ✓ |
+| Filtrage RAG par mode pédagogique | — | ✓ | — |
+| Branchement Progression Pédagogique existante | ✓ | — | ✓ |
+| Connexion aux RFCs existantes (053/054/059) | ✓ | — | — |
+
+Les axes ✓✓✓ constituent le socle indiscutable. Les axes ✓✓ consolident la robustesse. Les axes ✓ apportent l'ancrage dans l'écosystème Azy existant.
+
+---
+
+## 13. Prochaines étapes
+
+1. **Validation de la priorisation** par l'équipe produit Azy.
+2. **POC Maths 3ème** (cf. §7.4) — cible de validation du modèle sur 6 semaines.
+3. **Migration progressive** : commencer par les nouveaux personae pédagogiques, conversion des existants à la demande.
+4. **RFC dérivées à prévoir** :
+   - RFC sur le **classifieur matière + intention** (modèle, dataset, seuils de confiance, traitement des corrections élèves).
+   - RFC sur la **marketplace de Briques** entre profs / établissements.
+   - RFC sur l'**évaluation pédagogique automatisée** (extension azy-mcp : critères, modèle juge, agrégation).
+
+---
+
+## 14. Formule cible
+
+```
+Azy ne crée pas seulement des chatbots.
+Azy compose des assistants pédagogiques spécialisés,
+situés dans un niveau, un référentiel, une progression,
+et pilotés par des modes pédagogiques évaluables.
+```
+
+C'est cette extension qui transforme le modèle Personae générique en véritable plateforme pédagogique, et qui différencie Azy d'un GPT générique avec un prompt bien écrit.
+
+---
+
+## 15. Arbitrages produit — passe front (2026-05-27)
+
+Tri produit des améliorations §1 confronté à l'existant front (catalogues, inscription, aides contextuelles, matrice). Sépare **validé** / **en attente de clarification**.
+
+### 15.1 Points validés
+
+| Point | Décision | Mise en œuvre actée |
+|---|---|---|
+| **Scaffolding anti-déviance** (#1) | ✅ Indispensable | Une **liste de règles textuelles** saisissables/activables garantit l'absence de déviance (ne pas faire le devoir, guider…). Peut démarrer **via prompt** avant des objets dédiés. |
+| **Routage matière** (#2) | ✅ Retenu — **côté plugin / runtime**, PAS front-paramétrage | L'élève étant inscrit à X cours, le routage est **borné à son périmètre d'inscription**. Pas un sujet de configuration admin. |
+| **Bornage hors-périmètre** (#3) | ✅ Retenu — **côté plugin / runtime** | Refus de répondre sur une notion hors programme/niveau, à la question de l'élève. Même nature que #2. Le front n'affiche que le refus. |
+| **Santé du personae** (#4) | ✅ Retenu — **conditionné à une source de feedback** | Alimentée par les **retours explicites de l'élève** et/ou l'**analyse de sentiment (« humeur »)** dans ses messages. Sans feedback, pas d'indicateur fiable. |
+| **Presets de configuration** (#5) | ✅ Retenu — **raccourci côté prof** | Un preset (« Soutien scolaire »…) pré-règle les règles de scaffolding en 1 clic. **Côté config prof uniquement** ; l'élève ne le voit pas. |
+| **Aides contextuelles renforcées** (#6) | ✅ Retenu — trivial | Enrichir le catalogue d'aide existant (`personaeConceptHelp.ts`) : distinguer **Style** (comment on parle) / **Mode** (ce qu'on fait) / **Audience** (à qui). |
+| **Renommage UI** (#7) | ✅ Retenu — **wording UI uniquement** | « Assistant spécialisé / Public cible / Activation… ». Noms techniques + API **inchangés**. |
+| **Corpus typé** (#10) | ✅ **Requalifié INDISPENSABLE** | Au moment de l'**ingestion RAG** : **tag automatique** du type (cours / exercice / correction…) **+ validation par le prof**. C'est ensuite au prof de **choisir et classer ses documents** pour l'entraînement. |
+| **Discipline + Niveau (split)** (#12) | ✅ Retenu — **sans double saisie ressentie** | Le prof tape « Histoire 3ème » ; un **assistant IA splitte** en Discipline = Histoire + Niveau = 3ème. Saisie unique côté UI. |
+| **Progression** (#11) | ⏸️ **Reporté** (hors scope actuel) | Trop complexe / valeur non démontrée à ce stade. À ré-ouvrir plus tard. |
+
+### 15.2 Référentiels + Compétences — stratégie de seed (acté 2026-05-27)
+
+Décision structurante qui **transforme le frein de saisie en pré-remplissage** :
+
+- **Seed officiel** : livrer le produit avec les **référentiels du CM1 à la 2nde, dans toutes les matières**, récupérés depuis **Eduscol** (programmes officiels publics).
+- **Script d'intégration** : un script importe ces référentiels (à exécuter une fois, mutualisable cross-tenant — le BO est public).
+- **Compétences = dérivées des référentiels** : pas un objet à saisir séparément par le prof ; elles sont **extraites des référentiels** seedés.
+- **Côté prof** : il n'a **qu'à cocher sa matière** → une grande partie est déjà paramétrée (référentiel + compétences attendues). Il ne lui reste qu'à **choisir et classer ses propres documents** pour l'entraînement (cf. corpus typé #10).
+- **À articuler avec l'existant** : une quick-action « analyse de référentiels » existe déjà pour les experts profs → vérifier ce qu'elle fait avant de figer l'objet Référentiel (éviter le doublon).
+
+Effet : #8 (Référentiel) et #9 (Compétences) ne sont **plus un frein** — le coût de constitution est porté **une fois** par le seed Eduscol, pas par chaque prof.
+
+### 15.3 Mode pédagogique (#13) — résolu
+
+L'« acte pédagogique » (expliquer / guider / corriger / faire pratiquer) **n'est pas un objet de config exposé au prof en V1**. Il est **pré-réglé par défaut** (posture « guider sans donner la solution ») via les règles de scaffolding (#1) + presets (#5) ; l'assistant adapte l'acte au runtime selon la demande de l'élève. Le prof peut ajuster s'il le souhaite, mais **n'a rien à régler par défaut**. Un objet « Mode » explicite reste possible plus tard si un pilotage fin devient nécessaire.
+
+→ **Plus aucun point en suspens** : toutes les améliorations §1 sont tranchées.
+
+### 15.4 Principe directeur transverse — pré-remplir au maximum
+
+> *Décision produit (2026-05-27) : « Il faut pré-remplir au maximum. Paramétrages par défaut livrés, le prof ajuste seulement s'il le veut. »*
+
+C'est la **réponse directe au Risque #1** (modèle trop complexe → adoption faible). Chaque dimension applique ce principe :
+
+| Dimension | Pré-rempli par défaut | Ajustement prof |
+|---|---|---|
+| Référentiel + Compétences | Seed Eduscol — le prof **coche sa matière** | Surcharges locales possibles |
+| Discipline + Niveau | IA splitte « Histoire 3ème » | Correction manuelle si besoin |
+| Scaffolding / Mode | Preset par défaut (« guider, ne pas donner la solution ») | Autre preset / ajustement des règles |
+| Corpus typé | Tag automatique à l'ingestion | Validation / reclassement par le prof |
+| Style / Audience | Valeurs par défaut proposées | Choix dans le catalogue |
+
+**Objectif** : un prof obtient un assistant **fonctionnel en cochant sa matière**, et n'entre dans le détail que s'il le veut. Le front porte cette philosophie (defaults + presets + assistant IA de config), pas une UI de formulaires à 13 champs.
+
+### 15.5 Qui pré-remplit quoi — cascade de défauts + ligne de coupe V1
+
+#### Cascade de défauts (3 niveaux)
+
+Le pré-remplissage se construit en cascade : chaque étage prépare le suivant.
+
+| Niveau | Qui | Pré-remplit | Outil |
+|---|---|---|---|
+| **1. Plateforme** (Azy) | **Super admin** | Socle commun : référentiels Eduscol (CM1→2nde), presets pédagogiques, styles/audiences génériques, règles de scaffolding par défaut | **Écran super-admin** : import/màj référentiels (script Eduscol) + gestion des presets globaux |
+| **2. Tenant** (établissement / formateur) | **Owner** | Hérite du socle + surcharge/ajoute : ses référentiels (cas non-scolaire), presets, styles maison | UI owner (catalogues), valeurs héritées pré-affichées |
+| **3. Utilisateur** | **Prof** | Hérite tenant+plateforme. **Coche sa matière** → tout se remplit | UI actuelle (inscription, composition) |
+
+#### Cas non-scolaire (formateur entreprise)
+
+Pas de programme officiel → mais le socle plateforme fournit ce qui est **valable partout** (presets, styles, audiences, scaffolding) ≈ 70% pré-rempli. Le programme spécifique est **apporté par l'owner, aidé par l'IA** (« décris ta formation → l'IA structure un référentiel », = assistant IA de config). Même mécanique pour tous : **socle générique livré + spécifique apporté avec aide IA**.
+
+#### Ligne de coupe V1 — critère d'arrêt
+
+> Une amélioration entre en V1 **seulement si**, sans elle, un prof **ne peut pas** obtenir un assistant utilisable en cochant sa matière. On s'arrête quand **un prof obtient un assistant fonctionnel en 1 clic**.
+
+| ✅ Dans la ligne V1 (indispensable) | ⏸️ Après la ligne (amélioration continue) |
+|---|---|
+| Seed référentiels + presets + defaults | Santé fine du personae |
+| Split IA discipline/niveau | Compétences pilotables individuellement |
+| Corpus tag auto au RAG + aval prof | Progression temporelle |
+| Scaffolding par défaut (anti-déviance) | Évaluation LLM judge / golden dataset |
+| Écran super-admin pour le seed | Marketplace de briques entre profs |
+
+Un produit qui s'arrête à gauche est **déjà vendable et utilisable**. Tout ce qui est à droite améliore le pilotage et la finesse, mais n'est pas requis pour la V1.
+
+#### Implication front (mesurée)
+
+- **Nouveau** : un **écran super-admin** de gestion du socle (référentiels + presets globaux). Seule pièce vraiment nouvelle.
+- **Existant à enrichir** : les catalogues affichent les valeurs **héritées** (repère « hérité / personnalisé » quand l'owner surcharge).
+- **Rien d'autre côté prof** : il coche, il ajuste au besoin. Pas de formulaire à 13 champs.
+
+> Note de périmètre front : #2 et #3 relèvent du **runtime/plugin** (résolution à l'exécution selon l'inscription de l'élève), pas du paramétrage admin que porte le front. Le front n'intervient que sur l'**affichage** (matière détectée, refus hors-périmètre).
+
+---
+
+## 16. Recalage avec l'existant Azy & décisions d'architecture back (2026-05-27)
+
+> Synthèse des décisions techniques back, après audit du code. Détail + découpage PR : `docs/issues/2026-05-27-rfc-096-pedagogique-delta-back.md`.
+
+### 16.1 Le socle est déjà livré (0 rework)
+
+Les §2 (modèle actuel) et §5 (1 élève / N matières) **sont déjà la réalité du code** :
+
+| Brique RFC-096 | Couvert par | Statut |
+|---|---|---|
+| Rôle / Discipline / Niveau / Style | RFC-081 `Expert` / `Specialty` (porte **déjà `level` + `segment`**) / `Style` | ✅ livré |
+| Audience | RFC-095 `audience_personae` (B1) | ✅ livré |
+| Inscription élève (périmètre) | RFC-095 `student_subject_enrollment` (`user_id = discord_user_id`) | ✅ livré |
+| Lister/sélectionner les élèves | `GET /api/owner/students` | ✅ livré |
+| Routing matière borné au périmètre (§5) | RFC-095 B3 `resolve-dm` | 🔶 spécifié |
+
+→ Conséquence : le « split Discipline/Niveau » (#12 / §3.3.1) est surtout **UI** (`Specialty.level` existe déjà), pas un nouveau schéma.
+
+### 16.2 Décisions d'architecture back
+
+| # | Décision | Note |
+|---|---|---|
+| A1 | **Modèle relationnel, pas blob JSON.** Les nouveaux objets (Référentiel, Compétence…) = **tables** (catalogue public mutualisable + surcharges per-tenant). Le `pedagogical_extension` JSON (§7.1, annexe B) est une **vue de composition runtime**, pas le stockage. | cohérent multi-tenant search_path |
+| A2 | **Réutiliser `Specialty`** comme porteur Discipline/Niveau (pas de refactor). | `level`/`segment` déjà présents |
+| A3 | **Référentiel = hybride** (audit P0) : **réutiliser** le pipeline existant *référence → programme* (`ReferenceAnalysis` RFC-084 + `ExpertProgramQueryService` RFC-082 + `ClassroomProgramBuilder` RFC-083) ; **ajouter** un catalogue Référentiel+Compétence normalisé seedable (Eduscol). Référentiel (*ce qui doit être couvert*) ≠ Programme (*séquence d'enseignement*) — complémentaires. | ne pas dupliquer |
+| A4 | **Compétence dérivée en V1** (extraite du référentiel seedé, non saisie). Objet pilotable individuellement = post-V1. | = **§15.2** |
+| A5 | **Mode pédagogique non exposé en V1** (runtime auto, encadré par scaffolding par défaut). Objet de config = post-V1. | = **§15.3** |
+
+### 16.3 Découpage (derrière RFC-095 B3)
+
+P0 audit (✅ fait) → P1 catalogue Référentiel+Compétence + seed Eduscol → P2 écran super-admin → P3 split IA Discipline/Niveau → P4 scaffolding/presets → P5 corpus typé. Détail dans le doc compagnon.
+
+---
+
+*Fusion v1 interne + avis externe. RFC-096 attribué le 2026-05-27 (ex-`RFC-095-personae-pedagogique-v2`).*


### PR DESCRIPTION
## Summary
- Ajout de **RFC-095-PERSONAE-MULTI-LEVELS** dans `docs/rfc/` : système d'assistant DM avec inscription élèves aux matières et routing contraint
- Ajout de **RFC-096-PERSONAE-PEDAGOGIQUE** dans `docs/rfc/` : extension pédagogique avec Discipline, Niveau, Référentiel, Compétences et Mode pédagogique
- Ajout du **briefing équipes** dans `docs/issues/` : document de coordination pour les équipes n8n, MCP et plugin Discord

## Contexte
Ces documents définissent l'architecture Phase 1 (runtime DM) et Phase 2 (extension pédagogique) du système de personae. Le briefing résume les tasks préssenties pour chaque équipe et les décisions à rendre.

## Test plan
- [x] Fichiers placés dans les bons répertoires (`docs/rfc/` vs `docs/issues/`)
- [ ] Contenu vérifié par les équipes concernées

🤖 Generated with [Claude Code](https://claude.com/claude-code)