### PR TITLE
feat: webhooks registry export from PostgreSQL

### DIFF
--- a/docs/WEBHOOKS-REGISTRY.md
+++ b/docs/WEBHOOKS-REGISTRY.md
@@ -1,0 +1,126 @@
+# Webhooks Registry
+
+Ce fichier documente tous les webhooks actifs disponibles dans n8n.
+
+## Génération
+
+Le registry est généré depuis la base de données PostgreSQL avec :
+
+```bash
+python3 scripts/n8n/n8n_api.py export-webhooks-registry [output_file] [--simple]
+```
+
+**Options** :
+- `output_file` : Chemin du fichier JSON (défaut: `docs/webhooks-registry.json`)
+- `--simple` : Format simple (sans documentation complète)
+
+**Exemples** :
+```bash
+# Export complet (défaut)
+python3 scripts/n8n/n8n_api.py export-webhooks-registry
+
+# Export simple
+python3 scripts/n8n/n8n_api.py export-webhooks-registry --simple
+
+# Custom output
+python3 scripts/n8n/n8n_api.py export-webhooks-registry docs/webhooks.json
+```
+
+## Format JSON
+
+```json
+{
+  "version": "1.0",
+  "generated_at": "2026-06-09T...",
+  "total_webhooks": 196,
+  "excluded_torah": 35,
+  "categories": {
+    "MCP Tools": [
+      {
+        "name": "MCP - Analyze Message",
+        "path": "analyze-message",
+        "full_url": "http://pi6.local:5678/webhook/analyze-message",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Analyse complète d'un message",
+        "workflow_id": "EiNGvM8j4KMcheed"
+      }
+    ]
+  }
+}
+```
+
+## Catégories
+
+| Catégorie | Description |
+|-----------|-------------|
+| **MCP Tools** | Outils MCP (Model Context Protocol) |
+| **Discord** | Webhooks Discord (guild, DM, mentions, etc.) |
+| **Claude / LLM** | Appels Claude et autres LLM |
+| **YouTube** | Traitement vidéos YouTube |
+| **Document Processing** | Traitement PDF, Word, etc. |
+| **Testing / Utilities** | Outils de test et utilitaires |
+| **Other** | Autres webhooks non catégorisés |
+
+## Exclusions
+
+- **Workflows Torah** : Exclus du registry (35 workflows)
+- **Workflows inactifs** : Non inclus
+
+## Utilisation
+
+### Rechercher un webhook
+
+```bash
+# Par nom
+jq '.categories[] | .[] | select(.name | contains("DM"))' docs/webhooks-registry.json
+
+# Par path
+jq '.categories[] | .[] | select(.path == "discord/dm-resolve")' docs/webhooks-registry.json
+
+# Tous les webhooks d'une catégorie
+jq '.categories."MCP Tools"' docs/webhooks-registry.json
+```
+
+### Lister les catégories
+
+```bash
+jq '.categories | keys' docs/webhooks-registry.json
+```
+
+### Compter les webhooks par catégorie
+
+```bash
+jq '.categories | to_entries | map({category: .key, count: (.value | length)})' docs/webhooks-registry.json
+```
+
+## Mise à jour
+
+Pour mettre à jour le registry après avoir modifié des workflows :
+
+```bash
+# Re-générer le registry
+python3 scripts/n8n/n8n_api.py export-webhooks-registry
+
+# Committer les changements
+git add docs/webhooks-registry.json
+git commit -m "docs: update webhooks registry"
+```
+
+## Statistiques actuelles
+
+- **Total webhooks actifs** : 196
+- **Workflows exclus (Torah)** : 35
+- **Catégories** : 7
+
+### Répartition
+
+```
+MCP Tools:             87 webhooks
+Other:                 76 webhooks
+Discord:               26 webhooks
+Document Processing:    3 webhooks
+Claude / LLM:           2 webhooks
+Testing / Utilities:    1 webhook
+YouTube:                1 webhook
+```

--- a/docs/guides/CONSOMMATION-ROUTING-JSON-MCP-N8N.md
+++ b/docs/guides/CONSOMMATION-ROUTING-JSON-MCP-N8N.md
@@ -1,0 +1,486 @@
+# Consommation de `routing.json` — équipes MCP & n8n
+
+> **Date** : 2026-06-08
+> **Émetteur** : Équipe Frontend 2
+> **Destinataires** : équipe **azy.mcp** + équipe **n8n**
+> **Objet** : contrat de sortie du skill `classify-submission-complexity` et règles
+> de consommation côté orchestration (MCP + n8n). Décision arrêtée :
+> **interprétation 100 % script, pas de LLM** pour aiguiller la passe OCR.
+
+---
+
+## 1. Rappel — d'où vient `routing.json`
+
+Le skill `classify-submission-complexity` (livré par l'équipe Skills) effectue un
+**pré-tri purement algorithmique** des copies scannées : il calcule des métriques
+d'image (OpenCV + Pillow + NumPy) et écrit un `routing.json` déterministe qui
+indique **quel(s) LLM(s) vision** doit traiter la copie.
+
+- **Aucun appel LLM** dans le skill lui-même (Pi 4 8 Go suffit, < 1 s pour 5
+  pages multi-thread).
+- **Sortie unique** : un fichier `routing.json` consommable par un orchestrateur.
+- **Voir** : `skills/classify-submission-complexity/SKILL.md` (chez l'équipe Skills,
+  hors repo front).
+
+Ce document décrit **uniquement** ce qu'il faut faire de `routing.json`.
+
+---
+
+## 2. Contrat de sortie — `routing.json`
+
+```json
+{
+  "route": "single_pass_gemini | single_pass_claude | double_pass_gemini_claude",
+  "confidence": 0.95,
+  "reasons": [
+    "page 5 : ratures détectées (48 zone(s))",
+    "page 5 : hauteurs de lignes très hétérogènes (line_height_cv=5.394)"
+  ],
+  "rescan_recommended": true,
+  "page_assessments": [
+    {
+      "page_no": 1,
+      "label": "printed_clear | handwriting_clear | handwriting_hard | degraded",
+      "metrics": { "...": 0 },
+      "factors": ["clear_handwriting"]
+    }
+  ]
+}
+```
+
+### Sémantique des champs
+
+| Champ | Type | Sémantique pour l'orchestrateur |
+|---|---|---|
+| `route` | enum fermée (3) | **CLÉ DE ROUTAGE PRINCIPALE.** À switcher. |
+| `confidence` | `[0, 1]` | Indicateur. Garde-fou < 0.6 **déjà appliqué** côté skill (force `double_pass`). |
+| `reasons` | `string[]` FR | Texte prêt à afficher au prof. Ne pas reformuler par LLM. |
+| `rescan_recommended` | bool (optionnel) | Si `true` → **notifier le prof** (scan dégradé : flou extrême, page noire/blanche, doigt sur l'objectif). OCR optionnel mais qualité dégradée. |
+| `page_assessments` | array | Détail par page, utile pour l'audit / le debug, pas pour le routage. |
+
+### Valeurs possibles de `route`
+
+| Route | Action orchestrateur | Raison |
+|---|---|---|
+| `single_pass_gemini` | 1 appel **Gemini Pro Vision** | imprimé clair, passe la moins chère |
+| `single_pass_claude` | 1 appel **Claude Vision** | manuscrit clair, meilleur rendu |
+| `double_pass_gemini_claude` | **Gemini + Claude en parallèle**, puis reconcile | manuscrit difficile, ratures, scan dégradé |
+
+---
+
+## 3. Décision arrêtée — pas de LLM pour interpréter `routing.json`
+
+Le routage est consommé par **un switch déterministe** (script orchestrateur ou
+nœud Switch n8n), **jamais** par un LLM qui prendrait `routing.json` en entrée.
+
+### Justification
+
+| Critère | Switch script | LLM |
+|---|---|---|
+| Latence | < 1 ms | 1-3 s |
+| Coût | 0 | $$ par copie |
+| Déterminisme | total | non (deux runs → routes différentes possibles) |
+| Traçabilité | switch lisible en revue | prompt + sortie à auditer |
+| Valeur ajoutée | aiguillage mécanique sur enum 3 valeurs | nulle (garde-fou confiance déjà appliqué côté skill) |
+
+Le LLM intervient **après** le routage, dans la passe OCR choisie — pas pour
+décider de la passe.
+
+---
+
+## 4. Côté équipe **azy.mcp**
+
+### 4.1. Enregistrer le skill au catalogue
+
+- Déposer le **dossier complet** `classify-submission-complexity/` dans
+  `/storage6/pi6/azy.mcp/skills/` (voir layout §4.2).
+- Enregistrer côté chat.api : `POST /api/admin/skills` avec
+  `slug = classify-submission-complexity`, `mcp_path = ...`
+- Nature : **`public.skills`** (skill cloud azy.mcp, pas user_skills ni
+  anthropic_skills). Cf. `skills-architecture-overview.md` §3.
+
+### 4.2. Layout sur l'host MCP — venv embarqué
+
+Le skill embarque **son propre venv dédié** pour isoler ses dépendances
+(OpenCV, NumPy, PyMuPDF, Pillow — combinaisons sensibles aux versions
+système). À déposer côté MCP :
+
+```
+/storage6/pi6/azy.mcp/skills/classify-submission-complexity/
+├── SKILL.md
+├── requirements.txt
+├── scripts/
+│   ├── to_images.py
+│   ├── compute_metrics.py
+│   ├── classify_and_route.py
+│   └── notify_n8n.py        ← ajout §4.4, wrapper PUSH webhook
+├── tests/
+│   └── test_classify.py
+└── .venv/                    ← venv local au skill
+    ├── bin/python
+    └── lib/python3.x/site-packages/...
+```
+
+**Création du venv** (une fois, à l'installation du skill côté MCP) :
+
+```bash
+cd /storage6/pi6/azy.mcp/skills/classify-submission-complexity
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+L'exécuteur MCP **doit invoquer `.venv/bin/python`** (chemin absolu), pas le
+`python` système, pour garantir la reproductibilité et éviter les collisions
+de versions avec d'autres skills cohabitant sur l'host.
+
+### 4.3. Contrat d'exécution attendu (appel synchrone par chat.api / front)
+
+```http
+POST /api/skills/classify-submission-complexity/runs
+{
+  "input_files": [
+    { "file_id": "fid_xxx_page1.jpg" },
+    { "file_id": "fid_xxx_page2.jpg" }
+  ],
+  "params": {
+    "n8n_webhook_url": "https://n8n.azy.../webhook/correction-copies-routing",
+    "copie_id": "cpy_zzz"
+  }
+}
+```
+
+Réponse (via `SkillExecutor` cloud) :
+
+```json
+{
+  "run_id": "run_yyy",
+  "status": "succeeded",
+  "output_files": [
+    { "file_id": "fid_zzz_routing.json", "name": "routing.json" }
+  ],
+  "output": { "...routing.json inline si <4KB..." },
+  "n8n_notified": true
+}
+```
+
+**Important** : `routing.json` doit être retournable **inline** (< 4 KB
+typiquement) **OU** par `file_id`. Le notifieur §4.4 envoie le contenu inline
+à n8n, donc le caller (front / chat.api) peut juste regarder `n8n_notified`
+pour confirmer que la suite est lancée.
+
+### 4.4. Chaîne d'exécution complète côté MCP
+
+À chaque run, l'exécuteur MCP enchaîne 4 scripts dans le venv du skill :
+
+```bash
+VENV=/storage6/pi6/azy.mcp/skills/classify-submission-complexity/.venv
+SKILL=/storage6/pi6/azy.mcp/skills/classify-submission-complexity
+
+# 1) rastérise PDF / copie images dans le sandbox du run
+$VENV/bin/python $SKILL/scripts/to_images.py \
+  --inputs $RUN_INPUTS_DIR/*.{jpg,png,pdf} \
+  --out-dir $RUN_SANDBOX/pages
+
+# 2) calcule métriques (multi-thread auto sur os.cpu_count())
+$VENV/bin/python $SKILL/scripts/compute_metrics.py \
+  --images $RUN_SANDBOX/pages/*.png \
+  --out $RUN_SANDBOX/metrics.json
+
+# 3) classifie + écrit routing.json (déterministe, validé)
+$VENV/bin/python $SKILL/scripts/classify_and_route.py \
+  --metrics $RUN_SANDBOX/metrics.json \
+  --write $RUN_SANDBOX/routing.json
+
+# 4) PUSH webhook n8n (signal de fin + payload routing.json)
+$VENV/bin/python $SKILL/scripts/notify_n8n.py \
+  --routing $RUN_SANDBOX/routing.json \
+  --webhook-url "$N8N_WEBHOOK_URL" \
+  --copie-id "$COPIE_ID" \
+  --run-id "$RUN_ID"
+```
+
+L'étape **4** est ce qui « signale » à n8n que la copie est classifiée et
+qu'il faut enchaîner sur l'OCR. n8n est un **récepteur webhook**, pas un
+appelant — il ne poll pas MCP, il reçoit la notification PUSH.
+
+### 4.5. Multi-thread déjà géré côté skill
+
+Le skill utilise `multiprocessing.Pool(processes=os.cpu_count())` (déjà livré).
+L'exécuteur MCP **n'a pas à paralléliser lui-même** ; un seul run = une copie =
+N pages traitées en parallèle en interne. Sur un Pi 4 (4 cœurs), ~5 pages
+JPEG ≈ < 1 s.
+
+### 4.6. Dépendances Python à installer dans `.venv`
+
+```
+Pillow>=10.0,<12.0
+PyMuPDF>=1.23,<2.0          # si on accepte des PDF en entrée
+opencv-python-headless>=4.10,<5.0
+numpy>=1.24,<3.0
+requests>=2.31              # pour notify_n8n.py (PUSH webhook)
+```
+
+Cf. `skills/classify-submission-complexity/requirements.txt` (à compléter
+avec `requests` si pas déjà présent).
+
+### 4.7. `notify_n8n.py` — script PUSH webhook (~30 lignes)
+
+À déposer dans `scripts/notify_n8n.py` du skill :
+
+```python
+#!/usr/bin/env python3
+"""Pousse routing.json vers le webhook n8n. Étape 4 de la chaîne MCP.
+
+Le skill reste pur (déterministe, sans I/O réseau) ; ce wrapper est la seule
+brique avec un effet de bord externe (POST HTTP). Exit code != 0 si n8n
+répond en erreur, pour que l'exécuteur MCP puisse retry / alerter.
+"""
+import argparse
+import json
+import sys
+import requests
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--routing", required=True, help="chemin routing.json")
+    ap.add_argument("--webhook-url", required=True, help="URL webhook n8n")
+    ap.add_argument("--copie-id", required=True)
+    ap.add_argument("--run-id", required=True)
+    ap.add_argument("--timeout", type=float, default=10.0)
+    args = ap.parse_args()
+
+    with open(args.routing, encoding="utf-8") as f:
+        routing = json.load(f)
+
+    payload = {
+        "copie_id": args.copie_id,
+        "run_id": args.run_id,
+        "source": "classify-submission-complexity",
+        "routing": routing,            # contenu complet de routing.json
+    }
+    r = requests.post(args.webhook_url, json=payload, timeout=args.timeout)
+    if not r.ok:
+        print(f"ERREUR n8n {r.status_code}: {r.text[:200]}", file=sys.stderr)
+        sys.exit(1)
+    print(f"OK n8n notifié (HTTP {r.status_code}) route={routing['route']} "
+          f"copie={args.copie_id}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**À noter** : le payload encapsule `routing.json` sous la clé `routing` et
+ajoute `copie_id` + `run_id` pour permettre à n8n de retrouver la copie dans
+sa base. n8n lira `$json.routing.route`, `$json.routing.rescan_recommended`,
+etc.
+
+---
+
+## 5. Côté équipe **n8n**
+
+### 5.1. Workflow attendu — `correction-copies-routing` (récepteur webhook)
+
+n8n n'appelle pas MCP : **c'est MCP qui pousse** vers ce webhook après avoir
+produit `routing.json` (cf. §4.4–4.7).
+
+```
+[1] Webhook IN     POST /webhook/correction-copies-routing
+                   Body envoyé par notify_n8n.py :
+                   { copie_id, run_id, source, routing: {...routing.json...} }
+        ↓
+[2] IF             {{ $json.routing.rescan_recommended === true }}
+        ├── true  → [3a] Discord/Webhook notif prof + STOP (skip OCR)
+        └── false → [3b] Switch sur {{ $json.routing.route }}
+                              ├── single_pass_gemini         → [4a] Workflow OCR Gemini
+                              ├── single_pass_claude         → [4b] Workflow OCR Claude
+                              └── double_pass_gemini_claude  → [4c] Parallèle Gemini+Claude + reconcile
+                                                                          ↓
+                                                                  [5] Sortie : transcription + reasons
+```
+
+Le payload reçu par le Webhook IN ressemble à :
+
+```json
+{
+  "copie_id": "cpy_zzz",
+  "run_id": "run_yyy",
+  "source": "classify-submission-complexity",
+  "routing": {
+    "route": "double_pass_gemini_claude",
+    "confidence": 0.95,
+    "reasons": ["page 5 : ratures détectées (48 zone(s))", "..."],
+    "rescan_recommended": false,
+    "page_assessments": [ ... ]
+  }
+}
+```
+
+Tous les nœuds en aval accèdent au routage via `{{ $json.routing.* }}`.
+
+### 5.2. Nœud Switch n8n
+
+Mode : **Expression**, sur `{{ $json.routing.route }}` :
+
+| Branche | Valeur attendue | Workflow appelé |
+|---|---|---|
+| 0 | `single_pass_gemini` | `correction-copies-ocr-gemini` |
+| 1 | `single_pass_claude` | `correction-copies-ocr-claude` |
+| 2 | `double_pass_gemini_claude` | `correction-copies-ocr-double` |
+| _Fallback_ | (n'importe quoi d'autre) | **Erreur** : route invalide, log + alerte |
+
+Le validateur côté skill (`normalize_and_validate`) garantit déjà que `route`
+appartient à l'énumération — le fallback est une **ceinture de sécurité**, pas
+un comportement attendu.
+
+### 5.3. Gestion de `rescan_recommended`
+
+Si `true`, **arrêter l'OCR** et notifier le prof avec **les `reasons`
+telles quelles** (déjà rédigées en français correct, traçables) :
+
+> Exemple : « page 5 : flou extrême, scan quasi illisible (laplacian_variance=28.0) »
+
+Pas besoin de LLM pour reformuler.
+
+### 5.4. URL du webhook à fournir à MCP
+
+n8n doit publier l'URL stable du webhook (prod + staging) et la
+communiquer à l'équipe MCP qui la passera en paramètre `n8n_webhook_url`
+au run du skill. Format attendu :
+
+```
+https://n8n.azy.../webhook/correction-copies-routing       # prod
+https://n8n.azy.../webhook-test/correction-copies-routing  # staging / dev
+```
+
+**Sécurité** : protéger le webhook par un header `Authorization: Bearer
+<secret>` partagé avec MCP (à ajouter dans `notify_n8n.py` quand on aura le
+secret). Voir §6.4.
+
+### 5.5. Pas d'appel LLM pour interpréter `routing.json`
+
+À **interdire explicitement** dans le workflow :
+
+- ❌ pas de nœud « Anthropic » / « OpenAI » qui prend routing.json en entrée
+- ❌ pas de prompt « décide quelle passe OCR utiliser »
+- ✅ uniquement des nœuds Switch / IF / HTTP Request
+
+C'est la condition pour que le pré-tri reste à coût zéro.
+
+### 5.6. Reconcile pour `double_pass_gemini_claude`
+
+Hors scope de ce document — c'est le workflow OCR double qui gère la
+réconciliation Gemini ⇔ Claude. Le workflow `correction-copies-routing` se
+contente de l'invoquer et passer la main.
+
+---
+
+## 6. Points de vigilance
+
+### 6.1. Seuils `[PROVISOIRE]` non calibrés
+
+Le skill V1 marque explicitement comme **[PROVISOIRE]** les seuils suivants
+(cf. `SKILL.md` § Calibration) :
+
+- `align_printed`, `contrast_printed` → distinction imprimé vs manuscrit
+- `strike_hard` → détection de ratures (sensible aux carreaux du papier réglé)
+- `density_hard`, `linehcv_multi` → manuscrit dense vs multi-styles
+
+**Impact orchestration** : tant que la calibration V1.1 n'est pas faite
+(protocole : 20-30 copies réelles annotées — cf.
+[NOTE-INTENTION-CLASSIFY-SUBMISSION-CALIBRATION.md](./NOTE-INTENTION-CLASSIFY-SUBMISSION-CALIBRATION.md)),
+la frontière `single_pass_gemini` (imprimé) vs `single_pass_claude` (manuscrit)
+peut basculer du « mauvais » côté. Les routes `double_pass` restent **fiables**.
+
+**Conséquence pratique** : un workflow qui a tendance à voir trop de
+`double_pass_gemini_claude` consomme plus de tokens que prévu. À monitorer pour
+guider la calibration.
+
+### 6.2. Garde-fou de confiance déjà appliqué
+
+`confidence < 0.6` → le skill force lui-même `double_pass_gemini_claude`.
+**n8n ne doit pas dupliquer ce garde-fou** ni ajouter de seuil de confiance
+supplémentaire. Faire confiance à la valeur de `route`.
+
+### 6.3. Validation à l'arrivée
+
+Le skill valide déjà `routing.json` avant de l'écrire
+(`normalize_and_validate`). Côté n8n, **un seul check défensif suffit** :
+
+```js
+if (!["single_pass_gemini","single_pass_claude","double_pass_gemini_claude"]
+      .includes($json.routing.route)) {
+  throw new Error(`route invalide: ${$json.routing.route}`);
+}
+```
+
+Pas de re-validation des `page_assessments`, des métriques, etc.
+
+### 6.4. Sécurité du webhook MCP → n8n
+
+Le webhook `correction-copies-routing` accepte des données déclenchant des
+appels OCR payants. **Il doit être authentifié.** Conventions :
+
+- Secret partagé : `N8N_INGEST_TOKEN` (env côté MCP, header
+  `Authorization: Bearer <token>` ajouté par `notify_n8n.py`).
+- Côté n8n : nœud « Set » + IF en tête de workflow qui rejette toute requête
+  sans le bon header (HTTP 401).
+- Rotation du secret : possible sans redéploiement du skill puisque le token
+  est passé en param de run, pas en dur dans le code.
+
+### 6.5. Idempotence du webhook
+
+`notify_n8n.py` peut être re-exécuté (retry MCP) sur le même
+`(copie_id, run_id)`. n8n doit **dédupliquer** sur `(copie_id, run_id)` pour
+ne pas déclencher l'OCR deux fois. Implémentation : table d'idempotence simple
+(KV) ou nœud « De-duplicate » avec clé `{{ $json.copie_id + ':' + $json.run_id }}`.
+
+---
+
+## 7. Demandes par équipe — récap
+
+### Équipe MCP
+
+1. **Déposer le skill** dans `/storage6/pi6/azy.mcp/skills/classify-submission-complexity/`
+   (layout §4.2).
+2. **Créer le `.venv`** local au skill avec
+   `python3 -m venv .venv && .venv/bin/pip install -r requirements.txt`.
+3. **Ajouter `notify_n8n.py`** dans `scripts/` (code §4.7) — le seul script
+   du skill qui fait un appel réseau (PUSH webhook n8n).
+4. **Enchaîner les 4 étapes** côté exécuteur de run (§4.4), toutes via
+   `.venv/bin/python` (pas le `python` système).
+5. **Enregistrer le skill** au catalogue chat.api (`public.skills`).
+6. **Garantir le retour** de `routing.json` inline ou via `file_id` + flag
+   `n8n_notified: true` dans la réponse de run.
+7. **Lire** `N8N_INGEST_TOKEN` depuis l'env, le passer à `notify_n8n.py` en
+   header `Authorization: Bearer ...`.
+
+### Équipe n8n
+
+1. **Publier l'URL** du webhook prod + staging et la communiquer à MCP
+   (§5.4).
+2. **Créer le workflow** `correction-copies-routing` (squelette §5.1) —
+   trigger **Webhook IN**, pas HTTP Request sortant.
+3. Nœud **Switch sur `{{ $json.routing.route }}`** avec 3 branches +
+   fallback erreur.
+4. Nœud **IF `$json.routing.rescan_recommended`** en amont du Switch →
+   notif prof + STOP.
+5. **Authentifier** le webhook avec `N8N_INGEST_TOKEN` partagé MCP/n8n,
+   rejeter 401 si absent.
+6. **Dédupliquer** sur `(copie_id, run_id)` pour absorber les retry MCP.
+7. **Interdire** tout nœud LLM qui consommerait `routing.json` en entrée.
+8. **Logger** `routing.route` + `routing.confidence` pour piloter la
+   calibration V1.1.
+
+---
+
+## Références
+
+- `skills/classify-submission-complexity/SKILL.md` — spec du skill (chez équipe Skills).
+- [NOTE-INTENTION-CLASSIFY-SUBMISSION-CALIBRATION.md](./NOTE-INTENTION-CLASSIFY-SUBMISSION-CALIBRATION.md) — protocole calibration V1.1.
+- [skills-architecture-overview.md](./skills-architecture-overview.md) — 3 natures × 2 lieux d'exécution.
+- [LIEN-API-MCP-SKILLS.md](./LIEN-API-MCP-SKILLS.md) — enregistrement skill côté chat.api.
+- [INSTRUCTIONS-SKILLS-CORRECTION-COPIES.md](./INSTRUCTIONS-SKILLS-CORRECTION-COPIES.md) — pipeline correction complet (6 skills).
+- `docs/guides/skills-orchestration-cadrage.md` — décision « front orchestre » (v2).
+- `docs/rfc/RFC-099-WORKFLOW-CORRECTIONS-COPIES.md` — workflow produit.

--- a/docs/pending/REQUESTS-BACK-CHATAPI.md
+++ b/docs/pending/REQUESTS-BACK-CHATAPI.md
@@ -1,0 +1,138 @@
+# Demandes Front → Back chat.api
+
+**Émetteur** : Équipe Frontend 2 (Claude)
+**Date** : 2026-06-05
+**Statut** : 📤 à transmettre
+**Issue front meta** : [#2300 Planification équipes Frontend](https://github.com/fsebbah/azy.front/issues/2300)
+
+---
+
+## 1. Bug report user — endpoint + worker
+
+**Contexte** : réactivation du chantier `bug report user` (cf. specs `docs/issues/2026-06-01-bug-report-user-spec.md` + `2026-06-01-bug-report-back-spec.md`).
+
+**Demande** :
+- `POST /api/bug-reports` : reçoit screenshot DOM (base64) + console buffer + métadonnées (URL, user, tenant, viewport, route)
+- Worker async (Celery) qui invoque un agent Claude pour analyser le bug → créer une issue GitHub (label `bug-from-user`) → retourner `issue_url` et `status`
+- WebSocket push : notifier le user quand l'issue GitHub a été créée
+- Vue admin endpoints : `GET /api/bug-reports` (liste + filtres sévérité/état/période) + `GET /api/bug-reports/{id}` (détail)
+
+**Issues front liées** : [#2295](https://github.com/fsebbah/azy.front/issues/2295) (E1 capture) + [#2296](https://github.com/fsebbah/azy.front/issues/2296) (E2 form/API/admin)
+
+**Effort estimé back** : à votre cadrage
+
+---
+
+## 2. Endpoints Correction de copies (RFC-099 §6)
+
+**Contexte** : Phase 1 du module Correction de copies. Voir la RFC pour le shape complet.
+
+**Demande — Contrôles** :
+- `POST/GET/PATCH /api/grading/controls`
+- `POST /api/grading/controls/{id}/subject` (multipart PDF)
+- `POST /api/grading/controls/{id}/reference` (multipart PDF)
+- `POST /api/grading/controls/{id}/rubric` (JSON ou PDF)
+- `GET /api/grading/controls/{id}/grading-progress` (compteurs)
+
+**Demande — Soumissions** :
+- `POST /api/grading/submissions` (multipart photo + control_id + student_id) → `202 + execution_id`
+- `GET /api/grading/submissions/{id}` → état + résultats si dispo
+- `POST /api/grading/submissions/{id}/validate` (action approve/reject)
+- `POST /api/grading/submissions/{id}/publish` → publication vers Discord
+- `GET /api/grading/submissions/{id}/annotated-pdf` → signed URL Backblaze
+
+**Demande — Endpoints mobile optimisés** (RFC-099 §6.3) :
+- `/api/grading/mobile/controls` (paginé + ETag)
+- `/api/grading/mobile/controls/{id}/students` (statut par élève)
+- `/api/grading/mobile/submissions/upload` (multipart optimisé compression + retry)
+- `/api/grading/mobile/sync-queue` (reprise uploads après offline)
+
+**Tables PostgreSQL** : 5 tables `gradings_*` (cf. RFC-099 §5.2)
+
+**Storage Backblaze B2** : bucket `azy-grading-{tenant_id}` (région EU), structure §5.1, signed URLs, retention 5 ans configurable, RGPD.
+
+**Workflow async** : queue Celery `execute_grading_pipeline(submission_id)` qui appelle le MCP server. WebSocket push à chaque transition de statut.
+
+**Issue front liée** : [#2297](https://github.com/fsebbah/azy.front/issues/2297)
+
+**Effort estimé back** : ~10-12j (RFC-099 §13.1)
+
+---
+
+## 3. Endpoints Orchestrators v2 (RFC-101 §11.2)
+
+**Contexte** : POC v2 livré côté front (PR #2289 + #2290). Maintenant attente du back pour brancher.
+
+**Demande — CRUD** :
+- `POST /api/orchestrators/v2/save` (body : `OrchestratorV2Draft` — RFC-101 §11.2)
+- `GET /api/orchestrators/v2/{id}` + `PATCH` + `DELETE`
+- `GET /api/orchestrators/v2` (liste + filtres search/limit/status)
+
+**Demande — Exécution** :
+- `POST /api/orchestrators/v2/{id}/execute` → `202 + execution_id`
+- `GET /api/orchestrators/v2/executions/{exec_id}` → état + outputs
+- WS `/api/orchestrators/v2/executions/{exec_id}/logs` → stream temps réel
+
+**Demande — Validation** :
+- Sur erreur modalité LLM incompatible avec skill : retour `400 model_modality_mismatch` + liste modèles compatibles (cf. RFC-101 §10.6)
+- Tolérer champs supplémentaires (extras) dans le payload
+
+**Issue front liée** : (mentionnée dans #2300 §5.2)
+
+---
+
+## 4. Endpoints catalogue Personae
+
+**Contexte** : Cards Personae catalogue browsable.
+
+**Demande** :
+- `GET /api/personae/catalog/public` (vetted, accessible tous tenants)
+- `GET /api/personae/catalog/tenant` (partagés dans le tenant, RBAC `personae:read`)
+- `POST /api/personae/{id}/adopt` → clone le persona vers le user appelant
+
+**Issue front liée** : [#2298](https://github.com/fsebbah/azy.front/issues/2298) — actuellement bloquée
+
+---
+
+## 5. Endpoints catalogues skills (RFC-101 §11.1)
+
+**Contexte** : élargir le catalogue front (actuellement 17 Anthropic Skills statiques) avec sources multiples.
+
+**Demande** :
+- `GET /api/skills/catalog/anthropic` (optionnel — front a JSON statique)
+- `GET /api/skills/catalog/tenant` (skills publiés par le tenant, RBAC)
+- `GET /api/skills/catalog/local` (proxy vers Azy Local Agent — RFC-085 §3)
+- `GET /api/skills/catalog/community` (futur, marketplace)
+
+**Shape commun** : aligné RFC-101 §11.1 (id, name, description, source, category, icon, default_model, allowed_modalities, inputs, outputs).
+
+**Issue front liée** : (mentionnée dans #2300)
+
+**Priorité** : `tenant` + `local` en Phase 2 ; `community` en Phase 3.
+
+---
+
+## 6. RFC-100 — Suivi des travaux et progression élèves (à cadrer)
+
+**Contexte** : RFC-100 en rédaction côté front (E2). Endpoints back à définir une fois la RFC validée.
+
+**Anticipé** :
+- Tables `student_progress_*` (compétences vues, scores agrégés, alertes)
+- Endpoints CRUD + endpoints aggregations niveau classe / élève / cohorte
+- Webhook Discord pour récap périodique
+
+**Issue front liée** : [#2294](https://github.com/fsebbah/azy.front/issues/2294)
+
+**Effort estimé back** : ~5-7j (à confirmer après RFC validée)
+
+---
+
+## Format de réponse attendu
+
+Pour chaque demande, merci d'indiquer :
+- ✅ Pris en charge — date estimée
+- ⏳ Pris en compte — à planifier
+- ❓ Besoin de précisions (lesquelles)
+- ❌ Hors scope ou refusé (motif)
+
+Les réponses peuvent être ajoutées en commentaire sur les issues front correspondantes ou directement dans ce doc en PR.

--- a/docs/pending/REQUESTS-DISCORD-BOT.md
+++ b/docs/pending/REQUESTS-DISCORD-BOT.md
@@ -1,0 +1,96 @@
+# Demandes Front → Bot Discord
+
+**Émetteur** : Équipe Frontend 2 (Claude)
+**Date** : 2026-06-05
+**Statut** : 📤 à transmettre
+**Issue front meta** : [#2300 Planification équipes Frontend](https://github.com/fsebbah/azy.front/issues/2300)
+
+---
+
+## Périmètre bot Discord (rappel)
+
+Le bot Discord publie dans les channels Azy (channels personae) et gère les interactions élève (boutons, threads). Distinct du plugin chatbot qui gère la conversation Q/R.
+
+---
+
+## 1. Publication de corrections de copies (RFC-099 §8)
+
+**Contexte** : après validation prof d'une copie, le bot publie le feedback dans le channel personae de l'élève.
+
+**Demande — message structuré** :
+```
+📝 **Ta copie de DS n°3 - Géométrie est corrigée**
+Note : 14/20
+
+✅ Points forts :
+   • [extrait synthétisé du feedback]
+
+⚠️ À retravailler :
+   • [extrait synthétisé]
+
+[📄 Voir copie annotée]   [🎯 Exercices de remédiation]   [💬 Demander une clarification]
+```
+
+**Boutons interactifs Discord** :
+- **Voir copie annotée** → DM le PDF annoté (signed URL Backblaze, expirée 7j)
+- **Exercices de remédiation** → déclenche un orchestrator v2 via plugin chatbot (cf. `REQUESTS-PLUGIN-CHATBOT.md` §2)
+- **Demander une clarification** → ouvre un thread Discord avec le plugin chatbot (cf. `REQUESTS-PLUGIN-CHATBOT.md` §1)
+
+**Endpoint à appeler** : `POST /api/grading/submissions/{id}/publish` (côté chat.api) qui déclenche le bot via webhook
+
+**Privacy** :
+- Aucune copie élève en channel public
+- DM systématique pour le PDF annoté
+- Préférences user : opt-out notifications correction possible
+
+**Issue front liée** : [#2297](https://github.com/fsebbah/azy.front/issues/2297)
+
+**Effort estimé** : ~5j (RFC-099 §13.5)
+
+---
+
+## 2. Suivi élève — récap périodique (RFC-100, anticipé)
+
+**Contexte** : Phase 2 RFC-100. Récap hebdo généré par n8n cron.
+
+**Demande — message structuré** :
+```
+📊 **Ta progression cette semaine**
+
+🎯 Compétences travaillées : 8 (+2 cette semaine)
+📈 Évolution : +0.5 points / 20 sur la moyenne
+⚠️ Axes à renforcer : [liste 2-3 max]
+
+[📋 Voir le détail]   [🎯 Exercices ciblés]
+```
+
+**Issue front liée** : [#2294](https://github.com/fsebbah/azy.front/issues/2294)
+
+---
+
+## 3. Notifications bug report (optionnel)
+
+Cf. `REQUESTS-PLUGIN-CHATBOT.md` §4 — DM de confirmation à l'utilisateur quand son bug report a généré une issue GitHub.
+
+---
+
+## 4. Channels personae — création / archive (RFC-094 + RFC-099)
+
+**Contexte** : la RFC-099 suppose l'existence d'un channel personae par couple (élève, personae enseignant). Il faut s'assurer de la cohérence du naming et de la gestion lifecycle.
+
+**Demande** :
+- Helper côté bot pour résoudre le channel personae cible à partir de `(student_id, persona_id)`
+- Si le channel n'existe pas → le créer automatiquement (avec convention RFC-094)
+- Gestion archive en fin d'année scolaire
+
+**Issue front liée** : (RFC-094 existante, à recroiser)
+
+---
+
+## Format de réponse attendu
+
+Pour chaque sujet, merci d'indiquer :
+- ✅ Pris en charge — date estimée
+- ⏳ Pris en compte — à planifier après livraison back chat.api
+- ❓ Besoin de précisions
+- ❌ Hors scope bot Discord

--- a/docs/pending/REQUESTS-MCP-SERVER.md
+++ b/docs/pending/REQUESTS-MCP-SERVER.md
@@ -1,0 +1,89 @@
+# Demandes Front → MCP server
+
+**Émetteur** : Équipe Frontend 2 (Claude)
+**Date** : 2026-06-05
+**Statut** : 📤 à transmettre
+**Issue front meta** : [#2300 Planification équipes Frontend](https://github.com/fsebbah/azy.front/issues/2300)
+
+---
+
+## Périmètre MCP (rappel)
+
+Le MCP server exécute les **Skills Claude** (RFC-085 — définitions déclaratives YAML) et expose les **tools** bas niveau (pdf_extract, ocr, gmail_send, etc.). L'orchestration multi-LLM et les workflows sont côté **n8n** (cf. `REQUESTS-N8N.md`).
+
+---
+
+## 1. Skills Claude pour Correction de copies (RFC-099 §5.3)
+
+**Demande** : créer 6 Skills Claude réutilisables (format RFC-085 YAML/Markdown).
+
+| Skill | Description | LLM type attendu | Tools nécessaires |
+|---|---|---|---|
+| `extract_rubric` | Extrait critères évaluation depuis sujet + corrigé modèle | text + vision (Claude Sonnet/Opus) | `pdf_extract`, `claude_vision_analyze` |
+| `ingest_submission` | OCR copie scannée → texte structuré + identification questions | vision (Claude Opus pour précision) | `image_ocr`, `claude_vision_analyze` |
+| `split_responses` | Segmente la copie par question selon la rubric | text | `text_segmentation`, `regex_match` |
+| `compare_responses` | Compare réponse élève vs réponse attendue, par question | text (Claude Sonnet) | `text_similarity`, `claude_reasoning` |
+| `evaluate_score` | Note + critères structurés selon rubric | text | `rubric_apply`, `score_aggregate` |
+| `compose_feedback` | Génère feedback pédagogique en français avec ton persona (RFC-081) | text (Sonnet/Opus + persona prompt) | `persona_prompt_inject`, `markdown_format` |
+
+**Issue front liée** : [#2297](https://github.com/fsebbah/azy.front/issues/2297) (Phase 1 grading)
+
+---
+
+## 2. Tools bas niveau à exposer (pour les skills ci-dessus)
+
+| Tool | Description |
+|---|---|
+| `pdf_extract` | Extrait texte d'un PDF (avec layout + tableaux) |
+| `image_ocr` | OCR sur image (incluant écriture manuscrite) |
+| `claude_vision_analyze` | Wrapper d'appel vision LLM avec output structuré |
+| `text_segmentation` | Découpe un texte selon une structure attendue |
+| `score_aggregate` | Agrège scores selon rubric pondérée |
+| `persona_prompt_inject` | Injecte un persona enseignant (RFC-081) dans un prompt LLM |
+| `markdown_format` | Formate un texte en markdown structuré |
+
+Plusieurs de ces tools existent peut-être déjà — à confirmer.
+
+---
+
+## 3. Skills Claude pour Bug report user (#2295 + #2296)
+
+**Demande** : 1 Skill Claude pour analyser un bug report et produire une issue GitHub structurée.
+
+| Skill | Description | Tools nécessaires |
+|---|---|---|
+| `analyze_user_bug` | Reçoit screenshot + console + métadonnées → identifie type de bug, sévérité, composant impacté, propose un titre + body markdown formaté pour issue GitHub | `image_analyze`, `text_classify`, `markdown_format` |
+
+---
+
+## 4. Catalogue Skills exposé côté API (RFC-101 §11.1)
+
+Le front a besoin d'un catalogue exposé pour brancher la vue Orchestrators v2 (catalogue multi-sources Anthropic + local + tenant).
+
+**Demande** :
+- Maintenir le catalogue Skills (Anthropic + custom internes Azy)
+- Exposer via endpoint chat.api `GET /api/skills/catalog/anthropic` (chat.api proxy MCP)
+- Shape : aligné RFC-101 §11.1 (id, name, description, source, category, default_model, allowed_modalities, inputs, outputs)
+
+---
+
+## 5. Suivi des travaux / RFC-100 (anticipé)
+
+À prévoir 3 Skills Claude pour Phase 2 :
+- `extract_competencies` (depuis une rubric ou un cours)
+- `aggregate_progress` (cumule scores par compétence sur un historique)
+- `recommend_next_steps` (suggère exercices ciblés selon points faibles)
+
+**Issue front liée** : [#2294](https://github.com/fsebbah/azy.front/issues/2294)
+
+---
+
+## Format de réponse attendu
+
+Pour chaque skill / tool, merci d'indiquer :
+- ✅ Existe déjà (path skill MCP)
+- 🔧 À créer — effort estimé
+- ❓ Besoin de précisions
+- ❌ Hors scope MCP (rediriger vers n8n / chat.api)
+
+Les Skills Claude créés peuvent être versionnés dans `mcp-server/skills/` selon votre convention. Format YAML frontmatter aligné repo `anthropics/skills`.

--- a/docs/pending/REQUESTS-MOBILE.md
+++ b/docs/pending/REQUESTS-MOBILE.md
@@ -1,0 +1,119 @@
+# Demandes Front → Équipe Mobile
+
+**Émetteur** : Équipe Frontend 2 (Claude)
+**Date** : 2026-06-05
+**Statut** : 📤 à transmettre
+**Issue front meta** : [#2300 Planification équipes Frontend](https://github.com/fsebbah/azy.front/issues/2300)
+
+---
+
+## 1. App mobile prof — scan séquentiel copies (RFC-099 §11)
+
+**Contexte** : la RFC-099 (Correction de copies) repose sur une **app mobile prof dédiée** pour le scan séquentiel. La vue web Azy gère la création de contrôles + revue + publication, mais le **scan des copies se fait au téléphone**.
+
+**Vision UX (inspiration Examino)** :
+```
+Prof ouvre l'app → choisit un contrôle → choisit un élève → scanne sa copie
+→ retour automatique sur la liste élèves → suivant
+```
+
+Objectif : **15-20 secondes par copie** en routine.
+
+---
+
+## 2. Périmètre app mobile
+
+### 2.1. Trois écrans principaux
+
+1. **Liste contrôles** — paginée, filtrée sur `ready_for_grading`, cache local 24h, pull-to-refresh
+2. **Liste élèves d'un contrôle** — affichage statut soumission par élève (vert/jaune/blanc), recherche par nom
+3. **Capture caméra** — cadre d'aide A4, multi-pages (1 à 4 photos), rotation/recadrage auto, bouton « Envoyer »
+
+### 2.2. Fonctionnalités critiques (RFC-099 §11.2)
+
+| Feature | Priorité | Détail |
+|---|---|---|
+| Sélection contrôle | P0 | Liste paginée + cache 24h + pull-to-refresh |
+| Sélection élève | P0 | Liste classe avec statut soumission (vert/jaune/blanc) + recherche |
+| Capture multi-pages | P0 | Cadre d'aide A4, prise séquentielle 1-4 pages, rotation, recadrage auto |
+| Compression intelligente | P0 | Limite ~500 Ko/photo (1500×2000 px max, JPEG 80%) pour bandwidth école |
+| Queue offline | P0 | Photos en queue locale si offline, retry au retour réseau |
+| Indicateur statut soumission | P1 | Badges par élève après upload |
+| Notifications push | P1 | Notification quand correction prête à valider (deep link vers web) |
+| Auth SSO Firebase | P0 | Même token que web Azy |
+| Mode landscape | P2 | Scan A4 paysage |
+
+### 2.3. Endpoints back utilisés (cf. `REQUESTS-BACK-CHATAPI.md` §2)
+
+- `GET /api/grading/mobile/controls` (liste paginée + ETag)
+- `GET /api/grading/mobile/controls/{id}/students` (liste élèves + statut)
+- `POST /api/grading/mobile/submissions/upload` (multipart photo + control_id + student_id)
+- `GET /api/grading/mobile/sync-queue` (reprise uploads en queue après reboot)
+
+### 2.4. Sécurité
+
+- Token Firebase stocké dans Keychain (iOS) / EncryptedSharedPreferences (Android)
+- Photos chiffrées at-rest sur l'appareil (encryption OS standard)
+- HTTPS obligatoire
+- Aucune persistence des photos après upload réussi (purge auto 24h)
+
+---
+
+## 3. Effort estimé
+
+Cf. RFC-099 §11.6 :
+
+| Item | Effort |
+|---|---|
+| Setup projet + SSO Firebase | ~2j |
+| Écran liste contrôles | ~1j |
+| Écran liste élèves + statuts | ~1j |
+| Écran capture (camera + multi-pages + crop) | ~3j |
+| Upload multipart + retry + queue offline | ~2j |
+| Notifications push | ~1j |
+| Tests + polish + store submission | ~2-3j |
+| **Total mobile** | **~12-13j** (~2.5 sem 1 dev mobile) |
+
+---
+
+## 4. Choix techniques à confirmer
+
+- **Framework** : Flutter ou React Native ? (à votre discrétion, mais à figer)
+- **Camera lib** : qui supporte le bien recadrage automatique et la rotation
+- **Storage local** : SQLite ou Hive (Flutter) / AsyncStorage (RN) pour la queue
+- **Push notifications** : Firebase Cloud Messaging (cohérent avec SSO Firebase)
+- **Deep linking** : vers la vue web `/grading/{control_id}/{student_id}` quand notif arrive
+
+---
+
+## 5. Hors RFC-099 — opportunités
+
+À considérer post-Phase 1 :
+
+- **App élève** pour consulter ses corrections (sinon Discord seul)
+- **Mode offline complet** pour les écoles à faible connectivité
+- **Scan QR submission élève** (Edcafe — cf. RFC-099 §15 Tier 4) — alternative au scan prof
+
+---
+
+## 6. Lien avec la vue web Azy
+
+- L'app mobile **ne réplique pas** la vue web ; chacune a son scope :
+  - **Mobile = scan rapide**
+  - **Web = création/review/publication**
+- Le prof peut commencer un contrôle au web et terminer le scan au mobile (et inverse)
+- Sync data via les endpoints back communs
+
+---
+
+## Format de réponse attendu
+
+Pour chaque écran / feature, merci d'indiquer :
+- ✅ Pris en charge — date estimée
+- ⏳ Pris en compte — à planifier après livraison back endpoints mobile
+- ❓ Besoin de précisions
+- ❌ Hors scope
+
+Et **confirmer le framework choisi** (Flutter / React Native / natif) pour aligner les attentes.
+
+**Issue front liée** : [#2297](https://github.com/fsebbah/azy.front/issues/2297) (chantier parent RFC-099 Phase 1)

--- a/docs/pending/REQUESTS-N8N.md
+++ b/docs/pending/REQUESTS-N8N.md
@@ -1,0 +1,108 @@
+# Demandes Front → n8n
+
+**Émetteur** : Équipe Frontend 2 (Claude)
+**Date** : 2026-06-05
+**Statut** : 📤 à transmettre
+**Issue front meta** : [#2300 Planification équipes Frontend](https://github.com/fsebbah/azy.front/issues/2300)
+
+---
+
+## Périmètre n8n (rappel — clarification du 2026-06-05)
+
+n8n est l'**orchestrateur de workflows et dispatch multi-LLM** (Claude, OpenAI, Gemini, Ollama) avec fallback automatique. Il gère les automations cross-services et le routage intelligent vers les LLM.
+
+> ⚠ Auparavant, on avait évoqué ces responsabilités côté MCP server (RFC-101 §4-§5). Correction : c'est n8n qui gère ce périmètre.
+
+---
+
+## 1. Pipeline orchestrators v2 — exécution (RFC-101)
+
+**Contexte** : POC orchestrators v2 livré côté front (PR #2289 + #2290). Quand chat.api livrera `POST /api/orchestrators/v2/{id}/execute`, il doit déléguer l'exécution à n8n.
+
+**Demande — workflow n8n** :
+1. Reçoit un `OrchestratorV2Draft` (cf. RFC-101 §11.2) avec chaîne de skills + configs + LLM choisis
+2. Exécute la chaîne séquentielle (ou DAG futur) :
+   - Pour chaque skill : invoque le MCP server avec le LLM configuré
+   - Si LLM principal indisponible → bascule sur le fallback (Claude → OpenAI → Gemini → Ollama selon `fallback_models` du skill)
+   - Logs intermédiaires (skill name, LLM utilisé effectivement, durée)
+3. Callback HTTP vers chat.api pour mettre à jour le statut (`processing` → `awaiting_review` → etc.)
+4. Push WS via chat.api vers le front pour les logs temps réel
+
+**Décisions PO à respecter** :
+- Précédence LLM (RFC-101 §10.5) : skill default < user pref < session < per-call override
+- Mode éco non bloquant : si modalité incompatible → ne pas fallback silencieux, retourner une erreur structurée que chat.api propage au front (`400 model_modality_mismatch`)
+- Audit du LLM effectivement utilisé (utile pour facturation et debug)
+
+**Issue front liée** : (mentionnée dans #2300 §5)
+
+---
+
+## 2. Pipeline correction de copies (RFC-099)
+
+**Contexte** : workflow asynchrone déclenché par une nouvelle soumission de copie.
+
+**Demande — workflow n8n** :
+1. Trigger : webhook chat.api après `POST /api/grading/submissions` (passe `submission_id`)
+2. Récupère les métadonnées (sujet, corrigé, rubric, persona)
+3. Exécute la chaîne de Skills Claude :
+   ```
+   extract_rubric → ingest_submission → split_responses → 
+   compare_responses → evaluate_score → compose_feedback
+   ```
+4. Sélection LLM par skill (cf. RFC-099 §10 + RFC-101 §10) avec fallback automatique
+5. À chaque étape : callback HTTP vers chat.api → mise à jour DB + WS push vers front
+6. Étape finale : statut `awaiting_review` ; prof valide manuellement avant publication Discord
+
+**Issue front liée** : [#2297](https://github.com/fsebbah/azy.front/issues/2297)
+
+---
+
+## 3. Pipeline Bug report user
+
+**Contexte** : workflow d'analyse de bug remonté par un utilisateur.
+
+**Demande — workflow n8n** :
+1. Trigger : webhook chat.api après `POST /api/bug-reports`
+2. Récupère screenshot + console + métadonnées
+3. Invoque le Skill MCP `analyze_user_bug` (cf. `REQUESTS-MCP-SERVER.md` §3)
+4. Crée l'issue GitHub via GitHub API (token org)
+5. Callback chat.api avec `issue_url` + `status` → WS push vers user pour notification
+
+**Issues front liées** : [#2295](https://github.com/fsebbah/azy.front/issues/2295) + [#2296](https://github.com/fsebbah/azy.front/issues/2296)
+
+---
+
+## 4. Adapter LLM unifié (à factoriser)
+
+**Demande** : exposer un adapter LLM unique côté n8n qui :
+- Prend un `model_id` (claude-sonnet-4-6, claude-opus-4-8, gpt-4o, gemini-2.5-pro, ollama/llama3, etc.)
+- Prend un prompt + tools
+- Renvoie une réponse structurée
+- Gère le fallback automatique si le LLM principal n'est pas disponible
+
+Réutilisable par tous les workflows ci-dessus.
+
+---
+
+## 5. Suivi élèves — pipeline périodique (RFC-100, à anticiper)
+
+**Contexte** : Phase 2 RFC-100. Génération hebdomadaire d'un récap progression élève.
+
+**Demande — workflow n8n** :
+1. Trigger cron hebdo
+2. Pour chaque élève actif : invoque les skills MCP `aggregate_progress` + `recommend_next_steps`
+3. Publication récap dans le channel Discord de l'élève via webhook plugin Discord
+
+**Issue front liée** : [#2294](https://github.com/fsebbah/azy.front/issues/2294)
+
+---
+
+## Format de réponse attendu
+
+Pour chaque workflow, merci d'indiquer :
+- ✅ Pris en charge — date estimée
+- 🔧 En cours de design
+- ❓ Besoin de précisions
+- ❌ Hors scope n8n (rediriger ailleurs)
+
+Bien préciser l'**adapter LLM unifié** : déjà existant ou à créer ?

--- a/docs/pending/REQUESTS-PLUGIN-CHATBOT.md
+++ b/docs/pending/REQUESTS-PLUGIN-CHATBOT.md
@@ -1,0 +1,75 @@
+# Demandes Front → Plugin chatbot
+
+**Émetteur** : Équipe Frontend 2 (Claude)
+**Date** : 2026-06-05
+**Statut** : 📤 à transmettre
+**Issue front meta** : [#2300 Planification équipes Frontend](https://github.com/fsebbah/azy.front/issues/2300)
+
+---
+
+## Périmètre plugin chatbot (rappel)
+
+Le plugin chatbot fournit l'expérience conversationnelle sur Discord (et autres canaux à venir). Il consomme les Skills Claude exposés par le MCP server et les routes de chat.api.
+
+---
+
+## 1. Correction de copies — feedback élève via chat (RFC-099)
+
+**Contexte** : quand le prof valide une correction (RFC-099 §4.4), le feedback est publié dans le channel personae de l'élève (cf. `REQUESTS-DISCORD-BOT.md`). Mais l'élève peut vouloir **demander une clarification** au bot.
+
+**Demande** :
+- Le bot doit pouvoir charger le contexte de la dernière correction de l'élève (résultats + feedback complet) via chat.api
+- Répondre aux questions de clarification en utilisant le **persona enseignant** configuré (RFC-081) pour rester dans le ton
+- Skill MCP utilisé : `compose_feedback` avec le persona du prof (réutilisé pour cohérence)
+
+**Issue front liée** : [#2297](https://github.com/fsebbah/azy.front/issues/2297) + RFC-099 §8.3
+
+---
+
+## 2. Exercices de remédiation — lancement orchestrator dans le chat
+
+**Contexte** : RFC-099 §4.5 propose un bouton « Exercices de remédiation » sur le feedback de l'élève qui lance un orchestrator générant des exos ciblés.
+
+**Demande** :
+- Bouton interactif Discord (cf. `REQUESTS-DISCORD-BOT.md` §2) qui déclenche un orchestrator v2 (RFC-101)
+- L'orchestrator chaîne 2-3 skills : `analyze_weaknesses` → `generate_targeted_exercises` → `format_for_discord`
+- Le plugin chatbot reçoit le résultat et le publie dans le channel élève
+
+**Issues front liées** : [#2297](https://github.com/fsebbah/azy.front/issues/2297) + (RFC-099 §4.5)
+
+---
+
+## 3. Récap progression élève (RFC-100, anticipé)
+
+**Contexte** : Phase 2 RFC-100. Récap hebdo/mensuel généré par n8n cron + publié via plugin chatbot.
+
+**Demande** :
+- Le plugin reçoit le récap formaté depuis n8n
+- Publication dans le channel élève + résumé interactif (questions/réponses sur les axes faibles)
+- Skill MCP utilisé : `compose_progress_summary` avec persona enseignant
+
+**Issue front liée** : [#2294](https://github.com/fsebbah/azy.front/issues/2294)
+
+---
+
+## 4. Bug report user — confirmation post-création issue (anticipé)
+
+**Contexte** : Quand le user a rempli un bug report (RFC #2295 + #2296) et que n8n a créé l'issue GitHub, le plugin chatbot pourrait notifier en complément du toast frontend.
+
+**Demande optionnelle** :
+- Bot reçoit notification de création issue via webhook
+- Envoie un DM au user avec le lien de l'issue et un éventuel ETA
+
+**Issues front liées** : [#2295](https://github.com/fsebbah/azy.front/issues/2295) + [#2296](https://github.com/fsebbah/azy.front/issues/2296)
+
+**Priorité** : optionnel, à confirmer avec PO
+
+---
+
+## Format de réponse attendu
+
+Pour chaque sujet, merci d'indiquer :
+- ✅ Pris en charge — date estimée
+- ⏳ Pris en compte — à planifier après livraison MCP + n8n
+- ❓ Besoin de précisions
+- ❌ Hors scope plugin chatbot

--- a/docs/webhooks-registry.json
+++ b/docs/webhooks-registry.json
@@ -1,0 +1,1786 @@
+{
+  "version": "1.0",
+  "generated_at": "2026-06-09T13:01:58.093464",
+  "total_webhooks": 196,
+  "excluded_torah": 35,
+  "categories": {
+    "Claude / LLM": [
+      {
+        "name": "Claude - Call Stream With Skills",
+        "path": "claude-call-stream-with-skills",
+        "full_url": "http://pi6.local:5678/webhook/claude-call-stream-with-skills",
+        "method": "POST",
+        "category": "Claude / LLM",
+        "description": "Streaming Claude avec Skills API - le plus complexe des 4 webhooks.",
+        "workflow_id": "Q7DgbM7n5ybQB0UX"
+      },
+      {
+        "name": "Claude - Call With Skills",
+        "path": "claude-call-with-skills",
+        "full_url": "http://pi6.local:5678/webhook/claude-call-with-skills",
+        "method": "POST",
+        "category": "Claude / LLM",
+        "description": "Appel Claude avec Skills API via Batch Processing.",
+        "workflow_id": "Lj1IShrkenZq2udA"
+      }
+    ],
+    "Discord": [
+      {
+        "name": "DISCORD - Billing Portal",
+        "path": "discord-billing-portal",
+        "full_url": "http://pi6.local:5678/webhook/discord-billing-portal",
+        "method": "POST",
+        "category": "Discord",
+        "description": "Cree une session Stripe Billing Portal pour gerer l'abonnement.",
+        "workflow_id": "T7soEpQeDCXT68cW"
+      },
+      {
+        "name": "DISCORD - Credits Debit",
+        "path": "credits-debit",
+        "full_url": "http://pi6.local:5678/webhook/credits-debit",
+        "method": "POST",
+        "category": "Discord",
+        "description": "DISCORD - Credits Debit",
+        "workflow_id": "Z7GY1vc90CoF4pDH"
+      },
+      {
+        "name": "DISCORD - DM Resolve",
+        "path": "discord/dm-resolve",
+        "full_url": "http://pi6.local:5678/webhook/discord/dm-resolve",
+        "method": "POST",
+        "category": "Discord",
+        "description": "Résout le personae pour un DM élève. Orchestre 2 appels API puis dispatch selon le statut.",
+        "workflow_id": "DemkmfTGFYLy3Zt3"
+      },
+      {
+        "name": "DISCORD - Get Balance",
+        "path": "discord-get-balance",
+        "full_url": "http://pi6.local:5678/webhook/discord-get-balance",
+        "method": "POST",
+        "category": "Discord",
+        "description": "DISCORD - Get Balance",
+        "workflow_id": "MNx4tur8X03x6TVP"
+      },
+      {
+        "name": "DISCORD - Get Credits",
+        "path": "discord-get-credits",
+        "full_url": "http://pi6.local:5678/webhook/discord-get-credits",
+        "method": "POST",
+        "category": "Discord",
+        "description": "DISCORD - Get Credits",
+        "workflow_id": "RpF0YrYwyjKcBz4p"
+      },
+      {
+        "name": "DISCORD - Get Plans",
+        "path": "discord-get-plans",
+        "full_url": "http://pi6.local:5678/webhook/discord-get-plans",
+        "method": "GET",
+        "category": "Discord",
+        "description": "DISCORD - Get Plans",
+        "workflow_id": "10ptENKEPSpsRtBX"
+      },
+      {
+        "name": "DISCORD - Get Subscriber",
+        "path": "discord-get-subscriber",
+        "full_url": "http://pi6.local:5678/webhook/discord-get-subscriber",
+        "method": "POST",
+        "category": "Discord",
+        "description": "DISCORD - Get Subscriber",
+        "workflow_id": "WMsadHMNMRMoGqDp"
+      },
+      {
+        "name": "DISCORD - Get Transactions",
+        "path": "discord-get-transactions",
+        "full_url": "http://pi6.local:5678/webhook/discord-get-transactions",
+        "method": "GET",
+        "category": "Discord",
+        "description": "DISCORD - Get Transactions",
+        "workflow_id": "4QcMY4OlgnOfzRyX"
+      },
+      {
+        "name": "DISCORD - Registry",
+        "path": "discord-registry",
+        "full_url": "http://pi6.local:5678/webhook/discord-registry",
+        "method": "POST",
+        "category": "Discord",
+        "description": "Liste tous les workflows Discord disponibles avec leurs metadonnees.",
+        "workflow_id": "arEmH7jyo8Z9B6wl"
+      },
+      {
+        "name": "DISCORD - Student Context",
+        "path": "discord/student-context",
+        "full_url": "http://pi6.local:5678/webhook/discord/student-context",
+        "method": "POST",
+        "category": "Discord",
+        "description": "Enriches LLM prompt with student info (name, promo, exchange history) to personalize responses. Uses RedisSessionStore for session memory.",
+        "workflow_id": "jbljjN4t7VLx6ZIR"
+      },
+      {
+        "name": "DISCORD - Student Recap",
+        "path": "discord/student-recap",
+        "full_url": "http://pi6.local:5678/webhook/discord/student-recap",
+        "method": "POST",
+        "category": "Discord",
+        "description": "DISCORD - Student Recap",
+        "workflow_id": "WRt8mTcpgEGw27Rv"
+      },
+      {
+        "name": "DISCORD - Subject Detect",
+        "path": "discord/subject-detect",
+        "full_url": "http://pi6.local:5678/webhook/discord/subject-detect",
+        "method": "POST",
+        "category": "Discord",
+        "description": "DISCORD - Subject Detect",
+        "workflow_id": "n6PUaeAoeunYA45b"
+      },
+      {
+        "name": "DISCORD - Subject Switch",
+        "path": "discord/subject-switch",
+        "full_url": "http://pi6.local:5678/webhook/discord/subject-switch",
+        "method": "POST",
+        "category": "Discord",
+        "description": "Changement de contexte matiere - When chatbot-core receives `/matiere maths`, it calls azy.mcp to reload the correct expert + RAG + session.",
+        "workflow_id": "ruIScPLm7ObPdwGJ"
+      },
+      {
+        "name": "DISCORD - Subscribe",
+        "path": "discord-subscribe",
+        "full_url": "http://pi6.local:5678/webhook/discord-subscribe",
+        "method": "POST",
+        "category": "Discord",
+        "description": "Cree une session Stripe Checkout pour un abonnement.",
+        "workflow_id": "z3ptm83NqfKA1Qed"
+      },
+      {
+        "name": "GUILD - Create Room",
+        "path": "guild-create-room",
+        "full_url": "http://pi6.local:5678/webhook/guild-create-room",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Create Room",
+        "workflow_id": "sDJJIQ8HucgiN4op"
+      },
+      {
+        "name": "GUILD - Credits Exhausted Notification",
+        "path": "guild/credits/exhausted",
+        "full_url": "http://pi6.local:5678/webhook/guild/credits/exhausted",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Credits Exhausted Notification",
+        "workflow_id": "dYKWSpWnDa4aDpvb"
+      },
+      {
+        "name": "GUILD - Get Branding",
+        "path": "guild-get-branding",
+        "full_url": "http://pi6.local:5678/webhook/guild-get-branding",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Get Branding",
+        "workflow_id": "bBbAQFoAPGIxq6IW"
+      },
+      {
+        "name": "GUILD - Get Prompts",
+        "path": "guild-get-prompts",
+        "full_url": "http://pi6.local:5678/webhook/guild-get-prompts",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Get Prompts",
+        "workflow_id": "mlmmGParThBV13XF"
+      },
+      {
+        "name": "GUILD - Get Rooms",
+        "path": "guild-get-rooms",
+        "full_url": "http://pi6.local:5678/webhook/guild-get-rooms",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Get Rooms",
+        "workflow_id": "lyOqWORdnjaJUHcM"
+      },
+      {
+        "name": "GUILD - Member Leave Credits",
+        "path": "guild/member/leave",
+        "full_url": "http://pi6.local:5678/webhook/guild/member/leave",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Member Leave Credits",
+        "workflow_id": "dYYJjVhFERkan2nt"
+      },
+      {
+        "name": "GUILD - Server Sync",
+        "path": "server-sync",
+        "full_url": "http://pi6.local:5678/webhook/server-sync",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Server Sync",
+        "workflow_id": "g0vEIaV8JciCQEb0"
+      },
+      {
+        "name": "GUILD - Student Verify",
+        "path": "discord/student/verify",
+        "full_url": "http://pi6.local:5678/webhook/discord/student/verify",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Student Verify",
+        "workflow_id": "6iSsoCzbjuk9DxkT"
+      },
+      {
+        "name": "GUILD - Tenant Settings",
+        "path": "discord/tenant/settings",
+        "full_url": "http://pi6.local:5678/webhook/discord/tenant/settings",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Tenant Settings",
+        "workflow_id": "La7CyZJsJHrWM4AV"
+      },
+      {
+        "name": "GUILD - Update Branding",
+        "path": "guild-update-branding",
+        "full_url": "http://pi6.local:5678/webhook/guild-update-branding",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Update Branding",
+        "workflow_id": "LKhRCEbPelHlnUrb"
+      },
+      {
+        "name": "GUILD - Update Prompt",
+        "path": "guild-update-prompt",
+        "full_url": "http://pi6.local:5678/webhook/guild-update-prompt",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD - Update Prompt",
+        "workflow_id": "4xSZeiTp3ODJexKo"
+      },
+      {
+        "name": "GUILD---On-Startup-Register",
+        "path": "guild/register-if-needed",
+        "full_url": "http://pi6.local:5678/webhook/guild/register-if-needed",
+        "method": "POST",
+        "category": "Discord",
+        "description": "GUILD---On-Startup-Register",
+        "workflow_id": "ltWjzJmmYr6EhyD7"
+      }
+    ],
+    "Document Processing": [
+      {
+        "name": "Document Cancel",
+        "path": "document-cancel",
+        "full_url": "http://pi6.local:5678/webhook/document-cancel",
+        "method": "POST",
+        "category": "Document Processing",
+        "description": "Document Cancel",
+        "workflow_id": "3sduhqVBeBj5Ahiz"
+      },
+      {
+        "name": "Document Structure Extract",
+        "path": "document-structure-extract",
+        "full_url": "http://pi6.local:5678/webhook/document-structure-extract",
+        "method": "POST",
+        "category": "Document Processing",
+        "description": "Document Structure Extract",
+        "workflow_id": "KMNE2BVahFJcDycQ"
+      },
+      {
+        "name": "Document Translate Worker",
+        "path": "document-translate-worker",
+        "full_url": "http://pi6.local:5678/webhook/document-translate-worker",
+        "method": "POST",
+        "category": "Document Processing",
+        "description": "Document Translate Worker",
+        "workflow_id": "ciDPOuhIdoyio6BX"
+      }
+    ],
+    "MCP Tools": [
+      {
+        "name": "MCP - Academic Searcher",
+        "path": "academic-searcher",
+        "full_url": "http://pi6.local:5678/webhook/academic-searcher",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Academic Searcher",
+        "workflow_id": "dwclCArbcxpUNOL4"
+      },
+      {
+        "name": "MCP - Analyze Message",
+        "path": "analyze-message",
+        "full_url": "http://pi6.local:5678/webhook/analyze-message",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Analyse complète d'un message (sentiment, intentions, entités, priorité, langue)",
+        "workflow_id": "EiNGvM8j4KMcheed"
+      },
+      {
+        "name": "MCP - Bulk URL Processor",
+        "path": "bulk-url-processor",
+        "full_url": "http://pi6.local:5678/webhook/bulk-url-processor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Bulk URL Processor",
+        "workflow_id": "yRhm2W8Y7x5452Gg"
+      },
+      {
+        "name": "MCP - CSV Processor",
+        "path": "csv-processor",
+        "full_url": "http://pi6.local:5678/webhook/csv-processor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - CSV Processor",
+        "workflow_id": "VW7DqZcclwqtuqyT"
+      },
+      {
+        "name": "MCP - Chart Generator",
+        "path": "chart-generator",
+        "full_url": "http://pi6.local:5678/webhook/chart-generator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Chart Generator",
+        "workflow_id": "OxBlSMpOZqJVLdrn"
+      },
+      {
+        "name": "MCP - Code Generator",
+        "path": "code-generator",
+        "full_url": "http://pi6.local:5678/webhook/code-generator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Code Generator",
+        "workflow_id": "3dAX5G5VNZVIUlcw"
+      },
+      {
+        "name": "MCP - Content Analyzer",
+        "path": "content-analyzer",
+        "full_url": "http://pi6.local:5678/webhook/content-analyzer",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Analyse le contenu image/document et retourne un plan de pipeline pour azy.mcp PipelineExecutor.",
+        "workflow_id": "RmD172M71Rx9nUvy"
+      },
+      {
+        "name": "MCP - Cost Calculator",
+        "path": "cost-calculator",
+        "full_url": "http://pi6.local:5678/webhook/cost-calculator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Calcule le cout d'utilisation des modeles LLM en USD.",
+        "workflow_id": "sUkUNxu36VISWzke"
+      },
+      {
+        "name": "MCP - Create Free Subscriber",
+        "path": "create-free-subscriber",
+        "full_url": "http://pi6.local:5678/webhook/create-free-subscriber",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Crée un abonné gratuit avec crédits initiaux",
+        "workflow_id": "fwVJ9WLlQqmt2vrq"
+      },
+      {
+        "name": "MCP - DOCX Extractor",
+        "path": "docx-extractor",
+        "full_url": "http://pi6.local:5678/webhook/docx-extractor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Extrait le contenu textuel de fichiers DOCX avec support pour differents formats de sortie.",
+        "workflow_id": "1acfHfjbuzoAmHzv"
+      },
+      {
+        "name": "MCP - Dataset Generator",
+        "path": "mcp/dataset/generate",
+        "full_url": "http://pi6.local:5678/webhook/mcp/dataset/generate",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Generer automatiquement des datasets de test pour l'analyse d'intentions",
+        "workflow_id": "ET9SJcbyBO9DlXP1"
+      },
+      {
+        "name": "MCP - Documents Estimate",
+        "path": "documents/estimate",
+        "full_url": "http://pi6.local:5678/webhook/documents/estimate",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Estime le nombre de tokens, pages et credits requis pour traiter un document.",
+        "workflow_id": "6T0xLTZnCo750HEf"
+      },
+      {
+        "name": "MCP - Documents Process",
+        "path": "documents/process",
+        "full_url": "http://pi6.local:5678/webhook/documents/process",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Documents Process",
+        "workflow_id": "YgtyvTyGDNlDLYHp"
+      },
+      {
+        "name": "MCP - Documents Save",
+        "path": "documents/save",
+        "full_url": "http://pi6.local:5678/webhook/documents/save",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Documents Save",
+        "workflow_id": "rXxo6q8W8edGCgoV"
+      },
+      {
+        "name": "MCP - Documents Validate",
+        "path": "documents/validate",
+        "full_url": "http://pi6.local:5678/webhook/documents/validate",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Documents Validate",
+        "workflow_id": "je6LqhkNP4hgiivK"
+      },
+      {
+        "name": "MCP - Email IMAP",
+        "path": "email-imap",
+        "full_url": "http://pi6.local:5678/webhook/email-imap",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Email IMAP",
+        "workflow_id": "virECiQyCyP7LFgT"
+      },
+      {
+        "name": "MCP - Entity - Comment",
+        "path": "entity-comment",
+        "full_url": "http://pi6.local:5678/webhook/entity-comment",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Manages comments on entities (recipes, documents, courses, etc.) stored in PostgreSQL.",
+        "workflow_id": "d2D9fEeQ8zYuVHA6"
+      },
+      {
+        "name": "MCP - Entity - Rating",
+        "path": "entity-rating",
+        "full_url": "http://pi6.local:5678/webhook/entity-rating",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Manages entity ratings (recipes, documents, courses, etc.) stored in PostgreSQL.",
+        "workflow_id": "0LbAwUdFjTKGyHg5"
+      },
+      {
+        "name": "MCP - Entity - Save",
+        "path": "entity-save",
+        "full_url": "http://pi6.local:5678/webhook/entity-save",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "RFC-049 Entity Storage Architecture + RFC-053 bot_id isolation. Saves entities to both MongoDB (via API) AND Qdrant. Uses same UUID for entity_id and qdrant_point_id.",
+        "workflow_id": "8ZIfHNmN4YOayy7O"
+      },
+      {
+        "name": "MCP - Entity - Search",
+        "path": "entity-search",
+        "full_url": "http://pi6.local:5678/webhook/entity-search",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Recherche semantique multi-tenant dans Qdrant avec enrichissement MongoDB optionnel. RFC-049 + RFC-053 (bot_id isolation).",
+        "workflow_id": "vgTXZ9bH56N3v0YL"
+      },
+      {
+        "name": "MCP - Entity Extractor",
+        "path": "entity-extractor",
+        "full_url": "http://pi6.local:5678/webhook/entity-extractor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Entity Extractor",
+        "workflow_id": "5WoZg4BWXfAWOkDR"
+      },
+      {
+        "name": "MCP - Feedback Analyzer",
+        "path": "analyze-feedback",
+        "full_url": "http://pi6.local:5678/webhook/analyze-feedback",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Analyse le feedback utilisateur pour extraire des insights actionnables et ajuster le comportement de l'assistant IA.",
+        "workflow_id": "jIYd6z26dd1CCcX2"
+      },
+      {
+        "name": "MCP - Games Add",
+        "path": "games-add",
+        "full_url": "http://pi6.local:5678/webhook/games-add",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Games Add",
+        "workflow_id": "RpYQjfYM2dIgpRaS"
+      },
+      {
+        "name": "MCP - Games Analysis",
+        "path": "games-analysis",
+        "full_url": "http://pi6.local:5678/webhook/games-analysis",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Games Analysis",
+        "workflow_id": "lwbLrrUgBtqIakRT"
+      },
+      {
+        "name": "MCP - Games Lichess",
+        "path": "games-lichess",
+        "full_url": "http://pi6.local:5678/webhook/games-lichess",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Games Lichess",
+        "workflow_id": "0D2bRb5i5pKdNL9p"
+      },
+      {
+        "name": "MCP - Games List",
+        "path": "games-list",
+        "full_url": "http://pi6.local:5678/webhook/games-list",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Games List",
+        "workflow_id": "AC6TOb6oXmdwEaFS"
+      },
+      {
+        "name": "MCP - Gmail Server (All-in-One)",
+        "path": "mcp-gmail",
+        "full_url": "http://pi6.local:5678/webhook/mcp-gmail",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Gmail Server (All-in-One)",
+        "workflow_id": "Jz4ji4p0QStwstN0"
+      },
+      {
+        "name": "MCP - Google Calendar Server",
+        "path": "mcp-calendar",
+        "full_url": "http://pi6.local:5678/webhook/mcp-calendar",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Calendar Server",
+        "workflow_id": "u6pSGRx05aNgK0fv"
+      },
+      {
+        "name": "MCP - Google Classroom Server",
+        "path": "mcp-classroom",
+        "full_url": "http://pi6.local:5678/webhook/mcp-classroom",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Classroom Server",
+        "workflow_id": "KdlhTDaBa3EZX26C"
+      },
+      {
+        "name": "MCP - Google Contacts Server",
+        "path": "mcp-contacts",
+        "full_url": "http://pi6.local:5678/webhook/mcp-contacts",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Contacts Server",
+        "workflow_id": "A1mWo3qs0572wSp0"
+      },
+      {
+        "name": "MCP - Google Drive OCR",
+        "path": "google-drive-ocr",
+        "full_url": "http://pi6.local:5678/webhook/google-drive-ocr",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Drive OCR",
+        "workflow_id": "KoYmjpXfjgCrphhh"
+      },
+      {
+        "name": "MCP - Google Drive Server",
+        "path": "mcp-drive",
+        "full_url": "http://pi6.local:5678/webhook/mcp-drive",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Drive Server",
+        "workflow_id": "jRaOth5nYWI8Gl9q"
+      },
+      {
+        "name": "MCP - Google Maps",
+        "path": "mcp-google-maps",
+        "full_url": "http://pi6.local:5678/webhook/mcp-google-maps",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Maps",
+        "workflow_id": "2yybqbrzqWOsVfdL"
+      },
+      {
+        "name": "MCP - Google Searcher",
+        "path": "google-searcher",
+        "full_url": "http://pi6.local:5678/webhook/google-searcher",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Google Searcher",
+        "workflow_id": "6WtKoi2pkRShkVT7"
+      },
+      {
+        "name": "MCP - HTML Extractor",
+        "path": "html-extractor",
+        "full_url": "http://pi6.local:5678/webhook/html-extractor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - HTML Extractor",
+        "workflow_id": "soWXv3QQYzjNiN35"
+      },
+      {
+        "name": "MCP - Image Embedder",
+        "path": "image-embedder",
+        "full_url": "http://pi6.local:5678/webhook/image-embedder",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Analyse une image via GPT-4o-mini et genere un embedding semantique",
+        "workflow_id": "iEYtMhfT54nC5MFX"
+      },
+      {
+        "name": "MCP - Image Generator",
+        "path": "image-generator",
+        "full_url": "http://pi6.local:5678/webhook/image-generator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Image Generator",
+        "workflow_id": "b8UDsmsVt9QkAywZ"
+      },
+      {
+        "name": "MCP - Image OCR",
+        "path": "image-ocr",
+        "full_url": "http://pi6.local:5678/webhook/image-ocr",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Image OCR",
+        "workflow_id": "xQt71PPNeLGo9YPx"
+      },
+      {
+        "name": "MCP - JSON Transformer",
+        "path": "json-transformer",
+        "full_url": "http://pi6.local:5678/webhook/json-transformer",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - JSON Transformer",
+        "workflow_id": "n2t7kKIYePjcI7pl"
+      },
+      {
+        "name": "MCP - Knowledge Graph",
+        "path": "knowledge-graph",
+        "full_url": "http://pi6.local:5678/webhook/knowledge-graph",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Knowledge Graph",
+        "workflow_id": "e7YS4pgDKrxmvurW"
+      },
+      {
+        "name": "MCP - LLM Intention",
+        "path": "llm-intention",
+        "full_url": "http://pi6.local:5678/webhook/llm-intention",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Analyse l'intention utilisateur via LLM et propose des actions appropriees.",
+        "workflow_id": "bnZP1kGQboNyY67u"
+      },
+      {
+        "name": "MCP - LLM Summarizer",
+        "path": "llm-summarizer",
+        "full_url": "http://pi6.local:5678/webhook/llm-summarizer",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Summarizes text using multiple LLM providers (Anthropic, OpenAI, Mistral).",
+        "workflow_id": "3xOAo0G2fvmauIx1"
+      },
+      {
+        "name": "MCP - Language Detector",
+        "path": "language-detector",
+        "full_url": "http://pi6.local:5678/webhook/language-detector",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Detecte la langue d'un texte et retourne des informations detaillees.",
+        "workflow_id": "THC7Qt41GurxBuzJ"
+      },
+      {
+        "name": "MCP - Lichess Auth Callback",
+        "path": "lichess-auth-callback",
+        "full_url": "http://pi6.local:5678/webhook/lichess-auth-callback",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Lichess Auth Callback",
+        "workflow_id": "xWQ7GvTnaM6k4FQH"
+      },
+      {
+        "name": "MCP - Lichess Auth Start",
+        "path": "lichess-auth-start",
+        "full_url": "http://pi6.local:5678/webhook/lichess-auth-start",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Lichess Auth Start",
+        "workflow_id": "SggHvck1WZ61NWfT"
+      },
+      {
+        "name": "MCP - Lichess OAuth",
+        "path": "lichess-oauth-callback",
+        "full_url": "http://pi6.local:5678/webhook/lichess-oauth-callback",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Workflow OAuth complet pour Lichess",
+        "workflow_id": "RCY7MUDd4Off8e6R"
+      },
+      {
+        "name": "MCP - Lichess Webhook",
+        "path": "lichess-webhook",
+        "full_url": "http://pi6.local:5678/webhook/lichess-webhook",
+        "method": "GET",
+        "category": "MCP Tools",
+        "description": "Page de confirmation OAuth Lichess",
+        "workflow_id": "PXQ2w7pAEg8ukenO"
+      },
+      {
+        "name": "MCP - LinkedIn",
+        "path": "linkedin",
+        "full_url": "http://pi6.local:5678/webhook/linkedin",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - LinkedIn",
+        "workflow_id": "cLxDiCFSOTiaMUYn"
+      },
+      {
+        "name": "MCP - Mathpix",
+        "path": "mathpix",
+        "full_url": "http://pi6.local:5678/webhook/mathpix",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "OCR mathematique via Mathpix API. Convertit images de formules/equations en LaTeX, MathML, AsciiMath.",
+        "workflow_id": "6bWwcWZqx0tirOFk"
+      },
+      {
+        "name": "MCP - Metadata Extractor",
+        "path": "metadata-extractor",
+        "full_url": "http://pi6.local:5678/webhook/metadata-extractor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Metadata Extractor",
+        "workflow_id": "4J4bZ6JpPDkvD87t"
+      },
+      {
+        "name": "MCP - Microsoft Learn",
+        "path": "microsoft-learn",
+        "full_url": "http://pi6.local:5678/webhook/microsoft-learn",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Microsoft Learn",
+        "workflow_id": "HhSr04SPXwMHmJVa"
+      },
+      {
+        "name": "MCP - News Searcher",
+        "path": "news-searcher",
+        "full_url": "http://pi6.local:5678/webhook/news-searcher",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - News Searcher",
+        "workflow_id": "1UDizjOfHcBbPPRP"
+      },
+      {
+        "name": "MCP - OAuth Delete",
+        "path": "oauth-delete",
+        "full_url": "http://pi6.local:5678/webhook/oauth-delete",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - OAuth Delete",
+        "workflow_id": "HCc6BAPTkaDGK3Gk"
+      },
+      {
+        "name": "MCP - OAuth Get",
+        "path": "oauth-get",
+        "full_url": "http://pi6.local:5678/webhook/oauth-get",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - OAuth Get",
+        "workflow_id": "tOKoU7jRfSZhCNRP"
+      },
+      {
+        "name": "MCP - PDF Extractor",
+        "path": "pdf-extractor",
+        "full_url": "http://pi6.local:5678/webhook/pdf-extractor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - PDF Extractor",
+        "workflow_id": "Dfhnt08MMd8yWbTZ"
+      },
+      {
+        "name": "MCP - PDF Layout Translator",
+        "path": "pdf-layout-translator",
+        "full_url": "http://pi6.local:5678/webhook/pdf-layout-translator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - PDF Layout Translator",
+        "workflow_id": "fQgtLkQ8yFdTVjOC"
+      },
+      {
+        "name": "MCP - PDF OCR",
+        "path": "pdf-ocr",
+        "full_url": "http://pi6.local:5678/webhook/pdf-ocr",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Extraction de texte depuis PDF/images via OCR multi-providers",
+        "workflow_id": "16KwTyckYgt0cITG"
+      },
+      {
+        "name": "MCP - Progress Delete",
+        "path": "progress-delete",
+        "full_url": "http://pi6.local:5678/webhook/progress-delete",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Progress Delete",
+        "workflow_id": "f2Wo2r5J4pRu8MmE"
+      },
+      {
+        "name": "MCP - Progress Get",
+        "path": "progress-get",
+        "full_url": "http://pi6.local:5678/webhook/progress-get",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Progress Get",
+        "workflow_id": "KBqSLU1y1QoOmgzu"
+      },
+      {
+        "name": "MCP - Progress Update",
+        "path": "progress-update",
+        "full_url": "http://pi6.local:5678/webhook/progress-update",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Progress Update",
+        "workflow_id": "Oxw0je45OOKk11uK"
+      },
+      {
+        "name": "MCP - Qdrant - Search",
+        "path": "qdrant-search",
+        "full_url": "http://pi6.local:5678/webhook/qdrant-search",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Recherche semantique dans Qdrant avec embeddings OpenAI.",
+        "workflow_id": "taiQS0dy0t2wcbr1"
+      },
+      {
+        "name": "MCP - Quiz Generator",
+        "path": "quiz-generator",
+        "full_url": "http://pi6.local:5678/webhook/quiz-generator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Genere des quiz educatifs a partir de texte, sujet ou URL.",
+        "workflow_id": "SUlOgPqXDRlXPkpN"
+      },
+      {
+        "name": "MCP - Registry",
+        "path": "mcp-registry",
+        "full_url": "http://pi6.local:5678/webhook/mcp-registry",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Registry",
+        "workflow_id": "UKqO3AKOwkVmfd98"
+      },
+      {
+        "name": "MCP - Script Detector",
+        "path": "script-detector",
+        "full_url": "http://pi6.local:5678/webhook/script-detector",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Script Detector",
+        "workflow_id": "fSLm5HfKsXHpPKTf"
+      },
+      {
+        "name": "MCP - Speaker Identifier",
+        "path": "speaker-identifier",
+        "full_url": "http://pi6.local:5678/webhook/speaker-identifier",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Speaker Identifier",
+        "workflow_id": "Fqu6TOSpP5onWyy8"
+      },
+      {
+        "name": "MCP - Summarizer",
+        "path": "summarizer",
+        "full_url": "http://pi6.local:5678/webhook/summarizer",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Summarizes text using Anthropic Claude.",
+        "workflow_id": "NNmOnCc2mdXGZPfL"
+      },
+      {
+        "name": "MCP - Syllabus Generator",
+        "path": "syllabus-generator",
+        "full_url": "http://pi6.local:5678/webhook/syllabus-generator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Genere des syllabus educatifs complets avec modules, lecons, objectifs et evaluations.",
+        "workflow_id": "gUxqJkQubu3NGPOB"
+      },
+      {
+        "name": "MCP - Table Extractor",
+        "path": "table-extractor",
+        "full_url": "http://pi6.local:5678/webhook/table-extractor",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Table Extractor",
+        "workflow_id": "bOIWHh5jRZPvGWp3"
+      },
+      {
+        "name": "MCP - Tenant - Resolve",
+        "path": "mcp-tenant-resolve",
+        "full_url": "http://pi6.local:5678/webhook/mcp-tenant-resolve",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Resolves Discord guild_id to tenant_id + package + models (RFC-079).",
+        "workflow_id": "TJtH1UwOO6x9D2xi"
+      },
+      {
+        "name": "MCP - Test - Echo",
+        "path": "mcp-test-echo",
+        "full_url": "http://pi6.local:5678/webhook/mcp-test-echo",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Test - Echo",
+        "workflow_id": "OqrQ7uxgS1VmbYaz"
+      },
+      {
+        "name": "MCP - Text Classifier",
+        "path": "text-classifier",
+        "full_url": "http://pi6.local:5678/webhook/text-classifier",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Text Classifier",
+        "workflow_id": "xzpEplx1Lwll95pE"
+      },
+      {
+        "name": "MCP - Text Embedder",
+        "path": "text-embedder",
+        "full_url": "http://pi6.local:5678/webhook/text-embedder",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Genere des embeddings de texte via l'API OpenAI pour une utilisation en RAG, recherche semantique, etc.",
+        "workflow_id": "GMkO8Y7N6N5bgy1Q"
+      },
+      {
+        "name": "MCP - Text Generator",
+        "path": "text-generator",
+        "full_url": "http://pi6.local:5678/webhook/text-generator",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Generates text using OpenAI GPT models.",
+        "workflow_id": "RipM3vFw09xhPtXR"
+      },
+      {
+        "name": "MCP - Text to Speech",
+        "path": "text-to-speech",
+        "full_url": "http://pi6.local:5678/webhook/text-to-speech",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Convert text to speech audio using OpenAI TTS API.",
+        "workflow_id": "ygMdwJrg8sl5L0pG"
+      },
+      {
+        "name": "MCP - Tokenizer",
+        "path": "tokenizer",
+        "full_url": "http://pi6.local:5678/webhook/tokenizer",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Estime le nombre de tokens pour un texte donne et calcule l'utilisation du contexte pour differents modeles LLM.",
+        "workflow_id": "hKjyL9mPtl8H8N0C"
+      },
+      {
+        "name": "MCP - Tools - Registry",
+        "path": "mcp/tools/registry",
+        "full_url": "http://pi6.local:5678/webhook/mcp/tools/registry",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Tools - Registry",
+        "workflow_id": "2QwuEUpkgpipYjyL"
+      },
+      {
+        "name": "MCP - Tools Enricher",
+        "path": "tools-enricher",
+        "full_url": "http://pi6.local:5678/webhook/tools-enricher",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Enrichir automatiquement les metadonnees des tools n8n et les indexer dans Qdrant",
+        "workflow_id": "voie2ygi5GLP0HwY"
+      },
+      {
+        "name": "MCP - Tools Notify",
+        "path": "mcp/tools/notify",
+        "full_url": "http://pi6.local:5678/webhook/mcp/tools/notify",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Tools Notify",
+        "workflow_id": "OSrxWa6DdzXVvFJt"
+      },
+      {
+        "name": "MCP - Transcriber",
+        "path": "video-transcription",
+        "full_url": "http://pi6.local:5678/webhook/video-transcription",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Transcriber",
+        "workflow_id": "KalWt5icY3Eoz5bB"
+      },
+      {
+        "name": "MCP - Vector Store",
+        "path": "vector-store",
+        "full_url": "http://pi6.local:5678/webhook/vector-store",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Vector Store",
+        "workflow_id": "zOwekZmlRQbfEoZD"
+      },
+      {
+        "name": "MCP - Web Scraper",
+        "path": "web-scraper",
+        "full_url": "http://pi6.local:5678/webhook/web-scraper",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - Web Scraper",
+        "workflow_id": "A2L4SZvj4JcfcZQJ"
+      },
+      {
+        "name": "MCP - YouTube Searcher",
+        "path": "youtube-searcher",
+        "full_url": "http://pi6.local:5678/webhook/youtube-searcher",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - YouTube Searcher",
+        "workflow_id": "MdqUUKNDXz9gIXB6"
+      },
+      {
+        "name": "MCP - qdrant - Similar",
+        "path": "qdrant-similar",
+        "full_url": "http://pi6.local:5678/webhook/qdrant-similar",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP - qdrant - Similar",
+        "workflow_id": "y2WP91jjAvV3zIus"
+      },
+      {
+        "name": "MCP Gemini Image",
+        "path": "gemini-image",
+        "full_url": "http://pi6.local:5678/webhook/gemini-image",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Generateur d'images IA via Google Gemini/Vertex AI avec support multi-operations (generate, extractCharacter, createCharacterSheet, composeScene).",
+        "workflow_id": "De6a7Mdnj7z9hTlP"
+      },
+      {
+        "name": "MCP Qdrant - Save",
+        "path": "qdrant-save",
+        "full_url": "http://pi6.local:5678/webhook/qdrant-save",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "Saves entity data with optional Qdrant vector embedding storage.",
+        "workflow_id": "ROYxSkjw3s2isuJr"
+      },
+      {
+        "name": "MCP Veo Video",
+        "path": "veo-video",
+        "full_url": "http://pi6.local:5678/webhook/veo-video",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP Veo Video",
+        "workflow_id": "wlWgNRY2QBOzWXUY"
+      },
+      {
+        "name": "MCP-Document-Callback",
+        "path": "document-callback",
+        "full_url": "http://pi6.local:5678/webhook/document-callback",
+        "method": "POST",
+        "category": "MCP Tools",
+        "description": "MCP-Document-Callback",
+        "workflow_id": "LOiDsPw8oftAaXcd"
+      }
+    ],
+    "Other": [
+      {
+        "name": "ALERT - Anomaly Detected",
+        "path": "alert-anomaly-detected",
+        "full_url": "http://pi6.local:5678/webhook/alert-anomaly-detected",
+        "method": "POST",
+        "category": "Other",
+        "description": "Polls Redis Stream for reconciliation.anomaly events",
+        "workflow_id": "KKux2QAmZZ0n3zar"
+      },
+      {
+        "name": "Anthropic - List Skills",
+        "path": "anthropic-list-skills",
+        "full_url": "http://pi6.local:5678/webhook/anthropic-list-skills",
+        "method": "POST",
+        "category": "Other",
+        "description": "Liste les Skills Anthropic disponibles (pré-construits et custom).",
+        "workflow_id": "mK7qc0TZ4aBVwPSo"
+      },
+      {
+        "name": "Books Commentary Worker",
+        "path": "books-commentary-worker",
+        "full_url": "http://pi6.local:5678/webhook/books-commentary-worker",
+        "method": "POST",
+        "category": "Other",
+        "description": "Books Commentary Worker",
+        "workflow_id": "C4QLzAfVM1f8LpS5"
+      },
+      {
+        "name": "Books Job Status",
+        "path": "books-job-status",
+        "full_url": "http://pi6.local:5678/webhook/books-job-status",
+        "method": "POST",
+        "category": "Other",
+        "description": "Books Job Status",
+        "workflow_id": "xSwPuIY9Lp9IoqPj"
+      },
+      {
+        "name": "Books Translate Commentaries",
+        "path": "books-translate-commentaries",
+        "full_url": "http://pi6.local:5678/webhook/books-translate-commentaries",
+        "method": "POST",
+        "category": "Other",
+        "description": "Books Translate Commentaries",
+        "workflow_id": "yiuP2LfWBlP4RwuD"
+      },
+      {
+        "name": "Books Translation Manager",
+        "path": "books-translate",
+        "full_url": "http://pi6.local:5678/webhook/books-translate",
+        "method": "POST",
+        "category": "Other",
+        "description": "Books Translation Manager",
+        "workflow_id": "rzgpYqJjXnEpHinc"
+      },
+      {
+        "name": "Books Translation Worker",
+        "path": "books-translation-worker",
+        "full_url": "http://pi6.local:5678/webhook/books-translation-worker",
+        "method": "POST",
+        "category": "Other",
+        "description": "Books Translation Worker",
+        "workflow_id": "hiwiaLEMvKza8WX9"
+      },
+      {
+        "name": "CHANNELS - Private Check Or Create",
+        "path": "private-channel-request",
+        "full_url": "http://pi6.local:5678/webhook/private-channel-request",
+        "method": "POST",
+        "category": "Other",
+        "description": "Vérifie si un channel privé existe, sinon le crée via Discord API et l'enregistre dans api-backend.",
+        "workflow_id": "sVvcaRFCXjxd8xaF"
+      },
+      {
+        "name": "CHANNELS---Private-Register-Callback",
+        "path": "private-channel-callback",
+        "full_url": "http://pi6.local:5678/webhook/private-channel-callback",
+        "method": "POST",
+        "category": "Other",
+        "description": "CHANNELS---Private-Register-Callback",
+        "workflow_id": "zol6fTZm10bgHslR"
+      },
+      {
+        "name": "CONFIG---Get-Branding",
+        "path": "config/branding",
+        "full_url": "http://pi6.local:5678/webhook/config/branding",
+        "method": "POST",
+        "category": "Other",
+        "description": "CONFIG---Get-Branding",
+        "workflow_id": "YMffmWWY2zPA6o75"
+      },
+      {
+        "name": "CONFIG---Get-Help",
+        "path": "config/help",
+        "full_url": "http://pi6.local:5678/webhook/config/help",
+        "method": "POST",
+        "category": "Other",
+        "description": "CONFIG---Get-Help",
+        "workflow_id": "PkTIK0s6ssN5E4HF"
+      },
+      {
+        "name": "CONFIG---Help-Reset",
+        "path": "config/help/reset",
+        "full_url": "http://pi6.local:5678/webhook/config/help/reset",
+        "method": "POST",
+        "category": "Other",
+        "description": "CONFIG---Help-Reset",
+        "workflow_id": "R8iSfgONToE0tG3c"
+      },
+      {
+        "name": "Category Detect",
+        "path": "category-detect",
+        "full_url": "http://pi6.local:5678/webhook/category-detect",
+        "method": "POST",
+        "category": "Other",
+        "description": "Category Detect",
+        "workflow_id": "ywNQbKGOggzvI1oq"
+      },
+      {
+        "name": "Classroom Sync Status",
+        "path": "classroom-sync-status",
+        "full_url": "http://pi6.local:5678/webhook/classroom-sync-status",
+        "method": "GET",
+        "category": "Other",
+        "description": "Classroom Sync Status",
+        "workflow_id": "AkBydwInUwleDap3"
+      },
+      {
+        "name": "Credits - Get",
+        "path": "credits-get",
+        "full_url": "http://pi6.local:5678/webhook/credits-get",
+        "method": "POST",
+        "category": "Other",
+        "description": "Credits - Get",
+        "workflow_id": "Yq4EuPqBEt4q9H5t"
+      },
+      {
+        "name": "Credits Check",
+        "path": "credits-check",
+        "full_url": "http://pi6.local:5678/webhook/credits-check",
+        "method": "POST",
+        "category": "Other",
+        "description": "Credits Check",
+        "workflow_id": "YQJmym1DhLk9vHlD"
+      },
+      {
+        "name": "Credits Refund",
+        "path": "credits-refund",
+        "full_url": "http://pi6.local:5678/webhook/credits-refund",
+        "method": "POST",
+        "category": "Other",
+        "description": "Credits Refund",
+        "workflow_id": "fnHuFfqPXdF2L1Bm"
+      },
+      {
+        "name": "Data Lookup Enrich",
+        "path": "data-lookup-enrich",
+        "full_url": "http://pi6.local:5678/webhook/data-lookup-enrich",
+        "method": "POST",
+        "category": "Other",
+        "description": "Data Lookup Enrich",
+        "workflow_id": "eOo7TVs5SHmO9jCq"
+      },
+      {
+        "name": "ENTITIES - Social Actions",
+        "path": "entity-social-actions",
+        "full_url": "http://pi6.local:5678/webhook/entity-social-actions",
+        "method": "POST",
+        "category": "Other",
+        "description": "ENTITIES - Social Actions",
+        "workflow_id": "r3IriZ4hmS6PACNz"
+      },
+      {
+        "name": "Entitity - List",
+        "path": "entity-list",
+        "full_url": "http://pi6.local:5678/webhook/entity-list",
+        "method": "POST",
+        "category": "Other",
+        "description": "Entitity - List",
+        "workflow_id": "gzJ4nuRvVvoD0dGe"
+      },
+      {
+        "name": "Expert Program Classroom Sync",
+        "path": "expert-program-classroom-sync",
+        "full_url": "http://pi6.local:5678/webhook/expert-program-classroom-sync",
+        "method": "POST",
+        "category": "Other",
+        "description": "Expert Program Classroom Sync",
+        "workflow_id": "aPuyDLpRMjyQXnIr"
+      },
+      {
+        "name": "JOBS---User-Cleanup",
+        "path": "jobs/user-cleanup",
+        "full_url": "http://pi6.local:5678/webhook/jobs/user-cleanup",
+        "method": "POST",
+        "category": "Other",
+        "description": "JOBS---User-Cleanup",
+        "workflow_id": "KuT3m6Gu2Qb02nyX"
+      },
+      {
+        "name": "LEARNING - Adapt Difficulty",
+        "path": "learning-adapt-difficulty",
+        "full_url": "http://pi6.local:5678/webhook/learning-adapt-difficulty",
+        "method": "POST",
+        "category": "Other",
+        "description": "LEARNING - Adapt Difficulty",
+        "workflow_id": "FE27l6L0CTsDC0TA"
+      },
+      {
+        "name": "LEARNING - Badge Check",
+        "path": "learning-badge-check",
+        "full_url": "http://pi6.local:5678/webhook/learning-badge-check",
+        "method": "POST",
+        "category": "Other",
+        "description": "LEARNING - Badge Check",
+        "workflow_id": "bVWwe8BPUQaaXUg2"
+      },
+      {
+        "name": "LEARNING - Evaluate Photo",
+        "path": "learning-evaluate-photo",
+        "full_url": "http://pi6.local:5678/webhook/learning-evaluate-photo",
+        "method": "POST",
+        "category": "Other",
+        "description": "LEARNING - Evaluate Photo",
+        "workflow_id": "g1kTltLUWvGOqt8V"
+      },
+      {
+        "name": "LEARNING - Generate Dispatcher",
+        "path": "learning-generate",
+        "full_url": "http://pi6.local:5678/webhook/learning-generate",
+        "method": "POST",
+        "category": "Other",
+        "description": "LEARNING - Generate Dispatcher",
+        "workflow_id": "RgzRhwIcDRA3OPL2"
+      },
+      {
+        "name": "LEARNING - Job Status",
+        "path": "job-status/:job_id",
+        "full_url": "http://pi6.local:5678/webhook/job-status/:job_id",
+        "method": "GET",
+        "category": "Other",
+        "description": "LEARNING - Job Status",
+        "workflow_id": "WCRZTFV295P4lASV"
+      },
+      {
+        "name": "LLM - Call Messages",
+        "path": "llm-call-messages",
+        "full_url": "http://pi6.local:5678/webhook/llm-call-messages",
+        "method": "POST",
+        "category": "Other",
+        "description": "Appel LLM synchrone multi-provider avec pattern BYOT (Bring Your Own Token).",
+        "workflow_id": "V9aXcWyCd4omNDmA"
+      },
+      {
+        "name": "LLM - Call Stream",
+        "path": "llm-call-stream",
+        "full_url": "http://pi6.local:5678/webhook/llm-call-stream",
+        "method": "POST",
+        "category": "Other",
+        "description": "Streaming LLM multi-provider avec pattern callback asynchrone.",
+        "workflow_id": "jJe59jAy85SStBzT"
+      },
+      {
+        "name": "LLM - Request Validator",
+        "path": "llm-request-validator",
+        "full_url": "http://pi6.local:5678/webhook/llm-request-validator",
+        "method": "POST",
+        "category": "Other",
+        "description": "Validates user requests against a domain context using LLM (RFC-044).",
+        "workflow_id": "YOVBotXKSQX1eQSe"
+      },
+      {
+        "name": "LLM - URL Extractor",
+        "path": "llm-url-extractor",
+        "full_url": "http://pi6.local:5678/webhook/llm-url-extractor",
+        "method": "POST",
+        "category": "Other",
+        "description": "LLM - URL Extractor",
+        "workflow_id": "4iZccP1QAoAf4K3n"
+      },
+      {
+        "name": "LLM - Web Search",
+        "path": "web-search",
+        "full_url": "http://pi6.local:5678/webhook/web-search",
+        "method": "POST",
+        "category": "Other",
+        "description": "Performs web search using multiple LLM providers with grounding.",
+        "workflow_id": "Q6LCMkmdzhMccH9L"
+      },
+      {
+        "name": "MEMBERS---On-Join-Grant-Credits",
+        "path": "member-join",
+        "full_url": "http://pi6.local:5678/webhook/member-join",
+        "method": "POST",
+        "category": "Other",
+        "description": "MEMBERS---On-Join-Grant-Credits",
+        "workflow_id": "RhM489GYgj5YvXjl"
+      },
+      {
+        "name": "MENTION---On-Mention-Handler",
+        "path": "mention",
+        "full_url": "http://pi6.local:5678/webhook/mention",
+        "method": "POST",
+        "category": "Other",
+        "description": "MENTION---On-Mention-Handler",
+        "workflow_id": "0mgzf0u2NJcmNJ1X"
+      },
+      {
+        "name": "NOTIF - Badge Earned",
+        "path": "notif-badge-earned",
+        "full_url": "http://pi6.local:5678/webhook/notif-badge-earned",
+        "method": "POST",
+        "category": "Other",
+        "description": "Polls Redis Stream for badge:earned events",
+        "workflow_id": "erNUjr4vLdqfCV9w"
+      },
+      {
+        "name": "NOTIF - Course Expiring",
+        "path": "notif-course-expiring",
+        "full_url": "http://pi6.local:5678/webhook/notif-course-expiring",
+        "method": "POST",
+        "category": "Other",
+        "description": "Polls Redis Stream for course.access.expiring events",
+        "workflow_id": "GYF6dfeEjEdJZLjD"
+      },
+      {
+        "name": "NOTIF - Level Up",
+        "path": "notif-level-up",
+        "full_url": "http://pi6.local:5678/webhook/notif-level-up",
+        "method": "POST",
+        "category": "Other",
+        "description": "Polls Redis Stream for level:up events",
+        "workflow_id": "4UDZbUG3fIUgfPpH"
+      },
+      {
+        "name": "PLUGIN - Config Get",
+        "path": "plugin-config-get",
+        "full_url": "http://pi6.local:5678/webhook/plugin-config-get",
+        "method": "POST",
+        "category": "Other",
+        "description": "PLUGIN - Config Get",
+        "workflow_id": "sh4OmzbXupfSsVZ7"
+      },
+      {
+        "name": "PLUGIN - Config Update",
+        "path": "plugin-config-update",
+        "full_url": "http://pi6.local:5678/webhook/plugin-config-update",
+        "method": "POST",
+        "category": "Other",
+        "description": "PLUGIN - Config Update",
+        "workflow_id": "kldTRSDJJWDFogLm"
+      },
+      {
+        "name": "RAG - Delete Source",
+        "path": "rag-delete-source",
+        "full_url": "http://pi6.local:5678/webhook/rag-delete-source",
+        "method": "POST",
+        "category": "Other",
+        "description": "Deletes RAG source chunks from Qdrant.",
+        "workflow_id": "9mpim1TNu3kuotGY"
+      },
+      {
+        "name": "RAG - Process Source",
+        "path": "rag-process-source",
+        "full_url": "http://pi6.local:5678/webhook/rag-process-source",
+        "method": "POST",
+        "category": "Other",
+        "description": "Processes RAG sources (files/links) for indexation.",
+        "workflow_id": "mPRyOE0wir83CD7N"
+      },
+      {
+        "name": "Recipes - Generate",
+        "path": "recipes-generate",
+        "full_url": "http://pi6.local:5678/webhook/recipes-generate",
+        "method": "POST",
+        "category": "Other",
+        "description": "Recipes - Generate",
+        "workflow_id": "4Fr7QmrUlZiLZetb"
+      },
+      {
+        "name": "Recipes - Shopping",
+        "path": "recipes-shopping",
+        "full_url": "http://pi6.local:5678/webhook/recipes-shopping",
+        "method": "POST",
+        "category": "Other",
+        "description": "Recipes - Shopping",
+        "workflow_id": "fdXCLN5VxdnR0UKD"
+      },
+      {
+        "name": "Recipes - Timer",
+        "path": "recipes-timer",
+        "full_url": "http://pi6.local:5678/webhook/recipes-timer",
+        "method": "POST",
+        "category": "Other",
+        "description": "Recipes - Timer",
+        "workflow_id": "JcY4uCJQzUW1uoYZ"
+      },
+      {
+        "name": "Recipes - Timer Notify",
+        "path": "recipes-timer-notify",
+        "full_url": "http://pi6.local:5678/webhook/recipes-timer-notify",
+        "method": "POST",
+        "category": "Other",
+        "description": "Recipes - Timer Notify",
+        "workflow_id": "N1AppZjcKgxKIsSy"
+      },
+      {
+        "name": "SHOPPING---Cart-Add",
+        "path": "cart-add",
+        "full_url": "http://pi6.local:5678/webhook/cart-add",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Add",
+        "workflow_id": "87Td68CtEiSACJrK"
+      },
+      {
+        "name": "SHOPPING---Cart-Apply-Coupon",
+        "path": "cart-apply-coupon",
+        "full_url": "http://pi6.local:5678/webhook/cart-apply-coupon",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Apply-Coupon",
+        "workflow_id": "GMMcdZf6zYqjZWkO"
+      },
+      {
+        "name": "SHOPPING---Cart-Checkout",
+        "path": "cart-checkout",
+        "full_url": "http://pi6.local:5678/webhook/cart-checkout",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Checkout",
+        "workflow_id": "pQHxR0r41x4n8oE5"
+      },
+      {
+        "name": "SHOPPING---Cart-Checkout-Cancel",
+        "path": "cart-checkout-cancel",
+        "full_url": "http://pi6.local:5678/webhook/cart-checkout-cancel",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Checkout-Cancel",
+        "workflow_id": "kD9z9mYUdEzpZ4o8"
+      },
+      {
+        "name": "SHOPPING---Cart-Checkout-Success",
+        "path": "cart-checkout-success",
+        "full_url": "http://pi6.local:5678/webhook/cart-checkout-success",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Checkout-Success",
+        "workflow_id": "z6bqoIayyJGob9FY"
+      },
+      {
+        "name": "SHOPPING---Cart-Clear",
+        "path": "cart-clear",
+        "full_url": "http://pi6.local:5678/webhook/cart-clear",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Clear",
+        "workflow_id": "D6CO0hAo9fN0bz22"
+      },
+      {
+        "name": "SHOPPING---Cart-Get",
+        "path": "cart-get",
+        "full_url": "http://pi6.local:5678/webhook/cart-get",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Get",
+        "workflow_id": "davqLRszYqKVp2tl"
+      },
+      {
+        "name": "SHOPPING---Cart-Remove",
+        "path": "cart-remove",
+        "full_url": "http://pi6.local:5678/webhook/cart-remove",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Remove",
+        "workflow_id": "EU6OC7lrRuVEKbH3"
+      },
+      {
+        "name": "SHOPPING---Cart-Remove-Coupon",
+        "path": "cart-remove-coupon",
+        "full_url": "http://pi6.local:5678/webhook/cart-remove-coupon",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Remove-Coupon",
+        "workflow_id": "Sks2fPefx9LqTwMn"
+      },
+      {
+        "name": "SHOPPING---Cart-Update",
+        "path": "cart-update",
+        "full_url": "http://pi6.local:5678/webhook/cart-update",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Cart-Update",
+        "workflow_id": "JQ3MgJKdThCnXP9D"
+      },
+      {
+        "name": "SHOPPING---Orders-Get",
+        "path": "orders-get",
+        "full_url": "http://pi6.local:5678/webhook/orders-get",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Orders-Get",
+        "workflow_id": "j5fyZP8c7zg6f8qT"
+      },
+      {
+        "name": "SHOPPING---Orders-List",
+        "path": "orders-list",
+        "full_url": "http://pi6.local:5678/webhook/orders-list",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Orders-List",
+        "workflow_id": "KxtlcKTD5CC4uCf4"
+      },
+      {
+        "name": "SHOPPING---Product-Discovery-WebSearch",
+        "path": "product-discovery",
+        "full_url": "http://pi6.local:5678/webhook/product-discovery",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Product-Discovery-WebSearch",
+        "workflow_id": "39uw0mdSU5IPTJys"
+      },
+      {
+        "name": "SHOPPING---Products-Persist",
+        "path": "products-persist",
+        "full_url": "http://pi6.local:5678/webhook/products-persist",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Products-Persist",
+        "workflow_id": "51VCI44c7kPAi8Q7"
+      },
+      {
+        "name": "SHOPPING---Profile-Address-Add",
+        "path": "profile-address-add",
+        "full_url": "http://pi6.local:5678/webhook/profile-address-add",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Profile-Address-Add",
+        "workflow_id": "x2LQp3PKB2C0yble"
+      },
+      {
+        "name": "SHOPPING---Profile-Address-Remove",
+        "path": "profile-address-remove",
+        "full_url": "http://pi6.local:5678/webhook/profile-address-remove",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Profile-Address-Remove",
+        "workflow_id": "m3cBTQ5FE86PKFqz"
+      },
+      {
+        "name": "SHOPPING---Profile-Address-Set-Default",
+        "path": "profile-address-set-default",
+        "full_url": "http://pi6.local:5678/webhook/profile-address-set-default",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Profile-Address-Set-Default",
+        "workflow_id": "eImyGpKeADJBJDrB"
+      },
+      {
+        "name": "SHOPPING---Profile-Address-Update",
+        "path": "profile-address-update",
+        "full_url": "http://pi6.local:5678/webhook/profile-address-update",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Profile-Address-Update",
+        "workflow_id": "sqv0PTxgb3BSyDjv"
+      },
+      {
+        "name": "SHOPPING---Profile-Get",
+        "path": "profile-get",
+        "full_url": "http://pi6.local:5678/webhook/profile-get",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Profile-Get",
+        "workflow_id": "AuoKZbO92WZA1yVd"
+      },
+      {
+        "name": "SHOPPING---Profile-Update",
+        "path": "profile-update",
+        "full_url": "http://pi6.local:5678/webhook/profile-update",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Profile-Update",
+        "workflow_id": "PylhrpQ9M2HGogms"
+      },
+      {
+        "name": "SHOPPING---Shipping-Calculate",
+        "path": "shipping-calculate",
+        "full_url": "http://pi6.local:5678/webhook/shipping-calculate",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Shipping-Calculate",
+        "workflow_id": "irIORXSyZ9gMNVud"
+      },
+      {
+        "name": "SHOPPING---Shipping-Select",
+        "path": "shipping-select",
+        "full_url": "http://pi6.local:5678/webhook/shipping-select",
+        "method": "POST",
+        "category": "Other",
+        "description": "SHOPPING---Shipping-Select",
+        "workflow_id": "gi92jQb0ftFbdOAk"
+      },
+      {
+        "name": "Scriptorium QC Page Review",
+        "path": "scriptorium-qc-review",
+        "full_url": "http://pi6.local:5678/webhook/scriptorium-qc-review",
+        "method": "POST",
+        "category": "Other",
+        "description": "Scriptorium QC Page Review",
+        "workflow_id": "EoE4ANOREE4hIxVX"
+      },
+      {
+        "name": "Stripe - Register Project",
+        "path": "stripe-register-project",
+        "full_url": "http://pi6.local:5678/webhook/stripe-register-project",
+        "method": "POST",
+        "category": "Other",
+        "description": "Enregistre les secrets Stripe d'un projet dans Redis.",
+        "workflow_id": "aL5ibhL8rUe3Fxbm"
+      },
+      {
+        "name": "Stripe - Subscription Cancel",
+        "path": "stripe-subscription-cancel",
+        "full_url": "http://pi6.local:5678/webhook/stripe-subscription-cancel",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Cancel",
+        "workflow_id": "nsHQ4xr4kiNA3Mu7"
+      },
+      {
+        "name": "Stripe - Subscription Change Plan",
+        "path": "subscription-change-plan",
+        "full_url": "http://pi6.local:5678/webhook/subscription-change-plan",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Change Plan",
+        "workflow_id": "K60xx8kGU2DWcBKE"
+      },
+      {
+        "name": "Stripe - Subscription Checkout Create",
+        "path": "subscription-checkout-create",
+        "full_url": "http://pi6.local:5678/webhook/subscription-checkout-create",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Checkout Create",
+        "workflow_id": "q36nyuiWrZ0ktCoA"
+      },
+      {
+        "name": "Stripe - Subscription Payment Failure",
+        "path": "stripe-subscription-failure",
+        "full_url": "http://pi6.local:5678/webhook/stripe-subscription-failure",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Payment Failure",
+        "workflow_id": "E7HQ6IRdTt2EivKE"
+      },
+      {
+        "name": "Stripe - Subscription Renewal",
+        "path": "stripe-subscription-renewal",
+        "full_url": "http://pi6.local:5678/webhook/stripe-subscription-renewal",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Renewal",
+        "workflow_id": "dGqqwaoSshiFNUiN"
+      },
+      {
+        "name": "Stripe - Subscription Result",
+        "path": "subscription-result",
+        "full_url": "http://pi6.local:5678/webhook/subscription-result",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Result",
+        "workflow_id": "peHuqHt4lX6qMvdf"
+      },
+      {
+        "name": "Stripe - Subscription Success",
+        "path": "stripe-subscription-success",
+        "full_url": "http://pi6.local:5678/webhook/stripe-subscription-success",
+        "method": "POST",
+        "category": "Other",
+        "description": "Stripe - Subscription Success",
+        "workflow_id": "RUFeJAp570Z1YMhj"
+      }
+    ],
+    "Testing / Utilities": [
+      {
+        "name": "Stripe - Webhook Handler",
+        "path": "stripe-webhook",
+        "full_url": "http://pi6.local:5678/webhook/stripe-webhook",
+        "method": "POST",
+        "category": "Testing / Utilities",
+        "description": "Stripe - Webhook Handler",
+        "workflow_id": "PF1FifX7doIaYjzV"
+      }
+    ],
+    "YouTube": [
+      {
+        "name": "Recipes - YouTube",
+        "path": "recipes-youtube",
+        "full_url": "http://pi6.local:5678/webhook/recipes-youtube",
+        "method": "POST",
+        "category": "YouTube",
+        "description": "Recipes - YouTube",
+        "workflow_id": "MtvnVNO3xE0yDgm8"
+      }
+    ]
+  }
+}

--- a/docs/webhooks-registry.json
+++ b/docs/webhooks-registry.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-06-09T13:01:58.093464",
+  "generated_at": "2026-06-09T13:49:53.486456",
   "total_webhooks": 196,
   "excluded_torah": 35,
   "categories": {
@@ -11,8 +11,9 @@
         "full_url": "http://pi6.local:5678/webhook/claude-call-stream-with-skills",
         "method": "POST",
         "category": "Claude / LLM",
-        "description": "Streaming Claude avec Skills API - le plus complexe des 4 webhooks.",
-        "workflow_id": "Q7DgbM7n5ybQB0UX"
+        "description": "Streaming Claude avec Skills API - le plus complexe des 4 webhooks. Combine streaming par paquets + génération de fichiers.",
+        "workflow_id": "Q7DgbM7n5ybQB0UX",
+        "documentation": "## Claude - Call Stream With Skills\n\n**Endpoint:** POST /webhook/claude-call-stream-with-skills\n\n**Description:** Streaming Claude avec Skills API - le plus complexe des 4 webhooks.\nCombine streaming par paquets + génération de fichiers.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"api_key\", \"messages\", \"container\", \"callback_url\", \"correlation_id\"],\n  \"properties\": {\n    \"api_key\": { \"type\": \"string\" },\n    \"model\": { \"type\": \"string\", \"default\": \"claude-sonnet-4-20250514\" },\n    \"betas\": { \"type\": \"array\", \"default\": [\"code-execution-2025-08-25\", \"skills-2025-10-02\"] },\n    \"system\": { \"type\": \"string\" },\n    \"messages\": { \"type\": \"array\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 16000 },\n    \"container\": { \"skills\": [{ \"type\": \"anthropic\", \"skill_id\": \"docx|xlsx|pptx|pdf\" }] },\n    \"callback_url\": { \"type\": \"string\" },\n    \"correlation_id\": { \"type\": \"string\" },\n    \"stream_config\": {...},\n    \"metadata\": { \"type\": \"object\" }\n  }\n}\n```\n\n**Note:** Le tool code_execution est automatiquement ajouté.\n\n**Output (immediate):** { status: 'streaming', correlation_id }\n**Callbacks:** Packets to callback_url, final packet includes files"
       },
       {
         "name": "Claude - Call With Skills",
@@ -20,8 +21,48 @@
         "full_url": "http://pi6.local:5678/webhook/claude-call-with-skills",
         "method": "POST",
         "category": "Claude / LLM",
-        "description": "Appel Claude avec Skills API via Batch Processing.",
-        "workflow_id": "Lj1IShrkenZq2udA"
+        "description": "Appel Claude avec Skills API via Batch Processing. Résultats publiés sur Redis Stream (même pattern que MCP Tools Notify). | Requis: api_key, messages, container",
+        "workflow_id": "Lj1IShrkenZq2udA",
+        "input_schema": {
+          "required": [
+            "api_key",
+            "messages",
+            "container"
+          ],
+          "properties": {
+            "api_key": {
+              "type": "string"
+            },
+            "model": {
+              "type": "string",
+              "default": "claude-sonnet-4-20250514"
+            },
+            "messages": {
+              "type": "array"
+            },
+            "container": {
+              "skills": [
+                {
+                  "type": "anthropic",
+                  "skill_id": "docx"
+                }
+              ]
+            },
+            "redis_channel": {
+              "type": "string",
+              "default": "llm:results:{correlation_id}"
+            },
+            "correlation_id": {
+              "type": "string",
+              "description": "ID unique"
+            },
+            "metadata": {
+              "type": "object",
+              "description": "Transmis dans le résultat Redis"
+            }
+          }
+        },
+        "documentation": "## Claude - Call With Skills (Batch Mode + Redis)\n\n**Endpoint:** POST /webhook/claude-call-with-skills\n\n**Description:** Appel Claude avec Skills API via Batch Processing.\nRésultats publiés sur Redis Stream (même pattern que MCP Tools Notify).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"api_key\", \"messages\", \"container\"],\n  \"properties\": {\n    \"api_key\": { \"type\": \"string\" },\n    \"model\": { \"type\": \"string\", \"default\": \"claude-sonnet-4-20250514\" },\n    \"messages\": { \"type\": \"array\" },\n    \"container\": { \"skills\": [{ \"type\": \"anthropic\", \"skill_id\": \"docx\" }] },\n    \"redis_channel\": { \"type\": \"string\", \"default\": \"llm:results:{correlation_id}\" },\n    \"correlation_id\": { \"type\": \"string\", \"description\": \"ID unique\" },\n    \"metadata\": { \"type\": \"object\", \"description\": \"Transmis dans le résultat Redis\" }\n  }\n}\n```\n\n**Réponse (202):**\n```json\n{\n  \"status\": \"processing\",\n  \"batch_id\": \"msgbatch_xxx\",\n  \"correlation_id\": \"...\",\n  \"redis_channel\": \"llm:results:xxx\"\n}\n```\n\n**Résultat (sur Redis Stream):**\nLe Batch Poller publie sur le redis_channel quand terminé.\nFormat: event=batch_completed, success, files, content, etc.\n\n**Note:** Batch API = 50% moins cher, pas de timeout"
       }
     ],
     "Discord": [
@@ -32,7 +73,8 @@
         "method": "POST",
         "category": "Discord",
         "description": "Cree une session Stripe Billing Portal pour gerer l'abonnement.",
-        "workflow_id": "T7soEpQeDCXT68cW"
+        "workflow_id": "T7soEpQeDCXT68cW",
+        "documentation": "## DISCORD - Billing Portal\n\n**Endpoint:** POST /webhook/discord-billing-portal\n\n**Description:** Cree une session Stripe Billing Portal pour gerer l'abonnement.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah-fun\",\n  \"discord_user_id\": \"123456789\"\n}\n```\n\n**Flow:**\n1. Valider les parametres\n2. Recuperer stripe_customer_id depuis Torah API\n3. Recuperer stripe_key depuis Redis\n4. Creer session Stripe Billing Portal\n5. Retourner l'URL du portal\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"portal_url\": \"https://billing.stripe.com/session/xxx\",\n  \"return_url\": \"https://torah-fun.solutions/subscription\"\n}\n```\n\n**Use Cases:**\n- Changer de plan (upgrade/downgrade)\n- Mettre a jour le moyen de paiement\n- Annuler l'abonnement\n- Voir les factures"
       },
       {
         "name": "DISCORD - Credits Debit",
@@ -40,8 +82,9 @@
         "full_url": "http://pi6.local:5678/webhook/credits-debit",
         "method": "POST",
         "category": "Discord",
-        "description": "DISCORD - Credits Debit",
-        "workflow_id": "Z7GY1vc90CoF4pDH"
+        "description": "Débite des crédits du compte utilisateur",
+        "workflow_id": "Z7GY1vc90CoF4pDH",
+        "documentation": "## DISCORD - Credits Debit\n\n**Endpoint:** POST /webhook/credits-debit\n\n**Headers:**\n- `X-Project-ID` (required): ID du projet (ex: torah-fun)\n\n**Body:**\n```json\n{\n  \"discord_user_id\": \"636639897767378954\",\n  \"amount\": 5,\n  \"reason\": \"translation_page_12\"\n}\n```\n\n**API appellee:** POST /api/ecommerce/webhook/account/debit\n\n**Reponses:**\n- 200: Success\n- 402: Insufficient credits\n- 404: User not found"
       },
       {
         "name": "DISCORD - DM Resolve",
@@ -50,7 +93,8 @@
         "method": "POST",
         "category": "Discord",
         "description": "Résout le personae pour un DM élève. Orchestre 2 appels API puis dispatch selon le statut.",
-        "workflow_id": "DemkmfTGFYLy3Zt3"
+        "workflow_id": "DemkmfTGFYLy3Zt3",
+        "documentation": "## DISCORD - DM Resolve (RFC-095)\n\n**Endpoint:** POST /webhook/discord/dm-resolve\n\n**Description:** Résout le personae pour un DM élève. Orchestre 2 appels API puis dispatch selon le statut.\n\n**Input:**\n```json\n{\n  \"guild_id\": \"string\",\n  \"user_id\": \"string\",\n  \"question\": \"string\"\n}\n```\n\n**Flow:**\n1. Validate input\n2. GET /api/n8n/tenants/resolve → tenant_id\n3. GET /api/n8n/personae/resolve-dm → ResolveDmResponse\n4. Switch sur status:\n   - resolved → dispatch chatbot-core\n   - out_of_scope → retourne decline_reason\n   - needs_clarification → retourne candidates\n\n**Output:** Dépend du statut (voir RFC-095)\n\n**RFC:** RFC-095-PERSONAE-MULTI-LEVELS (B3)\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"status\", \"personae\", \"decline_reason\", \"clarification_candidates\"],\n  \"domain\": \"discord-education\"\n}\n```"
       },
       {
         "name": "DISCORD - Get Balance",
@@ -58,8 +102,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord-get-balance",
         "method": "POST",
         "category": "Discord",
-        "description": "DISCORD - Get Balance",
-        "workflow_id": "MNx4tur8X03x6TVP"
+        "description": "Récupère le solde du compte",
+        "workflow_id": "MNx4tur8X03x6TVP",
+        "documentation": "## DISCORD - Get Balance\n\n**Endpoint:** GET /webhook/discord-get-balance\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord de l'utilisateur\n\n**API appelée:** GET /api/ecommerce/webhook/account\n\n**Commande bot:** `/solde`"
       },
       {
         "name": "DISCORD - Get Credits",
@@ -67,8 +112,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord-get-credits",
         "method": "POST",
         "category": "Discord",
-        "description": "DISCORD - Get Credits",
-        "workflow_id": "RpF0YrYwyjKcBz4p"
+        "description": "Récupère les informations : credits",
+        "workflow_id": "RpF0YrYwyjKcBz4p",
+        "documentation": "## DISCORD - Get Credits\n\n**Endpoint:** GET /webhook/discord-get-credits\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord de l'utilisateur\n\n**API appelée:** GET /api/ecommerce/webhook/account\n\n**Commande bot:** `/credits`"
       },
       {
         "name": "DISCORD - Get Plans",
@@ -76,8 +122,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord-get-plans",
         "method": "GET",
         "category": "Discord",
-        "description": "DISCORD - Get Plans",
-        "workflow_id": "10ptENKEPSpsRtBX"
+        "description": "Liste les offres et tarifs disponibles",
+        "workflow_id": "10ptENKEPSpsRtBX",
+        "documentation": "## DISCORD - Get Plans\n\n**Endpoint:** GET /webhook/discord-get-plans\n\n**Query Parameters:**\n- `project_id` (required): ID du projet (ex: torah, mcp)\n\n**Source:** Stripe API (temps reel)\n\n**Flow:**\n1. Valider project_id\n2. Recuperer stripe_key depuis Redis (cle: project:{project_id})\n3. Appeler Stripe API /v1/prices\n4. Formater et retourner les plans\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"project_id\": \"torah\",\n  \"plans\": [\n    {\n      \"id\": \"price_xxx\",\n      \"product_id\": \"prod_xxx\",\n      \"name\": \"Premium\",\n      \"price\": 9.99,\n      \"currency\": \"eur\",\n      \"interval\": \"month\",\n      \"features\": [...]\n    }\n  ]\n}\n```"
       },
       {
         "name": "DISCORD - Get Subscriber",
@@ -85,8 +132,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord-get-subscriber",
         "method": "POST",
         "category": "Discord",
-        "description": "DISCORD - Get Subscriber",
-        "workflow_id": "WMsadHMNMRMoGqDp"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "WMsadHMNMRMoGqDp",
+        "documentation": "## DISCORD - Get Subscriber\n\n**Endpoint:** GET /webhook/discord-get-subscriber\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord de l'utilisateur\n\n**Source:** API Backend `/api/ecommerce/subscription/status/{discord_user_id}`\n\n**Commandes bot:** `/plan`, `/credits`\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"subscriber\": {\n    \"discord_user_id\": \"123456789\",\n    \"discord_username\": \"user#1234\",\n    \"credits\": 850,\n    \"subscription_plan\": \"premium\",\n    \"subscription_status\": \"active\",\n    \"is_active\": true\n  }\n}\n```"
       },
       {
         "name": "DISCORD - Get Transactions",
@@ -94,8 +142,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord-get-transactions",
         "method": "GET",
         "category": "Discord",
-        "description": "DISCORD - Get Transactions",
-        "workflow_id": "4QcMY4OlgnOfzRyX"
+        "description": "Récupère l'historique des transactions",
+        "workflow_id": "4QcMY4OlgnOfzRyX",
+        "documentation": "## DISCORD - Get Transactions\n\n**Endpoint:** GET /webhook/discord-get-transactions\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord\n- `limit` (optional): Max resultats (defaut: 20)\n- `offset` (optional): Pagination (defaut: 0)\n\n**Source:** PostgreSQL `transactions`\n\n**Commande bot:** `/account`\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"transactions\": [...],\n  \"pagination\": {\n    \"total\": 45,\n    \"limit\": 20,\n    \"offset\": 0,\n    \"has_more\": true\n  }\n}\n```"
       },
       {
         "name": "DISCORD - Registry",
@@ -104,7 +153,8 @@
         "method": "POST",
         "category": "Discord",
         "description": "Liste tous les workflows Discord disponibles avec leurs metadonnees.",
-        "workflow_id": "arEmH7jyo8Z9B6wl"
+        "workflow_id": "arEmH7jyo8Z9B6wl",
+        "documentation": "## DISCORD Registry\n\n**Endpoint:** GET /webhook/discord-registry\n\n**Description:** Liste tous les workflows Discord disponibles avec leurs metadonnees.\n\n**Response:**\n```json\n{\n  \"version\": \"1.0\",\n  \"updated_at\": \"2025-01-05T...\",\n  \"n8n\": {\n    \"host\": \"host2.local\",\n    \"port\": 5678,\n    \"webhook_base\": \"http://host2.local:5678/webhook\"\n  },\n  \"total_tools\": 5,\n  \"tools\": { ... }\n}\n```"
       },
       {
         "name": "DISCORD - Student Context",
@@ -113,7 +163,8 @@
         "method": "POST",
         "category": "Discord",
         "description": "Enriches LLM prompt with student info (name, promo, exchange history) to personalize responses. Uses RedisSessionStore for session memory.",
-        "workflow_id": "jbljjN4t7VLx6ZIR"
+        "workflow_id": "jbljjN4t7VLx6ZIR",
+        "documentation": "## DISCORD - Student Context (M4)\n\n**Endpoint:** POST /webhook/discord/student-context\n\n**Description:** Enriches LLM prompt with student info (name, promo, exchange history) to personalize responses. Uses RedisSessionStore for session memory.\n\n**Input:**\n```json\n{\n  \"guild_id\": \"string\",\n  \"user_id\": \"string\",\n  \"thread_id\": \"string\",\n  \"include_history\": true,\n  \"history_limit\": 10\n}\n```\n\n**Output:** Student context with conversation history and prompt context\n\n**RFC:** RFC-048 Discord Education Architecture - M4. Contexte etudiant dans le prompt\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"student\", \"current_subject\", \"conversation_history\", \"prompt_context\"],\n  \"domain\": \"discord-education\"\n}\n```"
       },
       {
         "name": "DISCORD - Student Recap",
@@ -121,8 +172,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord/student-recap",
         "method": "POST",
         "category": "Discord",
-        "description": "DISCORD - Student Recap",
-        "workflow_id": "WRt8mTcpgEGw27Rv"
+        "description": "Workflow: DISCORD   Student Recap",
+        "workflow_id": "WRt8mTcpgEGw27Rv",
+        "documentation": "## DISCORD - Student Recap (M6)\n\n**Endpoint:** POST /webhook/discord/student-recap\n\n**Input:**\n```json\n{\n  \"guild_id\": \"string\",\n  \"user_id\": \"string\",\n  \"thread_id\": \"string\",\n  \"period\": \"week\" | \"month\" | \"all\",\n  \"include_help_requests\": true\n}\n```\n\n**Flow:**\n1. Validate input (guild_id, user_id required)\n2. Fetch conversation history from Redis\n3. Optionally fetch help requests from backend\n4. Generate structured recap via LLM (Anthropic)\n\n**Output:** Structured recap with stats and _trace\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"recap\", \"stats\"],\n  \"domain\": \"education\"\n}\n```"
       },
       {
         "name": "DISCORD - Subject Detect",
@@ -130,8 +182,9 @@
         "full_url": "http://pi6.local:5678/webhook/discord/subject-detect",
         "method": "POST",
         "category": "Discord",
-        "description": "DISCORD - Subject Detect",
-        "workflow_id": "n6PUaeAoeunYA45b"
+        "description": "Workflow: DISCORD   Subject Detect",
+        "workflow_id": "n6PUaeAoeunYA45b",
+        "documentation": "## DISCORD - Subject Detect (M5 - RFC-048)\n\n**Endpoint:** POST /webhook/discord/subject-detect\n\n**Purpose:** Auto-detect school subject from message content using LLM classification.\nFallback to current_subject_slug if confidence < threshold.\n\n**Request:**\n```json\n{\n  \"message\": \"Comment calculer une derivee de x^2?\",\n  \"guild_id\": \"123456789\",\n  \"user_id\": \"987654321\",\n  \"available_subjects\": [\"optique\", \"maths\", \"physique\", \"anglais\"],\n  \"current_subject_slug\": \"optique\",\n  \"confidence_threshold\": 0.6\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"detected_subject\": \"maths\",\n    \"confidence\": 0.87,\n    \"reason\": \"Le message mentionne des derivees\",\n    \"fallback_used\": false,\n    \"current_subject\": \"optique\"\n  },\n  \"_trace\": {...}\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"detected_subject\", \"confidence\", \"reason\", \"fallback_used\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "DISCORD - Subject Switch",
@@ -140,7 +193,8 @@
         "method": "POST",
         "category": "Discord",
         "description": "Changement de contexte matiere - When chatbot-core receives `/matiere maths`, it calls azy.mcp to reload the correct expert + RAG + session.",
-        "workflow_id": "ruIScPLm7ObPdwGJ"
+        "workflow_id": "ruIScPLm7ObPdwGJ",
+        "documentation": "## DISCORD - Subject Switch (M3)\n\n**Endpoint:** POST /webhook/discord/subject-switch\n\n**Description:** Changement de contexte matiere - When chatbot-core receives `/matiere maths`, it calls azy.mcp to reload the correct expert + RAG + session.\n\n**Request:**\n```json\n{\n  \"guild_id\": \"123456789\",\n  \"user_id\": \"987654321\",\n  \"thread_id\": \"111222333\",\n  \"new_subject_slug\": \"maths\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": {\n    \"previous_subject\": \"optique\",\n    \"new_subject\": \"maths\",\n    \"expert\": { ... }\n  },\n  \"_trace\": { ... }\n}\n```\n\n**RFC:** RFC-048 (Discord Education Architecture)\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"previous_subject\", \"new_subject\", \"expert\"],\n  \"domain\": \"education\"\n}\n```"
       },
       {
         "name": "DISCORD - Subscribe",
@@ -149,7 +203,8 @@
         "method": "POST",
         "category": "Discord",
         "description": "Cree une session Stripe Checkout pour un abonnement.",
-        "workflow_id": "z3ptm83NqfKA1Qed"
+        "workflow_id": "z3ptm83NqfKA1Qed",
+        "documentation": "## DISCORD - Subscribe\n\n**Endpoint:** POST /webhook/discord-subscribe\n\n**Description:** Cree une session Stripe Checkout pour un abonnement.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"discord_user_id\": \"123456789\",\n  \"plan_id\": \"price_xxx\",\n  \"customer_email\": \"user@example.com\"\n}\n```\n\n**Note:** `customer_email` est optionnel mais recommande pour pre-remplir le checkout.\n\n**Flow:**\n1. Valider les parametres\n2. Lire stripe_key depuis Redis\n3. Creer session Stripe Checkout\n4. Retourner l'URL de paiement\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"checkout_url\": \"https://checkout.stripe.com/xxx\"\n}\n```"
       },
       {
         "name": "GUILD - Create Room",
@@ -157,8 +212,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild-create-room",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Create Room",
-        "workflow_id": "sDJJIQ8HucgiN4op"
+        "description": "Crée un(e) room",
+        "workflow_id": "sDJJIQ8HucgiN4op",
+        "documentation": "## GUILD - Create Room\n\n**Endpoint:** `POST /webhook/guild-create-room`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"name\": \"Salle Maths\", \"description\": \"...\", \"visual_config\": {...}, \"messages_config\": {...}}\n```\n\n**API Backend:** `POST /api/guilds/{guild_id}/rooms`\n\n**Scope:** `branding:write`"
       },
       {
         "name": "GUILD - Credits Exhausted Notification",
@@ -166,7 +222,7 @@
         "full_url": "http://pi6.local:5678/webhook/guild/credits/exhausted",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Credits Exhausted Notification",
+        "description": "Crédite le compte utilisateur",
         "workflow_id": "dYKWSpWnDa4aDpvb"
       },
       {
@@ -175,8 +231,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild-get-branding",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Get Branding",
-        "workflow_id": "bBbAQFoAPGIxq6IW"
+        "description": "Récupère les informations : branding",
+        "workflow_id": "bBbAQFoAPGIxq6IW",
+        "documentation": "## GUILD - Get Branding\n\n**Endpoint:** `POST /webhook/guild-get-branding`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/branding`\n\n**Scope:** `branding:read`"
       },
       {
         "name": "GUILD - Get Prompts",
@@ -184,8 +241,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild-get-prompts",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Get Prompts",
-        "workflow_id": "mlmmGParThBV13XF"
+        "description": "Récupère les informations : prompts",
+        "workflow_id": "mlmmGParThBV13XF",
+        "documentation": "## GUILD - Get Prompts\n\n**Endpoint:** `POST /webhook/guild-get-prompts`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"category\": \"identity\", \"language\": \"fr\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/prompts`\n\n**Scope:** `branding:read`\n\n**Params optionnels:** `category`, `language`, `layer`"
       },
       {
         "name": "GUILD - Get Rooms",
@@ -193,8 +251,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild-get-rooms",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Get Rooms",
-        "workflow_id": "lyOqWORdnjaJUHcM"
+        "description": "Récupère les informations : rooms",
+        "workflow_id": "lyOqWORdnjaJUHcM",
+        "documentation": "## GUILD - Get Rooms\n\n**Endpoint:** `POST /webhook/guild-get-rooms`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/rooms`\n\n**Scope:** `branding:read`\n\n**Response:** Liste des RoomModels (salles de cours)"
       },
       {
         "name": "GUILD - Member Leave Credits",
@@ -202,7 +261,7 @@
         "full_url": "http://pi6.local:5678/webhook/guild/member/leave",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Member Leave Credits",
+        "description": "Crédite le compte utilisateur",
         "workflow_id": "dYYJjVhFERkan2nt"
       },
       {
@@ -211,7 +270,7 @@
         "full_url": "http://pi6.local:5678/webhook/server-sync",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Server Sync",
+        "description": "Synchronisation de données",
         "workflow_id": "g0vEIaV8JciCQEb0"
       },
       {
@@ -220,7 +279,7 @@
         "full_url": "http://pi6.local:5678/webhook/discord/student/verify",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Student Verify",
+        "description": "Vérification et validation",
         "workflow_id": "6iSsoCzbjuk9DxkT"
       },
       {
@@ -229,7 +288,7 @@
         "full_url": "http://pi6.local:5678/webhook/discord/tenant/settings",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Tenant Settings",
+        "description": "Workflow: GUILD   Tenant Settings",
         "workflow_id": "La7CyZJsJHrWM4AV"
       },
       {
@@ -238,8 +297,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild-update-branding",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Update Branding",
-        "workflow_id": "LKhRCEbPelHlnUrb"
+        "description": "Met à jour branding",
+        "workflow_id": "LKhRCEbPelHlnUrb",
+        "documentation": "## GUILD - Update Branding\n\n**Endpoint:** `POST /webhook/guild-update-branding`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"visual_config\": {...}, \"messages_config\": {...}}\n```\n\n**API Backend:** `PUT /api/guilds/{guild_id}/branding`\n\n**Scope:** `branding:write`\n\n**Requis:** `bot.name`, `greetings[]`, `limitations[]`"
       },
       {
         "name": "GUILD - Update Prompt",
@@ -247,8 +307,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild-update-prompt",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD - Update Prompt",
-        "workflow_id": "4xSZeiTp3ODJexKo"
+        "description": "Met à jour prompt",
+        "workflow_id": "4xSZeiTp3ODJexKo",
+        "documentation": "## GUILD - Update Prompt\n\n**Endpoint:** `POST /webhook/guild-update-prompt`\n\n**Payload:**\n```json\n{\"guild_id\": \"123456789\", \"category\": \"identity\", \"key\": \"role\", \"value\": \"tuteur en maths\", \"language\": \"fr\"}\n```\n\n**API Backend:** `PUT /api/guilds/{guild_id}/prompts`\n\n**Scope:** `branding:write`\n\n**Note:** `value` accepte `string` ou `string[]`"
       },
       {
         "name": "GUILD---On-Startup-Register",
@@ -256,8 +317,9 @@
         "full_url": "http://pi6.local:5678/webhook/guild/register-if-needed",
         "method": "POST",
         "category": "Discord",
-        "description": "GUILD---On-Startup-Register",
-        "workflow_id": "ltWjzJmmYr6EhyD7"
+        "description": "Workflow: GUILD   On Startup Register",
+        "workflow_id": "ltWjzJmmYr6EhyD7",
+        "documentation": "## Guild Registration (Startup)\n\n**Webhook:** POST /guild/register-if-needed\n\n**Input:**\n- guild_id (requis)\n- project_id (requis)\n- name (optionnel)\n\n**Flow:**\n1. Check if guild exists\n2. If not → register it\n3. Return status"
       }
     ],
     "Document Processing": [
@@ -267,8 +329,9 @@
         "full_url": "http://pi6.local:5678/webhook/document-cancel",
         "method": "POST",
         "category": "Document Processing",
-        "description": "Document Cancel",
-        "workflow_id": "3sduhqVBeBj5Ahiz"
+        "description": "Workflow: Document Cancel",
+        "workflow_id": "3sduhqVBeBj5Ahiz",
+        "documentation": "## Document Cancel\n\n**Endpoint:** POST /webhook/document-cancel\n\n**Purpose:** Cancel a running job and return credits summary\n\n**Request:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"user_id\": \"discord_user_id\",\n  \"reason\": \"user_requested\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"uuid\",\n  \"previous_status\": \"processing\",\n  \"new_status\": \"cancelled\",\n  \"credits\": {\n    \"consumed\": { \"total_tokens\": 7500, \"cost_usd\": 0.015 },\n    \"saved\": { \"total_tokens\": 15000, \"cost_usd\": 0.030 }\n  }\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Cannot cancel completed job\",\n    \"status\": \"INVALID_STATE_TRANSITION\"\n  }\n}\n```\n\n**State transitions:**\n- pending → cancelled ✅\n- processing → cancelled ✅\n- completed/failed → ❌ (400)\n\n**API:** PATCH /api/v2/jobs/{job_id}\n\n**RFC:** RFC-017"
       },
       {
         "name": "Document Structure Extract",
@@ -276,8 +339,9 @@
         "full_url": "http://pi6.local:5678/webhook/document-structure-extract",
         "method": "POST",
         "category": "Document Processing",
-        "description": "Document Structure Extract",
-        "workflow_id": "KMNE2BVahFJcDycQ"
+        "description": "Extraction de données",
+        "workflow_id": "KMNE2BVahFJcDycQ",
+        "documentation": "## Document Structure Extract\n\n**Endpoint:** POST /webhook/document-structure-extract\n\n**Purpose:** Generic LLM-powered document extraction with flexible schema.\n\n**Request:**\n```json\n{\n  \"text\": \"# POULET AU CURRY\\n\\n1. Laver les blancs...\",\n  \"schema\": {\n    \"type\": \"recipe\",\n    \"fields\": {\n      \"title\": \"string\",\n      \"servings\": \"integer\",\n      \"ingredients\": [{\"name\": \"string\", \"quantity\": \"number\", \"unit\": \"string\"}]\n    }\n  },\n  \"context\": { \"type\": \"recipe\", \"language\": \"fr\" },\n  \"plugin_context\": { \"api_keys\": { \"anthropic\": \"sk-ant-...\" } }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"extracted\": { ... },\n  \"confidence\": 0.92,\n  \"missing_fields\": [\"description\"]\n}\n```\n\n**RFC:** RFC-018 (Recipe Enrichment)"
       },
       {
         "name": "Document Translate Worker",
@@ -285,8 +349,9 @@
         "full_url": "http://pi6.local:5678/webhook/document-translate-worker",
         "method": "POST",
         "category": "Document Processing",
-        "description": "Document Translate Worker",
-        "workflow_id": "ciDPOuhIdoyio6BX"
+        "description": "Traduction de texte",
+        "workflow_id": "ciDPOuhIdoyio6BX",
+        "documentation": "## Document Translate Worker\n\n**Endpoint:** POST /webhook/document-translate-worker\n\n**Input:**\n```json\n{\n  \"job_type\": \"pdf_translation\",\n  \"document\": {\n    \"type\": \"pdf | image | text | pages\",\n    \"content\": \"base64 | text | url\",\n    \"filename\": \"document.pdf\",\n    \"total_pages\": 35\n  },\n  \"source_language\": \"he\",\n  \"target_language\": \"fr\",\n  \"api_key\": \"sk-ant-...\",\n  \"openai_api_key\": \"sk-...\",\n  \"project_id\": \"...\",\n  \"callback_url\": \"https://...\",\n  \"job_id\": \"optional-custom-id\"\n}\n```\n\n**Async Callback (RFC-040):**\nIf `callback_url` provided:\n- Returns 202 immediately with job_id\n- POSTs result to callback_url when done\n- Headers: Content-Type, X-N8N-Signature (HMAC-SHA256)\n\n**Routage automatique:**\n- `pdf` → /webhook/pdf-extractor → extraction texte\n- `image` → /webhook/image-ocr (Mistral) → OCR\n- `text` → découpage automatique\n- `pages` → utilisation directe\n\n**Process:**\n1. Validate & create job\n2. Check callback_url (async vs sync)\n3. Respond immediately (202)\n4. Route by document.type → extract if needed\n5. Split into pages\n6. Translate each page (Claude)\n7. Update progress\n8. Combine & store result\n9. POST to callback_url if async"
       }
     ],
     "MCP Tools": [
@@ -296,8 +361,9 @@
         "full_url": "http://pi6.local:5678/webhook/academic-searcher",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Academic Searcher",
-        "workflow_id": "dwclCArbcxpUNOL4"
+        "description": "Recherche d'informations",
+        "workflow_id": "dwclCArbcxpUNOL4",
+        "documentation": "## MCP - Academic Searcher (Semantic Scholar)\n\n**Endpoint:** POST /webhook/academic-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `semantic_scholar_api_key` (optional): API key for higher rate limits\n- `options.max_results` (optional): 1-100 (default: 10)\n- `options.offset` (optional): Pagination offset (default: 0)\n- `options.year_range` (optional): e.g. \"2020-2024\" or \"2023-\"\n- `options.fields_of_study` (optional): Computer Science, Medicine, etc.\n- `execution_mode` (optional): online | offline\n\n**Returns:** Academic papers with title, abstract, authors, citations, PDF links\n\n**Note:** Semantic Scholar API is free with rate limits (100 req/5min without key)"
       },
       {
         "name": "MCP - Analyze Message",
@@ -305,8 +371,46 @@
         "full_url": "http://pi6.local:5678/webhook/analyze-message",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Analyse complète d'un message (sentiment, intentions, entités, priorité, langue)",
-        "workflow_id": "EiNGvM8j4KMcheed"
+        "description": "Analyse complète d'un message (sentiment, intentions, entités, priorité, langue) | Requis: user_id, guild_id, user_request, text",
+        "workflow_id": "EiNGvM8j4KMcheed",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "text"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (crédits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requête utilisateur originale (contextualise l'analyse)"
+            },
+            "text": {
+              "type": "string",
+              "description": "Texte/message à analyser"
+            },
+            "options": {
+              "type": "object",
+              "description": "Options d'analyse (sentiment, intent, entities, priority, language)",
+              "default": {
+                "sentiment": true,
+                "intent": true,
+                "entities": true,
+                "priority": true,
+                "language": true
+              }
+            }
+          }
+        },
+        "documentation": "## MCP - Analyze Message\n\n**Endpoint:** POST /webhook/analyze-message\n\n**Description:** Analyse complète d'un message (sentiment, intentions, entités, priorité, langue)\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"text\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (crédits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requête utilisateur originale (contextualise l'analyse)\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte/message à analyser\" },\n    \"options\": { \"type\": \"object\", \"description\": \"Options d'analyse (sentiment, intent, entities, priority, language)\", \"default\": {\"sentiment\": true, \"intent\": true, \"entities\": true, \"priority\": true, \"language\": true} }\n  }\n}\n```\n\n**Note:** API keys (google_api_key, openai_api_key) fournies par le système.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"sentiment\", \"intents\", \"entities\", \"priority\", \"language\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - Bulk URL Processor",
@@ -314,8 +418,9 @@
         "full_url": "http://pi6.local:5678/webhook/bulk-url-processor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Bulk URL Processor",
-        "workflow_id": "yRhm2W8Y7x5452Gg"
+        "description": "Traitement de données",
+        "workflow_id": "yRhm2W8Y7x5452Gg",
+        "documentation": "## MCP - Bulk URL Processor\n\n**Endpoint:** POST /webhook/bulk-url-processor\n\n**Parameters:**\n- `urls` (required): Array of URLs to process\n- `options.batch_size` (optional): URLs per batch (default: 5)\n- `options.delay_ms` (optional): Delay between batches in ms (default: 1000)\n- `options.extract_metadata` (optional): boolean (default: true)\n- `options.timeout_per_url` (optional): Timeout per URL in ms (default: 30000)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Results for each URL with status, title, description, success rate\n\n**Rate Limiting:** Built-in batching with configurable delay to avoid blocking"
       },
       {
         "name": "MCP - CSV Processor",
@@ -323,7 +428,7 @@
         "full_url": "http://pi6.local:5678/webhook/csv-processor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - CSV Processor",
+        "description": "Traitement de données",
         "workflow_id": "VW7DqZcclwqtuqyT"
       },
       {
@@ -332,8 +437,9 @@
         "full_url": "http://pi6.local:5678/webhook/chart-generator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Chart Generator",
-        "workflow_id": "OxBlSMpOZqJVLdrn"
+        "description": "Workflow: MCP   Chart Generator",
+        "workflow_id": "OxBlSMpOZqJVLdrn",
+        "documentation": "## MCP - Chart Generator\n\n**Endpoint:** POST /webhook/chart-generator\n\n**Parameters:**\n- `data` (required): Chart data - formats supported:\n  - Array: [{label: 'A', value: 10}, {label: 'B', value: 20}]\n  - Object: {labels: ['A','B'], values: [10,20]}\n  - Chart.js: {labels: [...], datasets: [...]}\n- `chart_type` (optional): bar | line | pie | doughnut | radar | polarArea (default: bar)\n- `title` (optional): Chart title\n- `dataset_label` (optional): Dataset label\n- `width` (optional): Width in pixels (default: 600)\n- `height` (optional): Height in pixels (default: 400)\n- `format` (optional): png | svg | webp (default: png)\n- `background_color` (optional): Background color (default: white)\n- `options.colors` (optional): Array of colors\n- `options.show_legend` (optional): Show legend (default: true)\n\n**Returns:** Chart URL and configuration\n\n**Provider:** QuickChart.io (free, no API key required)"
       },
       {
         "name": "MCP - Code Generator",
@@ -341,8 +447,9 @@
         "full_url": "http://pi6.local:5678/webhook/code-generator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Code Generator",
-        "workflow_id": "3dAX5G5VNZVIUlcw"
+        "description": "Workflow: MCP   Code Generator",
+        "workflow_id": "3dAX5G5VNZVIUlcw",
+        "documentation": "## MCP - Code Generator\n\n**Endpoint:** POST /webhook/code-generator\n\n**Parameters:**\n- `prompt` (required): Code generation request\n- `language` (optional): Programming language (python, javascript, etc.)\n- `framework` (optional): Framework to use (react, fastapi, etc.)\n- `context` (optional): Additional context or existing code\n- `model` (optional): gpt-4o, gpt-4o-mini (default: gpt-4o)\n- `temperature` (optional): 0-2 (default: 0.2 for deterministic code)\n- `max_tokens` (optional): Max tokens (default: 4096)\n\n**Returns:** Generated code with metadata"
       },
       {
         "name": "MCP - Content Analyzer",
@@ -350,8 +457,50 @@
         "full_url": "http://pi6.local:5678/webhook/content-analyzer",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Analyse le contenu image/document et retourne un plan de pipeline pour azy.mcp PipelineExecutor.",
-        "workflow_id": "RmD172M71Rx9nUvy"
+        "description": "Analyse le contenu image/document et retourne un plan de pipeline pour azy.mcp PipelineExecutor. | Requis: user_id, guild_id, user_request",
+        "workflow_id": "RmD172M71Rx9nUvy",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale (contextualise l'analyse)"
+            },
+            "image_url": {
+              "type": "string",
+              "description": "URL de l'image a analyser"
+            },
+            "image_data": {
+              "type": "string",
+              "description": "Image en base64 (alternative a image_url)"
+            },
+            "domain": {
+              "type": "string",
+              "description": "Domaine de l'analyse (general, recipes, etc.)",
+              "default": "general"
+            },
+            "available_tools": {
+              "type": "array",
+              "description": "Liste des outils disponibles pour le pipeline",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "documentation": "## MCP - Content Analyzer\n\n**Endpoint:** POST /webhook/content-analyzer\n\n**Description:** Analyse le contenu image/document et retourne un plan de pipeline pour azy.mcp PipelineExecutor.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (contextualise l'analyse)\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image a analyser\" },\n    \"image_data\": { \"type\": \"string\", \"description\": \"Image en base64 (alternative a image_url)\" },\n    \"domain\": { \"type\": \"string\", \"description\": \"Domaine de l'analyse (general, recipes, etc.)\", \"default\": \"general\" },\n    \"available_tools\": { \"type\": \"array\", \"description\": \"Liste des outils disponibles pour le pipeline\", \"items\": { \"type\": \"string\" } }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": true,\n  \"output_fields\": [\"analysis\", \"pipeline\", \"confidence\"],\n  \"domain\": \"orchestration\"\n}\n```"
       },
       {
         "name": "MCP - Cost Calculator",
@@ -359,8 +508,47 @@
         "full_url": "http://pi6.local:5678/webhook/cost-calculator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Calcule le cout d'utilisation des modeles LLM en USD.",
-        "workflow_id": "sUkUNxu36VISWzke"
+        "description": "Calcule le cout d'utilisation des modeles LLM en USD. | Requis: user_id, guild_id, user_request, model",
+        "workflow_id": "sUkUNxu36VISWzke",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "model"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "model": {
+              "type": "string",
+              "description": "Nom du modele LLM (gpt-4o, claude-3-sonnet, etc.)"
+            },
+            "input_tokens": {
+              "type": "integer",
+              "description": "Nombre de tokens en entree (default: 0)"
+            },
+            "output_tokens": {
+              "type": "integer",
+              "description": "Nombre de tokens en sortie (default: 0)"
+            },
+            "requests": {
+              "type": "integer",
+              "description": "Nombre de requetes (default: 1)"
+            }
+          }
+        },
+        "documentation": "## MCP - Cost Calculator\n\n**Endpoint:** POST /webhook/cost-calculator\n\n**Description:** Calcule le cout d'utilisation des modeles LLM en USD.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"model\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Nom du modele LLM (gpt-4o, claude-3-sonnet, etc.)\" },\n    \"input_tokens\": { \"type\": \"integer\", \"description\": \"Nombre de tokens en entree (default: 0)\" },\n    \"output_tokens\": { \"type\": \"integer\", \"description\": \"Nombre de tokens en sortie (default: 0)\" },\n    \"requests\": { \"type\": \"integer\", \"description\": \"Nombre de requetes (default: 1)\" }\n  }\n}\n```\n\n**Modeles supportes:**\n- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-3.5-turbo, o1-preview, o1-mini\n- Anthropic: claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet\n- Mistral: mistral-large, mistral-medium, mistral-small, mixtral-8x7b\n- Google: gemini-1.5-pro, gemini-1.5-flash\n- Embeddings: text-embedding-3-small/large, ada-002\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"costs\", \"pricing\"],\n  \"domain\": \"utility\"\n}\n```"
       },
       {
         "name": "MCP - Create Free Subscriber",
@@ -368,8 +556,9 @@
         "full_url": "http://pi6.local:5678/webhook/create-free-subscriber",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Crée un abonné gratuit avec crédits initiaux",
-        "workflow_id": "fwVJ9WLlQqmt2vrq"
+        "description": "Crée un abonné gratuit avec crédits initiaux **Category:** subscription **Keywords:** subscriber, free, credits, chess-bot",
+        "workflow_id": "fwVJ9WLlQqmt2vrq",
+        "documentation": "## MCP - Create Free Subscriber\n\n**Description:** Crée un abonné gratuit avec crédits initiaux\n**Category:** subscription\n**Keywords:** subscriber, free, credits, chess-bot\n\n**Endpoint:** POST /webhook/create-free-subscriber\n\n**Input:**\n- discord_user_id (required)\n- discord_username\n- discord_guild_id\n- plan_id (default: free)\n- initial_credits (default: 1500)\n\n**Appels API:**\n- POST /api/ecommerce/webhook/account/set (création + crédits)"
       },
       {
         "name": "MCP - DOCX Extractor",
@@ -377,8 +566,66 @@
         "full_url": "http://pi6.local:5678/webhook/docx-extractor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Extrait le contenu textuel de fichiers DOCX avec support pour differents formats de sortie.",
-        "workflow_id": "1acfHfjbuzoAmHzv"
+        "description": "Extrait le contenu textuel de fichiers DOCX avec support pour differents formats de sortie. | Requis: file_url|file_base64",
+        "workflow_id": "1acfHfjbuzoAmHzv",
+        "input_schema": {
+          "required": [
+            "file_url|file_base64"
+          ],
+          "optional": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord (tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale (tracing)"
+            },
+            "file_url": {
+              "type": "string",
+              "description": "URL du fichier DOCX"
+            },
+            "file_base64": {
+              "type": "string",
+              "description": "Fichier DOCX encode en base64"
+            },
+            "output_format": {
+              "type": "string",
+              "enum": [
+                "text",
+                "html",
+                "markdown"
+              ],
+              "default": "text"
+            },
+            "include_metadata": {
+              "type": "boolean",
+              "default": false
+            },
+            "include_images": {
+              "type": "boolean",
+              "default": false
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "Pour extraction vision"
+            },
+            "use_vision": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "documentation": "## MCP - DOCX Extractor\n\n**Endpoint:** POST /webhook/docx-extractor\n\n**Description:** Extrait le contenu textuel de fichiers DOCX avec support pour differents formats de sortie.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"file_url|file_base64\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du fichier DOCX\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Fichier DOCX encode en base64\" },\n    \"output_format\": { \"type\": \"string\", \"enum\": [\"text\", \"html\", \"markdown\"], \"default\": \"text\" },\n    \"include_metadata\": { \"type\": \"boolean\", \"default\": false },\n    \"include_images\": { \"type\": \"boolean\", \"default\": false },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"Pour extraction vision\" },\n    \"use_vision\": { \"type\": \"boolean\", \"default\": false }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": true,\n  \"output_fields\": [\"content\", \"format\", \"metadata\"],\n  \"domain\": \"document\"\n}\n```\n\n**Note:** L'extraction complete necessite mammoth.js."
       },
       {
         "name": "MCP - Dataset Generator",
@@ -386,8 +633,65 @@
         "full_url": "http://pi6.local:5678/webhook/mcp/dataset/generate",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Generer automatiquement des datasets de test pour l'analyse d'intentions",
-        "workflow_id": "ET9SJcbyBO9DlXP1"
+        "description": "Generer automatiquement des datasets de test pour l'analyse d'intentions | Requis: user_id, guild_id, user_request, domain",
+        "workflow_id": "ET9SJcbyBO9DlXP1",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "domain"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "domain": {
+              "type": "string",
+              "description": "Domaine cible (ex: email, shopping)"
+            },
+            "categories": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "simple",
+                "ambigu",
+                "multi-etape",
+                "elliptique"
+              ],
+              "description": "Categories de test"
+            },
+            "count_per_category": {
+              "type": "integer",
+              "default": 10,
+              "description": "Nombre de cas par categorie"
+            },
+            "tools_focus": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Outils a prioriser"
+            },
+            "language": {
+              "type": "string",
+              "default": "fr",
+              "description": "Langue de generation"
+            }
+          }
+        },
+        "documentation": "## MCP - Dataset Generator (RFC-037-B)\n\n**Endpoint:** POST /webhook/mcp/dataset/generate\n\n**Description:** Generer automatiquement des datasets de test pour l'analyse d'intentions\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"domain\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"domain\": { \"type\": \"string\", \"description\": \"Domaine cible (ex: email, shopping)\" },\n    \"categories\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"default\": [\"simple\", \"ambigu\", \"multi-etape\", \"elliptique\"], \"description\": \"Categories de test\" },\n    \"count_per_category\": { \"type\": \"integer\", \"default\": 10, \"description\": \"Nombre de cas par categorie\" },\n    \"tools_focus\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"description\": \"Outils a prioriser\" },\n    \"language\": { \"type\": \"string\", \"default\": \"fr\", \"description\": \"Langue de generation\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"dataset\", \"csv_content\", \"total_cases\", \"by_category\"],\n  \"domain\": \"ai\"\n}\n```"
       },
       {
         "name": "MCP - Documents Estimate",
@@ -396,7 +700,57 @@
         "method": "POST",
         "category": "MCP Tools",
         "description": "Estime le nombre de tokens, pages et credits requis pour traiter un document.",
-        "workflow_id": "6T0xLTZnCo750HEf"
+        "workflow_id": "6T0xLTZnCo750HEf",
+        "input_schema": {
+          "required": [],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (optional, tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord (optional, tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur (optional, tracing)"
+            },
+            "file_url": {
+              "type": "string",
+              "description": "URL du document"
+            },
+            "file_base64": {
+              "type": "string",
+              "description": "Document en base64"
+            },
+            "file_type": {
+              "type": "string",
+              "description": "Type de fichier (pdf, png, etc.)"
+            },
+            "action": {
+              "type": "string",
+              "description": "Action: translate | summarize"
+            },
+            "plugin_context": {
+              "type": "object",
+              "description": "Config pricing/ocr_thresholds"
+            }
+          },
+          "oneOf": [
+            {
+              "required": [
+                "file_url"
+              ]
+            },
+            {
+              "required": [
+                "file_base64"
+              ]
+            }
+          ]
+        },
+        "documentation": "## MCP - Documents Estimate\n\n**Endpoint:** POST /webhook/documents/estimate\n\n**Description:** Estime le nombre de tokens, pages et credits requis pour traiter un document.\n\n**InputSchema:**\n```json\n{\n  \"required\": [],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (optional, tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (optional, tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur (optional, tracing)\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du document\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Document en base64\" },\n    \"file_type\": { \"type\": \"string\", \"description\": \"Type de fichier (pdf, png, etc.)\" },\n    \"action\": { \"type\": \"string\", \"description\": \"Action: translate | summarize\" },\n    \"plugin_context\": { \"type\": \"object\", \"description\": \"Config pricing/ocr_thresholds\" }\n  },\n  \"oneOf\": [\n    { \"required\": [\"file_url\"] },\n    { \"required\": [\"file_base64\"] }\n  ]\n}\n```\n\n**Output:**\n- `estimation`: { tokens, pages, ocr_required, detected_language }\n- `credits`: { estimated, breakdown, max_possible }\n- `ocr_thresholds`: { applied, config }\n- `warnings`: array\n- `_trace`: { service_response, provider, mode, latency_ms, user_id, guild_id, user_request }\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"estimation\", \"credits\", \"ocr_thresholds\", \"warnings\"],\n  \"domain\": \"documents\"\n}\n```"
       },
       {
         "name": "MCP - Documents Process",
@@ -404,8 +758,9 @@
         "full_url": "http://pi6.local:5678/webhook/documents/process",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Documents Process",
-        "workflow_id": "YgtyvTyGDNlDLYHp"
+        "description": "Traitement de données",
+        "workflow_id": "YgtyvTyGDNlDLYHp",
+        "documentation": "## MCP - Documents Process (RFC-014 + RFC-040)\n\n**Endpoint:** POST /webhook/documents/process\n\n**Input:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"context\": {\n    \"project_id\": \"...\",\n    \"file_url\": \"https://...\",\n    \"action\": \"translate|process\"\n  },\n  \"plugin_context\": { \"api_keys\": {...} },\n  \"callback_url\": \"https://...\" // Optional\n}\n```\n\n**RFC-040 Async Pattern:**\n- If `callback_url` present: 202 Accepted + callback\n- If no `callback_url`: 200 OK sync response\n\n**Callback Headers (RFC-040):**\n- Content-Type: application/json\n- X-N8N-Signature: HMAC-SHA256(payload)\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"text\", \"structure\", \"metadata\"],\n  \"domain\": \"documents\"\n}\n```"
       },
       {
         "name": "MCP - Documents Save",
@@ -413,8 +768,9 @@
         "full_url": "http://pi6.local:5678/webhook/documents/save",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Documents Save",
-        "workflow_id": "rXxo6q8W8edGCgoV"
+        "description": "Workflow: MCP   Documents Save",
+        "workflow_id": "rXxo6q8W8edGCgoV",
+        "documentation": "## MCP - Documents Save (RFC-014)\n\n**Endpoint:** POST /webhook/documents/save\n\n**Purpose:** Save processed document to Google Drive\n\n**Input:**\n- `content` (string): Text content to save\n- OR `file_base64` (string): Binary file in base64\n- `filename` (required): Name for the file\n- `folder_id` (optional): Google Drive folder ID\n- `google_access_token`: OAuth2 token for Drive\n- `mime_type` (optional): Default 'text/plain'\n\n**Output:**\n- `success`: boolean\n- `drive_url`: URL to access file\n- `file_id`: Google Drive file ID\n\n**Auth:** Requires Google OAuth2 access token"
       },
       {
         "name": "MCP - Documents Validate",
@@ -422,8 +778,9 @@
         "full_url": "http://pi6.local:5678/webhook/documents/validate",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Documents Validate",
-        "workflow_id": "je6LqhkNP4hgiivK"
+        "description": "Vérification et validation",
+        "workflow_id": "je6LqhkNP4hgiivK",
+        "documentation": "## MCP - Documents Validate\n\n**Endpoint:** POST /webhook/documents/validate\n\n**Input:**\n- `file_url` ou `file_base64`: Document\n- `action`: process | translate | summarize\n- `user_message`: Message utilisateur a interpreter\n- `available_actions`: Actions disponibles\n- `plugin_context`: Config plugin\n\n**Output:**\n- `valid`: boolean\n- `can_proceed`: boolean\n- `missing`: params manquants\n- `questions`: questions a poser\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"is_valid\", \"errors\", \"warnings\"],\n  \"domain\": \"documents\"\n}\n```"
       },
       {
         "name": "MCP - Email IMAP",
@@ -431,8 +788,9 @@
         "full_url": "http://pi6.local:5678/webhook/email-imap",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Email IMAP",
-        "workflow_id": "virECiQyCyP7LFgT"
+        "description": "Workflow: MCP   Email IMAP",
+        "workflow_id": "virECiQyCyP7LFgT",
+        "documentation": "## MCP - Email IMAP\n\n**Endpoint:** POST /webhook/email-imap\n\n**Parameters:**\n- `action` (required): list_folders | search | fetch_email\n- `imap_host` (required): IMAP server hostname\n- `imap_port` (optional): IMAP port (default: 993)\n- `imap_user` (required): IMAP username\n- `imap_password` (required): IMAP password\n\n**For search:**\n- `folder` (optional): Mailbox folder (default: INBOX)\n- `search_criteria` (optional): IMAP search string (default: UNSEEN)\n\n**For fetch_email:**\n- `folder` (optional): Mailbox folder\n- `uid` (required): Email UID to fetch\n\n**Returns:** Folder list, email search results, or full email content\n\n**Note:** Full IMAP functionality requires n8n IMAP credential configuration"
       },
       {
         "name": "MCP - Entity - Comment",
@@ -440,8 +798,67 @@
         "full_url": "http://pi6.local:5678/webhook/entity-comment",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Manages comments on entities (recipes, documents, courses, etc.) stored in PostgreSQL.",
-        "workflow_id": "d2D9fEeQ8zYuVHA6"
+        "description": "Manages comments on entities (recipes, documents, courses, etc.) stored in PostgreSQL. | Requis: action, entity_id, user_id",
+        "workflow_id": "d2D9fEeQ8zYuVHA6",
+        "input_schema": {
+          "type": "object",
+          "required": [
+            "action",
+            "entity_id",
+            "user_id"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "comment",
+                "list",
+                "edit",
+                "delete"
+              ],
+              "description": "Action CRUD"
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "UUID de l'entite"
+            },
+            "entity_type": {
+              "type": "string",
+              "description": "Type d'entite: recipe, document, course, etc."
+            },
+            "user_id": {
+              "type": "string",
+              "description": "Discord user ID"
+            },
+            "content": {
+              "type": "string",
+              "description": "Contenu du commentaire (requis pour comment/edit)"
+            },
+            "comment_id": {
+              "type": "string",
+              "description": "UUID du commentaire (requis pour edit/delete)"
+            },
+            "parent_id": {
+              "type": "string",
+              "description": "UUID du commentaire parent (pour reponses)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Discord guild ID (optionnel)"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 20,
+              "description": "Nombre max de commentaires (pour action=list)"
+            },
+            "offset": {
+              "type": "integer",
+              "default": 0,
+              "description": "Pagination offset (pour action=list)"
+            }
+          }
+        },
+        "documentation": "## MCP - Entity - Comment\n\n**Endpoint:** POST /webhook/entity-comment\n\n**Description:** Manages comments on entities (recipes, documents, courses, etc.) stored in PostgreSQL.\n\n**InputSchema:**\n```json\n{\n  \"type\": \"object\",\n  \"required\": [\"action\", \"entity_id\", \"user_id\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"comment\", \"list\", \"edit\", \"delete\"], \"description\": \"Action CRUD\" },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID de l'entite\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type d'entite: recipe, document, course, etc.\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"Discord user ID\" },\n    \"content\": { \"type\": \"string\", \"description\": \"Contenu du commentaire (requis pour comment/edit)\" },\n    \"comment_id\": { \"type\": \"string\", \"description\": \"UUID du commentaire (requis pour edit/delete)\" },\n    \"parent_id\": { \"type\": \"string\", \"description\": \"UUID du commentaire parent (pour reponses)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (optionnel)\" },\n    \"limit\": { \"type\": \"integer\", \"default\": 20, \"description\": \"Nombre max de commentaires (pour action=list)\" },\n    \"offset\": { \"type\": \"integer\", \"default\": 0, \"description\": \"Pagination offset (pour action=list)\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"comment_id\", \"comments\", \"created_at\", \"updated_at\"],\n  \"domain\": \"entity\"\n}\n```"
       },
       {
         "name": "MCP - Entity - Rating",
@@ -449,8 +866,50 @@
         "full_url": "http://pi6.local:5678/webhook/entity-rating",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Manages entity ratings (recipes, documents, courses, etc.) stored in PostgreSQL.",
-        "workflow_id": "0LbAwUdFjTKGyHg5"
+        "description": "Manages entity ratings (recipes, documents, courses, etc.) stored in PostgreSQL. | Requis: action, entity_id, user_id",
+        "workflow_id": "0LbAwUdFjTKGyHg5",
+        "input_schema": {
+          "type": "object",
+          "required": [
+            "action",
+            "entity_id",
+            "user_id"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "rate",
+                "get",
+                "delete"
+              ],
+              "description": "rate=noter, get=obtenir stats, delete=supprimer note"
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "UUID de l'entite"
+            },
+            "entity_type": {
+              "type": "string",
+              "description": "Type d'entite: recipe, document, course, etc."
+            },
+            "user_id": {
+              "type": "string",
+              "description": "Discord user ID"
+            },
+            "rating": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5,
+              "description": "Note 1-5 (requis pour action=rate)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Discord guild ID (optionnel)"
+            }
+          }
+        },
+        "documentation": "## MCP - Entity - Rating\n\n**Endpoint:** POST /webhook/entity-rating\n\n**Description:** Manages entity ratings (recipes, documents, courses, etc.) stored in PostgreSQL.\n\n**InputSchema:**\n```json\n{\n  \"type\": \"object\",\n  \"required\": [\"action\", \"entity_id\", \"user_id\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"rate\", \"get\", \"delete\"], \"description\": \"rate=noter, get=obtenir stats, delete=supprimer note\" },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID de l'entite\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type d'entite: recipe, document, course, etc.\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"Discord user ID\" },\n    \"rating\": { \"type\": \"integer\", \"minimum\": 1, \"maximum\": 5, \"description\": \"Note 1-5 (requis pour action=rate)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (optionnel)\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"rating\", \"new_average\", \"total_ratings\", \"user_rating\"],\n  \"domain\": \"entity\"\n}\n```"
       },
       {
         "name": "MCP - Entity - Save",
@@ -458,8 +917,89 @@
         "full_url": "http://pi6.local:5678/webhook/entity-save",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "RFC-049 Entity Storage Architecture + RFC-053 bot_id isolation. Saves entities to both MongoDB (via API) AND Qdrant. Uses same UUID for entity_id and qdrant_point_id.",
-        "workflow_id": "8ZIfHNmN4YOayy7O"
+        "description": "RFC-049 Entity Storage Architecture + RFC-053 bot_id isolation. Saves entities to both MongoDB (via API) AND Qdrant. Uses same UUID for entity_id and qdrant_point_id. | Requis: action, entity_type, data, backend_api_url, backend_service_token",
+        "workflow_id": "8ZIfHNmN4YOayy7O",
+        "input_schema": {
+          "required": [
+            "action",
+            "entity_type",
+            "data",
+            "backend_api_url",
+            "backend_service_token"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "save",
+                "update",
+                "delete"
+              ]
+            },
+            "entity_type": {
+              "type": "string",
+              "enum": [
+                "recipe",
+                "document",
+                "course",
+                "quiz",
+                "flashcard"
+              ]
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "UUID (requis pour update/delete)"
+            },
+            "data": {
+              "type": "object",
+              "description": "Entity data"
+            },
+            "backend_api_url": {
+              "type": "string",
+              "description": "Backend API URL"
+            },
+            "backend_service_token": {
+              "type": "string",
+              "description": "Service token for auth"
+            },
+            "tenant_id": {
+              "type": "string",
+              "description": "Tenant ID (or via X-Tenant-ID header)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Discord guild ID (RFC-053)"
+            },
+            "bot_id": {
+              "type": "string",
+              "description": "Discord bot application ID (RFC-053 RAG isolation)"
+            },
+            "embedding": {
+              "type": "array",
+              "description": "Pre-computed embedding (optional)"
+            },
+            "user_id": {
+              "type": "string"
+            },
+            "qdrant_host": {
+              "type": "string"
+            },
+            "qdrant_port": {
+              "type": "integer"
+            },
+            "qdrant_collection": {
+              "type": "string"
+            },
+            "api_key": {
+              "type": "string",
+              "description": "Qdrant API key (fallback)"
+            },
+            "openai_api_key": {
+              "type": "string"
+            }
+          }
+        },
+        "documentation": "## MCP - Entity - Save\n\n**Endpoint:** POST /webhook/entity-save\n\n**Description:** RFC-049 Entity Storage Architecture + RFC-053 bot_id isolation. Saves entities to both MongoDB (via API) AND Qdrant. Uses same UUID for entity_id and qdrant_point_id.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"action\", \"entity_type\", \"data\", \"backend_api_url\", \"backend_service_token\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"save\", \"update\", \"delete\"] },\n    \"entity_type\": { \"type\": \"string\", \"enum\": [\"recipe\", \"document\", \"course\", \"quiz\", \"flashcard\"] },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID (requis pour update/delete)\" },\n    \"data\": { \"type\": \"object\", \"description\": \"Entity data\" },\n    \"backend_api_url\": { \"type\": \"string\", \"description\": \"Backend API URL\" },\n    \"backend_service_token\": { \"type\": \"string\", \"description\": \"Service token for auth\" },\n    \"tenant_id\": { \"type\": \"string\", \"description\": \"Tenant ID (or via X-Tenant-ID header)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (RFC-053)\" },\n    \"bot_id\": { \"type\": \"string\", \"description\": \"Discord bot application ID (RFC-053 RAG isolation)\" },\n    \"embedding\": { \"type\": \"array\", \"description\": \"Pre-computed embedding (optional)\" },\n    \"user_id\": { \"type\": \"string\" },\n    \"qdrant_host\": { \"type\": \"string\" },\n    \"qdrant_port\": { \"type\": \"integer\" },\n    \"qdrant_collection\": { \"type\": \"string\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"Qdrant API key (fallback)\" },\n    \"openai_api_key\": { \"type\": \"string\" }\n  }\n}\n```\n\n**Headers:**\n- X-Tenant-ID: Tenant identifier (or pass tenant_id in body)"
       },
       {
         "name": "MCP - Entity - Search",
@@ -467,8 +1007,97 @@
         "full_url": "http://pi6.local:5678/webhook/entity-search",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Recherche semantique multi-tenant dans Qdrant avec enrichissement MongoDB optionnel. RFC-049 + RFC-053 (bot_id isolation).",
-        "workflow_id": "vgTXZ9bH56N3v0YL"
+        "description": "Recherche semantique multi-tenant dans Qdrant avec enrichissement MongoDB optionnel. RFC-049 + RFC-053 (bot_id isolation). | Requis: action, query",
+        "workflow_id": "vgTXZ9bH56N3v0YL",
+        "input_schema": {
+          "required": [
+            "action",
+            "query"
+          ],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": [
+                "search",
+                "similar"
+              ],
+              "description": "search=par query, similar=par entity_id"
+            },
+            "query": {
+              "type": "string",
+              "description": "Texte de recherche (pour action=search)"
+            },
+            "entity_id": {
+              "type": "string",
+              "description": "UUID pour recherche similaire (pour action=similar)"
+            },
+            "entity_type": {
+              "type": "string",
+              "description": "Filtrer par type d'entite"
+            },
+            "limit": {
+              "type": "integer",
+              "default": 10,
+              "description": "Nombre de resultats max"
+            },
+            "enrich": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enrichir depuis MongoDB"
+            },
+            "backend_api_url": {
+              "type": "string",
+              "description": "Backend API URL (requis si enrich=true)"
+            },
+            "backend_service_token": {
+              "type": "string",
+              "description": "Service token (requis si enrich=true)"
+            },
+            "fields": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Champs a recuperer depuis DB"
+            },
+            "filters": {
+              "type": "object",
+              "description": "Filtres additionnels Qdrant"
+            },
+            "tenant_id": {
+              "type": "string",
+              "description": "Tenant ID (or via X-Tenant-ID header)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Discord guild ID (RFC-053)"
+            },
+            "bot_id": {
+              "type": "string",
+              "description": "Discord bot application ID (RFC-053 RAG isolation)"
+            },
+            "user_id": {
+              "type": "string"
+            },
+            "qdrant_host": {
+              "type": "string"
+            },
+            "qdrant_port": {
+              "type": "integer"
+            },
+            "qdrant_collection": {
+              "type": "string"
+            },
+            "api_key": {
+              "type": "string",
+              "description": "Qdrant API key (fallback)"
+            },
+            "openai_api_key": {
+              "type": "string"
+            }
+          }
+        },
+        "documentation": "## MCP - Entity - Search\n\n**Endpoint:** POST /webhook/entity-search\n\n**Description:** Recherche semantique multi-tenant dans Qdrant avec enrichissement MongoDB optionnel. RFC-049 + RFC-053 (bot_id isolation).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"action\", \"query\"],\n  \"properties\": {\n    \"action\": { \"type\": \"string\", \"enum\": [\"search\", \"similar\"], \"description\": \"search=par query, similar=par entity_id\" },\n    \"query\": { \"type\": \"string\", \"description\": \"Texte de recherche (pour action=search)\" },\n    \"entity_id\": { \"type\": \"string\", \"description\": \"UUID pour recherche similaire (pour action=similar)\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Filtrer par type d'entite\" },\n    \"limit\": { \"type\": \"integer\", \"default\": 10, \"description\": \"Nombre de resultats max\" },\n    \"enrich\": { \"type\": \"boolean\", \"default\": false, \"description\": \"Enrichir depuis MongoDB\" },\n    \"backend_api_url\": { \"type\": \"string\", \"description\": \"Backend API URL (requis si enrich=true)\" },\n    \"backend_service_token\": { \"type\": \"string\", \"description\": \"Service token (requis si enrich=true)\" },\n    \"fields\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"description\": \"Champs a recuperer depuis DB\" },\n    \"filters\": { \"type\": \"object\", \"description\": \"Filtres additionnels Qdrant\" },\n    \"tenant_id\": { \"type\": \"string\", \"description\": \"Tenant ID (or via X-Tenant-ID header)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (RFC-053)\" },\n    \"bot_id\": { \"type\": \"string\", \"description\": \"Discord bot application ID (RFC-053 RAG isolation)\" },\n    \"user_id\": { \"type\": \"string\" },\n    \"qdrant_host\": { \"type\": \"string\" },\n    \"qdrant_port\": { \"type\": \"integer\" },\n    \"qdrant_collection\": { \"type\": \"string\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"Qdrant API key (fallback)\" },\n    \"openai_api_key\": { \"type\": \"string\" }\n  }\n}\n```\n\n**Multi-tenant:** CRITICAL - Qdrant queries MUST filter by tenant_id.\n**RFC-053:** Filtre inclusif bot_id (documents legacy sans bot_id restent accessibles).\n\n**Returns:**\n- `results`: Array avec score et payload\n- `entity`: Donnees enrichies MongoDB (si enrich=true)\n- `_trace`: Informations de tracabilite"
       },
       {
         "name": "MCP - Entity Extractor",
@@ -476,8 +1105,9 @@
         "full_url": "http://pi6.local:5678/webhook/entity-extractor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Entity Extractor",
-        "workflow_id": "5WoZg4BWXfAWOkDR"
+        "description": "Extraction de données",
+        "workflow_id": "5WoZg4BWXfAWOkDR",
+        "documentation": "## MCP - Entity Extractor\n\n**Endpoint:** POST /webhook/entity-extractor\n\n**Parameters:**\n- `text` (required): Text to extract entities from\n- `entity_types` (optional): Array of types to extract [\"PERSON\", \"ORGANIZATION\", \"LOCATION\", ...]\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of entities with type and confidence\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"entities\", \"types\", \"confidence\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - Feedback Analyzer",
@@ -485,8 +1115,45 @@
         "full_url": "http://pi6.local:5678/webhook/analyze-feedback",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Analyse le feedback utilisateur pour extraire des insights actionnables et ajuster le comportement de l'assistant IA.",
-        "workflow_id": "jIYd6z26dd1CCcX2"
+        "description": "Analyse le feedback utilisateur pour extraire des insights actionnables et ajuster le comportement de l'assistant IA. | Requis: user_id, guild_id, user_request, comment",
+        "workflow_id": "jIYd6z26dd1CCcX2",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "comment"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "comment": {
+              "type": "string",
+              "description": "Commentaire feedback a analyser"
+            },
+            "feedback_type": {
+              "type": "string",
+              "description": "positive | negative | neutral",
+              "default": "unknown"
+            },
+            "language": {
+              "type": "string",
+              "description": "Langue (fr, en)",
+              "default": "fr"
+            }
+          }
+        },
+        "documentation": "## MCP - Feedback Analyzer\n\n**Endpoint:** POST /webhook/analyze-feedback\n\n**Description:** Analyse le feedback utilisateur pour extraire des insights actionnables et ajuster le comportement de l'assistant IA.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"comment\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"comment\": { \"type\": \"string\", \"description\": \"Commentaire feedback a analyser\" },\n    \"feedback_type\": { \"type\": \"string\", \"description\": \"positive | negative | neutral\", \"default\": \"unknown\" },\n    \"language\": { \"type\": \"string\", \"description\": \"Langue (fr, en)\", \"default\": \"fr\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"category\", \"issue\", \"detected_problems\", \"user_preference\", \"suggested_action\", \"confidence\"],\n  \"domain\": \"feedback_analysis\"\n}\n```\n\n**Model:** gpt-4o-mini"
       },
       {
         "name": "MCP - Games Add",
@@ -494,8 +1161,9 @@
         "full_url": "http://pi6.local:5678/webhook/games-add",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Games Add",
-        "workflow_id": "RpYQjfYM2dIgpRaS"
+        "description": "Workflow: MCP   Games Add",
+        "workflow_id": "RpYQjfYM2dIgpRaS",
+        "documentation": "## MCP - Games Add\n\n**Endpoint:** POST /webhook/games-add\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"game\": {\n    \"white\": \"user\",\n    \"black\": \"opponent_name\",\n    \"result\": \"win\",\n    \"pgn\": \"1. e4 e5 2. Nf3 ...\",\n    \"source\": \"manual\",\n    \"time_control\": \"10+0\",\n    \"opening\": \"Sicilian Defense\"\n  }\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"game_id\": \"665f1a2b3c4d5e6f7a8b9c0d\",\n  \"created\": true\n}\n```\n\n### Champs game\n- `white`: requis\n- `black`: requis\n- `result`: requis (win, loss, draw)\n- `source`: optionnel (manual, lichess, pgn_import)\n- `pgn`: optionnel\n- `time_control`: optionnel\n- `opening`: optionnel\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Games Analysis",
@@ -503,8 +1171,9 @@
         "full_url": "http://pi6.local:5678/webhook/games-analysis",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Games Analysis",
-        "workflow_id": "lwbLrrUgBtqIakRT"
+        "description": "Analyse de données",
+        "workflow_id": "lwbLrrUgBtqIakRT",
+        "documentation": "## MCP - Games Analysis\n\n**Endpoint:** POST /webhook/games-analysis\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"game_id\": \"665f1a2b3c4d5e6f7a8b9c0d\",\n  \"analysis\": {\n    \"done\": true,\n    \"accuracy\": {\n      \"white\": 85.5,\n      \"black\": 72.3\n    },\n    \"mistakes\": {\n      \"blunders\": 2,\n      \"mistakes\": 3,\n      \"inaccuracies\": 5\n    },\n    \"key_moments\": [\n      {\n        \"move_number\": 15,\n        \"description\": \"Blunder\",\n        \"evaluation_before\": 1.5,\n        \"evaluation_after\": -3.2\n      }\n    ],\n    \"summary\": \"Bonne ouverture...\"\n  }\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Analyse mise a jour\",\n  \"game_id\": \"665f1a2b...\"\n}\n```\n\n### Erreurs\n- 404: game_id introuvable\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Games Lichess",
@@ -512,8 +1181,9 @@
         "full_url": "http://pi6.local:5678/webhook/games-lichess",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Games Lichess",
-        "workflow_id": "0D2bRb5i5pKdNL9p"
+        "description": "Workflow: MCP   Games Lichess",
+        "workflow_id": "0D2bRb5i5pKdNL9p",
+        "documentation": "## MCP - Games Lichess\n\n**Endpoint:** POST /webhook/games-lichess\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"game_id\": \"665f1a2b3c4d5e6f7a8b9c0d\",\n  \"lichess_game_id\": \"AbCdEfGh\",\n  \"lichess_url\": \"https://lichess.org/AbCdEfGh\"\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Partie liee a Lichess\",\n  \"game_id\": \"665f1a2b...\",\n  \"lichess_game_id\": \"AbCdEfGh\",\n  \"lichess_url\": \"https://lichess.org/AbCdEfGh\"\n}\n```\n\n### Usage\nMarque une partie locale comme importee\ndepuis Lichess. Permet de retrouver la\npartie originale sur Lichess.\n\n### Erreurs\n- 404: game_id introuvable\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Games List",
@@ -521,8 +1191,9 @@
         "full_url": "http://pi6.local:5678/webhook/games-list",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Games List",
-        "workflow_id": "AC6TOb6oXmdwEaFS"
+        "description": "Liste des ressources",
+        "workflow_id": "AC6TOb6oXmdwEaFS",
+        "documentation": "## MCP - Games List\n\n**Endpoint:** POST /webhook/games-list\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"limit\": 20,\n  \"offset\": 0,\n  \"filters\": {\n    \"result\": \"win\",\n    \"source\": \"lichess\",\n    \"has_analysis\": true\n  }\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"games\": [\n    {\n      \"game_id\": \"...\",\n      \"white\": \"user\",\n      \"black\": \"opponent\",\n      \"result\": \"win\",\n      \"pgn\": \"1. e4 e5...\"\n    }\n  ],\n  \"total\": 42,\n  \"limit\": 20,\n  \"offset\": 0\n}\n```\n\n### Filtres\n- `result`: win, loss, draw\n- `source`: manual, lichess, pgn_import\n- `has_analysis`: true/false\n\n### Pagination\n- `limit`: 1-100 (defaut 20)\n- `offset`: defaut 0\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Gmail Server (All-in-One)",
@@ -530,8 +1201,9 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-gmail",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Gmail Server (All-in-One)",
-        "workflow_id": "Jz4ji4p0QStwstN0"
+        "description": "Workflow: MCP   Gmail Server (All in One)",
+        "workflow_id": "Jz4ji4p0QStwstN0",
+        "documentation": "## Message Tools\n"
       },
       {
         "name": "MCP - Google Calendar Server",
@@ -539,8 +1211,9 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-calendar",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Calendar Server",
-        "workflow_id": "u6pSGRx05aNgK0fv"
+        "description": "Workflow: MCP   Google Calendar Server",
+        "workflow_id": "u6pSGRx05aNgK0fv",
+        "documentation": "## USAGE\n\nOpen the Calendar MCP Server node to obtain the webhook URL.\n\nUse POST requests with:\n- `access_token`\n- `resource` (event/calendar)\n- `operation`"
       },
       {
         "name": "MCP - Google Classroom Server",
@@ -548,7 +1221,7 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-classroom",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Classroom Server",
+        "description": "Workflow: MCP   Google Classroom Server",
         "workflow_id": "KdlhTDaBa3EZX26C"
       },
       {
@@ -557,7 +1230,7 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-contacts",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Contacts Server",
+        "description": "Workflow: MCP   Google Contacts Server",
         "workflow_id": "A1mWo3qs0572wSp0"
       },
       {
@@ -566,8 +1239,54 @@
         "full_url": "http://pi6.local:5678/webhook/google-drive-ocr",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Drive OCR",
-        "workflow_id": "KoYmjpXfjgCrphhh"
+        "description": "Paramètres: google_access_token, folder_id, file_id, mistral_api_key, max_files | Requis: google_access_token",
+        "workflow_id": "KoYmjpXfjgCrphhh",
+        "input_schema": {
+          "required": [
+            "google_access_token"
+          ],
+          "properties": {
+            "google_access_token": {
+              "type": "string",
+              "description": "Google OAuth2 access token"
+            },
+            "folder_id": {
+              "type": "string",
+              "description": "List files in folder"
+            },
+            "file_id": {
+              "type": "string",
+              "description": "Process specific file with OCR"
+            },
+            "mistral_api_key": {
+              "type": "string",
+              "description": "Mistral API key (required for OCR)"
+            },
+            "max_files": {
+              "type": "integer",
+              "description": "Max files to list",
+              "default": 100
+            },
+            "include_images": {
+              "type": "boolean",
+              "description": "Include base64 images in OCR response",
+              "default": false
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID (optional, for tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID (optional, for tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request (optional, for tracing)"
+            }
+          }
+        },
+        "documentation": "## MCP - Google Drive OCR\n\n**Endpoint:** POST /webhook/google-drive-ocr\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"google_access_token\"],\n  \"properties\": {\n    \"google_access_token\": { \"type\": \"string\", \"description\": \"Google OAuth2 access token\" },\n    \"folder_id\": { \"type\": \"string\", \"description\": \"List files in folder\" },\n    \"file_id\": { \"type\": \"string\", \"description\": \"Process specific file with OCR\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key (required for OCR)\" },\n    \"max_files\": { \"type\": \"integer\", \"description\": \"Max files to list\", \"default\": 100 },\n    \"include_images\": { \"type\": \"boolean\", \"description\": \"Include base64 images in OCR response\", \"default\": false },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**Note:** Requires `google_access_token` AND (`folder_id` OR `file_id`).\n\n**Operations:**\n- List files: provide `folder_id`\n- OCR file: provide `file_id` + `mistral_api_key`\n\n**API:** Mistral OCR (mistral-ocr-latest) + Google Drive v3"
       },
       {
         "name": "MCP - Google Drive Server",
@@ -575,7 +1294,7 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-drive",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Drive Server",
+        "description": "Workflow: MCP   Google Drive Server",
         "workflow_id": "jRaOth5nYWI8Gl9q"
       },
       {
@@ -584,8 +1303,9 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-google-maps",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Maps",
-        "workflow_id": "2yybqbrzqWOsVfdL"
+        "description": "Workflow: MCP   Google Maps",
+        "workflow_id": "2yybqbrzqWOsVfdL",
+        "documentation": "## MCP Google Maps Tools\n\n**Endpoint:** POST `/webhook/mcp-google-maps`\n\n**GitHub Issue:** #137\n\n---\n\n### Operations disponibles:\n\n1. **geocode** - Adresse -> Coordonnees\n2. **reverse_geocode** - Coordonnees -> Adresse\n3. **directions** - Calcul d'itineraire\n4. **search_places** - Recherche de lieux\n5. **place_details** - Details d'un lieu\n6. **air_quality** - Qualite de l'air\n7. **pollen** - Donnees pollen\n8. **timezone** - Fuseau horaire\n\n---\n\n### Parametres requis:\n\n- `operation`: string\n- `api_key`: string (cle API Google Maps)\n\n### Parametres selon operation:\n\nVoir documentation complete dans `docs/issues/google-maps-api-integration.md`"
       },
       {
         "name": "MCP - Google Searcher",
@@ -593,8 +1313,9 @@
         "full_url": "http://pi6.local:5678/webhook/google-searcher",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Google Searcher",
-        "workflow_id": "6WtKoi2pkRShkVT7"
+        "description": "Recherche d'informations",
+        "workflow_id": "6WtKoi2pkRShkVT7",
+        "documentation": "## MCP - Google Searcher\n\n**Endpoint:** POST /webhook/google-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `num_results` (optional): Number of results 1-100 (default: 10)\n- `language` (optional): Language code, e.g., 'en', 'fr' (default: en)\n- `country` (optional): Country code, e.g., 'us', 'fr' (default: us)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Organic results, knowledge graph, answer box, related searches\n\n**Note:** Requires SerpAPI credentials"
       },
       {
         "name": "MCP - HTML Extractor",
@@ -602,7 +1323,7 @@
         "full_url": "http://pi6.local:5678/webhook/html-extractor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - HTML Extractor",
+        "description": "Extraction de données",
         "workflow_id": "soWXv3QQYzjNiN35"
       },
       {
@@ -611,8 +1332,38 @@
         "full_url": "http://pi6.local:5678/webhook/image-embedder",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Analyse une image via GPT-4o-mini et genere un embedding semantique",
-        "workflow_id": "iEYtMhfT54nC5MFX"
+        "description": "Analyse une image via GPT-4o-mini et genere un embedding semantique | Requis: user_id, guild_id, user_request",
+        "workflow_id": "iEYtMhfT54nC5MFX",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "image_url": {
+              "type": "string",
+              "description": "URL de l'image a analyser"
+            },
+            "image_base64": {
+              "type": "string",
+              "description": "Image encodee en base64"
+            }
+          }
+        },
+        "documentation": "## MCP - Image Embedder\n\n**Endpoint:** POST /webhook/image-embedder\n\n**Description:** Analyse une image via GPT-4o-mini et genere un embedding semantique\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image a analyser\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Image encodee en base64\" }\n  }\n}\n```\n\n**Note:** image_url OU image_base64 requis (au moins un des deux). API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"embedding\", \"analysis\", \"dimensions\"],\n  \"domain\": \"vision\"\n}\n```"
       },
       {
         "name": "MCP - Image Generator",
@@ -620,8 +1371,9 @@
         "full_url": "http://pi6.local:5678/webhook/image-generator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Image Generator",
-        "workflow_id": "b8UDsmsVt9QkAywZ"
+        "description": "Workflow: MCP   Image Generator",
+        "workflow_id": "b8UDsmsVt9QkAywZ",
+        "documentation": "## MCP - Image Generator (DALL-E) - RFC-040 Async Callback Pattern\n\n**Endpoint:** POST /webhook/image-generator\n\n**Parameters:**\n- `prompt` (required): Image generation prompt\n- `openai_api_key` (required): OpenAI API key\n- `callback_url` (optional): URL for async callback (enables async mode)\n- `job_id` (optional): Custom job ID (auto-generated if not provided)\n- `options.model` (optional): dall-e-3 | dall-e-2 (default: dall-e-3)\n- `options.size` (optional): 1024x1024 | 1792x1024 | 1024x1792 (default: 1024x1024)\n- `options.quality` (optional): standard | hd (default: standard)\n- `options.style` (optional): vivid | natural (default: vivid)\n- `options.n` (optional): Number of images (default: 1)\n- `options.response_format` (optional): url | b64_json (default: url)\n- `execution_mode` (optional): online | offline\n\n**Sync Mode (no callback_url):** Returns generated image directly\n**Async Mode (with callback_url):** Returns 202 Accepted immediately, POSTs result to callback_url when done\n\n**Callback Headers:** Content-Type: application/json, X-N8N-Signature: HMAC-SHA256(payload, N8N_WEBHOOK_SECRET)\n\n**Pricing (DALL-E 3):** Standard $0.04-0.08, HD $0.08-0.12 per image"
       },
       {
         "name": "MCP - Image OCR",
@@ -629,8 +1381,50 @@
         "full_url": "http://pi6.local:5678/webhook/image-ocr",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Image OCR",
-        "workflow_id": "xQt71PPNeLGo9YPx"
+        "description": "Paramètres: image_url, image_base64, file_type, mistral_api_key, include_images | Requis: image_url OR image_base64, mistral_api_key",
+        "workflow_id": "xQt71PPNeLGo9YPx",
+        "input_schema": {
+          "required": [
+            "image_url OR image_base64",
+            "mistral_api_key"
+          ],
+          "properties": {
+            "image_url": {
+              "type": "string",
+              "description": "URL of image to OCR"
+            },
+            "image_base64": {
+              "type": "string",
+              "description": "Base64-encoded image"
+            },
+            "file_type": {
+              "type": "string",
+              "description": "Image type (jpg, png, etc.)"
+            },
+            "mistral_api_key": {
+              "type": "string",
+              "description": "Mistral API key"
+            },
+            "include_images": {
+              "type": "boolean",
+              "description": "Include images in response",
+              "default": false
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID (optional, for tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID (optional, for tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request (optional, for tracing)"
+            }
+          }
+        },
+        "documentation": "## MCP - Image OCR\n\n**Endpoint:** POST /webhook/image-ocr\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"image_url OR image_base64\", \"mistral_api_key\"],\n  \"properties\": {\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL of image to OCR\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Base64-encoded image\" },\n    \"file_type\": { \"type\": \"string\", \"description\": \"Image type (jpg, png, etc.)\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key\" },\n    \"include_images\": { \"type\": \"boolean\", \"description\": \"Include images in response\", \"default\": false },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"image_url\": \"https://...\",\n    \"file_type\": \"jpg\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"mistral\": \"...\" }\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"text\": \"...\", \"pages\": [...] },\n  \"meta\": { \"provider\": \"mistral\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** Mistral OCR (mistral-ocr-latest)"
       },
       {
         "name": "MCP - JSON Transformer",
@@ -638,8 +1432,9 @@
         "full_url": "http://pi6.local:5678/webhook/json-transformer",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - JSON Transformer",
-        "workflow_id": "n2t7kKIYePjcI7pl"
+        "description": "Workflow: MCP   JSON Transformer",
+        "workflow_id": "n2t7kKIYePjcI7pl",
+        "documentation": "## MCP - JSON Transformer\n\n**Endpoint:** POST /webhook/json-transformer\n\n**Parameters:**\n- `data` (required): JSON object or array to transform\n- `action` (optional): Transformation action (default: identity)\n- `options` (optional): Action-specific options\n\n**Actions:**\n- `identity`: Return data as-is\n- `flatten`: Flatten nested object (options: separator)\n- `unflatten`: Unflatten to nested object\n- `pick`: Pick specific keys (options: keys[])\n- `omit`: Omit specific keys (options: keys[])\n- `rename`: Rename keys (options: mapping{})\n- `filter`: Filter array (options: key, value, operator: eq|neq|gt|gte|lt|lte|contains|startsWith|endsWith)\n- `sort`: Sort array (options: key, order: asc|desc)\n- `group`: Group array by key (options: key)\n- `map`: Map array with template (options: template{})\n- `merge`: Merge with object (options: with{})\n- `to_array`: Object to [{key,value}]\n- `to_object`: [{key,value}] to object"
       },
       {
         "name": "MCP - Knowledge Graph",
@@ -647,7 +1442,7 @@
         "full_url": "http://pi6.local:5678/webhook/knowledge-graph",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Knowledge Graph",
+        "description": "Workflow: MCP   Knowledge Graph",
         "workflow_id": "e7YS4pgDKrxmvurW"
       },
       {
@@ -656,8 +1451,64 @@
         "full_url": "http://pi6.local:5678/webhook/llm-intention",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Analyse l'intention utilisateur via LLM et propose des actions appropriees.",
-        "workflow_id": "bnZP1kGQboNyY67u"
+        "description": "Analyse l'intention utilisateur via LLM et propose des actions appropriees. | Requis: user_id, guild_id, user_request, message",
+        "workflow_id": "bnZP1kGQboNyY67u",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "message"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale (contextualise l'analyse)"
+            },
+            "message": {
+              "type": "string",
+              "description": "Message a analyser (alias: query)"
+            },
+            "context": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "description": "Domaine: recipe|torah|general"
+                },
+                "allowed_actions": {
+                  "type": "array",
+                  "description": "Actions autorisees"
+                },
+                "min_score": {
+                  "type": "number",
+                  "default": 0.7
+                },
+                "auto_fallback": {
+                  "type": "boolean",
+                  "default": false
+                }
+              }
+            },
+            "history": {
+              "type": "array",
+              "description": "Historique conversation [{role, content}]"
+            },
+            "attached_file": {
+              "type": "object",
+              "description": "Fichier joint {name, type, url}"
+            }
+          }
+        },
+        "documentation": "## MCP - LLM Intention\n\n**Endpoint:** POST /webhook/llm-intention\n\n**Description:** Analyse l'intention utilisateur via LLM et propose des actions appropriees.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"message\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (contextualise l'analyse)\" },\n    \"message\": { \"type\": \"string\", \"description\": \"Message a analyser (alias: query)\" },\n    \"context\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"type\": { \"type\": \"string\", \"description\": \"Domaine: recipe|torah|general\" },\n        \"allowed_actions\": { \"type\": \"array\", \"description\": \"Actions autorisees\" },\n        \"min_score\": { \"type\": \"number\", \"default\": 0.7 },\n        \"auto_fallback\": { \"type\": \"boolean\", \"default\": false }\n      }\n    },\n    \"history\": { \"type\": \"array\", \"description\": \"Historique conversation [{role, content}]\" },\n    \"attached_file\": { \"type\": \"object\", \"description\": \"Fichier joint {name, type, url}\" }\n  }\n}\n```\n\n**Note:** API keys (anthropic_api_key) fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"intent\", \"query_analysis\", \"proposed_actions\", \"is_relevant\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - LLM Summarizer",
@@ -665,8 +1516,44 @@
         "full_url": "http://pi6.local:5678/webhook/llm-summarizer",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Summarizes text using multiple LLM providers (Anthropic, OpenAI, Mistral).",
-        "workflow_id": "3xOAo0G2fvmauIx1"
+        "description": "Summarizes text using multiple LLM providers (Anthropic, OpenAI, Mistral). | Requis: text",
+        "workflow_id": "3xOAo0G2fvmauIx1",
+        "input_schema": {
+          "required": [
+            "text"
+          ],
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Text to summarize (required)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request context for personalized summary"
+            },
+            "provider": {
+              "type": "string",
+              "description": "LLM provider: anthropic (default), openai, mistral"
+            },
+            "format": {
+              "type": "string",
+              "description": "Output format: bullet-points, paragraph, executive-summary"
+            },
+            "max_tokens": {
+              "type": "integer",
+              "description": "Max output tokens (default: 1024)"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID for tracing"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID for tracing"
+            }
+          }
+        },
+        "documentation": "## MCP - LLM Summarizer\n\n**Endpoint:** POST /webhook/llm-summarizer\n\n**Description:** Summarizes text using multiple LLM providers (Anthropic, OpenAI, Mistral).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\"],\n  \"properties\": {\n    \"text\": { \"type\": \"string\", \"description\": \"Text to summarize (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized summary\" },\n    \"provider\": { \"type\": \"string\", \"description\": \"LLM provider: anthropic (default), openai, mistral\" },\n    \"format\": { \"type\": \"string\", \"description\": \"Output format: bullet-points, paragraph, executive-summary\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 1024)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"summary\", \"original_length\", \"summary_length\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - Language Detector",
@@ -674,8 +1561,35 @@
         "full_url": "http://pi6.local:5678/webhook/language-detector",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Detecte la langue d'un texte et retourne des informations detaillees.",
-        "workflow_id": "THC7Qt41GurxBuzJ"
+        "description": "Detecte la langue d'un texte et retourne des informations detaillees. | Requis: user_id, guild_id, user_request, text",
+        "workflow_id": "THC7Qt41GurxBuzJ",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "text"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "text": {
+              "type": "string",
+              "description": "Texte a analyser pour detection de langue"
+            }
+          }
+        },
+        "documentation": "## MCP - Language Detector\n\n**Endpoint:** POST /webhook/language-detector\n\n**Description:** Detecte la langue d'un texte et retourne des informations detaillees.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"text\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte a analyser pour detection de langue\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Returns:**\n- `code`: ISO 639-1 language code (en, fr, es, de, zh, ja, ar, etc.)\n- `name`: Full language name in English\n- `confidence`: Detection confidence (0.0 to 1.0)\n- `script`: Writing script (latin, cyrillic, arabic, han, etc.)\n- `is_mixed`: Boolean if multiple languages detected\n- `languages`: Array of detected languages if mixed\n\n**Model:** gpt-4o-mini (fast, cost-effective)\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"code\", \"name\", \"confidence\", \"script\"],\n  \"domain\": \"language\"\n}\n```"
       },
       {
         "name": "MCP - Lichess Auth Callback",
@@ -683,8 +1597,9 @@
         "full_url": "http://pi6.local:5678/webhook/lichess-auth-callback",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Lichess Auth Callback",
-        "workflow_id": "xWQ7GvTnaM6k4FQH"
+        "description": "Workflow: MCP   Lichess Auth Callback",
+        "workflow_id": "xWQ7GvTnaM6k4FQH",
+        "documentation": "## MCP - Lichess Auth Callback\n\n**Endpoint:** POST /webhook/lichess-auth-callback\n\n### Input\n```json\n{\n  \"code\": \"lic_abc123...\",\n  \"state\": \"base64...\",\n  \"code_verifier\": \"xyz789...\"\n}\n```\n\nLe caller (chess plugin) doit :\n1. Recevoir le callback de Lichess (?code=...&state=...)\n2. Ajouter le code_verifier (stocké lors de auth-start)\n3. Appeler ce endpoint\n\n### Flow\n1. Valide code, state, code_verifier\n2. Décode state → tenant_id + user_id\n3. Échange code → access_token (Lichess API)\n4. Récupère profil Lichess\n5. Stocke tokens (POST /api/n8n/oauth/store)\n6. Lie lichess_username (POST /api/n8n/progress/lichess)\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Compte Lichess 'player123' connecté\",\n  \"lichess_username\": \"player123\"\n}\n```\n\n### Variables d'environnement\n- `LICHESS_CLIENT_ID`\n- `LICHESS_REDIRECT_URI`\n- `BACKEND_API_URL`\n- `N8N_API_KEY`\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Lichess Auth Start",
@@ -692,8 +1607,9 @@
         "full_url": "http://pi6.local:5678/webhook/lichess-auth-start",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Lichess Auth Start",
-        "workflow_id": "SggHvck1WZ61NWfT"
+        "description": "Workflow: MCP   Lichess Auth Start",
+        "workflow_id": "SggHvck1WZ61NWfT",
+        "documentation": "## MCP - Lichess Auth Start\n\n**Endpoint:** POST /webhook/lichess-auth-start\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"redirect_uri\": \"https://app.local/callback\" \n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"auth_url\": \"https://lichess.org/oauth?...\",\n  \"state\": \"base64...\",\n  \"code_verifier\": \"abc123...\",\n  \"message\": \"Redirigez l'utilisateur...\"\n}\n```\n\n### Flow\n1. Valide tenant_id + user_id\n2. Génère state (contient tenant_id + user_id) + PKCE\n3. Stocke placeholder en OAuth store\n4. Retourne URL d'autorisation Lichess\n\n### Note\nLe `code_verifier` est retourné au caller qui doit\nle passer au callback (ou le stocker côté client).\n\n### Variables d'environnement\n- `LICHESS_CLIENT_ID`\n- `LICHESS_REDIRECT_URI`\n- `BACKEND_API_URL`\n- `N8N_API_KEY`\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Lichess OAuth",
@@ -701,8 +1617,9 @@
         "full_url": "http://pi6.local:5678/webhook/lichess-oauth-callback",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Workflow OAuth complet pour Lichess",
-        "workflow_id": "RCY7MUDd4Off8e6R"
+        "description": "Workflow OAuth complet pour Lichess **Category:** oauth **Keywords:** lichess, oauth, token, discord, chess",
+        "workflow_id": "RCY7MUDd4Off8e6R",
+        "documentation": "## MCP - Lichess OAuth\n\n**Description:** Workflow OAuth complet pour Lichess\n**Category:** oauth\n**Keywords:** lichess, oauth, token, discord, chess\n\n**Endpoint:** GET /webhook/lichess-oauth-callback\n\n**URL externe:** https://lichess.azy.solutions/webhook/lichess-oauth-callback\n\n**Flow:**\n1. Reçoit callback Lichess (?code&state)\n2. Récupère flow data depuis Redis (code_verifier, user_id)\n3. Échange code contre token via Lichess API\n4. Stocke token dans Redis\n5. Cleanup flow data\n6. Affiche page succès\n\n**Redis Keys:**\n- `oauth:flow:{state}` - Flow temporaire (10 min TTL)\n- `oauth:token:lichess:{user_id}` - Token stocké"
       },
       {
         "name": "MCP - Lichess Webhook",
@@ -710,8 +1627,9 @@
         "full_url": "http://pi6.local:5678/webhook/lichess-webhook",
         "method": "GET",
         "category": "MCP Tools",
-        "description": "Page de confirmation OAuth Lichess",
-        "workflow_id": "PXQ2w7pAEg8ukenO"
+        "description": "Page de confirmation OAuth Lichess **Category:** oauth **Keywords:** lichess, oauth, callback, discord, chess",
+        "workflow_id": "PXQ2w7pAEg8ukenO",
+        "documentation": "## MCP - Lichess Webhook\n\n**Description:** Page de confirmation OAuth Lichess\n**Category:** oauth\n**Keywords:** lichess, oauth, callback, discord, chess\n\n**Endpoint:** GET /webhook/lichess-webhook\n\n**URL externe:** https://lichess.azy.solutions/webhook/lichess-webhook\n\n**Query params:**\n- `code`: Code d'autorisation Lichess\n- `state`: État OAuth (contient user_id encodé)\n\n**Output:** Page HTML de confirmation ou erreur"
       },
       {
         "name": "MCP - LinkedIn",
@@ -719,8 +1637,9 @@
         "full_url": "http://pi6.local:5678/webhook/linkedin",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - LinkedIn",
-        "workflow_id": "cLxDiCFSOTiaMUYn"
+        "description": "Workflow: MCP   LinkedIn",
+        "workflow_id": "cLxDiCFSOTiaMUYn",
+        "documentation": "## MCP - LinkedIn\n\n**Endpoint:** POST /webhook/linkedin\n\n**Parameters:**\n- `action`: post | post_with_image\n- `text` (required): Post content\n- `image_url` (for post_with_image): URL of image\n\n**Note:** Requires LinkedIn OAuth credentials configured"
       },
       {
         "name": "MCP - Mathpix",
@@ -728,8 +1647,76 @@
         "full_url": "http://pi6.local:5678/webhook/mathpix",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "OCR mathematique via Mathpix API. Convertit images de formules/equations en LaTeX, MathML, AsciiMath.",
-        "workflow_id": "6bWwcWZqx0tirOFk"
+        "description": "OCR mathematique via Mathpix API. Convertit images de formules/equations en LaTeX, MathML, AsciiMath. | Requis: image_url|image_base64, mathpix_app_id, mathpix_app_key",
+        "workflow_id": "6bWwcWZqx0tirOFk",
+        "input_schema": {
+          "required": [
+            "image_url|image_base64",
+            "mathpix_app_id",
+            "mathpix_app_key"
+          ],
+          "optional": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur pour tracabilite"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete originale de l'utilisateur"
+            },
+            "image_url": {
+              "type": "string",
+              "description": "URL de l'image avec equations"
+            },
+            "image_base64": {
+              "type": "string",
+              "description": "Image encodee en base64"
+            },
+            "mathpix_app_id": {
+              "type": "string",
+              "description": "Mathpix App ID"
+            },
+            "mathpix_app_key": {
+              "type": "string",
+              "description": "Mathpix App Key"
+            },
+            "formats": {
+              "type": "array",
+              "description": "Formats de sortie",
+              "default": [
+                "latex_styled",
+                "text",
+                "data"
+              ]
+            },
+            "include_asciimath": {
+              "type": "boolean",
+              "default": true
+            },
+            "include_latex": {
+              "type": "boolean",
+              "default": true
+            },
+            "include_mathml": {
+              "type": "boolean",
+              "default": false
+            },
+            "include_svg": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        },
+        "documentation": "## MCP - Mathpix\n\n**Endpoint:** POST /webhook/mathpix\n\n**Description:** OCR mathematique via Mathpix API. Convertit images de formules/equations en LaTeX, MathML, AsciiMath.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"image_url|image_base64\", \"mathpix_app_id\", \"mathpix_app_key\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur pour tracabilite\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete originale de l'utilisateur\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image avec equations\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Image encodee en base64\" },\n    \"mathpix_app_id\": { \"type\": \"string\", \"description\": \"Mathpix App ID\" },\n    \"mathpix_app_key\": { \"type\": \"string\", \"description\": \"Mathpix App Key\" },\n    \"formats\": { \"type\": \"array\", \"description\": \"Formats de sortie\", \"default\": [\"latex_styled\", \"text\", \"data\"] },\n    \"include_asciimath\": { \"type\": \"boolean\", \"default\": true },\n    \"include_latex\": { \"type\": \"boolean\", \"default\": true },\n    \"include_mathml\": { \"type\": \"boolean\", \"default\": false },\n    \"include_svg\": { \"type\": \"boolean\", \"default\": false }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": true,\n  \"output_fields\": [\"latex\", \"text\", \"confidence\", \"asciimath\", \"mathml\"],\n  \"domain\": \"math_ocr\"\n}\n```"
       },
       {
         "name": "MCP - Metadata Extractor",
@@ -737,8 +1724,9 @@
         "full_url": "http://pi6.local:5678/webhook/metadata-extractor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Metadata Extractor",
-        "workflow_id": "4J4bZ6JpPDkvD87t"
+        "description": "Extraction de données",
+        "workflow_id": "4J4bZ6JpPDkvD87t",
+        "documentation": "## MCP - Metadata Extractor\n\n**Endpoint:** POST /webhook/metadata-extractor\n\n**Parameters:**\n- `data` (required): URL or HTML content\n- `source` (optional): url | html (default: url)\n- `options.include_json_ld` (optional): boolean (default: true)\n- `options.include_twitter` (optional): boolean (default: true)\n- `options.include_opengraph` (optional): boolean (default: true)\n- `options.include_standard` (optional): boolean (default: true)\n- `options.fetch_favicon` (optional): boolean (default: true)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Normalized metadata with OG, Twitter, JSON-LD, standard meta tags\n\n**Priority:** OpenGraph > Twitter Cards > JSON-LD > Standard Meta\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"metadata\", \"extracted_fields\"],\n  \"domain\": \"extraction\"\n}\n```"
       },
       {
         "name": "MCP - Microsoft Learn",
@@ -746,8 +1734,9 @@
         "full_url": "http://pi6.local:5678/webhook/microsoft-learn",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Microsoft Learn",
-        "workflow_id": "HhSr04SPXwMHmJVa"
+        "description": "Workflow: MCP   Microsoft Learn",
+        "workflow_id": "HhSr04SPXwMHmJVa",
+        "documentation": "## MCP - Microsoft Learn\n\n**Endpoint:** POST /webhook/microsoft-learn\n\n### Protocol\nUtilise MCP (Model Context Protocol) avec Streamable HTTP:\n1. Initialize session\n2. Send initialized notification\n3. Call tool\n4. Parse SSE response\n\n### Operations\n\n**1. search** - Recherche documentation\n```json\n{\n  \"operation\": \"search\",\n  \"query\": \"Azure Functions tutorial\",\n  \"product\": \"azure\",\n  \"max_results\": 5\n}\n```\n\n**2. fetch** - Récupère article complet\n```json\n{\n  \"operation\": \"fetch\",\n  \"url\": \"https://learn.microsoft.com/...\"\n}\n```\n\n**3. code_samples** - Exemples de code\n```json\n{\n  \"operation\": \"code_samples\",\n  \"query\": \"blob storage upload\",\n  \"language\": \"python\"\n}\n```\n\n### MCP Server\n- **URL:** https://learn.microsoft.com/api/mcp\n- **Protocol:** JSON-RPC 2.0 / Streamable HTTP\n- **Version:** 2025-03-26\n- **Auth:** Aucune\n\n### Tools disponibles\n- `microsoft_docs_search`\n- `microsoft_docs_fetch`\n- `microsoft_code_sample_search`"
       },
       {
         "name": "MCP - News Searcher",
@@ -755,8 +1744,9 @@
         "full_url": "http://pi6.local:5678/webhook/news-searcher",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - News Searcher",
-        "workflow_id": "1UDizjOfHcBbPPRP"
+        "description": "Recherche d'informations",
+        "workflow_id": "1UDizjOfHcBbPPRP",
+        "documentation": "## MCP - News Searcher (GNews)\n\n**Endpoint:** POST /webhook/news-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `gnews_api_key` (required): GNews API key\n- `options.language` (optional): fr | en | de | es... (default: fr)\n- `options.country` (optional): fr | us | gb... (default: fr)\n- `options.max_results` (optional): 1-100 (default: 10)\n- `options.from_date` (optional): ISO date (YYYY-MM-DD)\n- `options.to_date` (optional): ISO date (YYYY-MM-DD)\n- `options.sort_by` (optional): publishedAt | relevance (default: publishedAt)\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of news articles with title, description, content, source\n\n**Note:** GNews free tier: 100 requests/day"
       },
       {
         "name": "MCP - OAuth Delete",
@@ -764,8 +1754,9 @@
         "full_url": "http://pi6.local:5678/webhook/oauth-delete",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - OAuth Delete",
-        "workflow_id": "HCc6BAPTkaDGK3Gk"
+        "description": "Supprime une ressource",
+        "workflow_id": "HCc6BAPTkaDGK3Gk",
+        "documentation": "## MCP - OAuth Delete\n\n**Endpoint:** POST /webhook/oauth-delete\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"provider\": \"lichess\"\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Token OAuth lichess supprime\",\n  \"provider\": \"lichess\",\n  \"user_id\": \"discord_123456\"\n}\n```\n\n### Usage\nSupprime le token OAuth pour un provider\nspecifique. Utilise pour:\n- Deconnexion de Lichess\n- Revocation d'acces\n- Nettoyage de tokens expires\n\n### Providers supportes\n- `lichess`\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - OAuth Get",
@@ -773,8 +1764,9 @@
         "full_url": "http://pi6.local:5678/webhook/oauth-get",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - OAuth Get",
-        "workflow_id": "tOKoU7jRfSZhCNRP"
+        "description": "Récupère des données",
+        "workflow_id": "tOKoU7jRfSZhCNRP",
+        "documentation": "## MCP - OAuth Get\n\n**Endpoint:** POST /webhook/oauth-get\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"provider\": \"lichess\"\n}\n```\n\n### Output (token existe)\n```json\n{\n  \"success\": true,\n  \"has_token\": true,\n  \"provider\": \"lichess\",\n  \"access_token\": \"lip_xxxx\",\n  \"refresh_token\": \"lrt_xxxx\",\n  \"expires_at\": \"2026-04-12T14:00:00+00:00\",\n  \"is_expired\": false,\n  \"scope\": \"challenge:read challenge:write\",\n  \"provider_user_id\": \"DrNykterstein\"\n}\n```\n\n### Output (pas de token)\n```json\n{\n  \"success\": true,\n  \"has_token\": false,\n  \"provider\": \"lichess\",\n  \"message\": \"Aucun token OAuth...\"\n}\n```\n\n### Securite\nLes tokens sont dechiffres a la volee\n(AES-256-GCM cote backend).\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - PDF Extractor",
@@ -782,8 +1774,9 @@
         "full_url": "http://pi6.local:5678/webhook/pdf-extractor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - PDF Extractor",
-        "workflow_id": "Dfhnt08MMd8yWbTZ"
+        "description": "Extraction de données",
+        "workflow_id": "Dfhnt08MMd8yWbTZ",
+        "documentation": "## MCP - PDF Extractor\n\n**Endpoint:** POST /webhook/pdf-extractor\n\n**Parameters:**\n- `pdf_url` (string): URL of PDF to extract\n- OR upload binary PDF file\n- `execution_mode` (optional): online | offline\n\n**Returns:** Extracted text, page count, and metadata\n\n**Analyzable:**\n```json\n{\"accepts_image\": false, \"accepts_media\": false, \"output_fields\": [\"text\", \"pages\", \"metadata\"], \"domain\": \"documents\"}\n```"
       },
       {
         "name": "MCP - PDF Layout Translator",
@@ -791,8 +1784,75 @@
         "full_url": "http://pi6.local:5678/webhook/pdf-layout-translator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - PDF Layout Translator",
-        "workflow_id": "fQgtLkQ8yFdTVjOC"
+        "description": "Paramètres: file_url, file_base64, file_type, mistral_api_key, api_key | Requis: file_url|file_base64, mistral_api_key, api_key, openai_api_key",
+        "workflow_id": "fQgtLkQ8yFdTVjOC",
+        "input_schema": {
+          "required": [
+            "file_url|file_base64",
+            "mistral_api_key",
+            "api_key",
+            "openai_api_key"
+          ],
+          "optional": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "target_language",
+            "source_language",
+            "callback_url"
+          ],
+          "properties": {
+            "file_url": {
+              "type": "string",
+              "description": "URL of PDF to process"
+            },
+            "file_base64": {
+              "type": "string",
+              "description": "Base64 encoded PDF"
+            },
+            "file_type": {
+              "type": "string",
+              "default": "pdf"
+            },
+            "mistral_api_key": {
+              "type": "string",
+              "description": "Mistral API key for Pixtral OCR"
+            },
+            "api_key": {
+              "type": "string",
+              "description": "Anthropic API key for translation"
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "OpenAI API key for verification"
+            },
+            "target_language": {
+              "type": "string",
+              "default": "fr"
+            },
+            "source_language": {
+              "type": "string",
+              "default": "auto"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID for tracing"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID for tracing"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Original user request"
+            },
+            "callback_url": {
+              "type": "string",
+              "description": "URL to send result"
+            }
+          }
+        },
+        "documentation": "## MCP - PDF Layout Translator\n\n**Endpoint:** POST /webhook/pdf-layout-translator\n\n**Pattern:** Async avec job_id\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"file_url|file_base64\", \"mistral_api_key\", \"api_key\", \"openai_api_key\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\", \"target_language\", \"source_language\", \"callback_url\"],\n  \"properties\": {\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL of PDF to process\" },\n    \"file_base64\": { \"type\": \"string\", \"description\": \"Base64 encoded PDF\" },\n    \"file_type\": { \"type\": \"string\", \"default\": \"pdf\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key for Pixtral OCR\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"Anthropic API key for translation\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"OpenAI API key for verification\" },\n    \"target_language\": { \"type\": \"string\", \"default\": \"fr\" },\n    \"source_language\": { \"type\": \"string\", \"default\": \"auto\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Original user request\" },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL to send result\" }\n  }\n}\n```\n\n**RFC-014 Support:**\n- Accepts both root-level and context.* fields\n- Returns immediate ACK with job_id, result via callback\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": true,\n  \"output_fields\": [\"job_id\", \"success\", \"status\", \"_trace\"],\n  \"domain\": \"document-processing\"\n}\n```"
       },
       {
         "name": "MCP - PDF OCR",
@@ -800,8 +1860,61 @@
         "full_url": "http://pi6.local:5678/webhook/pdf-ocr",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Extraction de texte depuis PDF/images via OCR multi-providers",
-        "workflow_id": "16KwTyckYgt0cITG"
+        "description": "Extraction de texte depuis PDF/images via OCR multi-providers | Requis: user_id, guild_id, user_request",
+        "workflow_id": "16KwTyckYgt0cITG",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (crédits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requête utilisateur originale"
+            },
+            "file_url": {
+              "type": "string",
+              "description": "URL du fichier (HTTP ou gs://)"
+            },
+            "file_data": {
+              "type": "string",
+              "description": "Contenu base64 du fichier"
+            },
+            "provider": {
+              "type": "string",
+              "enum": [
+                "mistral",
+                "google",
+                "mathpix"
+              ],
+              "default": "mistral",
+              "description": "Provider OCR"
+            },
+            "include_images": {
+              "type": "boolean",
+              "default": false,
+              "description": "Inclure les images extraites"
+            },
+            "callback_url": {
+              "type": "string",
+              "description": "URL callback async (RFC-040)"
+            },
+            "job_id": {
+              "type": "string",
+              "description": "ID job personnalisé"
+            }
+          }
+        },
+        "documentation": "## MCP - PDF OCR (Multi-Provider)\n\n**Endpoint:** POST /webhook/pdf-ocr\n\n**Description:** Extraction de texte depuis PDF/images via OCR multi-providers\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (crédits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requête utilisateur originale\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du fichier (HTTP ou gs://)\" },\n    \"file_data\": { \"type\": \"string\", \"description\": \"Contenu base64 du fichier\" },\n    \"provider\": { \"type\": \"string\", \"enum\": [\"mistral\", \"google\", \"mathpix\"], \"default\": \"mistral\", \"description\": \"Provider OCR\" },\n    \"include_images\": { \"type\": \"boolean\", \"default\": false, \"description\": \"Inclure les images extraites\" },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL callback async (RFC-040)\" },\n    \"job_id\": { \"type\": \"string\", \"description\": \"ID job personnalisé\" }\n  }\n}\n```\n\n**Note:** file_url OU file_data requis (au moins un des deux). API keys fournies par le système.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"text\", \"pages\", \"provider\", \"confidence\"],\n  \"domain\": \"documents\"\n}\n```"
       },
       {
         "name": "MCP - Progress Delete",
@@ -809,8 +1922,9 @@
         "full_url": "http://pi6.local:5678/webhook/progress-delete",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Progress Delete",
-        "workflow_id": "f2Wo2r5J4pRu8MmE"
+        "description": "Supprime une ressource",
+        "workflow_id": "f2Wo2r5J4pRu8MmE",
+        "documentation": "## MCP - Progress Delete (GDPR)\n\n**Endpoint:** POST /webhook/progress-delete\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"confirm\": true\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"message\": \"Toutes les donnees...\",\n  \"deleted\": {\n    \"user_progress\": { \"deleted\": true },\n    \"user_games\": 5,\n    \"user_oauth_tokens\": 1\n  }\n}\n```\n\n### Suppression cascade\n- `user_progress` (progression, badges, lecons)\n- `user_games` (parties jouees)\n- `user_oauth_tokens` (tokens Lichess)\n\n### Securite\n- Requiert `confirm: true` explicite\n- Action irreversible\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Progress Get",
@@ -818,8 +1932,9 @@
         "full_url": "http://pi6.local:5678/webhook/progress-get",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Progress Get",
-        "workflow_id": "KBqSLU1y1QoOmgzu"
+        "description": "Récupère des données",
+        "workflow_id": "KBqSLU1y1QoOmgzu",
+        "documentation": "## MCP - Progress Get\n\n**Endpoint:** POST /webhook/progress-get\n\n### Input\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"domain\": \"chess\" | \"cooking\" | null,\n  \"include\": [\"stats\", \"lessons\", \"badges\", \"lichess_elo\"]\n}\n```\n\n### Output\n```json\n{\n  \"success\": true,\n  \"stats\": {...},\n  \"lessons\": [...],\n  \"badges\": [...],\n  \"lichess\": { \"connected\": true, \"profile\": {...} }\n}\n```\n\n### Sources\n- Backend API: `/api/n8n/progress`\n- Lichess API: profile, elo history (si connecté et demandé)\n\n### RFC-039 compliant"
       },
       {
         "name": "MCP - Progress Update",
@@ -827,8 +1942,9 @@
         "full_url": "http://pi6.local:5678/webhook/progress-update",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Progress Update",
-        "workflow_id": "Oxw0je45OOKk11uK"
+        "description": "Met à jour une ressource",
+        "workflow_id": "Oxw0je45OOKk11uK",
+        "documentation": "## MCP - Progress Update\n\n**Endpoint:** POST /webhook/progress-update\n\n### Operations (RFC-039 compliant)\n\n**1. session** - Incrémenter sessions\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"operation\": \"session\",\n  \"data\": {}\n}\n```\n\n**2. add_lesson** - Ajouter leçon\n```json\n{\n  \"tenant_id\": \"chess_plugin\",\n  \"user_id\": \"discord_123456\",\n  \"operation\": \"add_lesson\",\n  \"data\": {\n    \"lesson_id\": \"endgame_101\",\n    \"domain\": \"chess\",\n    \"score\": 85,\n    \"duration_minutes\": 12\n  }\n}\n```\n\n**3. award_badge**\n```json\n{\n  \"operation\": \"award_badge\",\n  \"data\": {\n    \"badge_id\": \"first_win\",\n    \"domain\": \"chess\",\n    \"metadata\": { \"opponent\": \"bot_easy\" }\n  }\n}\n```\n\n**4. preferences**\n```json\n{\n  \"operation\": \"preferences\",\n  \"data\": {\n    \"difficulty_level\": \"intermediate\",\n    \"notifications\": true\n  }\n}\n```\n\n**5. link_lichess**\n```json\n{\n  \"operation\": \"link_lichess\",\n  \"data\": { \"lichess_username\": \"player123\" }\n}\n```"
       },
       {
         "name": "MCP - Qdrant - Search",
@@ -836,8 +1952,65 @@
         "full_url": "http://pi6.local:5678/webhook/qdrant-search",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Recherche semantique dans Qdrant avec embeddings OpenAI.",
-        "workflow_id": "taiQS0dy0t2wcbr1"
+        "description": "Recherche semantique dans Qdrant avec embeddings OpenAI. | Requis: query, entity_type, qdrant_host, qdrant_port, qdrant_collection",
+        "workflow_id": "taiQS0dy0t2wcbr1",
+        "input_schema": {
+          "required": [
+            "query",
+            "entity_type",
+            "qdrant_host",
+            "qdrant_port",
+            "qdrant_collection",
+            "openai_api_key"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord (tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale (tracing)"
+            },
+            "query": {
+              "type": "string",
+              "description": "Requete de recherche"
+            },
+            "entity_type": {
+              "type": "string",
+              "description": "Type d'entite a rechercher"
+            },
+            "limit": {
+              "type": "integer",
+              "description": "Max resultats (default: 10)"
+            },
+            "filters": {
+              "type": "object",
+              "description": "Filtres optionnels"
+            },
+            "qdrant_host": {
+              "type": "string",
+              "description": "Host Qdrant"
+            },
+            "qdrant_port": {
+              "type": "integer",
+              "description": "Port Qdrant"
+            },
+            "qdrant_collection": {
+              "type": "string",
+              "description": "Nom collection"
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "Cle API OpenAI"
+            }
+          }
+        },
+        "documentation": "## MCP - Qdrant - Search\n\n**Endpoint:** POST /webhook/qdrant-search\n\n**Description:** Recherche semantique dans Qdrant avec embeddings OpenAI.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"query\", \"entity_type\", \"qdrant_host\", \"qdrant_port\", \"qdrant_collection\", \"openai_api_key\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"query\": { \"type\": \"string\", \"description\": \"Requete de recherche\" },\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type d'entite a rechercher\" },\n    \"limit\": { \"type\": \"integer\", \"description\": \"Max resultats (default: 10)\" },\n    \"filters\": { \"type\": \"object\", \"description\": \"Filtres optionnels\" },\n    \"qdrant_host\": { \"type\": \"string\", \"description\": \"Host Qdrant\" },\n    \"qdrant_port\": { \"type\": \"integer\", \"description\": \"Port Qdrant\" },\n    \"qdrant_collection\": { \"type\": \"string\", \"description\": \"Nom collection\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"Cle API OpenAI\" }\n  }\n}\n```\n\n**Note:** user_id, guild_id, user_request sont OPTIONNELS (tracing uniquement).\n\n**Returns:**\n- `results`: Array de resultats avec score\n- `total`: Nombre total de resultats\n- `query`: Requete originale\n- `_trace`: Informations de tracabilite\n\n**Model:** text-embedding-3-small"
       },
       {
         "name": "MCP - Quiz Generator",
@@ -845,8 +2018,80 @@
         "full_url": "http://pi6.local:5678/webhook/quiz-generator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Genere des quiz educatifs a partir de texte, sujet ou URL.",
-        "workflow_id": "SUlOgPqXDRlXPkpN"
+        "description": "Genere des quiz educatifs a partir de texte, sujet ou URL. | Requis: user_id, guild_id, user_request, data",
+        "workflow_id": "SUlOgPqXDRlXPkpN",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "data"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "data": {
+              "type": "string",
+              "description": "Texte, sujet ou URL pour generer le quiz"
+            },
+            "source": {
+              "type": "string",
+              "enum": [
+                "text",
+                "topic",
+                "url"
+              ],
+              "default": "text"
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "num_questions": {
+                  "type": "integer",
+                  "default": 10
+                },
+                "question_types": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "multiple_choice",
+                    "true_false"
+                  ]
+                },
+                "difficulty": {
+                  "type": "string",
+                  "enum": [
+                    "easy",
+                    "medium",
+                    "hard"
+                  ],
+                  "default": "medium"
+                },
+                "language": {
+                  "type": "string",
+                  "default": "fr"
+                },
+                "include_explanations": {
+                  "type": "boolean",
+                  "default": true
+                }
+              }
+            }
+          }
+        },
+        "documentation": "## MCP - Quiz Generator\n\n**Endpoint:** POST /webhook/quiz-generator\n\n**Description:** Genere des quiz educatifs a partir de texte, sujet ou URL.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"data\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"data\": { \"type\": \"string\", \"description\": \"Texte, sujet ou URL pour generer le quiz\" },\n    \"source\": { \"type\": \"string\", \"enum\": [\"text\", \"topic\", \"url\"], \"default\": \"text\" },\n    \"options\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"num_questions\": { \"type\": \"integer\", \"default\": 10 },\n        \"question_types\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"default\": [\"multiple_choice\", \"true_false\"] },\n        \"difficulty\": { \"type\": \"string\", \"enum\": [\"easy\", \"medium\", \"hard\"], \"default\": \"medium\" },\n        \"language\": { \"type\": \"string\", \"default\": \"fr\" },\n        \"include_explanations\": { \"type\": \"boolean\", \"default\": true }\n      }\n    }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"quiz\", \"questions\", \"metadata\"],\n  \"domain\": \"education\"\n}\n```"
       },
       {
         "name": "MCP - Registry",
@@ -854,7 +2099,7 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-registry",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Registry",
+        "description": "Liste des webhooks disponibles avec métadonnées",
         "workflow_id": "UKqO3AKOwkVmfd98"
       },
       {
@@ -863,8 +2108,42 @@
         "full_url": "http://pi6.local:5678/webhook/script-detector",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Script Detector",
-        "workflow_id": "fSLm5HfKsXHpPKTf"
+        "description": "Paramètres: user_id, guild_id, user_request, text, image_url",
+        "workflow_id": "fSLm5HfKsXHpPKTf",
+        "input_schema": {
+          "required": [],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "text": {
+              "type": "string",
+              "description": "Texte a analyser (mode gratuit Unicode)"
+            },
+            "image_url": {
+              "type": "string",
+              "description": "URL de l'image a analyser"
+            },
+            "image_base64": {
+              "type": "string",
+              "description": "Image en base64 (alternative a image_url)"
+            },
+            "file_url": {
+              "type": "string",
+              "description": "URL du fichier (PDF ou image)"
+            }
+          }
+        },
+        "documentation": "## MCP - Script Detector\n\n**Endpoint:** POST /webhook/script-detector\n\n**Purpose:** Detect writing script (hebrew, arabic, latin, etc.) from text, images, or PDFs.\n\n**InputSchema:**\n```json\n{\n  \"required\": [],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte a analyser (mode gratuit Unicode)\" },\n    \"image_url\": { \"type\": \"string\", \"description\": \"URL de l'image a analyser\" },\n    \"image_base64\": { \"type\": \"string\", \"description\": \"Image en base64 (alternative a image_url)\" },\n    \"file_url\": { \"type\": \"string\", \"description\": \"URL du fichier (PDF ou image)\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme via openai_api_key.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": true,\n  \"output_fields\": [\"primary_script\", \"scripts\", \"is_rtl\", \"recommended_providers\"],\n  \"domain\": \"script_detection\"\n}\n```\n\n---\n\n### Mode 1: Text (GRATUIT - analyse Unicode)\n```json\n{ \"text\": \"שלום עולם Hello\" }\n```\n\n### Mode 2: Image (OpenAI Vision)\n```json\n{\n  \"image_url\": \"https://...\",\n  \"openai_api_key\": \"sk-...\"\n}\n```\n\n### Mode 3: PDF (Vision sur page 1)\n```json\n{\n  \"file_url\": \"https://...document.pdf\",\n  \"openai_api_key\": \"sk-...\"\n}\n```\n\n**Scripts:** hebrew, arabic, latin, cyrillic, greek, han, hiragana, katakana, hangul, thai, devanagari, tamil, etc."
       },
       {
         "name": "MCP - Speaker Identifier",
@@ -872,8 +2151,53 @@
         "full_url": "http://pi6.local:5678/webhook/speaker-identifier",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Speaker Identifier",
-        "workflow_id": "Fqu6TOSpP5onWyy8"
+        "description": "Paramètres: data, assemblyai_api_key, source, options.speakers_expected, options.language | Requis: data, assemblyai_api_key",
+        "workflow_id": "Fqu6TOSpP5onWyy8",
+        "input_schema": {
+          "required": [
+            "data",
+            "assemblyai_api_key"
+          ],
+          "properties": {
+            "data": {
+              "type": "string",
+              "description": "Audio URL or base64 encoded audio"
+            },
+            "assemblyai_api_key": {
+              "type": "string",
+              "description": "AssemblyAI API key"
+            },
+            "source": {
+              "type": "string",
+              "description": "'url' or 'base64' (default: url)"
+            },
+            "options.speakers_expected": {
+              "type": "number",
+              "description": "Number of expected speakers"
+            },
+            "options.language": {
+              "type": "string",
+              "description": "Language code or 'auto'"
+            },
+            "options.include_transcription": {
+              "type": "boolean",
+              "description": "Include full transcript (default: true)"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID (optional, for tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID (optional, for tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request (optional, for tracing)"
+            }
+          }
+        },
+        "documentation": "## MCP - Speaker Identifier\n\n**Endpoint:** POST /webhook/speaker-identifier\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"data\", \"assemblyai_api_key\"],\n  \"properties\": {\n    \"data\": { \"type\": \"string\", \"description\": \"Audio URL or base64 encoded audio\" },\n    \"assemblyai_api_key\": { \"type\": \"string\", \"description\": \"AssemblyAI API key\" },\n    \"source\": { \"type\": \"string\", \"description\": \"'url' or 'base64' (default: url)\" },\n    \"options.speakers_expected\": { \"type\": \"number\", \"description\": \"Number of expected speakers\" },\n    \"options.language\": { \"type\": \"string\", \"description\": \"Language code or 'auto'\" },\n    \"options.include_transcription\": { \"type\": \"boolean\", \"description\": \"Include full transcript (default: true)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"data\": \"https://...\",\n    \"source\": \"url\"\n  },\n  \"plugin_context\": {\n    \"api_keys\": { \"assemblyai\": \"...\" }\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { \"speakers\": [...], \"utterances\": [...] },\n  \"meta\": { \"provider\": \"assemblyai\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** AssemblyAI Speaker Diarization"
       },
       {
         "name": "MCP - Summarizer",
@@ -881,8 +2205,48 @@
         "full_url": "http://pi6.local:5678/webhook/summarizer",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Summarizes text using Anthropic Claude.",
-        "workflow_id": "NNmOnCc2mdXGZPfL"
+        "description": "Summarizes text using Anthropic Claude. | Requis: text",
+        "workflow_id": "NNmOnCc2mdXGZPfL",
+        "input_schema": {
+          "required": [
+            "text"
+          ],
+          "properties": {
+            "text": {
+              "type": "string",
+              "description": "Text to summarize (required)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request context for personalized summary"
+            },
+            "style": {
+              "type": "string",
+              "description": "Summary style: brief, detailed, bullet-points"
+            },
+            "max_length": {
+              "type": "integer",
+              "description": "Target word count"
+            },
+            "language": {
+              "type": "string",
+              "description": "Output language"
+            },
+            "max_tokens": {
+              "type": "integer",
+              "description": "Max output tokens (default: 1024)"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID for tracing"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID for tracing"
+            }
+          }
+        },
+        "documentation": "## MCP - Summarizer\n\n**Endpoint:** POST /webhook/summarizer\n\n**Description:** Summarizes text using Anthropic Claude.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\"],\n  \"properties\": {\n    \"text\": { \"type\": \"string\", \"description\": \"Text to summarize (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized summary\" },\n    \"style\": { \"type\": \"string\", \"description\": \"Summary style: brief, detailed, bullet-points\" },\n    \"max_length\": { \"type\": \"integer\", \"description\": \"Target word count\" },\n    \"language\": { \"type\": \"string\", \"description\": \"Output language\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 1024)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"summary\", \"original_length\", \"summary_length\", \"compression_ratio\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - Syllabus Generator",
@@ -890,8 +2254,74 @@
         "full_url": "http://pi6.local:5678/webhook/syllabus-generator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Genere des syllabus educatifs complets avec modules, lecons, objectifs et evaluations.",
-        "workflow_id": "gUxqJkQubu3NGPOB"
+        "description": "Genere des syllabus educatifs complets avec modules, lecons, objectifs et evaluations. | Requis: user_id, guild_id, user_request, topic",
+        "workflow_id": "gUxqJkQubu3NGPOB",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "topic"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "topic": {
+              "type": "string",
+              "description": "Sujet/theme du cours"
+            },
+            "context": {
+              "type": "string",
+              "description": "Contexte supplementaire"
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "level": {
+                  "type": "string",
+                  "enum": [
+                    "debutant",
+                    "intermediaire",
+                    "avance"
+                  ],
+                  "default": "intermediaire"
+                },
+                "duration_weeks": {
+                  "type": "integer",
+                  "default": 8
+                },
+                "hours_per_week": {
+                  "type": "integer",
+                  "default": 4
+                },
+                "language": {
+                  "type": "string",
+                  "default": "fr"
+                },
+                "format": {
+                  "type": "string",
+                  "enum": [
+                    "theorique",
+                    "pratique",
+                    "hybride"
+                  ],
+                  "default": "hybride"
+                }
+              }
+            }
+          }
+        },
+        "documentation": "## MCP - Syllabus Generator\n\n**Endpoint:** POST /webhook/syllabus-generator\n\n**Description:** Genere des syllabus educatifs complets avec modules, lecons, objectifs et evaluations.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"topic\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"topic\": { \"type\": \"string\", \"description\": \"Sujet/theme du cours\" },\n    \"context\": { \"type\": \"string\", \"description\": \"Contexte supplementaire\" },\n    \"options\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"level\": { \"type\": \"string\", \"enum\": [\"debutant\", \"intermediaire\", \"avance\"], \"default\": \"intermediaire\" },\n        \"duration_weeks\": { \"type\": \"integer\", \"default\": 8 },\n        \"hours_per_week\": { \"type\": \"integer\", \"default\": 4 },\n        \"language\": { \"type\": \"string\", \"default\": \"fr\" },\n        \"format\": { \"type\": \"string\", \"enum\": [\"theorique\", \"pratique\", \"hybride\"], \"default\": \"hybride\" }\n      }\n    }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"syllabus\", \"modules\", \"lessons\", \"metadata\"],\n  \"domain\": \"education\"\n}\n```"
       },
       {
         "name": "MCP - Table Extractor",
@@ -899,8 +2329,9 @@
         "full_url": "http://pi6.local:5678/webhook/table-extractor",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Table Extractor",
-        "workflow_id": "bOIWHh5jRZPvGWp3"
+        "description": "Extraction de données",
+        "workflow_id": "bOIWHh5jRZPvGWp3",
+        "documentation": "## MCP - Table Extractor (Mistral OCR)\n\n**Endpoint:** POST /webhook/table-extractor\n\n**Parameters:**\n- `data` (required): Image URL or base64 data\n- `source` (optional): url | base64 (default: url)\n- `mistral_api_key` (required): Mistral API key\n- `options.output_format` (optional): json | markdown | csv (default: json)\n- `options.detect_headers` (optional): boolean (default: true)\n- `options.merge_cells` (optional): boolean (default: true)\n- `options.confidence_threshold` (optional): 0-1 (default: 0.8)\n- `execution_mode` (optional): online | offline\n\n**Async Mode (RFC-040):**\n- `callback_url` (optional): URL to POST results when processing completes\n- `job_id` (optional): Custom job ID (auto-generated if not provided)\n\nWhen `callback_url` is provided:\n- Returns immediately with 202 Accepted: `{success: true, job_id, status: \"processing\"}`\n- POSTs result to callback_url with HMAC signature header `X-N8N-Signature`\n\n**Returns:** Extracted tables with headers, rows, confidence scores\n\n**Model:** pixtral-12b-2409 (Mistral Vision)\n\n**Analyzable:**\n```json\n{\"accepts_image\": true, \"accepts_media\": false, \"output_fields\": [\"tables\", \"rows\", \"columns\", \"confidence\"], \"domain\": \"documents\"}\n```"
       },
       {
         "name": "MCP - Tenant - Resolve",
@@ -909,7 +2340,15 @@
         "method": "POST",
         "category": "MCP Tools",
         "description": "Resolves Discord guild_id to tenant_id + package + models (RFC-079).",
-        "workflow_id": "TJtH1UwOO6x9D2xi"
+        "workflow_id": "TJtH1UwOO6x9D2xi",
+        "input_schema": {
+          "action": "resolve",
+          "user_id": "string (optionnel)",
+          "guild_id": "string (requis)",
+          "backend_api_url": "string",
+          "backend_service_token": "string"
+        },
+        "documentation": "## MCP - Tenant - Resolve v2.0\n\n**Endpoint:** POST /webhook/tenant-resolve\n\n**Description:** Resolves Discord guild_id to tenant_id + package + models (RFC-079).\n\n**InputSchema:**\n```json\n{\n  \"action\": \"resolve\",\n  \"user_id\": \"string (optionnel)\",\n  \"guild_id\": \"string (requis)\",\n  \"backend_api_url\": \"string\",\n  \"backend_service_token\": \"string\"\n}\n```\n\n**Returns (RFC-079):**\n```json\n{\n  \"data\": {\n    \"tenant_id\": \"Z6F3GSWB\",\n    \"package\": {\n      \"code\": \"mid-complet\",\n      \"source\": \"discord_guild_default\",\n      \"models\": {\n        \"chat\": \"claude-sonnet-4-5\",\n        \"chat_mini\": \"claude-haiku-4-5\",\n        \"embedding\": \"text-embedding-3-large\",\n        \"vision\": null,\n        \"voice\": null,\n        \"reasoning\": null\n      }\n    }\n  }\n}\n```\n\n**RFC:** RFC-079 Tenant Package Configuration"
       },
       {
         "name": "MCP - Test - Echo",
@@ -917,7 +2356,7 @@
         "full_url": "http://pi6.local:5678/webhook/mcp-test-echo",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Test - Echo",
+        "description": "Workflow: MCP   Test   Echo",
         "workflow_id": "OqrQ7uxgS1VmbYaz"
       },
       {
@@ -926,8 +2365,9 @@
         "full_url": "http://pi6.local:5678/webhook/text-classifier",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Text Classifier",
-        "workflow_id": "xzpEplx1Lwll95pE"
+        "description": "Workflow: MCP   Text Classifier",
+        "workflow_id": "xzpEplx1Lwll95pE",
+        "documentation": "## MCP - Text Classifier\n\n**Endpoint:** POST /webhook/text-classifier\n\n**Parameters:**\n- `text` (required): Text to classify\n- `categories` (required): Array of category labels\n- `multi_label` (optional): true for multi-label classification (default: false)\n- `execution_mode` (optional): online | offline\n\n**Returns:** Classification result with category/confidence scores\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"category\", \"confidence\", \"scores\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - Text Embedder",
@@ -935,8 +2375,50 @@
         "full_url": "http://pi6.local:5678/webhook/text-embedder",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Genere des embeddings de texte via l'API OpenAI pour une utilisation en RAG, recherche semantique, etc.",
-        "workflow_id": "GMkO8Y7N6N5bgy1Q"
+        "description": "Genere des embeddings de texte via l'API OpenAI pour une utilisation en RAG, recherche semantique, etc. | Requis: text, openai_api_key",
+        "workflow_id": "GMkO8Y7N6N5bgy1Q",
+        "input_schema": {
+          "required": [
+            "text",
+            "openai_api_key"
+          ],
+          "optional": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord (tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale (tracing)"
+            },
+            "text": {
+              "type": "string|array",
+              "description": "Texte(s) a encoder"
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "Cle API OpenAI"
+            },
+            "model": {
+              "type": "string",
+              "description": "Modele (default: text-embedding-3-small)"
+            },
+            "dimensions": {
+              "type": "integer",
+              "description": "Dimensions output (default: 1536)"
+            }
+          }
+        },
+        "documentation": "## MCP - Text Embedder\n\n**Endpoint:** POST /webhook/text-embedder\n\n**Description:** Genere des embeddings de texte via l'API OpenAI pour une utilisation en RAG, recherche semantique, etc.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\", \"openai_api_key\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"text\": { \"type\": \"string|array\", \"description\": \"Texte(s) a encoder\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"Cle API OpenAI\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Modele (default: text-embedding-3-small)\" },\n    \"dimensions\": { \"type\": \"integer\", \"description\": \"Dimensions output (default: 1536)\" }\n  }\n}\n```\n\n**Modeles disponibles:**\n- `text-embedding-3-small` (default) - Rapide, economique\n- `text-embedding-3-large` - Haute qualite\n- `text-embedding-ada-002` - Legacy\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"embeddings\", \"dimensions\", \"count\"],\n  \"domain\": \"embedding\"\n}\n```\n\n**Note:** user_id, guild_id, user_request sont OPTIONNELS (utilises pour le tracing)."
       },
       {
         "name": "MCP - Text Generator",
@@ -944,8 +2426,48 @@
         "full_url": "http://pi6.local:5678/webhook/text-generator",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Generates text using OpenAI GPT models.",
-        "workflow_id": "RipM3vFw09xhPtXR"
+        "description": "Generates text using OpenAI GPT models. | Requis: prompt",
+        "workflow_id": "RipM3vFw09xhPtXR",
+        "input_schema": {
+          "required": [
+            "prompt"
+          ],
+          "properties": {
+            "prompt": {
+              "type": "string",
+              "description": "Text generation prompt (required)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request context for personalized generation"
+            },
+            "system_prompt": {
+              "type": "string",
+              "description": "System instructions for the model"
+            },
+            "model": {
+              "type": "string",
+              "description": "Model: gpt-4o (default), gpt-4o-mini, gpt-4-turbo"
+            },
+            "temperature": {
+              "type": "number",
+              "description": "Temperature 0-2 (default: 0.7)"
+            },
+            "max_tokens": {
+              "type": "integer",
+              "description": "Max output tokens (default: 2048)"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID for tracing"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID for tracing"
+            }
+          }
+        },
+        "documentation": "## MCP - Text Generator\n\n**Endpoint:** POST /webhook/text-generator\n\n**Description:** Generates text using OpenAI GPT models.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"prompt\"],\n  \"properties\": {\n    \"prompt\": { \"type\": \"string\", \"description\": \"Text generation prompt (required)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context for personalized generation\" },\n    \"system_prompt\": { \"type\": \"string\", \"description\": \"System instructions for the model\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Model: gpt-4o (default), gpt-4o-mini, gpt-4-turbo\" },\n    \"temperature\": { \"type\": \"number\", \"description\": \"Temperature 0-2 (default: 0.7)\" },\n    \"max_tokens\": { \"type\": \"integer\", \"description\": \"Max output tokens (default: 2048)\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"text\", \"model\", \"finish_reason\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "MCP - Text to Speech",
@@ -953,8 +2475,75 @@
         "full_url": "http://pi6.local:5678/webhook/text-to-speech",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Convert text to speech audio using OpenAI TTS API.",
-        "workflow_id": "ygMdwJrg8sl5L0pG"
+        "description": "Convert text to speech audio using OpenAI TTS API. | Requis: text",
+        "workflow_id": "ygMdwJrg8sl5L0pG",
+        "input_schema": {
+          "required": [
+            "text"
+          ],
+          "optional": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord (tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale (tracing)"
+            },
+            "text": {
+              "type": "string",
+              "description": "Text to convert to speech (required)"
+            },
+            "voice": {
+              "type": "string",
+              "enum": [
+                "alloy",
+                "echo",
+                "fable",
+                "onyx",
+                "nova",
+                "shimmer"
+              ],
+              "default": "alloy"
+            },
+            "model": {
+              "type": "string",
+              "enum": [
+                "tts-1",
+                "tts-1-hd"
+              ],
+              "default": "tts-1"
+            },
+            "format": {
+              "type": "string",
+              "enum": [
+                "mp3",
+                "opus",
+                "aac",
+                "flac",
+                "wav",
+                "pcm"
+              ],
+              "default": "mp3"
+            },
+            "speed": {
+              "type": "number",
+              "minimum": 0.25,
+              "maximum": 4.0,
+              "default": 1
+            }
+          }
+        },
+        "documentation": "## MCP - Text to Speech\n\n**Endpoint:** POST /webhook/text-to-speech\n\n**Description:** Convert text to speech audio using OpenAI TTS API.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"text\"],\n  \"optional\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale (tracing)\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Text to convert to speech (required)\" },\n    \"voice\": { \"type\": \"string\", \"enum\": [\"alloy\", \"echo\", \"fable\", \"onyx\", \"nova\", \"shimmer\"], \"default\": \"alloy\" },\n    \"model\": { \"type\": \"string\", \"enum\": [\"tts-1\", \"tts-1-hd\"], \"default\": \"tts-1\" },\n    \"format\": { \"type\": \"string\", \"enum\": [\"mp3\", \"opus\", \"aac\", \"flac\", \"wav\", \"pcm\"], \"default\": \"mp3\" },\n    \"speed\": { \"type\": \"number\", \"minimum\": 0.25, \"maximum\": 4.0, \"default\": 1 }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"audio_base64\", \"format\", \"voice\", \"model\"],\n  \"domain\": \"audio\"\n}\n```\n\n**Note:** user_id, guild_id, user_request are OPTIONAL for tracing purposes."
       },
       {
         "name": "MCP - Tokenizer",
@@ -962,8 +2551,39 @@
         "full_url": "http://pi6.local:5678/webhook/tokenizer",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Estime le nombre de tokens pour un texte donne et calcule l'utilisation du contexte pour differents modeles LLM.",
-        "workflow_id": "hKjyL9mPtl8H8N0C"
+        "description": "Estime le nombre de tokens pour un texte donne et calcule l'utilisation du contexte pour differents modeles LLM. | Requis: user_id, guild_id, user_request, text",
+        "workflow_id": "hKjyL9mPtl8H8N0C",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request",
+            "text"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "text": {
+              "type": "string",
+              "description": "Texte a tokenizer"
+            },
+            "model": {
+              "type": "string",
+              "description": "Modele pour limite de contexte (default: gpt-4o)"
+            }
+          }
+        },
+        "documentation": "## MCP - Tokenizer\n\n**Endpoint:** POST /webhook/tokenizer\n\n**Description:** Estime le nombre de tokens pour un texte donne et calcule l'utilisation du contexte pour differents modeles LLM.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\", \"text\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"text\": { \"type\": \"string\", \"description\": \"Texte a tokenizer\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Modele pour limite de contexte (default: gpt-4o)\" }\n  }\n}\n```\n\n**Modeles supportes:**\n- OpenAI: gpt-4o, gpt-4o-mini, gpt-4-turbo, gpt-4, gpt-3.5-turbo\n- Anthropic: claude-3-opus, claude-3-sonnet, claude-3-haiku, claude-3.5-sonnet\n- Mistral: mistral-large, mistral-small\n- Google: gemini-1.5-pro, gemini-1.5-flash\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"estimated_tokens\", \"context_limit\", \"usage_percent\", \"statistics\"],\n  \"domain\": \"utility\"\n}\n```\n\n**Note:** Les comptes de tokens sont des estimations (~5-10% variance)."
       },
       {
         "name": "MCP - Tools - Registry",
@@ -971,7 +2591,7 @@
         "full_url": "http://pi6.local:5678/webhook/mcp/tools/registry",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Tools - Registry",
+        "description": "Liste des webhooks disponibles avec métadonnées",
         "workflow_id": "2QwuEUpkgpipYjyL"
       },
       {
@@ -980,8 +2600,65 @@
         "full_url": "http://pi6.local:5678/webhook/tools-enricher",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Enrichir automatiquement les metadonnees des tools n8n et les indexer dans Qdrant",
-        "workflow_id": "voie2ygi5GLP0HwY"
+        "description": "Enrichir automatiquement les metadonnees des tools n8n et les indexer dans Qdrant | Requis: user_id, guild_id, user_request",
+        "workflow_id": "voie2ygi5GLP0HwY",
+        "input_schema": {
+          "required": [
+            "user_id",
+            "guild_id",
+            "user_request"
+          ],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (credits, quotas)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "mode": {
+              "type": "string",
+              "enum": [
+                "full",
+                "incremental",
+                "specific"
+              ],
+              "default": "full",
+              "description": "Mode d'enrichissement"
+            },
+            "workflow_ids": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Liste d'IDs specifiques (mode specific)"
+            },
+            "dry_run": {
+              "type": "boolean",
+              "default": false,
+              "description": "Test sans ecriture Qdrant"
+            },
+            "batch_size": {
+              "type": "integer",
+              "default": 10,
+              "description": "Taille des batches"
+            },
+            "callback_url": {
+              "type": "string",
+              "description": "URL callback async (RFC-040)"
+            },
+            "job_id": {
+              "type": "string",
+              "description": "ID job personnalise"
+            }
+          }
+        },
+        "documentation": "## MCP - Tools Enricher (RFC-032 + RFC-040)\n\n**Endpoint:** POST /webhook/tools-enricher\n\n**Description:** Enrichir automatiquement les metadonnees des tools n8n et les indexer dans Qdrant\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_id\", \"guild_id\", \"user_request\"],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (credits, quotas)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"mode\": { \"type\": \"string\", \"enum\": [\"full\", \"incremental\", \"specific\"], \"default\": \"full\", \"description\": \"Mode d'enrichissement\" },\n    \"workflow_ids\": { \"type\": \"array\", \"items\": { \"type\": \"string\" }, \"description\": \"Liste d'IDs specifiques (mode specific)\" },\n    \"dry_run\": { \"type\": \"boolean\", \"default\": false, \"description\": \"Test sans ecriture Qdrant\" },\n    \"batch_size\": { \"type\": \"integer\", \"default\": 10, \"description\": \"Taille des batches\" },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL callback async (RFC-040)\" },\n    \"job_id\": { \"type\": \"string\", \"description\": \"ID job personnalise\" }\n  }\n}\n```\n\n**Note:** API keys fournies par le systeme.\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"stats\", \"results\", \"errors\"],\n  \"domain\": \"ai\"\n}\n```\n\n**Category:** ai\n**Keywords:** tools, enrichment, metadata, qdrant, embeddings, indexation, semantic"
       },
       {
         "name": "MCP - Tools Notify",
@@ -989,8 +2666,9 @@
         "full_url": "http://pi6.local:5678/webhook/mcp/tools/notify",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Tools Notify",
-        "workflow_id": "OSrxWa6DdzXVvFJt"
+        "description": "Envoi de notifications",
+        "workflow_id": "OSrxWa6DdzXVvFJt",
+        "documentation": "## MCP - Tools Notify\n\n**Endpoint:** POST /webhook/mcp/tools/notify\n\n**Note:** Utilise le micro-service Redis XADD (services/redis_xadd_service.py)\nSolution pour n8n 2.0 (Execute Command supprimé)"
       },
       {
         "name": "MCP - Transcriber",
@@ -998,8 +2676,88 @@
         "full_url": "http://pi6.local:5678/webhook/video-transcription",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Transcriber",
-        "workflow_id": "KalWt5icY3Eoz5bB"
+        "description": "Paramètres: videoUrl, videoBase64, videoMimeType, operation, language | Requis: videoUrl OR videoBase64",
+        "workflow_id": "KalWt5icY3Eoz5bB",
+        "input_schema": {
+          "required": [
+            "videoUrl OR videoBase64"
+          ],
+          "properties": {
+            "videoUrl": {
+              "type": "string",
+              "description": "URL of video to transcribe"
+            },
+            "videoBase64": {
+              "type": "string",
+              "description": "Base64-encoded video"
+            },
+            "videoMimeType": {
+              "type": "string",
+              "description": "MIME type for base64 video",
+              "default": "video/mp4"
+            },
+            "operation": {
+              "type": "string",
+              "description": "Operation type",
+              "default": "transcribe"
+            },
+            "language": {
+              "type": "string",
+              "description": "Output language",
+              "default": "auto"
+            },
+            "model": {
+              "type": "string",
+              "description": "Model to use",
+              "default": "gemini-2.5-flash"
+            },
+            "enableChunking": {
+              "type": "boolean",
+              "description": "Enable chunking",
+              "default": false
+            },
+            "chunkDuration": {
+              "type": "number",
+              "description": "Chunk duration in seconds",
+              "default": 10
+            },
+            "videoDuration": {
+              "type": "number",
+              "description": "Video duration",
+              "default": 0
+            },
+            "customInstructions": {
+              "type": "string",
+              "description": "Custom instructions"
+            },
+            "startTime": {
+              "type": "string",
+              "description": "Start time"
+            },
+            "endTime": {
+              "type": "string",
+              "description": "End time"
+            },
+            "execution_mode": {
+              "type": "string",
+              "description": "Execution mode",
+              "default": "online"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID (optional, for tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID (optional, for tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request (optional, for tracing)"
+            }
+          }
+        },
+        "documentation": "## MCP - Transcriber\n\n**Endpoint:** POST /webhook/video-transcription\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"videoUrl OR videoBase64\"],\n  \"properties\": {\n    \"videoUrl\": { \"type\": \"string\", \"description\": \"URL of video to transcribe\" },\n    \"videoBase64\": { \"type\": \"string\", \"description\": \"Base64-encoded video\" },\n    \"videoMimeType\": { \"type\": \"string\", \"description\": \"MIME type for base64 video\", \"default\": \"video/mp4\" },\n    \"operation\": { \"type\": \"string\", \"description\": \"Operation type\", \"default\": \"transcribe\" },\n    \"language\": { \"type\": \"string\", \"description\": \"Output language\", \"default\": \"auto\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Model to use\", \"default\": \"gemini-2.5-flash\" },\n    \"enableChunking\": { \"type\": \"boolean\", \"description\": \"Enable chunking\", \"default\": false },\n    \"chunkDuration\": { \"type\": \"number\", \"description\": \"Chunk duration in seconds\", \"default\": 10 },\n    \"videoDuration\": { \"type\": \"number\", \"description\": \"Video duration\", \"default\": 0 },\n    \"customInstructions\": { \"type\": \"string\", \"description\": \"Custom instructions\" },\n    \"startTime\": { \"type\": \"string\", \"description\": \"Start time\" },\n    \"endTime\": { \"type\": \"string\", \"description\": \"End time\" },\n    \"execution_mode\": { \"type\": \"string\", \"description\": \"Execution mode\", \"default\": \"online\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request (optional, for tracing)\" }\n  }\n}\n```\n\n**RFC-014 Context Support:**\n```json\n{\n  \"context\": {\n    \"videoUrl\": \"https://...\"\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"data\": { ... },\n  \"meta\": { \"provider\": \"gemini\" },\n  \"_trace\": { ... }\n}\n```\n\n**API:** Google Vertex AI (Gemini)"
       },
       {
         "name": "MCP - Vector Store",
@@ -1007,8 +2765,9 @@
         "full_url": "http://pi6.local:5678/webhook/vector-store",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Vector Store",
-        "workflow_id": "zOwekZmlRQbfEoZD"
+        "description": "Workflow: MCP   Vector Store",
+        "workflow_id": "zOwekZmlRQbfEoZD",
+        "documentation": "## MCP - Vector Store\n\n**Endpoint:** POST /webhook/vector-store\n\n**Parameters:**\n- `action` (required): store | search | delete\n- `collection` (optional): Collection name (default: 'default')\n- `vector` (for store/search): Vector array\n- `payload` (for store): Metadata to store with vector\n- `id` (for store/delete): Vector ID\n- `ids` (for delete): Array of IDs to delete\n- `limit` (for search): Max results (default: 10)\n- `execution_mode` (optional): online | offline\n\n**Environment:**\n- `QDRANT_URL`: Qdrant server URL\n- `QDRANT_API_KEY`: API key (optional)\n\n**Returns:** Operation result with stored/found/deleted data"
       },
       {
         "name": "MCP - Web Scraper",
@@ -1016,8 +2775,9 @@
         "full_url": "http://pi6.local:5678/webhook/web-scraper",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - Web Scraper",
-        "workflow_id": "A2L4SZvj4JcfcZQJ"
+        "description": "Workflow: MCP   Web Scraper",
+        "workflow_id": "A2L4SZvj4JcfcZQJ",
+        "documentation": "## MCP - Web Scraper\n\n**Endpoint:** POST /webhook/web-scraper\n\n**Parameters:**\n- `url` (required): URL to scrape\n- `options.render_js` (optional): auto | true | false (default: false)\n- `options.extract_content` (optional): boolean (default: true)\n- `options.include_html` (optional): boolean (default: true)\n- `options.screenshot` (optional): boolean (default: false)\n- `options.wait_for` (optional): networkidle | domcontentloaded | selector:#main\n- `options.timeout_ms` (optional): Timeout in ms (default: 60000)\n- `execution_mode` (optional): online | offline\n\n**Returns:** HTML, extracted content (title, text, excerpt, byline), status code\n\n**Note:** This is a simple HTTP-based scraper. For JS-heavy sites, use render_js: true (requires Playwright microservice)"
       },
       {
         "name": "MCP - YouTube Searcher",
@@ -1025,8 +2785,9 @@
         "full_url": "http://pi6.local:5678/webhook/youtube-searcher",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - YouTube Searcher",
-        "workflow_id": "MdqUUKNDXz9gIXB6"
+        "description": "Recherche d'informations",
+        "workflow_id": "MdqUUKNDXz9gIXB6",
+        "documentation": "## MCP - YouTube Searcher\n\n**Endpoint:** POST /webhook/youtube-searcher\n\n**Parameters:**\n- `query` (required): Search query\n- `type` (optional): video, channel, playlist (default: video)\n- `max_results` (optional): 1-50 (default: 10)\n- `order` (optional): relevance, date, rating, viewCount, title\n- `execution_mode` (optional): online | offline\n\n**Returns:** List of videos/channels with metadata\n\n**Note:** Requires Google API credentials with YouTube Data API v3 enabled"
       },
       {
         "name": "MCP - qdrant - Similar",
@@ -1034,8 +2795,9 @@
         "full_url": "http://pi6.local:5678/webhook/qdrant-similar",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP - qdrant - Similar",
-        "workflow_id": "y2WP91jjAvV3zIus"
+        "description": "Workflow: MCP   qdrant   Similar",
+        "workflow_id": "y2WP91jjAvV3zIus",
+        "documentation": "## Recipes - Similar\n\n**Endpoint:** POST /webhook/recipes-similar\n\n**Parameters:**\n- `recipe_id` (required*): ID of recipe in Qdrant\n- `recipe` (required*): Full recipe object (alternative)\n- `limit` (optional): Max results (default: 5)\n- `exclude_self` (optional): Exclude source recipe (default: true)\n\n**Returns:** Similar recipes based on embedding similarity"
       },
       {
         "name": "MCP Gemini Image",
@@ -1044,7 +2806,65 @@
         "method": "POST",
         "category": "MCP Tools",
         "description": "Generateur d'images IA via Google Gemini/Vertex AI avec support multi-operations (generate, extractCharacter, createCharacterSheet, composeScene).",
-        "workflow_id": "De6a7Mdnj7z9hTlP"
+        "workflow_id": "De6a7Mdnj7z9hTlP",
+        "input_schema": {
+          "required": [],
+          "properties": {
+            "user_id": {
+              "type": "string",
+              "description": "ID utilisateur (tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID serveur Discord (tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Requete utilisateur originale"
+            },
+            "operation": {
+              "type": "string",
+              "description": "Operation: generate, extractCharacter, createCharacterSheet, composeScene (default: generate)"
+            },
+            "prompt": {
+              "type": "string",
+              "description": "Prompt de generation (operation: generate)"
+            },
+            "sourceImage": {
+              "type": "string",
+              "description": "Image source base64/URL (operations: extractCharacter, createCharacterSheet)"
+            },
+            "scenePrompt": {
+              "type": "string",
+              "description": "Description de scene (operation: composeScene)"
+            },
+            "referenceImages": {
+              "type": "array",
+              "description": "Images de reference (operation: composeScene)"
+            },
+            "aspectRatio": {
+              "type": "string",
+              "description": "Ratio (default: 16:9)"
+            },
+            "outputFormat": {
+              "type": "string",
+              "description": "Format sortie (default: png)"
+            },
+            "model": {
+              "type": "string",
+              "description": "Modele Gemini"
+            },
+            "uploadToGcs": {
+              "type": "boolean",
+              "description": "Upload vers GCS"
+            },
+            "gcsBucket": {
+              "type": "string",
+              "description": "Bucket GCS"
+            }
+          }
+        },
+        "documentation": "## MCP Gemini Image\n\n**Endpoint:** POST /webhook/gemini-image\n\n**Description:** Generateur d'images IA via Google Gemini/Vertex AI avec support multi-operations (generate, extractCharacter, createCharacterSheet, composeScene).\n\n**InputSchema:**\n```json\n{\n  \"required\": [],\n  \"properties\": {\n    \"user_id\": { \"type\": \"string\", \"description\": \"ID utilisateur (tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"ID serveur Discord (tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Requete utilisateur originale\" },\n    \"operation\": { \"type\": \"string\", \"description\": \"Operation: generate, extractCharacter, createCharacterSheet, composeScene (default: generate)\" },\n    \"prompt\": { \"type\": \"string\", \"description\": \"Prompt de generation (operation: generate)\" },\n    \"sourceImage\": { \"type\": \"string\", \"description\": \"Image source base64/URL (operations: extractCharacter, createCharacterSheet)\" },\n    \"scenePrompt\": { \"type\": \"string\", \"description\": \"Description de scene (operation: composeScene)\" },\n    \"referenceImages\": { \"type\": \"array\", \"description\": \"Images de reference (operation: composeScene)\" },\n    \"aspectRatio\": { \"type\": \"string\", \"description\": \"Ratio (default: 16:9)\" },\n    \"outputFormat\": { \"type\": \"string\", \"description\": \"Format sortie (default: png)\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Modele Gemini\" },\n    \"uploadToGcs\": { \"type\": \"boolean\", \"description\": \"Upload vers GCS\" },\n    \"gcsBucket\": { \"type\": \"string\", \"description\": \"Bucket GCS\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"image\", \"gcs\", \"textFeedback\", \"metadata\"],\n  \"domain\": \"image-generation\"\n}\n```\n\n**Note:** user_id, guild_id, user_request sont optionnels (tracing uniquement)."
       },
       {
         "name": "MCP Qdrant - Save",
@@ -1052,8 +2872,66 @@
         "full_url": "http://pi6.local:5678/webhook/qdrant-save",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "Saves entity data with optional Qdrant vector embedding storage.",
-        "workflow_id": "ROYxSkjw3s2isuJr"
+        "description": "Saves entity data with optional Qdrant vector embedding storage. | Requis: entity_type, data, qdrant_host, qdrant_port, qdrant_collection",
+        "workflow_id": "ROYxSkjw3s2isuJr",
+        "input_schema": {
+          "required": [
+            "entity_type",
+            "data",
+            "qdrant_host",
+            "qdrant_port",
+            "qdrant_collection",
+            "openai_api_key"
+          ],
+          "properties": {
+            "entity_type": {
+              "type": "string",
+              "description": "Type of entity being saved"
+            },
+            "data": {
+              "type": "object",
+              "description": "Entity data to save (title, description, tags, etc.)"
+            },
+            "qdrant_host": {
+              "type": "string",
+              "description": "Qdrant server hostname"
+            },
+            "qdrant_port": {
+              "type": "integer",
+              "description": "Qdrant server port"
+            },
+            "qdrant_collection": {
+              "type": "string",
+              "description": "Qdrant collection name"
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "OpenAI API key for embeddings"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID (optional, for tracing)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Discord guild ID (optional, for tracing)"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "Original user request (optional, for tracing)"
+            },
+            "store_embedding": {
+              "type": "boolean",
+              "description": "Whether to store embedding in Qdrant",
+              "default": true
+            },
+            "llm_metadata": {
+              "type": "object",
+              "description": "LLM provider metadata (optional)"
+            }
+          }
+        },
+        "documentation": "## MCP Qdrant - Save\n\n**Endpoint:** POST /webhook/qdrant-save\n\n**Description:** Saves entity data with optional Qdrant vector embedding storage.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"entity_type\", \"data\", \"qdrant_host\", \"qdrant_port\", \"qdrant_collection\", \"openai_api_key\"],\n  \"properties\": {\n    \"entity_type\": { \"type\": \"string\", \"description\": \"Type of entity being saved\" },\n    \"data\": { \"type\": \"object\", \"description\": \"Entity data to save (title, description, tags, etc.)\" },\n    \"qdrant_host\": { \"type\": \"string\", \"description\": \"Qdrant server hostname\" },\n    \"qdrant_port\": { \"type\": \"integer\", \"description\": \"Qdrant server port\" },\n    \"qdrant_collection\": { \"type\": \"string\", \"description\": \"Qdrant collection name\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"OpenAI API key for embeddings\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID (optional, for tracing)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Discord guild ID (optional, for tracing)\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"Original user request (optional, for tracing)\" },\n    \"store_embedding\": { \"type\": \"boolean\", \"description\": \"Whether to store embedding in Qdrant\", \"default\": true },\n    \"llm_metadata\": { \"type\": \"object\", \"description\": \"LLM provider metadata (optional)\" }\n  }\n}\n```\n\n**Note:** user_id, guild_id, user_request are OPTIONAL - extracted for tracing only."
       },
       {
         "name": "MCP Veo Video",
@@ -1061,7 +2939,7 @@
         "full_url": "http://pi6.local:5678/webhook/veo-video",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP Veo Video",
+        "description": "Workflow: MCP Veo Video",
         "workflow_id": "wlWgNRY2QBOzWXUY"
       },
       {
@@ -1070,8 +2948,9 @@
         "full_url": "http://pi6.local:5678/webhook/document-callback",
         "method": "POST",
         "category": "MCP Tools",
-        "description": "MCP-Document-Callback",
-        "workflow_id": "LOiDsPw8oftAaXcd"
+        "description": "Workflow: MCP Document Callback",
+        "workflow_id": "LOiDsPw8oftAaXcd",
+        "documentation": "## TORAH - Document Callback\n\n**Endpoint:** POST /webhook/torah-document-callback\n\n**Receives callback from MCP-Documents-Process:**\n```json\n{\n  \"job_id\": \"uuid\",\n  \"conversation_id\": \"...\",\n  \"user_id\": \"discord_user_id\",\n  \"guild_id\": \"...\",\n  \"channel_id\": \"...\",\n  \"success\": true,\n  \"result\": { \"text\": \"...\", \"output_type\": \"text\", \"word_count\": 100 },\n  \"metrics\": { \"tokens_used\": 1000, \"processing_time_ms\": 5000 },\n  \"error\": null\n}\n```\n\n**Actions:**\n1. Update job status in Redis\n2. Send Discord notification"
       }
     ],
     "Other": [
@@ -1081,8 +2960,9 @@
         "full_url": "http://pi6.local:5678/webhook/alert-anomaly-detected",
         "method": "POST",
         "category": "Other",
-        "description": "Polls Redis Stream for reconciliation.anomaly events",
-        "workflow_id": "KKux2QAmZZ0n3zar"
+        "description": "Polls Redis Stream for reconciliation.anomaly events and publishes admin alerts to Discord.",
+        "workflow_id": "KKux2QAmZZ0n3zar",
+        "documentation": "## ALERT - Anomaly Detected\n\n**Trigger:** Cron every 10 seconds\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPolls Redis Stream for reconciliation.anomaly events\nand publishes admin alerts to Discord.\n\n**Input Stream:** `system:events:stream`\n**Output Stream:** `notifications:stream`\n**Type:** webhook (admin channel)"
       },
       {
         "name": "Anthropic - List Skills",
@@ -1090,8 +2970,38 @@
         "full_url": "http://pi6.local:5678/webhook/anthropic-list-skills",
         "method": "POST",
         "category": "Other",
-        "description": "Liste les Skills Anthropic disponibles (pré-construits et custom).",
-        "workflow_id": "mK7qc0TZ4aBVwPSo"
+        "description": "Liste les Skills Anthropic disponibles (pré-construits et custom). | Requis: api_key",
+        "workflow_id": "mK7qc0TZ4aBVwPSo",
+        "input_schema": {
+          "required": [
+            "api_key"
+          ],
+          "properties": {
+            "api_key": {
+              "type": "string",
+              "description": "Anthropic API key (REQUIRED)"
+            },
+            "source": {
+              "type": "string",
+              "enum": [
+                "all",
+                "anthropic",
+                "custom"
+              ],
+              "default": "all"
+            },
+            "betas": {
+              "type": "array",
+              "default": [
+                "skills-2025-10-02"
+              ]
+            },
+            "metadata": {
+              "type": "object"
+            }
+          }
+        },
+        "documentation": "## Anthropic - List Skills\n\n**Endpoint:** POST /webhook/anthropic-list-skills\n\n**Description:** Liste les Skills Anthropic disponibles (pré-construits et custom).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"api_key\"],\n  \"properties\": {\n    \"api_key\": { \"type\": \"string\", \"description\": \"Anthropic API key (REQUIRED)\" },\n    \"source\": { \"type\": \"string\", \"enum\": [\"all\", \"anthropic\", \"custom\"], \"default\": \"all\" },\n    \"betas\": { \"type\": \"array\", \"default\": [\"skills-2025-10-02\"] },\n    \"metadata\": { \"type\": \"object\" }\n  }\n}\n```\n\n**Skills pré-construits:**\n- `docx` : Word Document\n- `xlsx` : Excel Spreadsheet\n- `pptx` : PowerPoint Presentation\n- `pdf` : PDF Document\n\n**BYOT Pattern** - api_key requis, pas de fallback env."
       },
       {
         "name": "Books Commentary Worker",
@@ -1099,8 +3009,9 @@
         "full_url": "http://pi6.local:5678/webhook/books-commentary-worker",
         "method": "POST",
         "category": "Other",
-        "description": "Books Commentary Worker",
-        "workflow_id": "C4QLzAfVM1f8LpS5"
+        "description": "Workflow: Books Commentary Worker",
+        "workflow_id": "C4QLzAfVM1f8LpS5",
+        "documentation": "## Books Commentary Worker\n\n**Endpoint:** POST /webhook/books-commentary-worker\n\n**Called by:** books-translate-commentaries workflow\n\n**Process:**\n1. Respond immediately (async)\n2. PATCH /api/jobs → in_progress\n3. Loop through each commentary:\n   - Claude translation\n   - GPT-4o verification\n   - POST /api/translations/save (with llm_usage)\n   - PATCH /api/jobs (progress)\n4. PATCH /api/jobs → completed\n\n**RFC-040 Async Callback:**\n- If callback_url provided: 202 Accepted + callback at end\n- HMAC signature: X-N8N-Signature header\n\n**Time:** ~6s per commentary"
       },
       {
         "name": "Books Job Status",
@@ -1108,8 +3019,9 @@
         "full_url": "http://pi6.local:5678/webhook/books-job-status",
         "method": "POST",
         "category": "Other",
-        "description": "Books Job Status",
-        "workflow_id": "xSwPuIY9Lp9IoqPj"
+        "description": "Workflow: Books Job Status",
+        "workflow_id": "xSwPuIY9Lp9IoqPj",
+        "documentation": "## Books Job Status\n\n**Endpoint:** GET /webhook/books-job-status\n\n**Request:**\n```\nGET /webhook/books-job-status?job_id=job_abc123\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"in_progress\",\n  \"text_name\": \"The Book of Maccabees II\",\n  \"chapter\": 1,\n  \"current_verse\": 15,\n  \"total_verses\": 41,\n  \"translations_saved\": 14,\n  \"progress_percent\": 34.1,\n  \"tokens\": {\n    \"total\": 25000\n  }\n}\n```"
       },
       {
         "name": "Books Translate Commentaries",
@@ -1117,8 +3029,9 @@
         "full_url": "http://pi6.local:5678/webhook/books-translate-commentaries",
         "method": "POST",
         "category": "Other",
-        "description": "Books Translate Commentaries",
-        "workflow_id": "yiuP2LfWBlP4RwuD"
+        "description": "Traduction de texte",
+        "workflow_id": "yiuP2LfWBlP4RwuD",
+        "documentation": "## Books Translate Commentaries\n\n**Endpoint:** POST /webhook/books-translate-commentaries\n\n**Request:**\n```json\n{\n  \"text_name\": \"Genesis\",\n  \"chapter\": 1,\n  \"commentator\": \"Rashi\",\n  \"api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"text_name\": \"Genesis\",\n  \"chapter\": 1,\n  \"commentator\": \"Rashi\",\n  \"commentaries_count\": 45,\n  \"to_translate\": 32\n}\n```\n\n**Flow:**\n1. Validate input\n2. Fetch commentaries from Books API\n3. Filter untranslated commentaries\n4. Create job\n5. Launch worker (async)\n6. Return job_id immediately"
       },
       {
         "name": "Books Translation Manager",
@@ -1126,8 +3039,9 @@
         "full_url": "http://pi6.local:5678/webhook/books-translate",
         "method": "POST",
         "category": "Other",
-        "description": "Books Translation Manager",
-        "workflow_id": "rzgpYqJjXnEpHinc"
+        "description": "Workflow: Books Translation Manager",
+        "workflow_id": "rzgpYqJjXnEpHinc",
+        "documentation": "## Books Translation Manager\n\n**Endpoint:** POST /webhook/books-translate\n\n**Request:**\n```json\n{\n  \"project\": \"Second Temple\",\n  \"text_name\": \"The Book of Maccabees II\",\n  \"chapter\": 1,\n  \"api_key\": \"...\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"job_id\": \"job_abc123\",\n  \"status\": \"started\",\n  \"text_name\": \"The Book of Maccabees II\",\n  \"chapter\": 1,\n  \"verses_count\": 41,\n  \"verses_to_translate\": 35\n}\n```\n\n**Flow:**\n1. Validate input\n2. Fetch chapter from Books API\n3. Filter untranslated verses\n4. Create job via POST /api/jobs\n5. Launch worker workflow (async)\n6. Return job_id immediately"
       },
       {
         "name": "Books Translation Worker",
@@ -1135,8 +3049,9 @@
         "full_url": "http://pi6.local:5678/webhook/books-translation-worker",
         "method": "POST",
         "category": "Other",
-        "description": "Books Translation Worker",
-        "workflow_id": "hiwiaLEMvKza8WX9"
+        "description": "Workflow: Books Translation Worker",
+        "workflow_id": "hiwiaLEMvKza8WX9",
+        "documentation": "## Books Translation Worker\n\n**Endpoint:** POST /webhook/books-translation-worker\n\n**Called by:** books-translation-manager workflow\n\n**Process:**\n1. Parse input and check for callback_url\n2. If callback_url: respond 202 Accepted (async)\n   Else: respond 200 OK (sync)\n3. PATCH /api/jobs → in_progress\n4. Loop through each verse:\n   - Claude translation (draft)\n   - GPT-4o verification\n   - POST /api/translations/save (with llm_usage)\n   - PATCH /api/jobs (progress)\n5. PATCH /api/jobs → completed\n6. If callback_url: POST result with HMAC signature\n\n**RFC-040 Async Callback Pattern:**\n- callback_url: URL to POST result\n- job_id: from input or generated\n- X-N8N-Signature: HMAC-SHA256 of body\n\n**llm_usage format:**\n```json\n{\n  \"llm_usage\": [\n    { \"model\": \"claude-sonnet-4\", \"provider\": \"anthropic\", \"input_tokens\": 1500, \"output_tokens\": 800 },\n    { \"model\": \"gpt-4o\", \"provider\": \"openai\", \"input_tokens\": 1200, \"output_tokens\": 600 }\n  ]\n}\n```\n\n**Time:** ~5s per verse"
       },
       {
         "name": "CHANNELS - Private Check Or Create",
@@ -1144,8 +3059,42 @@
         "full_url": "http://pi6.local:5678/webhook/private-channel-request",
         "method": "POST",
         "category": "Other",
-        "description": "Vérifie si un channel privé existe, sinon le crée via Discord API et l'enregistre dans api-backend.",
-        "workflow_id": "sVvcaRFCXjxd8xaF"
+        "description": "Vérifie si un channel privé existe, sinon le crée via Discord API et l'enregistre dans api-backend. | Requis: discord_user_id, guild_id, bot_token",
+        "workflow_id": "sVvcaRFCXjxd8xaF",
+        "input_schema": {
+          "type": "object",
+          "required": [
+            "discord_user_id",
+            "guild_id",
+            "bot_token"
+          ],
+          "properties": {
+            "discord_user_id": {
+              "type": "string",
+              "description": "ID Discord de l'utilisateur"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "ID du serveur Discord"
+            },
+            "bot_token": {
+              "type": "string",
+              "description": "Token du bot Discord (passé par le plugin)"
+            },
+            "channel_type": {
+              "type": "string",
+              "default": "support"
+            },
+            "category_id": {
+              "type": "string",
+              "description": "ID de la catégorie Discord (optionnel)"
+            },
+            "metadata": {
+              "type": "object"
+            }
+          }
+        },
+        "documentation": "## CHANNELS - Private Check Or Create\n\n**RFC:** RFC-004\n\n**Description:** Vérifie si un channel privé existe, sinon le crée via Discord API et l'enregistre dans api-backend.\n\n**Endpoint:** POST /webhook/private-channel-request\n\n**InputSchema:**\n```json\n{\"type\":\"object\",\"required\":[\"discord_user_id\",\"guild_id\",\"bot_token\"],\"properties\":{\"discord_user_id\":{\"type\":\"string\",\"description\":\"ID Discord de l'utilisateur\"},\"guild_id\":{\"type\":\"string\",\"description\":\"ID du serveur Discord\"},\"bot_token\":{\"type\":\"string\",\"description\":\"Token du bot Discord (passé par le plugin)\"},\"channel_type\":{\"type\":\"string\",\"default\":\"support\"},\"category_id\":{\"type\":\"string\",\"description\":\"ID de la catégorie Discord (optionnel)\"},\"metadata\":{\"type\":\"object\"}}}\n```\n\n**Flow:**\n1. GET api-backend → channel exists?\n2. Si non → POST Discord API (create channel)\n3. POST api-backend (register)\n4. Return channel info"
       },
       {
         "name": "CHANNELS---Private-Register-Callback",
@@ -1153,7 +3102,7 @@
         "full_url": "http://pi6.local:5678/webhook/private-channel-callback",
         "method": "POST",
         "category": "Other",
-        "description": "CHANNELS---Private-Register-Callback",
+        "description": "Workflow: CHANNELS   Private Register Callback",
         "workflow_id": "zol6fTZm10bgHslR"
       },
       {
@@ -1162,8 +3111,9 @@
         "full_url": "http://pi6.local:5678/webhook/config/branding",
         "method": "POST",
         "category": "Other",
-        "description": "CONFIG---Get-Branding",
-        "workflow_id": "YMffmWWY2zPA6o75"
+        "description": "Récupère les informations : branding",
+        "workflow_id": "YMffmWWY2zPA6o75",
+        "documentation": "## RFC-008: Get Branding\n\n**Webhook:** GET /config/branding\n\n**Query params:**\n- guild_id (requis)\n\n**Flow:**\n1. Validate guild_id\n2. Map guild_id → project_id\n3. GET /api/config/branding\n4. Return BrandingConfig"
       },
       {
         "name": "CONFIG---Get-Help",
@@ -1171,8 +3121,9 @@
         "full_url": "http://pi6.local:5678/webhook/config/help",
         "method": "POST",
         "category": "Other",
-        "description": "CONFIG---Get-Help",
-        "workflow_id": "PkTIK0s6ssN5E4HF"
+        "description": "Récupère les informations : help",
+        "workflow_id": "PkTIK0s6ssN5E4HF",
+        "documentation": "## RFC-008: Get Help Config\n\n**Webhook:** GET /config/help\n\n**Query params:**\n- guild_id (requis)\n\n**Flow:**\n1. Validate guild_id\n2. Map guild_id → project_id\n3. GET /api/config/help\n4. Return HelpConfig"
       },
       {
         "name": "CONFIG---Help-Reset",
@@ -1180,8 +3131,9 @@
         "full_url": "http://pi6.local:5678/webhook/config/help/reset",
         "method": "POST",
         "category": "Other",
-        "description": "CONFIG---Help-Reset",
-        "workflow_id": "R8iSfgONToE0tG3c"
+        "description": "Workflow: CONFIG   Help Reset",
+        "workflow_id": "R8iSfgONToE0tG3c",
+        "documentation": "## RFC-008: Reset Help Config\n\n**Webhook:** POST /config/help/reset\n\n**Body:**\n- guild_id (requis)\n\n**Flow:**\n1. Validate guild_id\n2. Map guild_id → project_id\n3. POST /api/config/help/reset\n4. Return success"
       },
       {
         "name": "Category Detect",
@@ -1189,8 +3141,9 @@
         "full_url": "http://pi6.local:5678/webhook/category-detect",
         "method": "POST",
         "category": "Other",
-        "description": "Category Detect",
-        "workflow_id": "ywNQbKGOggzvI1oq"
+        "description": "Workflow: Category Detect",
+        "workflow_id": "ywNQbKGOggzvI1oq",
+        "documentation": "## Category Detect\n\n**Endpoint:** POST /webhook/category-detect\n\n**Purpose:** Detect categories in items using ruleset (JSON mapping or LLM).\n\n**Request:**\n```json\n{\n  \"items\": [\"beurre\", \"curry\", \"poulet\", \"lait de coco\"],\n  \"ruleset\": \"allergens_inco\",\n  \"options\": {\n    \"include_possible\": true,\n    \"language\": \"fr\"\n  }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"detected\": {\n    \"confirmed\": [{\"type\": \"lait\", \"label\": \"Lait\", \"icon\": \"🥛\", \"sources\": [\"beurre\"]}],\n    \"possible_traces\": [{\"type\": \"celeri\", \"label\": \"Céleri\", \"sources\": [\"curry\"], \"reason\": \"Traces possibles\"}]\n  },\n  \"warnings\": [\"Ce plat contient de la noix de coco...\"]\n}\n```\n\n**Available rulesets:**\n- `allergens_inco`: 14 INCO allergens (JSON mapping)\n- `cuisine_tags`: Cuisine style tags (LLM)\n\n**RFC:** RFC-018 (Recipe Enrichment)"
       },
       {
         "name": "Classroom Sync Status",
@@ -1198,7 +3151,7 @@
         "full_url": "http://pi6.local:5678/webhook/classroom-sync-status",
         "method": "GET",
         "category": "Other",
-        "description": "Classroom Sync Status",
+        "description": "Synchronisation de données",
         "workflow_id": "AkBydwInUwleDap3"
       },
       {
@@ -1207,8 +3160,9 @@
         "full_url": "http://pi6.local:5678/webhook/credits-get",
         "method": "POST",
         "category": "Other",
-        "description": "Credits - Get",
-        "workflow_id": "Yq4EuPqBEt4q9H5t"
+        "description": "Récupère des données",
+        "workflow_id": "Yq4EuPqBEt4q9H5t",
+        "documentation": "## Credits - Get\n\n**Endpoint:** GET /webhook/credits-get\n\n**Query Parameters:**\n- `project_id` (required): ID du projet\n- `discord_user_id` (required): ID Discord de l'utilisateur\n\n**Backend APIs:**\n- GET /api/ecommerce/webhook/account (credits)\n- GET /api/ecommerce/webhook/account/logs (transactions)\n\n**Commande bot:** `/credits`"
       },
       {
         "name": "Credits Check",
@@ -1216,8 +3170,9 @@
         "full_url": "http://pi6.local:5678/webhook/credits-check",
         "method": "POST",
         "category": "Other",
-        "description": "Credits Check",
-        "workflow_id": "YQJmym1DhLk9vHlD"
+        "description": "Crédite le compte utilisateur",
+        "workflow_id": "YQJmym1DhLk9vHlD",
+        "documentation": "## Credits Check\n\n**Endpoint:** POST /webhook/credits-check\n\n**Purpose:** Check user credits balance\n\n**Request:**\n```json\n{\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\",\n  \"credits\": 450,\n  \"has_credits\": true\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"User not found\",\n    \"status\": \"NOT_FOUND\"\n  }\n}\n```\n\n**API:** GET /api/ecommerce/subscription/credits/{discord_user_id}?project_id=...\n\n**RFC:** RFC-017"
       },
       {
         "name": "Credits Refund",
@@ -1225,8 +3180,9 @@
         "full_url": "http://pi6.local:5678/webhook/credits-refund",
         "method": "POST",
         "category": "Other",
-        "description": "Credits Refund",
-        "workflow_id": "fnHuFfqPXdF2L1Bm"
+        "description": "Crédite le compte utilisateur",
+        "workflow_id": "fnHuFfqPXdF2L1Bm",
+        "documentation": "## Credits Refund\n\n**Endpoint:** POST /webhook/credits-refund\n\n**Purpose:** Refund credits to user account\n\n**Request:**\n```json\n{\n  \"discord_user_id\": \"123456789\",\n  \"project_id\": \"torah\",\n  \"amount\": 50,\n  \"job_id\": \"uuid\",\n  \"reason\": \"job_cancelled\"\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"operation\": \"refund\",\n  \"amount\": 50,\n  \"credits_before\": 400,\n  \"credits_after\": 450\n}\n```\n\n**Error:**\n```json\n{\n  \"error\": {\n    \"code\": 404,\n    \"message\": \"User not found\",\n    \"status\": \"NOT_FOUND\"\n  }\n}\n```\n\n**API:** POST /api/ecommerce/subscription/credits/{id}/refund\n\n**RFC:** RFC-017"
       },
       {
         "name": "Data Lookup Enrich",
@@ -1234,8 +3190,9 @@
         "full_url": "http://pi6.local:5678/webhook/data-lookup-enrich",
         "method": "POST",
         "category": "Other",
-        "description": "Data Lookup Enrich",
-        "workflow_id": "eOo7TVs5SHmO9jCq"
+        "description": "Workflow: Data Lookup Enrich",
+        "workflow_id": "eOo7TVs5SHmO9jCq",
+        "documentation": "## Data Lookup Enrich\n\n**Endpoint:** POST /webhook/data-lookup-enrich\n\n**Purpose:** Enrich items with external data sources (nutrition, prices, etc.).\n\n**Request:**\n```json\n{\n  \"items\": [\n    {\"name\": \"poulet\", \"quantity\": 650, \"unit\": \"g\"},\n    {\"name\": \"lait de coco\", \"quantity\": 400, \"unit\": \"ml\"}\n  ],\n  \"source\": \"openfoodfacts\",\n  \"fields\": [\"energy_kcal\", \"protein_g\", \"fat_g\", \"carbs_g\"],\n  \"aggregate\": { \"method\": \"sum\", \"divide_by\": 4 }\n}\n```\n\n**Response:**\n```json\n{\n  \"success\": true,\n  \"enriched_items\": [...],\n  \"aggregated\": {\n    \"energy_kcal\": 536,\n    \"protein_g\": 38\n  },\n  \"data_quality\": {\n    \"matched\": 5,\n    \"estimated\": 1,\n    \"not_found\": 0\n  }\n}\n```\n\n**Available sources:**\n- `openfoodfacts`: OpenFoodFacts API (free, community)\n- `ciqual`: CIQUAL database (Phase 2)\n- `custom_api`: Custom API endpoint\n\n**RFC:** RFC-018 (Recipe Enrichment)"
       },
       {
         "name": "ENTITIES - Social Actions",
@@ -1243,8 +3200,9 @@
         "full_url": "http://pi6.local:5678/webhook/entity-social-actions",
         "method": "POST",
         "category": "Other",
-        "description": "ENTITIES - Social Actions",
-        "workflow_id": "r3IriZ4hmS6PACNz"
+        "description": "Workflow: ENTITIES   Social Actions",
+        "workflow_id": "r3IriZ4hmS6PACNz",
+        "documentation": "## ENTITIES - Social Actions (Generic)\n\n**Endpoint:** POST /webhook/entity-social-actions\n\n**Body Parameters:**\n- `entity_type`: recipes, translations, trainings, articles...\n- `entity_id`: UUID of the entity\n- `action`: comments, rating, favorite, favorites\n- `method`: GET, POST, DELETE (default: POST)\n\n**Headers:**\n- `X-Project-ID`: bot-appetit, torah-bot, torah-fun...\n\n**Body (depends on action):**\n- comments: `discord_user_id`, `content`, `discord_username`\n- rating: `discord_user_id`, `score` (1-5)\n- favorite: `discord_user_id`\n\n**Replaces:**\n- recipes-add-comment\n- recipes-get-comments\n- recipes-add-rating\n- recipes-get-ratings\n- recipes-delete-comment"
       },
       {
         "name": "Entitity - List",
@@ -1252,8 +3210,9 @@
         "full_url": "http://pi6.local:5678/webhook/entity-list",
         "method": "POST",
         "category": "Other",
-        "description": "Entitity - List",
-        "workflow_id": "gzJ4nuRvVvoD0dGe"
+        "description": "Liste des ressources",
+        "workflow_id": "gzJ4nuRvVvoD0dGe",
+        "documentation": "## Recipes - List & Get\n\n**Endpoint:** POST /webhook/recipes-list\n\n**Actions:**\n- `list`: List user's recipes (user_id, limit, offset, tags)\n- `get`: Get recipe details (recipe_id)\n- `delete`: Delete recipe (recipe_id)\n\n**Pagination:** limit (default 20), offset (default 0)\n**Filters:** tags (comma-separated)"
       },
       {
         "name": "Expert Program Classroom Sync",
@@ -1261,7 +3220,7 @@
         "full_url": "http://pi6.local:5678/webhook/expert-program-classroom-sync",
         "method": "POST",
         "category": "Other",
-        "description": "Expert Program Classroom Sync",
+        "description": "Synchronisation de données",
         "workflow_id": "aPuyDLpRMjyQXnIr"
       },
       {
@@ -1270,7 +3229,7 @@
         "full_url": "http://pi6.local:5678/webhook/jobs/user-cleanup",
         "method": "POST",
         "category": "Other",
-        "description": "JOBS---User-Cleanup",
+        "description": "Workflow: JOBS   User Cleanup",
         "workflow_id": "KuT3m6Gu2Qb02nyX"
       },
       {
@@ -1279,8 +3238,9 @@
         "full_url": "http://pi6.local:5678/webhook/learning-adapt-difficulty",
         "method": "POST",
         "category": "Other",
-        "description": "LEARNING - Adapt Difficulty",
-        "workflow_id": "FE27l6L0CTsDC0TA"
+        "description": "Workflow: LEARNING   Adapt Difficulty",
+        "workflow_id": "FE27l6L0CTsDC0TA",
+        "documentation": "## LEARNING - Adapt Difficulty (RFC-022)\n\n**Endpoint:** POST /webhook/learning-adapt-difficulty\n\n**Parameters:**\n- `learner_discord_id` (required): Discord user ID\n- `guild_id` (required): Discord guild ID\n\n**Algorithm:**\n- avg_score >= 90 & success_rate >= 85 → hard (3)\n- avg_score >= 75 & success_rate >= 70 → medium (2)  \n- avg_score >= 60 & success_rate >= 50 → easy (1)\n- else → easy with reinforcement\n\n**Returns:**\n- `recommended_difficulty`: easy | medium | hard\n- `difficulty_score`: 1-3\n- `metrics`: Learner performance data\n- `focus_areas`: Strengths and weaknesses\n- `recommendations`: Personalized suggestions"
       },
       {
         "name": "LEARNING - Badge Check",
@@ -1288,8 +3248,9 @@
         "full_url": "http://pi6.local:5678/webhook/learning-badge-check",
         "method": "POST",
         "category": "Other",
-        "description": "LEARNING - Badge Check",
-        "workflow_id": "bVWwe8BPUQaaXUg2"
+        "description": "Workflow: LEARNING   Badge Check",
+        "workflow_id": "bVWwe8BPUQaaXUg2",
+        "documentation": "## LEARNING - Badge Check (RFC-022)\n\n**Endpoint:** POST /webhook/learning-badge-check\n\n**Parameters:**\n- `learner_discord_id` (required): Discord user ID\n- `guild_id` (required): Discord guild ID\n\n**Returns:**\n- `badges_awarded`: List of newly awarded badges\n- `badges_awarded_count`: Number of badges awarded\n- `progress_summary`: Current learner progress\n\n**Badges Checked:**\nfirst_lesson, first_course, week_streak, month_streak, quiz_master, level_5, level_10"
       },
       {
         "name": "LEARNING - Evaluate Photo",
@@ -1297,8 +3258,9 @@
         "full_url": "http://pi6.local:5678/webhook/learning-evaluate-photo",
         "method": "POST",
         "category": "Other",
-        "description": "LEARNING - Evaluate Photo",
-        "workflow_id": "g1kTltLUWvGOqt8V"
+        "description": "Workflow: LEARNING   Evaluate Photo",
+        "workflow_id": "g1kTltLUWvGOqt8V",
+        "documentation": "## LEARNING - Evaluate Photo (RFC-022)\n\n**Endpoint:** POST /webhook/learning-evaluate-photo\n\n**Parameters:**\n- `submission_id` (required): UUID of the submission\n- `image_url` (required): URL of the photo to evaluate\n- `guild_id` (required): Discord guild ID\n- `recipe_name` (optional): Name of the expected recipe\n- `recipe_description` (optional): Description of what to evaluate\n- `criteria` (optional): Array of criteria [\"Texture\", \"Couleur\", ...]\n\n**Returns:**\n- `grade`: Overall score (0-100)\n- `feedback`: Constructive feedback\n- `evaluation.criteria`: Per-criteria scores\n- `evaluation.improvements`: Suggestions\n- `evaluation.highlights`: Positive points\n- `xp_earned`: XP awarded based on grade"
       },
       {
         "name": "LEARNING - Generate Dispatcher",
@@ -1306,7 +3268,7 @@
         "full_url": "http://pi6.local:5678/webhook/learning-generate",
         "method": "POST",
         "category": "Other",
-        "description": "LEARNING - Generate Dispatcher",
+        "description": "Génération de contenu",
         "workflow_id": "RgzRhwIcDRA3OPL2"
       },
       {
@@ -1315,7 +3277,7 @@
         "full_url": "http://pi6.local:5678/webhook/job-status/:job_id",
         "method": "GET",
         "category": "Other",
-        "description": "LEARNING - Job Status",
+        "description": "Workflow: LEARNING   Job Status",
         "workflow_id": "WCRZTFV295P4lASV"
       },
       {
@@ -1324,8 +3286,57 @@
         "full_url": "http://pi6.local:5678/webhook/llm-call-messages",
         "method": "POST",
         "category": "Other",
-        "description": "Appel LLM synchrone multi-provider avec pattern BYOT (Bring Your Own Token).",
-        "workflow_id": "V9aXcWyCd4omNDmA"
+        "description": "Appel LLM synchrone multi-provider avec pattern BYOT (Bring Your Own Token). | Requis: provider, model, api_key, messages",
+        "workflow_id": "V9aXcWyCd4omNDmA",
+        "input_schema": {
+          "required": [
+            "provider",
+            "model",
+            "api_key",
+            "messages"
+          ],
+          "properties": {
+            "provider": {
+              "type": "string",
+              "enum": [
+                "anthropic",
+                "openai",
+                "mistral"
+              ]
+            },
+            "model": {
+              "type": "string",
+              "description": "Model ID (ex: claude-sonnet-4-20250514, gpt-4o)"
+            },
+            "api_key": {
+              "type": "string",
+              "description": "API key for the provider (REQUIRED, no fallback)"
+            },
+            "system": {
+              "type": "string",
+              "description": "System prompt"
+            },
+            "messages": {
+              "type": "array",
+              "description": "Messages array [{role, content}]"
+            },
+            "max_tokens": {
+              "type": "integer",
+              "default": 4096
+            },
+            "temperature": {
+              "type": "number",
+              "default": 0.7,
+              "minimum": 0,
+              "maximum": 2
+            },
+            "metadata": {
+              "type": "object",
+              "description": "Passthrough metadata"
+            }
+          }
+        },
+        "documentation": "## LLM - Call Messages (Multi-Provider BYOT)\n\n**Endpoint:** POST /webhook/llm-call-messages\n\n**Description:** Appel LLM synchrone multi-provider avec pattern BYOT (Bring Your Own Token).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"provider\", \"model\", \"api_key\", \"messages\"],\n  \"properties\": {\n    \"provider\": { \"type\": \"string\", \"enum\": [\"anthropic\", \"openai\", \"mistral\"] },\n    \"model\": { \"type\": \"string\", \"description\": \"Model ID (ex: claude-sonnet-4-20250514, gpt-4o)\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"API key for the provider (REQUIRED, no fallback)\" },\n    \"system\": { \"type\": \"string\", \"description\": \"System prompt\" },\n    \"messages\": { \"type\": \"array\", \"description\": \"Messages array [{role, content}]\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 4096 },\n    \"temperature\": { \"type\": \"number\", \"default\": 0.7, \"minimum\": 0, \"maximum\": 2 },\n    \"metadata\": { \"type\": \"object\", \"description\": \"Passthrough metadata\" }\n  }\n}\n```\n\n**Providers supportes:**\n- `anthropic` → Claude (claude-sonnet-4-20250514, claude-haiku-4-5-20251001, etc.)\n- `openai` → GPT (gpt-4o, gpt-4o-mini, etc.)\n- `mistral` → Mistral (mistral-large-latest, mistral-medium, etc.)\n\n**BYOT Pattern:** api_key est OBLIGATOIRE. Aucun fallback sur les variables d'environnement."
       },
       {
         "name": "LLM - Call Stream",
@@ -1333,8 +3344,64 @@
         "full_url": "http://pi6.local:5678/webhook/llm-call-stream",
         "method": "POST",
         "category": "Other",
-        "description": "Streaming LLM multi-provider avec pattern callback asynchrone.",
-        "workflow_id": "jJe59jAy85SStBzT"
+        "description": "Streaming LLM multi-provider avec pattern callback asynchrone. | Requis: provider, model, api_key, messages, callback_url",
+        "workflow_id": "jJe59jAy85SStBzT",
+        "input_schema": {
+          "required": [
+            "provider",
+            "model",
+            "api_key",
+            "messages",
+            "callback_url",
+            "correlation_id"
+          ],
+          "properties": {
+            "provider": {
+              "enum": [
+                "anthropic",
+                "openai",
+                "mistral"
+              ]
+            },
+            "model": {
+              "type": "string"
+            },
+            "api_key": {
+              "type": "string",
+              "description": "REQUIRED, no fallback"
+            },
+            "system": {
+              "type": "string"
+            },
+            "messages": {
+              "type": "array"
+            },
+            "max_tokens": {
+              "type": "integer",
+              "default": 4096
+            },
+            "temperature": {
+              "type": "number",
+              "default": 0.7
+            },
+            "callback_url": {
+              "type": "string",
+              "description": "URL for async packet delivery"
+            },
+            "correlation_id": {
+              "type": "string"
+            },
+            "stream_config": {
+              "flush_timeout_ms": 500,
+              "flush_token_count": 20,
+              "flush_size_bytes": 4096
+            },
+            "metadata": {
+              "type": "object"
+            }
+          }
+        },
+        "documentation": "## LLM - Call Stream (Multi-Provider BYOT)\n\n**Endpoint:** POST /webhook/llm-call-stream\n\n**Description:** Streaming LLM multi-provider avec pattern callback asynchrone.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"provider\", \"model\", \"api_key\", \"messages\", \"callback_url\", \"correlation_id\"],\n  \"properties\": {\n    \"provider\": { \"enum\": [\"anthropic\", \"openai\", \"mistral\"] },\n    \"model\": { \"type\": \"string\" },\n    \"api_key\": { \"type\": \"string\", \"description\": \"REQUIRED, no fallback\" },\n    \"system\": { \"type\": \"string\" },\n    \"messages\": { \"type\": \"array\" },\n    \"max_tokens\": { \"type\": \"integer\", \"default\": 4096 },\n    \"temperature\": { \"type\": \"number\", \"default\": 0.7 },\n    \"callback_url\": { \"type\": \"string\", \"description\": \"URL for async packet delivery\" },\n    \"correlation_id\": { \"type\": \"string\" },\n    \"stream_config\": {\n      \"flush_timeout_ms\": 500,\n      \"flush_token_count\": 20,\n      \"flush_size_bytes\": 4096\n    },\n    \"metadata\": { \"type\": \"object\" }\n  }\n}\n```\n\n**Output (immediate):**\n```json\n{ \"status\": \"streaming\", \"correlation_id\": \"...\" }\n```\n\n**Callbacks:** POST to callback_url with chunk packets"
       },
       {
         "name": "LLM - Request Validator",
@@ -1342,8 +3409,67 @@
         "full_url": "http://pi6.local:5678/webhook/llm-request-validator",
         "method": "POST",
         "category": "Other",
-        "description": "Validates user requests against a domain context using LLM (RFC-044).",
-        "workflow_id": "YOVBotXKSQX1eQSe"
+        "description": "Validates user requests against a domain context using LLM (RFC-044). | Requis: user_request, domain",
+        "workflow_id": "YOVBotXKSQX1eQSe",
+        "input_schema": {
+          "required": [
+            "user_request",
+            "domain"
+          ],
+          "properties": {
+            "user_request": {
+              "type": "string",
+              "description": "User request to validate"
+            },
+            "domain": {
+              "type": "object",
+              "required": [
+                "name",
+                "description"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "bot_name": {
+                  "type": "string"
+                },
+                "contradiction_examples": {
+                  "type": "array"
+                },
+                "constraints_schema": {
+                  "type": "object"
+                },
+                "user_level_hints": {
+                  "type": "object"
+                },
+                "out_of_scope_examples": {
+                  "type": "array"
+                }
+              }
+            },
+            "has_image": {
+              "type": "boolean",
+              "description": "Has image attachment"
+            },
+            "image_attachments": {
+              "type": "array",
+              "description": "Image attachments"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID for tracing (optional)"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID for tracing (optional)"
+            }
+          }
+        },
+        "documentation": "## LLM - Request Validator\n\n**Endpoint:** POST /webhook/llm-request-validator\n\n**Description:** Validates user requests against a domain context using LLM (RFC-044).\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"user_request\", \"domain\"],\n  \"properties\": {\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request to validate\" },\n    \"domain\": {\n      \"type\": \"object\",\n      \"required\": [\"name\", \"description\"],\n      \"properties\": {\n        \"name\": { \"type\": \"string\" },\n        \"description\": { \"type\": \"string\" },\n        \"bot_name\": { \"type\": \"string\" },\n        \"contradiction_examples\": { \"type\": \"array\" },\n        \"constraints_schema\": { \"type\": \"object\" },\n        \"user_level_hints\": { \"type\": \"object\" },\n        \"out_of_scope_examples\": { \"type\": \"array\" }\n      }\n    },\n    \"has_image\": { \"type\": \"boolean\", \"description\": \"Has image attachment\" },\n    \"image_attachments\": { \"type\": \"array\", \"description\": \"Image attachments\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing (optional)\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing (optional)\" }\n  }\n}\n```\n\n**Note:** API key from request or env (ANTHROPIC_API_KEY).\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": true,\n  \"accepts_media\": false,\n  \"output_fields\": [\"is_valid\", \"issue_type\", \"user_state\", \"response\"],\n  \"domain\": \"nlp\"\n}\n```"
       },
       {
         "name": "LLM - URL Extractor",
@@ -1351,8 +3477,9 @@
         "full_url": "http://pi6.local:5678/webhook/llm-url-extractor",
         "method": "POST",
         "category": "Other",
-        "description": "LLM - URL Extractor",
-        "workflow_id": "4iZccP1QAoAf4K3n"
+        "description": "Extraction de données",
+        "workflow_id": "4iZccP1QAoAf4K3n",
+        "documentation": "## LLM - URL Extractor (RFC-040)\n\n**Endpoint:** POST /webhook/llm-url-extractor\n\n**Input:** urls[], query, provider, output_schema, callback_url\n\n**Providers:** claude, openai, gemini, mistral\n\n**RFC-040:** If callback_url → 202 + async callback\n\n**Note:** Uses HTTP Request nodes for fetching (not fetch())"
       },
       {
         "name": "LLM - Web Search",
@@ -1360,8 +3487,93 @@
         "full_url": "http://pi6.local:5678/webhook/web-search",
         "method": "POST",
         "category": "Other",
-        "description": "Performs web search using multiple LLM providers with grounding.",
-        "workflow_id": "Q6LCMkmdzhMccH9L"
+        "description": "Performs web search using multiple LLM providers with grounding. | Requis: query",
+        "workflow_id": "Q6LCMkmdzhMccH9L",
+        "input_schema": {
+          "required": [
+            "query"
+          ],
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search query (required)"
+            },
+            "provider": {
+              "type": "string",
+              "description": "LLM provider: openai, openai-mini, claude, claude-haiku, anthropic, gemini, gemini-pro, mistral, mistral-premium (default: gemini)"
+            },
+            "model": {
+              "type": "string",
+              "description": "Override model"
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "search_depth": {
+                  "type": "string",
+                  "description": "medium or deep"
+                },
+                "max_results": {
+                  "type": "integer",
+                  "description": "Max search results"
+                },
+                "language": {
+                  "type": "string",
+                  "description": "Output language"
+                },
+                "allowed_domains": {
+                  "type": "array",
+                  "description": "Allowed domains (Claude only)"
+                },
+                "blocked_domains": {
+                  "type": "array",
+                  "description": "Blocked domains"
+                },
+                "include_sources": {
+                  "type": "boolean",
+                  "description": "Include sources"
+                }
+              }
+            },
+            "output_schema": {
+              "type": "object",
+              "description": "Structured output schema"
+            },
+            "messages": {
+              "type": "array",
+              "description": "Conversation history"
+            },
+            "user_request": {
+              "type": "string",
+              "description": "User request context"
+            },
+            "user_id": {
+              "type": "string",
+              "description": "User ID for tracing"
+            },
+            "guild_id": {
+              "type": "string",
+              "description": "Guild ID for tracing"
+            },
+            "openai_api_key": {
+              "type": "string",
+              "description": "OpenAI API key (required for OpenAI)"
+            },
+            "anthropic_api_key": {
+              "type": "string",
+              "description": "Anthropic API key (required for Claude)"
+            },
+            "google_api_key": {
+              "type": "string",
+              "description": "Google API key (required for Gemini)"
+            },
+            "mistral_api_key": {
+              "type": "string",
+              "description": "Mistral API key (required for Mistral)"
+            }
+          }
+        },
+        "documentation": "## LLM - Web Search (Multi-Provider)\n\n**Endpoint:** POST /webhook/web-search\n\n**Description:** Performs web search using multiple LLM providers with grounding.\n\n**InputSchema:**\n```json\n{\n  \"required\": [\"query\"],\n  \"properties\": {\n    \"query\": { \"type\": \"string\", \"description\": \"Search query (required)\" },\n    \"provider\": { \"type\": \"string\", \"description\": \"LLM provider: openai, openai-mini, claude, claude-haiku, anthropic, gemini, gemini-pro, mistral, mistral-premium (default: gemini)\" },\n    \"model\": { \"type\": \"string\", \"description\": \"Override model\" },\n    \"options\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"search_depth\": { \"type\": \"string\", \"description\": \"medium or deep\" },\n        \"max_results\": { \"type\": \"integer\", \"description\": \"Max search results\" },\n        \"language\": { \"type\": \"string\", \"description\": \"Output language\" },\n        \"allowed_domains\": { \"type\": \"array\", \"description\": \"Allowed domains (Claude only)\" },\n        \"blocked_domains\": { \"type\": \"array\", \"description\": \"Blocked domains\" },\n        \"include_sources\": { \"type\": \"boolean\", \"description\": \"Include sources\" }\n      }\n    },\n    \"output_schema\": { \"type\": \"object\", \"description\": \"Structured output schema\" },\n    \"messages\": { \"type\": \"array\", \"description\": \"Conversation history\" },\n    \"user_request\": { \"type\": \"string\", \"description\": \"User request context\" },\n    \"user_id\": { \"type\": \"string\", \"description\": \"User ID for tracing\" },\n    \"guild_id\": { \"type\": \"string\", \"description\": \"Guild ID for tracing\" },\n    \"openai_api_key\": { \"type\": \"string\", \"description\": \"OpenAI API key (required for OpenAI)\" },\n    \"anthropic_api_key\": { \"type\": \"string\", \"description\": \"Anthropic API key (required for Claude)\" },\n    \"google_api_key\": { \"type\": \"string\", \"description\": \"Google API key (required for Gemini)\" },\n    \"mistral_api_key\": { \"type\": \"string\", \"description\": \"Mistral API key (required for Mistral)\" }\n  }\n}\n```\n\n**Analyzable:**\n```json\n{\n  \"accepts_image\": false,\n  \"accepts_media\": false,\n  \"output_fields\": [\"content\", \"sources\", \"structured_data\"],\n  \"domain\": \"search\"\n}\n```\n\n**Notes:**\n- `allowed_domains` only works with Claude\n- Mistral search is NOT guaranteed (agent decides)\n- Gemini uses Google Search, OpenAI uses Bing, Claude/Mistral use Brave"
       },
       {
         "name": "MEMBERS---On-Join-Grant-Credits",
@@ -1369,7 +3581,7 @@
         "full_url": "http://pi6.local:5678/webhook/member-join",
         "method": "POST",
         "category": "Other",
-        "description": "MEMBERS---On-Join-Grant-Credits",
+        "description": "Crédite le compte utilisateur",
         "workflow_id": "RhM489GYgj5YvXjl"
       },
       {
@@ -1378,8 +3590,9 @@
         "full_url": "http://pi6.local:5678/webhook/mention",
         "method": "POST",
         "category": "Other",
-        "description": "MENTION---On-Mention-Handler",
-        "workflow_id": "0mgzf0u2NJcmNJ1X"
+        "description": "Workflow: MENTION   On Mention Handler",
+        "workflow_id": "0mgzf0u2NJcmNJ1X",
+        "documentation": "## RFC-007: Mention Service Handler\n\n**Webhook:** POST /mention\n\n**Input:**\n- guild_id (requis)\n- user_id (requis)\n- content\n- username\n- llm_config (optionnel)\n\n**Flow:**\n1. Validate input\n2. Map guild_id → project_id + branding\n3. Call Process-Question\n4. Call Format-Response\n5. Return MentionResult"
       },
       {
         "name": "NOTIF - Badge Earned",
@@ -1387,8 +3600,9 @@
         "full_url": "http://pi6.local:5678/webhook/notif-badge-earned",
         "method": "POST",
         "category": "Other",
-        "description": "Polls Redis Stream for badge:earned events",
-        "workflow_id": "erNUjr4vLdqfCV9w"
+        "description": "Polls Redis Stream for badge:earned events and publishes notifications to Discord.",
+        "workflow_id": "erNUjr4vLdqfCV9w",
+        "documentation": "## NOTIF - Badge Earned\n\n**Trigger:** Cron every 10 seconds\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPolls Redis Stream for badge:earned events\nand publishes notifications to Discord.\n\n**Input Stream:** `xp:events:stream`\n**Output Stream:** `notifications:stream`"
       },
       {
         "name": "NOTIF - Course Expiring",
@@ -1396,8 +3610,9 @@
         "full_url": "http://pi6.local:5678/webhook/notif-course-expiring",
         "method": "POST",
         "category": "Other",
-        "description": "Polls Redis Stream for course.access.expiring events",
-        "workflow_id": "GYF6dfeEjEdJZLjD"
+        "description": "Polls Redis Stream for course.access.expiring events and publishes notifications to Discord.",
+        "workflow_id": "GYF6dfeEjEdJZLjD",
+        "documentation": "## NOTIF - Course Expiring\n\n**Trigger:** Cron every 10 seconds\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPolls Redis Stream for course.access.expiring events\nand publishes notifications to Discord.\n\n**Input Stream:** `learning:events:stream`\n**Output Stream:** `notifications:stream`"
       },
       {
         "name": "NOTIF - Level Up",
@@ -1405,8 +3620,9 @@
         "full_url": "http://pi6.local:5678/webhook/notif-level-up",
         "method": "POST",
         "category": "Other",
-        "description": "Polls Redis Stream for level:up events",
-        "workflow_id": "4UDZbUG3fIUgfPpH"
+        "description": "Polls Redis Stream for level:up events and publishes notifications to Discord.",
+        "workflow_id": "4UDZbUG3fIUgfPpH",
+        "documentation": "## NOTIF - Level Up\n\n**Trigger:** Cron every 10 seconds\n\n**Source:** RFC-030 (Option B)\n\n**Description:**\nPolls Redis Stream for level:up events\nand publishes notifications to Discord.\n\n**Input Stream:** `xp:events:stream`\n**Output Stream:** `notifications:stream`\n**Redis DB:** REDIS_DB_NOTIFICATION (5)"
       },
       {
         "name": "PLUGIN - Config Get",
@@ -1414,8 +3630,9 @@
         "full_url": "http://pi6.local:5678/webhook/plugin-config-get",
         "method": "POST",
         "category": "Other",
-        "description": "PLUGIN - Config Get",
-        "workflow_id": "sh4OmzbXupfSsVZ7"
+        "description": "Récupère des données",
+        "workflow_id": "sh4OmzbXupfSsVZ7",
+        "documentation": "## PLUGIN - Config Get\n\n**Endpoint:** `POST /webhook/plugin-config-get`\n\n**Payload IN:**\n```json\n{\"guild_id\": \"1458159736775119115\"}\n```\n\n**API Backend:** `GET /api/guilds/{guild_id}/plugin-config`\n\n**Payload OUT:** Configuration complète du plugin pour le guild:\n- plugin, entity, redis, qdrant, n8n\n- search, features, rate_limit\n- branding, keywords, prompts, scope, settings\n\n**Usage:** Plugin Discord / chatbot-core initialise sa config"
       },
       {
         "name": "PLUGIN - Config Update",
@@ -1423,8 +3640,9 @@
         "full_url": "http://pi6.local:5678/webhook/plugin-config-update",
         "method": "POST",
         "category": "Other",
-        "description": "PLUGIN - Config Update",
-        "workflow_id": "kldTRSDJJWDFogLm"
+        "description": "Met à jour une ressource",
+        "workflow_id": "kldTRSDJJWDFogLm",
+        "documentation": "## PLUGIN - Config Update\n\n**Endpoint:** `POST /webhook/plugin-config-update`\n\n**Payload IN:**\n```json\n{\n  \"guild_id\": \"1458159736775119115\",\n  \"entity\": {\"type\": \"recipes\", \"collection\": \"recipes\"},\n  \"qdrant\": {\"collection\": \"recipes\", \"min_score\": 0.75},\n  \"branding\": {\"bot\": {\"name\": \"Bot Appetit\"}},\n  ...\n}\n```\n\n**Champs obligatoires:** `guild_id`, `entity.type`, `entity.collection`\n\n**API Backend:** `PUT /api/guilds/{guild_id}/plugin-config`\n\n**Usage:** Dashboard admin met à jour la config plugin"
       },
       {
         "name": "RAG - Delete Source",
@@ -1432,8 +3650,9 @@
         "full_url": "http://pi6.local:5678/webhook/rag-delete-source",
         "method": "POST",
         "category": "Other",
-        "description": "Deletes RAG source chunks from Qdrant.",
-        "workflow_id": "9mpim1TNu3kuotGY"
+        "description": "Deletes RAG source chunks from Qdrant. Receives webhook from chatbot-core API after source deletion.",
+        "workflow_id": "9mpim1TNu3kuotGY",
+        "documentation": "## RAG - Delete Source\n\n**Endpoint:** POST /webhook/rag-delete-source\n\n**Description:** Deletes RAG source chunks from Qdrant.\nReceives webhook from chatbot-core API after source deletion.\n\n**Webhook Payload (from API):**\n```json\n{\n  \"action\": \"delete\",\n  \"source_id\": \"src_xxx\",\n  \"tenant_id\": \"Z6F3GSWB\",\n  \"guild_id\": \"1286607696153546774\",\n  \"bot_id\": \"987654321\",\n  \"b2_file_key\": \"tenant/rag/guild/bot/src/file.pdf\",\n  \"backend_api_url\": \"https://apidev.azy.solutions\",\n  \"backend_service_token\": \"xxx\"\n}\n```\n\n**Actions:**\n1. Delete all Qdrant points where source_id matches\n2. Optionally confirm deletion back to API"
       },
       {
         "name": "RAG - Process Source",
@@ -1441,8 +3660,9 @@
         "full_url": "http://pi6.local:5678/webhook/rag-process-source",
         "method": "POST",
         "category": "Other",
-        "description": "Processes RAG sources (files/links) for indexation.",
-        "workflow_id": "mPRyOE0wir83CD7N"
+        "description": "Processes RAG sources (files/links) for indexation. Receives webhooks from chatbot-core API after upload/link/retry. Extracts text, chunks, vectorizes and stores in Qdrant. Reports progress and completion back to API.",
+        "workflow_id": "mPRyOE0wir83CD7N",
+        "documentation": "## RAG - Process Source\n\n**Endpoint:** POST /webhook/rag-process-source\n\n**Description:** Processes RAG sources (files/links) for indexation.\nReceives webhooks from chatbot-core API after upload/link/retry.\nExtracts text, chunks, vectorizes and stores in Qdrant.\nReports progress and completion back to API.\n\n**Webhook Payload (from API):**\n```json\n{\n  \"action\": \"process\" | \"retry\",\n  \"source_id\": \"src_xxx\",\n  \"tenant_id\": \"Z6F3GSWB\",\n  \"guild_id\": \"1286607696153546774\",\n  \"bot_id\": \"987654321\",\n  \"file_type\": \"pdf\" | \"txt\" | \"md\" | \"docx\" | \"xlsx\" | \"pptx\" | \"mp4\" | \"mp3\" | \"yt\",\n  \"b2_file_key\": \"tenant/rag/guild/bot/src/file.pdf\",\n  \"url\": \"https://youtube.com/...\",\n  \"extraction_mode\": \"subtitles\" | \"whisper\" | \"metadata\",\n  \"backend_api_url\": \"https://apidev.azy.solutions\",\n  \"backend_service_token\": \"xxx\"\n}\n```\n\n**Callbacks to API:**\n- POST /api/discord/n8n/sources/{source_id}/progress\n- POST /api/discord/n8n/sources/{source_id}/complete"
       },
       {
         "name": "Recipes - Generate",
@@ -1450,8 +3670,9 @@
         "full_url": "http://pi6.local:5678/webhook/recipes-generate",
         "method": "POST",
         "category": "Other",
-        "description": "Recipes - Generate",
-        "workflow_id": "4Fr7QmrUlZiLZetb"
+        "description": "Génération de contenu",
+        "workflow_id": "4Fr7QmrUlZiLZetb",
+        "documentation": "## Recipes - Generate\n\n**Endpoint:** POST /webhook/recipes-generate\n\n**Parameters:**\n- `query` (required*): Recipe request\n- `random` (optional): true for random suggestion\n- `preferences`: { vegan, vegetarian, allergies[], max_time_minutes, difficulty, servings, must_use_ingredients[] }\n- `anthropic_api_key` or `openai_api_key` (required)\n- `language`: fr (default), en, es, it"
       },
       {
         "name": "Recipes - Shopping",
@@ -1459,8 +3680,9 @@
         "full_url": "http://pi6.local:5678/webhook/recipes-shopping",
         "method": "POST",
         "category": "Other",
-        "description": "Recipes - Shopping",
-        "workflow_id": "fdXCLN5VxdnR0UKD"
+        "description": "Workflow: Recipes   Shopping",
+        "workflow_id": "fdXCLN5VxdnR0UKD",
+        "documentation": "## Recipes - Shopping List\n\n**Endpoint:** POST /webhook/recipes-shopping\n\n**Actions:**\n- `get`: Get shopping list\n- `add`: Add single item (name, quantity, unit, category)\n- `add_from_recipe`: Add all ingredients from recipe (recipe_id)\n- `check`: Check/uncheck item (item_id, is_checked)\n- `remove`: Remove item (item_id)\n- `clear`: Clear list (checked_only: true/false)\n\n**Required:** user_id for all actions"
       },
       {
         "name": "Recipes - Timer",
@@ -1468,8 +3690,9 @@
         "full_url": "http://pi6.local:5678/webhook/recipes-timer",
         "method": "POST",
         "category": "Other",
-        "description": "Recipes - Timer",
-        "workflow_id": "JcY4uCJQzUW1uoYZ"
+        "description": "Workflow: Recipes   Timer",
+        "workflow_id": "JcY4uCJQzUW1uoYZ",
+        "documentation": "## Recipes - Timer\n\n**Endpoint:** POST /webhook/recipes-timer\n\n**Actions:**\n- `create`: Create a new timer\n- `list`: List user's timers (active/completed/cancelled/all)\n- `cancel`: Cancel a timer\n\n**Required (create):** user_id, discord_channel_id, label, duration_minutes\n**Required (list):** user_id\n**Required (cancel):** user_id, timer_id\n\n**Note:** duration_minutes must be 1-1440 (24h max)"
       },
       {
         "name": "Recipes - Timer Notify",
@@ -1477,8 +3700,9 @@
         "full_url": "http://pi6.local:5678/webhook/recipes-timer-notify",
         "method": "POST",
         "category": "Other",
-        "description": "Recipes - Timer Notify",
-        "workflow_id": "N1AppZjcKgxKIsSy"
+        "description": "Envoi de notifications",
+        "workflow_id": "N1AppZjcKgxKIsSy",
+        "documentation": "## Recipes - Timer Notify (DM)\n\n**Endpoint:** POST /webhook/recipes-timer-notify\n\n**Called by:** Celery when timer expires\n\n**Flow:** Create DM Channel -> Send Message to DM\n\n**Parameters:**\n- `discord_user_id` (required): User to DM\n- `discord_bot_token` (optional): Bot token (or set DISCORD_BOT_TOKEN env var)\n- `label` (required): Timer message\n- `recipe_id`, `recipe_title`, `duration_minutes` (optional): Context"
       },
       {
         "name": "SHOPPING---Cart-Add",
@@ -1486,7 +3710,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-add",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Add",
+        "description": "Workflow: SHOPPING   Cart Add",
         "workflow_id": "87Td68CtEiSACJrK"
       },
       {
@@ -1495,7 +3719,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-apply-coupon",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Apply-Coupon",
+        "description": "Workflow: SHOPPING   Cart Apply Coupon",
         "workflow_id": "GMMcdZf6zYqjZWkO"
       },
       {
@@ -1504,7 +3728,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-checkout",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Checkout",
+        "description": "Workflow: SHOPPING   Cart Checkout",
         "workflow_id": "pQHxR0r41x4n8oE5"
       },
       {
@@ -1513,7 +3737,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-checkout-cancel",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Checkout-Cancel",
+        "description": "Workflow: SHOPPING   Cart Checkout Cancel",
         "workflow_id": "kD9z9mYUdEzpZ4o8"
       },
       {
@@ -1522,7 +3746,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-checkout-success",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Checkout-Success",
+        "description": "Workflow: SHOPPING   Cart Checkout Success",
         "workflow_id": "z6bqoIayyJGob9FY"
       },
       {
@@ -1531,7 +3755,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-clear",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Clear",
+        "description": "Workflow: SHOPPING   Cart Clear",
         "workflow_id": "D6CO0hAo9fN0bz22"
       },
       {
@@ -1540,7 +3764,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-get",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Get",
+        "description": "Récupère des données",
         "workflow_id": "davqLRszYqKVp2tl"
       },
       {
@@ -1549,7 +3773,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-remove",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Remove",
+        "description": "Workflow: SHOPPING   Cart Remove",
         "workflow_id": "EU6OC7lrRuVEKbH3"
       },
       {
@@ -1558,7 +3782,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-remove-coupon",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Remove-Coupon",
+        "description": "Workflow: SHOPPING   Cart Remove Coupon",
         "workflow_id": "Sks2fPefx9LqTwMn"
       },
       {
@@ -1567,7 +3791,7 @@
         "full_url": "http://pi6.local:5678/webhook/cart-update",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Cart-Update",
+        "description": "Met à jour une ressource",
         "workflow_id": "JQ3MgJKdThCnXP9D"
       },
       {
@@ -1576,7 +3800,7 @@
         "full_url": "http://pi6.local:5678/webhook/orders-get",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Orders-Get",
+        "description": "Récupère des données",
         "workflow_id": "j5fyZP8c7zg6f8qT"
       },
       {
@@ -1585,7 +3809,7 @@
         "full_url": "http://pi6.local:5678/webhook/orders-list",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Orders-List",
+        "description": "Liste des ressources",
         "workflow_id": "KxtlcKTD5CC4uCf4"
       },
       {
@@ -1594,8 +3818,9 @@
         "full_url": "http://pi6.local:5678/webhook/product-discovery",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Product-Discovery-WebSearch",
-        "workflow_id": "39uw0mdSU5IPTJys"
+        "description": "Recherche d'informations",
+        "workflow_id": "39uw0mdSU5IPTJys",
+        "documentation": "# 🛒 Product Discovery Workflow v2.0\n\n## Architecture\n```\nWebhook → Validate → LLM Batch (4 couches) → Split → Search // → Aggregate → Response\n```\n\n## Endpoint\n```\nPOST /webhook/product-discovery\n```\n\n## Headers requis\n| Header | Description |\n|--------|-------------|\n| `X-OpenAI-API-Key` | Clé API OpenAI |\n| `X-Project-ID` | ID du plugin |\n\n## Body\n```json\n{\n  \"items\": [\n    {\"item_name\": \"farine\", \"category\": \"ingredient\"}\n  ],\n  \"context\": \"Pour faire des crêpes\",\n  \"discord_user_id\": \"123...\",\n  \"locale\": \"fr-FR\"\n}\n```\n\n## Raisonnement 4 couches\n1. **Lexical** - Désambiguïsation\n2. **Context** - Analyse usage\n3. **Knowledge** - Probabilités culturelles\n4. **Precision** - Non-surspécification\n\n## Output\n- `shopping_list` avec raisonnement\n- 1 produit par item\n- `total_cents` / `total_display`"
       },
       {
         "name": "SHOPPING---Products-Persist",
@@ -1603,7 +3828,7 @@
         "full_url": "http://pi6.local:5678/webhook/products-persist",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Products-Persist",
+        "description": "Workflow: SHOPPING   Products Persist",
         "workflow_id": "51VCI44c7kPAi8Q7"
       },
       {
@@ -1612,7 +3837,7 @@
         "full_url": "http://pi6.local:5678/webhook/profile-address-add",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Profile-Address-Add",
+        "description": "Workflow: SHOPPING   Profile Address Add",
         "workflow_id": "x2LQp3PKB2C0yble"
       },
       {
@@ -1621,7 +3846,7 @@
         "full_url": "http://pi6.local:5678/webhook/profile-address-remove",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Profile-Address-Remove",
+        "description": "Workflow: SHOPPING   Profile Address Remove",
         "workflow_id": "m3cBTQ5FE86PKFqz"
       },
       {
@@ -1630,7 +3855,7 @@
         "full_url": "http://pi6.local:5678/webhook/profile-address-set-default",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Profile-Address-Set-Default",
+        "description": "Workflow: SHOPPING   Profile Address Set Default",
         "workflow_id": "eImyGpKeADJBJDrB"
       },
       {
@@ -1639,7 +3864,7 @@
         "full_url": "http://pi6.local:5678/webhook/profile-address-update",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Profile-Address-Update",
+        "description": "Met à jour une ressource",
         "workflow_id": "sqv0PTxgb3BSyDjv"
       },
       {
@@ -1648,7 +3873,7 @@
         "full_url": "http://pi6.local:5678/webhook/profile-get",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Profile-Get",
+        "description": "Récupère des données",
         "workflow_id": "AuoKZbO92WZA1yVd"
       },
       {
@@ -1657,7 +3882,7 @@
         "full_url": "http://pi6.local:5678/webhook/profile-update",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Profile-Update",
+        "description": "Met à jour une ressource",
         "workflow_id": "PylhrpQ9M2HGogms"
       },
       {
@@ -1666,7 +3891,7 @@
         "full_url": "http://pi6.local:5678/webhook/shipping-calculate",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Shipping-Calculate",
+        "description": "Workflow: SHOPPING   Shipping Calculate",
         "workflow_id": "irIORXSyZ9gMNVud"
       },
       {
@@ -1675,7 +3900,7 @@
         "full_url": "http://pi6.local:5678/webhook/shipping-select",
         "method": "POST",
         "category": "Other",
-        "description": "SHOPPING---Shipping-Select",
+        "description": "Workflow: SHOPPING   Shipping Select",
         "workflow_id": "gi92jQb0ftFbdOAk"
       },
       {
@@ -1684,8 +3909,9 @@
         "full_url": "http://pi6.local:5678/webhook/scriptorium-qc-review",
         "method": "POST",
         "category": "Other",
-        "description": "Scriptorium QC Page Review",
-        "workflow_id": "EoE4ANOREE4hIxVX"
+        "description": "Workflow: Scriptorium QC Page Review",
+        "workflow_id": "EoE4ANOREE4hIxVX",
+        "documentation": "## Scriptorium QC Page Review v1.3\n\n**Endpoint:** POST /webhook/scriptorium-qc-review\n\n**Auth:** Header Auth (clé partagée)\n\n---\n⚠️ **SETUP REQUIS APRÈS IMPORT:**\n1. Créer credential Header Auth:\n   - Name: `Scriptorium API Key`\n   - Header: `Authorization`\n   - Value: `<clé partagée avec Scriptorium>`\n2. Ouvrir node 'Webhook Trigger'\n3. Sélectionner le credential créé\n4. Sauvegarder et activer\n---\n\n**Input:**\n- `page.image_base64`: Image JPEG (≤2 Mpx)\n- `prompt.rendered_text`: Prompt système\n- `qc.*`: Indicateurs heuristiques\n- `model`: (optionnel) anthropic|openai|google|mistral\n- `options.include_ocr`: (optionnel) OCR hybride\n- `api_keys.anthropic`: Clé API Anthropic\n- `api_keys.openai`: Clé API OpenAI\n- `api_keys.google`: Clé API Google\n- `api_keys.mistral`: Clé API Mistral\n\n**Output:**\n- `decision`: confirme_qc|infirme_qc|revue_humaine\n- `confidence`: 0.0-1.0\n- `verdict_recommended`: accepte|a_verifier|rejete\n- `ocr.*`: (si include_ocr) texte extrait\n\n**Ref:** RFC-02 §11, §23, §25"
       },
       {
         "name": "Stripe - Register Project",
@@ -1693,8 +3919,9 @@
         "full_url": "http://pi6.local:5678/webhook/stripe-register-project",
         "method": "POST",
         "category": "Other",
-        "description": "Enregistre les secrets Stripe d'un projet dans Redis.",
-        "workflow_id": "aL5ibhL8rUe3Fxbm"
+        "description": "Enregistre les secrets Stripe d'un projet dans Redis. Appele par le plugin au demarrage.",
+        "workflow_id": "aL5ibhL8rUe3Fxbm",
+        "documentation": "## STRIPE - Register Project\n\n**Endpoint:** POST /webhook/stripe-register-project\n\n**Description:** Enregistre les secrets Stripe d'un projet dans Redis.\nAppele par le plugin au demarrage.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"stripe_key\": \"sk_live_xxx\",\n  \"webhook_secret\": \"whsec_xxx\",\n  \"display_name\": \"Torah App\"\n}\n```\n\n**Redis:**\n```\nHSET project:torah stripe_key \"sk_xxx\"\nHSET project:torah webhook_secret \"whsec_xxx\"\n```\n\n**Response:**\n```json\n{\"success\": true, \"message\": \"Project registered\"}\n```"
       },
       {
         "name": "Stripe - Subscription Cancel",
@@ -1702,8 +3929,9 @@
         "full_url": "http://pi6.local:5678/webhook/stripe-subscription-cancel",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Cancel",
-        "workflow_id": "nsHQ4xr4kiNA3Mu7"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "nsHQ4xr4kiNA3Mu7",
+        "documentation": "## Torah Subscription Cancel Callback\n\n**Endpoint:** POST /webhook/torah-sub-cancel\n\n**Triggered by:** Stripe webhook handler on `customer.subscription.deleted`\n\n**Actions:**\n1. Update subscription_status to 'canceled'\n2. Set subscription_plan to 'free'\n3. Optionally archive private Discord room\n4. Send cancellation confirmation DM\n5. Log in payment_history\n\n**Input:**\n```json\n{\n  \"event_type\": \"customer.subscription.deleted\",\n  \"data\": {\n    \"customer_id\": \"cus_xxx\",\n    \"subscription_id\": \"sub_xxx\",\n    \"status\": \"canceled\"\n  }\n}\n```"
       },
       {
         "name": "Stripe - Subscription Change Plan",
@@ -1711,8 +3939,9 @@
         "full_url": "http://pi6.local:5678/webhook/subscription-change-plan",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Change Plan",
-        "workflow_id": "K60xx8kGU2DWcBKE"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "K60xx8kGU2DWcBKE",
+        "documentation": "## Stripe Subscription Change Plan\n\n**Endpoint:** POST /webhook/subscription-change-plan\n\n**Purpose:** Upgrade or downgrade a subscription to a new plan/price.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"stripe_subscription_id\": \"sub_xxx\",\n  \"new_price_id\": \"price_xxx\",\n  \"proration_behavior\": \"create_prorations\"\n}\n```\n\n**Proration behaviors:**\n- `create_prorations` (default): Charge/credit prorated amount\n- `none`: No proration, change takes effect at next billing\n- `always_invoice`: Create invoice immediately\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"subscription_id\": \"sub_xxx\",\n  \"status\": \"active\",\n  \"new_price_id\": \"price_xxx\",\n  \"current_period_end\": 1234567890\n}\n```\n\n**Setup:** Utilise Redis pour la config projet (cle: project:{project_id})"
       },
       {
         "name": "Stripe - Subscription Checkout Create",
@@ -1720,8 +3949,9 @@
         "full_url": "http://pi6.local:5678/webhook/subscription-checkout-create",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Checkout Create",
-        "workflow_id": "q36nyuiWrZ0ktCoA"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "q36nyuiWrZ0ktCoA",
+        "documentation": "## Stripe Subscription Checkout Create\n\n**Endpoint:** POST /webhook/subscription-checkout-create\n\n**Purpose:** Creates a Stripe Checkout session for subscription signup.\nActs as a proxy - each project has its own Stripe account.\n\n**Input:**\n```json\n{\n  \"project_id\": \"torah\",\n  \"price_id\": \"price_xxx\",\n  \"customer_email\": \"user@example.com\",\n  \"callbacks\": {\n    \"success\": \"http://...\",\n    \"renewal\": \"http://...\"\n  },\n  \"urls\": {\n    \"success\": \"https://...\",\n    \"cancel\": \"https://...\"\n  },\n  \"metadata\": {},\n  \"options\": {\n    \"trial_days\": 7\n  }\n}\n```\n\n**Output:**\n```json\n{\n  \"success\": true,\n  \"checkout_url\": \"https://checkout.stripe.com/...\",\n  \"session_id\": \"cs_xxx\"\n}\n```\n\n**Setup:** Utilise Redis pour la config projet (cle: project:{project_id})"
       },
       {
         "name": "Stripe - Subscription Payment Failure",
@@ -1729,8 +3959,9 @@
         "full_url": "http://pi6.local:5678/webhook/stripe-subscription-failure",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Payment Failure",
-        "workflow_id": "E7HQ6IRdTt2EivKE"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "E7HQ6IRdTt2EivKE",
+        "documentation": "## Torah Payment Failure Callback\n\n**Endpoint:** POST /webhook/torah-sub-failure\n\n**Triggered by:** Stripe webhook handler on `invoice.payment_failed`\n\n**Actions:**\n1. Update subscription_status to 'past_due'\n2. Send warning DM to user with payment update link\n3. Log failed payment in payment_history\n4. (Optional) Start grace period countdown\n\n**Input:**\n```json\n{\n  \"event_type\": \"invoice.payment_failed\",\n  \"data\": {\n    \"customer_id\": \"cus_xxx\",\n    \"subscription_id\": \"sub_xxx\",\n    \"amount_due\": 999,\n    \"attempt_count\": 1\n  }\n}\n```"
       },
       {
         "name": "Stripe - Subscription Renewal",
@@ -1738,8 +3969,9 @@
         "full_url": "http://pi6.local:5678/webhook/stripe-subscription-renewal",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Renewal",
-        "workflow_id": "dGqqwaoSshiFNUiN"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "dGqqwaoSshiFNUiN",
+        "documentation": "## Torah Subscription Renewal Callback\n\n**Endpoint:** POST /webhook/torah-sub-renewal\n\n**Triggered by:** Stripe webhook handler on `invoice.payment_succeeded`\n\n**Actions:**\n1. Add monthly credits based on plan\n2. Update current_period_end in database\n3. Log payment in payment_history\n4. Send renewal confirmation DM\n\n**Input:**\n```json\n{\n  \"event_type\": \"invoice.payment_succeeded\",\n  \"data\": {\n    \"customer_id\": \"cus_xxx\",\n    \"subscription_id\": \"sub_xxx\",\n    \"amount_paid\": 999,\n    \"period_start\": 1234567890,\n    \"period_end\": 1237246290\n  }\n}\n```"
       },
       {
         "name": "Stripe - Subscription Result",
@@ -1747,8 +3979,9 @@
         "full_url": "http://pi6.local:5678/webhook/subscription-result",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Result",
-        "workflow_id": "peHuqHt4lX6qMvdf"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "peHuqHt4lX6qMvdf",
+        "documentation": "## STRIPE - Subscription Result\n\n**Endpoint:** GET /webhook/subscription-result\n\n**Purpose:** Affiche une page HTML après checkout/portal Stripe.\n\n**Query params:**\n- `project_id` - ID du projet (requis)\n- `action` - success, cancel, ou portal (requis)\n- `session_id` - ID de session Stripe (optionnel)\n\n**Response:** Page HTML avec message et bouton Discord"
       },
       {
         "name": "Stripe - Subscription Success",
@@ -1756,8 +3989,9 @@
         "full_url": "http://pi6.local:5678/webhook/stripe-subscription-success",
         "method": "POST",
         "category": "Other",
-        "description": "Stripe - Subscription Success",
-        "workflow_id": "RUFeJAp570Z1YMhj"
+        "description": "Récupère les informations d'abonnement",
+        "workflow_id": "RUFeJAp570Z1YMhj",
+        "documentation": "## Torah Subscription Success Callback\n\n**Endpoint:** POST /webhook/torah-sub-success\n\n**Triggered by:** Stripe webhook handler on `checkout.session.completed`\n\n**Actions:**\n1. Update subscriber in PostgreSQL (stripe IDs, status, plan)\n2. Add initial credits based on plan\n3. Create/update private Discord room\n4. Send welcome DM to user\n5. Log payment in payment_history\n\n**Input:**\n```json\n{\n  \"event_type\": \"checkout.session.completed\",\n  \"data\": {\n    \"customer_id\": \"cus_xxx\",\n    \"customer_email\": \"user@example.com\",\n    \"subscription_id\": \"sub_xxx\",\n    \"metadata\": {\n      \"discord_user_id\": \"123456789\",\n      \"plan\": \"premium\"\n    }\n  }\n}\n```"
       }
     ],
     "Testing / Utilities": [
@@ -1767,8 +4001,9 @@
         "full_url": "http://pi6.local:5678/webhook/stripe-webhook",
         "method": "POST",
         "category": "Testing / Utilities",
-        "description": "Stripe - Webhook Handler",
-        "workflow_id": "PF1FifX7doIaYjzV"
+        "description": "Workflow: Stripe   Webhook Handler",
+        "workflow_id": "PF1FifX7doIaYjzV",
+        "documentation": "## STRIPE - Webhook Handler\n\n**Endpoint:** POST /webhook/stripe-webhook\n\n**Note:** Le project_id est extrait des metadata de l'evenement Stripe.\n\n**Events geres:**\n- checkout.session.completed\n- invoice.paid\n- customer.subscription.deleted\n\n**Signature:** Verified via Torah API (event_id lookup)"
       }
     ],
     "YouTube": [
@@ -1778,8 +4013,9 @@
         "full_url": "http://pi6.local:5678/webhook/recipes-youtube",
         "method": "POST",
         "category": "YouTube",
-        "description": "Recipes - YouTube",
-        "workflow_id": "MtvnVNO3xE0yDgm8"
+        "description": "Workflow: Recipes   YouTube",
+        "workflow_id": "MtvnVNO3xE0yDgm8",
+        "documentation": "## Recipes - YouTube\n\n**Endpoint:** POST /webhook/recipes-youtube\n\n**Parameters:**\n- `query` (required): Search query (e.g., \"recette tiramisu\")\n- `google_api_key` (required): YouTube Data API key\n- `anthropic_api_key` or `openai_api_key` (required): For recipe extraction\n- `preferences`: { language, max_videos, prefer_short }\n- `callback_url` (optional): URL for async callback (RFC-040)\n- `job_id` (optional): Custom job ID, auto-generated if callback_url provided\n\n**Flow:** YouTube Search → Transcribe (Gemini) → Extract Recipe (Claude)\n\n**Async Mode (RFC-040):** If callback_url provided, returns 202 immediately and POSTs result to callback with X-N8N-Signature header"
       }
     ]
   }

--- a/scripts/n8n/n8n_api.py
+++ b/scripts/n8n/n8n_api.py
@@ -514,6 +514,76 @@ def list_workflows_by_webhook_path(webhook_path):
         for wh in w.get('webhooks', []):
             print(f"   └─ {wh.get('httpMethod', 'GET')} /{wh.get('path')} (webhookId: {wh.get('webhookId')})")
 
+def infer_description_from_name(name, method="POST"):
+    """Infer a description from workflow name when no documentation available"""
+    name_clean = name.replace('_', ' ').replace('-', ' ')
+    name_lower = name.lower()
+
+    # Pattern matching for common operations
+    if 'debit' in name_lower:
+        return "Débite des crédits du compte utilisateur"
+    elif 'credit' in name_lower and 'get' not in name_lower:
+        return "Crédite le compte utilisateur"
+    elif 'billing' in name_lower and 'portal' in name_lower:
+        return "Accès au portail de facturation"
+    elif 'billing' in name_lower:
+        return "Gestion de la facturation"
+    elif 'subscriber' in name_lower or 'subscription' in name_lower:
+        return "Récupère les informations d'abonnement"
+    elif 'transaction' in name_lower:
+        return "Récupère l'historique des transactions"
+    elif 'balance' in name_lower:
+        return "Récupère le solde du compte"
+    elif 'plans' in name_lower or 'pricing' in name_lower:
+        return "Liste les offres et tarifs disponibles"
+    elif 'get' in name_lower:
+        entity = name_clean.split('Get')[-1].strip() if 'Get' in name_clean else name_clean
+        entity = entity.lower().replace('discord', '').replace('mcp', '').strip()
+        return f"Récupère les informations : {entity}" if entity else "Récupère des données"
+    elif 'create' in name_lower:
+        entity = name_clean.split('Create')[-1].strip() if 'Create' in name_clean else name_clean
+        entity = entity.lower().replace('discord', '').replace('mcp', '').strip()
+        return f"Crée un(e) {entity}" if entity else "Crée une ressource"
+    elif 'update' in name_lower:
+        entity = name_clean.split('Update')[-1].strip() if 'Update' in name_clean else name_clean
+        entity = entity.lower().replace('discord', '').replace('mcp', '').strip()
+        return f"Met à jour {entity}" if entity else "Met à jour une ressource"
+    elif 'delete' in name_lower:
+        entity = name_clean.split('Delete')[-1].strip() if 'Delete' in name_clean else name_clean
+        entity = entity.lower().replace('discord', '').replace('mcp', '').strip()
+        return f"Supprime {entity}" if entity else "Supprime une ressource"
+    elif 'list' in name_lower:
+        entity = name_clean.split('List')[-1].strip() if 'List' in name_clean else name_clean
+        entity = entity.lower().replace('discord', '').replace('mcp', '').strip()
+        return f"Liste {entity}" if entity else "Liste des ressources"
+    elif 'resolve' in name_lower:
+        return "Résolution et routage de requête"
+    elif 'sync' in name_lower:
+        return "Synchronisation de données"
+    elif 'verify' in name_lower or 'validate' in name_lower:
+        return "Vérification et validation"
+    elif 'notification' in name_lower or 'notify' in name_lower:
+        return "Envoi de notifications"
+    elif 'search' in name_lower:
+        return "Recherche d'informations"
+    elif 'analyze' in name_lower or 'analysis' in name_lower:
+        return "Analyse de données"
+    elif 'generate' in name_lower:
+        return "Génération de contenu"
+    elif 'transcribe' in name_lower or 'transcript' in name_lower:
+        return "Transcription audio/vidéo"
+    elif 'translate' in name_lower:
+        return "Traduction de texte"
+    elif 'extract' in name_lower:
+        return "Extraction de données"
+    elif 'process' in name_lower:
+        return "Traitement de données"
+    elif 'registry' in name_lower:
+        return "Liste des webhooks disponibles avec métadonnées"
+    else:
+        # Fallback: use the workflow name as-is
+        return f"Workflow: {name_clean}"
+
 def categorize_webhook(name, path, sticky_content=""):
     """Categorize a webhook based on its name and content"""
     name_lower = name.lower()
@@ -604,16 +674,56 @@ def export_webhooks_registry(output_file='docs/webhooks-registry.json', format_t
             sticky_node = next((n for n in nodes if n.get('type') == 'n8n-nodes-base.stickyNote'), None)
             sticky_content = sticky_node.get('parameters', {}).get('content', '') if sticky_node else ''
 
-            # Extract description from sticky note
+            # Extract rich metadata from sticky note
+            import re
+
             description = ""
+            input_schema = None
+            endpoint_line = ""
+
             if sticky_content:
-                import re
-                desc_match = re.search(r'\*\*Description[:\s]*\*\*\s*\n?([^\n*]+)', sticky_content, re.IGNORECASE)
+                # Extract endpoint line
+                endpoint_match = re.search(r'\*\*Endpoint:\*\*\s*([^\n]+)', sticky_content, re.IGNORECASE)
+                if endpoint_match:
+                    endpoint_line = endpoint_match.group(1).strip()
+
+                # Extract description (multi-line, jusqu'au prochain ##)
+                desc_match = re.search(r'\*\*Description[:\s]*\*\*\s*\n?([^\n#]+(?:\n[^\n#]+)*)', sticky_content, re.IGNORECASE | re.MULTILINE)
                 if desc_match:
                     description = desc_match.group(1).strip()
+                    # Clean up extra whitespace
+                    description = ' '.join(description.split())
 
-            if not description:
-                description = name
+                # Extract InputSchema
+                schema_match = re.search(r'\*\*InputSchema:\*\*\s*```json\s*({[\s\S]*?})\s*```', sticky_content, re.IGNORECASE)
+                if schema_match:
+                    try:
+                        input_schema = json.loads(schema_match.group(1))
+                    except:
+                        pass
+
+            # Build better description
+            if description and description != name and description != endpoint_line:
+                # Keep extracted description (it's meaningful)
+                pass
+            elif input_schema and 'properties' in input_schema:
+                # Generate description from InputSchema properties
+                props = input_schema.get('properties', {})
+                if props:
+                    props_desc = ', '.join(list(props.keys())[:5])  # First 5 params
+                    description = f"Paramètres: {props_desc}"
+                else:
+                    # Infer from name
+                    description = infer_description_from_name(name, params.get('httpMethod', 'POST'))
+            else:
+                # Infer from name as fallback
+                description = infer_description_from_name(name, params.get('httpMethod', 'POST'))
+
+            # Add required parameters info if available (but not if already in description)
+            if input_schema and 'required' in input_schema and input_schema['required']:
+                required_params = ', '.join(input_schema['required'][:5])  # Max 5
+                if 'Requis:' not in description:
+                    description = f"{description} | Requis: {required_params}"
 
             # Categorize
             category = categorize_webhook(name, webhook_path, sticky_content)
@@ -630,6 +740,10 @@ def export_webhooks_registry(output_file='docs/webhooks-registry.json', format_t
                 'description': description,
                 'workflow_id': w['id']
             }
+
+            # Add InputSchema if available
+            if input_schema:
+                webhook_entry['input_schema'] = input_schema
 
             # Add detailed documentation if requested
             if format_type == 'detailed' and sticky_content:

--- a/scripts/n8n/n8n_api.py
+++ b/scripts/n8n/n8n_api.py
@@ -9,6 +9,7 @@ import sys
 import json
 import requests
 from pathlib import Path
+from datetime import datetime
 
 # PostgreSQL support (optional, for webhook path search)
 try:
@@ -114,8 +115,43 @@ def api_request(method, endpoint, data=None, debug=False):
         print(f"Request error: {e}")
         return None
 
+def list_workflows_from_db():
+    """List all workflows from PostgreSQL database"""
+    conn = get_db_connection()
+    if not conn:
+        return []
+
+    try:
+        cursor = conn.cursor()
+        query = """
+            SELECT id, name, active, nodes
+            FROM workflow_entity
+            ORDER BY "updatedAt" DESC
+        """
+        cursor.execute(query)
+        rows = cursor.fetchall()
+
+        workflows = []
+        for row in rows:
+            workflow_id, name, active, nodes = row
+            workflows.append({
+                'id': workflow_id,
+                'name': name,
+                'active': active,
+                'nodes': nodes
+            })
+
+        cursor.close()
+        conn.close()
+        return workflows
+    except Exception as e:
+        print(f"❌ Database query error: {e}")
+        if conn:
+            conn.close()
+        return []
+
 def list_workflows():
-    """List all workflows"""
+    """List all workflows (tries API first, falls back to DB)"""
     response = api_request('GET', '/workflows')
     if response and response.status_code == 200:
         data = response.json()
@@ -123,9 +159,16 @@ def list_workflows():
             status = '✅' if w['active'] else '❌'
             print(f"{status} {w['id']}: {w['name']}")
     else:
-        print(f"Error: {response.status_code if response else 'No response'}")
-        if response:
-            print(response.text)
+        print(f"API unavailable, falling back to PostgreSQL...")
+        workflows = list_workflows_from_db()
+        if workflows:
+            for w in workflows:
+                status = '✅' if w['active'] else '❌'
+                print(f"{status} {w['id']}: {w['name']}")
+        else:
+            print(f"Error: No workflows found")
+            if response:
+                print(response.text)
 
 def get_workflow(workflow_id):
     """Get workflow details"""
@@ -470,6 +513,167 @@ def list_workflows_by_webhook_path(webhook_path):
         print(f"{status} {w['id']}: {w['name']}")
         for wh in w.get('webhooks', []):
             print(f"   └─ {wh.get('httpMethod', 'GET')} /{wh.get('path')} (webhookId: {wh.get('webhookId')})")
+
+def categorize_webhook(name, path, sticky_content=""):
+    """Categorize a webhook based on its name and content"""
+    name_lower = name.lower()
+    path_lower = path.lower() if path else ""
+
+    # Priority categories based on name patterns
+    if 'torah' in name_lower or 'torah' in path_lower:
+        return None  # Excluded
+    elif 'mcp' in name_lower or 'mcp' in path_lower:
+        return 'MCP Tools'
+    elif 'claude' in name_lower:
+        return 'Claude / LLM'
+    elif 'discord' in name_lower:
+        return 'Discord'
+    elif 'guild' in name_lower:
+        return 'Discord'
+    elif 'youtube' in name_lower or 'yt' in name_lower:
+        return 'YouTube'
+    elif 'gmail' in name_lower or 'email' in name_lower or 'mail' in name_lower:
+        return 'Email / Gmail'
+    elif 'drive' in name_lower or 'google' in name_lower:
+        return 'Google Drive / Docs'
+    elif 'calendar' in name_lower:
+        return 'Calendar'
+    elif 'notion' in name_lower:
+        return 'Notion'
+    elif 'airtable' in name_lower or 'baserow' in name_lower:
+        return 'Database'
+    elif 'pdf' in name_lower or 'document' in name_lower:
+        return 'Document Processing'
+    elif 'image' in name_lower or 'video' in name_lower or 'audio' in name_lower:
+        return 'Media Processing'
+    elif 'telegram' in name_lower or 'whatsapp' in name_lower:
+        return 'Messaging'
+    elif 'webhook' in name_lower or 'test' in name_lower:
+        return 'Testing / Utilities'
+    else:
+        return 'Other'
+
+def export_webhooks_registry(output_file='docs/webhooks-registry.json', format_type='detailed'):
+    """
+    Export all active webhooks to a JSON registry file.
+
+    Args:
+        output_file: Path to output JSON file
+        format_type: 'detailed' (full docs) or 'simple' (path + title only)
+    """
+    print("Exporting webhooks registry from PostgreSQL...")
+
+    workflows = list_workflows_from_db()
+    if not workflows:
+        print("❌ No workflows found in database")
+        return False
+
+    print(f"Found {len(workflows)} total workflows")
+
+    # Extract webhooks from active workflows
+    registry = {}
+    excluded_count = 0
+
+    for w in workflows:
+        if not w['active']:
+            continue
+
+        name = w['name']
+
+        # Skip Torah workflows
+        if 'torah' in name.lower():
+            excluded_count += 1
+            continue
+
+        # Find webhook nodes
+        nodes = w.get('nodes', [])
+        if not nodes:
+            continue
+
+        for node in nodes:
+            if 'webhook' not in node.get('type', '').lower():
+                continue
+
+            params = node.get('parameters', {})
+            webhook_path = params.get('path') or node.get('webhookId')
+
+            if not webhook_path:
+                continue
+
+            # Extract sticky note documentation
+            sticky_node = next((n for n in nodes if n.get('type') == 'n8n-nodes-base.stickyNote'), None)
+            sticky_content = sticky_node.get('parameters', {}).get('content', '') if sticky_node else ''
+
+            # Extract description from sticky note
+            description = ""
+            if sticky_content:
+                import re
+                desc_match = re.search(r'\*\*Description[:\s]*\*\*\s*\n?([^\n*]+)', sticky_content, re.IGNORECASE)
+                if desc_match:
+                    description = desc_match.group(1).strip()
+
+            if not description:
+                description = name
+
+            # Categorize
+            category = categorize_webhook(name, webhook_path, sticky_content)
+            if category is None:  # Excluded
+                excluded_count += 1
+                continue
+
+            webhook_entry = {
+                'name': name,
+                'path': webhook_path,
+                'full_url': f"{N8N_WEBHOOK_BASE_URL}/{webhook_path}",
+                'method': params.get('httpMethod', 'POST'),
+                'category': category,
+                'description': description,
+                'workflow_id': w['id']
+            }
+
+            # Add detailed documentation if requested
+            if format_type == 'detailed' and sticky_content:
+                webhook_entry['documentation'] = sticky_content
+
+            # Use path as key to avoid duplicates
+            registry[webhook_path] = webhook_entry
+
+    # Organize by category
+    categorized = {}
+    for path, entry in registry.items():
+        cat = entry['category']
+        if cat not in categorized:
+            categorized[cat] = []
+        categorized[cat].append(entry)
+
+    # Sort categories and webhooks within categories
+    sorted_registry = {}
+    for cat in sorted(categorized.keys()):
+        sorted_registry[cat] = sorted(categorized[cat], key=lambda x: x['name'])
+
+    # Build final output
+    output = {
+        'version': '1.0',
+        'generated_at': datetime.now().isoformat(),
+        'total_webhooks': len(registry),
+        'excluded_torah': excluded_count,
+        'categories': sorted_registry
+    }
+
+    # Write to file
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    print(f"\n✅ Exported {len(registry)} webhooks to {output_file}")
+    print(f"   Excluded {excluded_count} Torah workflows")
+    print(f"   Categories: {len(sorted_registry)}")
+    for cat, webhooks in sorted_registry.items():
+        print(f"      - {cat}: {len(webhooks)} webhooks")
+
+    return True
 
 def batch_reimport(list_file, workflows_dir=None, dry_run=False, delete_old=True, log_file=None):
     """
@@ -859,6 +1063,12 @@ def show_help():
     print("  find-by-webhook <path>  Find workflows by webhook path (PostgreSQL)")
     print("                          Searches n8n database for workflows with matching webhook")
     print("")
+    print("  export-webhooks-registry [output_file] [--simple]")
+    print("                          Export all active webhooks to JSON registry")
+    print("                          Default: docs/webhooks-registry.json")
+    print("                          --simple: Export only path + title (no documentation)")
+    print("                          Excludes Torah workflows")
+    print("")
     print("  batch-reimport <list_file_or_workflow> [--dry-run] [--no-delete]")
     print("                          Reimport workflow(s) from list file or single workflow")
     print("                          - List file: one workflow name per line")
@@ -944,6 +1154,16 @@ def main():
             print("Example: python3 n8n_api.py find-by-webhook server-sync")
             return
         list_workflows_by_webhook_path(sys.argv[2])
+    elif action == 'export-webhooks-registry':
+        # Parse options
+        format_type = 'simple' if '--simple' in sys.argv else 'detailed'
+        # Get output file (skip options starting with --)
+        output_file = 'docs/webhooks-registry.json'
+        for arg in sys.argv[2:]:
+            if not arg.startswith('--'):
+                output_file = arg
+                break
+        export_webhooks_registry(output_file, format_type)
     elif action == 'batch-reimport':
         if len(sys.argv) < 3:
             print("Usage: python3 n8n_api.py batch-reimport <list_file_or_workflow> [options]")


### PR DESCRIPTION
## Summary
- Ajoute une commande pour exporter tous les webhooks actifs en JSON
- Contourne le problème d'API indisponible en lisant depuis PostgreSQL
- Documentation complète de tous les webhooks disponibles

## Nouveau script

### Commande
```bash
python3 scripts/n8n/n8n_api.py export-webhooks-registry [output] [--simple]
```

### Fonctionnalités
- **list_workflows_from_db()** : Liste workflows depuis PostgreSQL
- **export_webhooks_registry()** : Génère le JSON avec catégorisation
- **categorize_webhook()** : Catégorisation automatique par nom/path
- **Fallback DB** : `list` utilise PostgreSQL si API down

## Registry généré

### Statistiques
- **196 webhooks actifs** documentés
- **35 workflows Torah** exclus (comme MCP registry)
- **7 catégories** : MCP Tools (87), Other (76), Discord (26), etc.

### Format JSON
```json
{
  "name": "MCP - Analyze Message",
  "path": "analyze-message",
  "full_url": "http://pi6.local:5678/webhook/analyze-message",
  "method": "POST",
  "category": "MCP Tools",
  "description": "Analyse complète d'un message",
  "workflow_id": "EiNGvM8j4KMcheed"
}
```

## Fichiers créés
- `docs/webhooks-registry.json` : Registry complet
- `docs/WEBHOOKS-REGISTRY.md` : Documentation d'utilisation

## Utilisation

### Rechercher un webhook
```bash
jq '.categories."MCP Tools"' docs/webhooks-registry.json
```

### Lister par catégorie
```bash
jq '.categories | keys' docs/webhooks-registry.json
```

### Mettre à jour
```bash
python3 scripts/n8n/n8n_api.py export-webhooks-registry
```

## Test plan
- [x] Export réussi depuis PostgreSQL
- [x] 196 webhooks extraits
- [x] Torah workflows exclus
- [x] Catégorisation fonctionnelle
- [x] JSON valide généré

🤖 Generated with [Claude Code](https://claude.com/claude-code)