### PR TITLE
fix(n8n): HMAC RAG (node Crypto) + Merge append LLM + export snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ workflows-2026-03-24/
 .untracked/
 merge_staging.sh
 workflows-2026-04-09/
+workflows-2026-06-26-save

--- a/docs/daily/2026-06-29.md
+++ b/docs/daily/2026-06-29.md
@@ -1,50 +1,34 @@
 # Daily — 2026-06-29
 
 ## ✅ Hier
-- Aucune activité enregistrée sur 24h (aucun commit, aucune PR mergée, aucune issue fermée) — journée sans livrable tracé côté dépôt.
+- **Stripe Webhook Handler** : correction de l'extraction des métadonnées pour `invoice.paid` (lecture dans `lines.data[0].metadata` / `parent.subscription_details.metadata`, l'objet racine étant vide) + correction du node **Merge** (`combine` → `append`, qui crashait « Fields to Match »).
+- **DISCORD - Subscribe** : propagation de `backend_api_url` + `backend_service_token` dans les métadonnées Stripe (`metadata[]` + `subscription_data[metadata][]`) pour que le Webhook Handler lise les credentials backend depuis le payload Stripe (multi-env, sans Redis ni hardcode).
+- **LLM - Call Messages** : node **Merge** corrigé (`append`) — répond à la cause « corps vide = 500 » remontée par l'équipe MCP (toutes les branches atteignent désormais le Respond). *(non commité)*
+- **RAG - Ingest (RFC-099)** : node `Verify HMAC` réécrit — `require('crypto')` / `Buffer` / `process.env` ne passent pas dans le sandbox Code. Remplacé par un node **Crypto natif** (`hmac`/SHA256/hex, secret via `{{ $env.N8N_RAG_WEBHOOK_SECRET }}`) + comparaison JS pure. *(non commité)*
+- **Outillage** : script `scripts/n8n/export_snapshot.py` — export des workflows actifs dans un dossier daté (`workflows-2026-06-26`), nommage identique à `workflows/`, garde-fou refusant d'écrire dans `workflows/`. *(non commité)*
+- **Triage azy.daily** : `azy.daily#28` clôturée (URL `/api/ecommerce/stripe/admin/projects` livrée, vérifiée live) ; commentaires postés sur `azy.daily#38` (exécution/orchestration skills), `azy.daily#40` (qualification 5 sujets), `azy.daily#76` (confirmation conditionnelle ingestion `scope_id`), `azy.daily#75` (routage MAJ ×2).
 
 ## 🚀 Aujourd'hui — priorités
-- Avancer le lot RFC-089 sur la synchronisation Google Classroom : sécuriser le webhook avant d'optimiser le débit — `fsebbah/n8n-workflows#354` (désactiver body logging) puis `fsebbah/n8n-workflows#355` (rate-limit token bucket) et `fsebbah/n8n-workflows#356` (bascule async > 20 courseWork).
-- Démarrer le lot RFC031 alertes/cron (`fsebbah/n8n-workflows#287`, `fsebbah/n8n-workflows#288`, `fsebbah/n8n-workflows#289`, `fsebbah/n8n-workflows#290`) car les 4 tickets forment une chaîne cohérente (cron sync → stats → alertes → monitor DLQ).
-- Clarifier la standardisation des inputSchema webhook (`fsebbah/n8n-workflows#323` + guide `fsebbah/n8n-workflows#325`), prérequis transverse aux futurs webhooks.
+- **Committer** les changements en cours (HMAC RAG, Merge LLM, export_snapshot) sur une branche dédiée + PR.
+- **Valider le correctif HMAC** après réimport : (1) résolution de `{{ $env.N8N_RAG_WEBHOOK_SECRET }}` dans le node Crypto ; (2) parité de sérialisation du body signé émetteur ↔ n8n.
+- **Sujet 4 de `azy.daily#40`** (adapter LLM unifié) : ajouter le **fallback auto** (précédence RFC-101 §10.5) à `LLM - Call Messages` — seul sujet 100 % autonome n8n avec le sujet 1.
 
-## 📋 Tâches du jour (issues ouvertes)
-- `fsebbah/n8n-workflows#360` — Enhancement : utiliser navigation API pour pagination des traités
-- `fsebbah/n8n-workflows#356` — [RFC-089] M7 - Bascule async pour opérations > 20 courseWork
-- `fsebbah/n8n-workflows#355` — [RFC-089] M6 - Implémenter rate-limit token bucket Google Classroom
-- `fsebbah/n8n-workflows#354` — [RFC-089] M5 - Désactiver body logging sur webhook classroom-sync
-- `fsebbah/n8n-workflows#345` — feat: Workflow webhook pour découpe vidéo YouTube
-- `fsebbah/n8n-workflows#325` — ISSUE-012-WEBHOOK-INPUTSCHEMA-GUIDE
-- `fsebbah/n8n-workflows#323` — ISSUE-012-webhook-inputschema-standardization
-- `fsebbah/n8n-workflows#290` — RFC031-N8N-005-ALERT-DLQ-MONITOR
-- `fsebbah/n8n-workflows#289` — RFC031-N8N-004-ALERT-CLARIFICATION-HIGH
-- `fsebbah/n8n-workflows#288` — RFC031-N8N-003-CRON-STATS-DAILY
-- `fsebbah/n8n-workflows#287` — RFC031-N8N-002-CRON-KEYWORDS-SYNC
-- `fsebbah/n8n-workflows#278` — RFC027-N8N-NOTIFICATIONS
-- `fsebbah/n8n-workflows#276` — REDIS-STREAMS-EVENTS-API
-- `fsebbah/n8n-workflows#271` — README
-- `fsebbah/n8n-workflows#229` — ACCOUNT_USAGE_DETAILS
-- `fsebbah/n8n-workflows#218` — plan-resume
-- `fsebbah/n8n-workflows#207` — moyen-paiement
-- `fsebbah/n8n-workflows#176` — BOOKS_API
-- `fsebbah/n8n-workflows#151` — RFC: Mode batch asynchrone pour traductions de textes libres (sans source)
-- `fsebbah/n8n-workflows#142` — 141-discord-translation-workflow
-- `fsebbah/n8n-workflows#140` — 002-discord-bot-setup
-- `fsebbah/n8n-workflows#130` — reponse_image_neo_banana
-- `fsebbah/n8n-workflows#43` — README
-- `fsebbah/n8n-workflows#42` — 04-advanced-integrations
-- `fsebbah/n8n-workflows#41` — 03-outlook-workflows
-- `fsebbah/n8n-workflows#40` — 02-imap-workflows
-- `fsebbah/n8n-workflows#39` — 01-prerequisites
-- `fsebbah/n8n-workflows#38` — outlook-workflows-analysis
-- `fsebbah/n8n-workflows#37` — imap-workflows-analysis
-- `fsebbah/n8n-workflows#36` — ISSUE_026_TRANSLATE_PHASE5_MODES
+## 📋 Tâches du jour (issues azy.daily n8n)
+- `azy.daily#40` — [n8n-workflows] 5 workflows orchestration/dispatch LLM (qualifiée ; sujet 4 ✅, sujet 1 lié #58, sujets 2/3/5 bloqués #38+#36)
+- `azy.daily#76` — ingestion par `scope_id` sans guild/bot (confirmation conditionnelle postée ; en attente #14)
+- `azy.daily#23` — stratégie extraction PDF RAG (émise vers back/RAG/PO ; en attente arbitrage budget/GPU/vendor)
+- `azy.daily#58` — généraliser Torah Router en orchestrateur de jobs réutilisable (base du sujet 1 #40)
 
 ## 🔗 Dépendances / besoins inter-équipes
-- RAS (aucune dépendance inter-équipes ne ressort des sources fournies).
+- **[PO/back] `azy.daily#14`** — figer la clé d'isolation RAG : `scope_id` **remplace** ou **complète** `(guild_id, bot_id)` dans le `must` (ingestion n8n + retrieval MCP). Verrou commun à #76, #25 et la moitié de #40.
+- **[azy.mcp] `azy.daily#38`** — skills custom RFC-085 (6 correction + 3 RFC-100) à créer : prérequis des sujets 2/3/5 de #40.
+- **[chat.api] `azy.daily#36`** — endpoints `/api/grading/submissions`, `/api/bug-reports` + callbacks : prérequis des sujets 2/3 de #40.
 
 ## ⚠️ Blockers / risques
-- Forte accumulation d'issues ouvertes (~30) sans activité de merge sur 24h : risque d'enlisement, prioriser les lots RFC-089 et RFC031 pour débloquer du flux (réf. `fsebbah/n8n-workflows#354` · bloquant : non).
+- **Accès `$env` dans le node Crypto** (HMAC RAG) : à confirmer après réimport ; si vide, désactiver `N8N_BLOCK_ENV_ACCESS_IN_NODE` côté conteneur (vars Docker déjà chargées). Sans secret résolu, ingestion RAG en 401/500.
+- **Sérialisation HMAC** : signature sur `JSON.stringify($json.body)` (compact) — l'émetteur doit signer le même JSON (ordre de clés identique), sinon mismatch. Voie robuste = signer le raw body (`rawBody` du webhook).
+- **`azy.daily#76` bloqué sur #14** : ne pas livrer la tolérance guild/bot avant que la clé d'isolation soit tranchée — sinon sources ingérées non retrouvables.
 
 ## 🗳️ Décisions souhaitées
-- Ordre d'attaque du lot RFC-089 — options : (a) sécurité d'abord (`fsebbah/n8n-workflows#354`) / (b) performance d'abord (`fsebbah/n8n-workflows#355`, `fsebbah/n8n-workflows#356`) ; reco : (a), couper le body logging avant d'augmenter le débit.
+- **Clé d'isolation RAG (#14)** — options : (a) `scope_id` **remplace** `(guild,bot)` dans le `must` ; (b) `scope_id` **complète** (guild/bot optionnels, conservés pour Discord). Reco n8n + MCP : (b) — `scope_id` filtre dur, guild/bot nullable rétro-compat.
+- **Ordre de livraison #40** — reco : sujet 4 (fallback) → sujet 1 (#58) → 3 (dès `analyze_user_bug`) → 2 (dès 6 skills + grading API) → 5 (Phase 2).

--- a/scripts/n8n/export_snapshot.py
+++ b/scripts/n8n/export_snapshot.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Export all active workflows from n8n into a SNAPSHOT directory.
+
+Unlike export_all_active.py (which writes into ./workflows), this script writes
+into a dedicated snapshot directory (default: workflows-2026-06-26), one file
+per workflow named with the SAME convention as ./workflows
+(spaces -> '_', parentheses and dashes preserved).
+
+SAFETY: this script refuses to write into the ./workflows directory.
+It never overwrites or modifies ./workflows.
+
+Usage:
+    python3 scripts/n8n/export_snapshot.py [output_dir]
+
+    output_dir defaults to "workflows-2026-06-26" (relative to repo root).
+"""
+
+import os
+import sys
+import json
+import requests
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+PROTECTED_DIR = (REPO_ROOT / "workflows").resolve()
+DEFAULT_OUTPUT = "workflows-2026-06-26"
+
+
+def load_env():
+    env_file = REPO_ROOT / ".env.local"
+    config = {}
+    if env_file.exists():
+        with open(env_file) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith('#') and '=' in line:
+                    key, value = line.split('=', 1)
+                    config[key] = value
+    return config
+
+
+config = load_env()
+
+N8N_API_URL = config.get('N8N_API_URL', 'http://pi6.local:5678/api/v1')
+N8N_API_KEY = config.get('N8N_API_KEY', '')
+
+if not N8N_API_KEY or N8N_API_KEY == 'your-n8n-api-key-here':
+    print("Error: N8N_API_KEY not configured in .env.local")
+    sys.exit(1)
+
+HEADERS = {
+    'X-N8N-API-KEY': N8N_API_KEY,
+    'Content-Type': 'application/json'
+}
+
+# Characters that are unsafe on common filesystems -> replaced with '-'
+_UNSAFE_CHARS = ['/', '\\', ':', '*', '?', '"', '<', '>', '|']
+
+
+def workflow_filename(name):
+    """Match ./workflows naming: spaces -> '_', keep () and -, drop unsafe chars."""
+    safe = name
+    for ch in _UNSAFE_CHARS:
+        safe = safe.replace(ch, '-')
+    safe = safe.replace(' ', '_')
+    return f"{safe}.json"
+
+
+def get_all_workflows():
+    all_workflows = []
+    cursor = None
+    page = 1
+    limit = 250
+
+    while True:
+        url = f"{N8N_API_URL}/workflows?limit={limit}"
+        if cursor:
+            url += f"&cursor={cursor}"
+
+        print(f"Fetching page {page}... ", end="", flush=True)
+        try:
+            response = requests.get(url, headers=HEADERS)
+            if response.status_code != 200:
+                print(f"Error: {response.status_code}")
+                print(response.text)
+                break
+            data = response.json()
+            workflows = data.get('data', [])
+            all_workflows.extend(workflows)
+            print(f"got {len(workflows)} workflows (total: {len(all_workflows)})")
+            next_cursor = data.get('nextCursor')
+            if not next_cursor or len(workflows) < limit:
+                break
+            cursor = next_cursor
+            page += 1
+        except requests.exceptions.RequestException as e:
+            print(f"Request error: {e}")
+            break
+
+    return all_workflows
+
+
+def export_workflow(workflow_id):
+    url = f"{N8N_API_URL}/workflows/{workflow_id}"
+    try:
+        response = requests.get(url, headers=HEADERS)
+        if response.status_code == 200:
+            return response.json()
+    except requests.exceptions.RequestException:
+        pass
+    return None
+
+
+def clean_workflow_for_export(workflow):
+    fields_to_remove = [
+        'id', 'versionId', 'createdAt', 'updatedAt',
+        'meta', 'triggerCount', 'staticData', 'isArchived',
+        'activeVersionId', 'versionCounter', 'description',
+        'pinData', 'shared', 'homeProject', 'scopes'
+    ]
+    for field in fields_to_remove:
+        workflow.pop(field, None)
+    return workflow
+
+
+def main():
+    output_name = sys.argv[1] if len(sys.argv) > 1 else DEFAULT_OUTPUT
+    output_dir = (REPO_ROOT / output_name).resolve()
+
+    # SAFETY GUARD: never write into ./workflows
+    if output_dir == PROTECTED_DIR or PROTECTED_DIR in output_dir.parents:
+        print(f"ABORT: refusing to write into the protected workflows directory ({PROTECTED_DIR})")
+        sys.exit(1)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 60)
+    print("n8n Active Workflows SNAPSHOT Export")
+    print(f"Output: {output_dir}")
+    print("=" * 60)
+    print()
+
+    print("Step 1: Fetching workflow list...")
+    all_workflows = get_all_workflows()
+    print(f"\nTotal workflows found: {len(all_workflows)}")
+
+    active_workflows = [w for w in all_workflows if w.get('active')]
+    print(f"Active workflows: {len(active_workflows)}")
+    print()
+
+    print("Step 2: Exporting active workflows...")
+    print("-" * 60)
+
+    exported = 0
+    errors = 0
+
+    for i, w in enumerate(active_workflows, 1):
+        workflow_id = w['id']
+        name = w['name']
+
+        full_workflow = export_workflow(workflow_id)
+        if not full_workflow:
+            print(f"[{i}/{len(active_workflows)}] ERROR: {name}")
+            errors += 1
+            continue
+
+        clean_workflow = clean_workflow_for_export(full_workflow)
+        filepath = output_dir / workflow_filename(name)
+
+        with open(filepath, 'w', encoding='utf-8') as f:
+            json.dump(clean_workflow, f, indent=2, ensure_ascii=False)
+
+        print(f"[{i}/{len(active_workflows)}] {name}")
+        exported += 1
+
+    print()
+    print("=" * 60)
+    print("Snapshot export complete!")
+    print(f"  Exported: {exported}")
+    print(f"  Errors: {errors}")
+    print(f"  Output: {output_dir}")
+    print("=" * 60)
+
+
+if __name__ == '__main__':
+    main()

--- a/workflows/LLM_-_Call_Messages.json
+++ b/workflows/LLM_-_Call_Messages.json
@@ -316,10 +316,7 @@
     },
     {
       "parameters": {
-        "mode": "combine",
-        "mergeByFields": {
-          "values": []
-        },
+        "mode": "append",
         "options": {}
       },
       "id": "merge-responses",

--- a/workflows/RAG_-_Ingest_(RFC-099).json
+++ b/workflows/RAG_-_Ingest_(RFC-099).json
@@ -30,7 +30,22 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// HMAC VERIFICATION - RFC-099\n// ============================================\n\nconst crypto = require('crypto');\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\n// Get HMAC signature from header\nconst signatureHeader = headers['x-webhook-signature'] || headers['X-Webhook-Signature'] || '';\nconst providedSignature = signatureHeader.replace('sha256=', '');\n\n// Get secret from env\nconst secret = process.env.N8N_RAG_WEBHOOK_SECRET;\n\nif (!secret) {\n  return {\n    hmac_valid: false,\n    error: 'N8N_RAG_WEBHOOK_SECRET not configured',\n    http_code: 500\n  };\n}\n\nif (!signatureHeader) {\n  return {\n    hmac_valid: false,\n    error: 'Missing X-Webhook-Signature header',\n    http_code: 401\n  };\n}\n\n// Compute HMAC-SHA256\n// Body should be the raw JSON string\nconst bodyString = JSON.stringify(body, null, 0); // Compact JSON\nconst hmac = crypto.createHmac('sha256', secret);\nhmac.update(bodyString, 'utf8');\nconst computedSignature = hmac.digest('hex');\n\n// Timing-safe comparison\nconst isValid = crypto.timingSafeEqual(\n  Buffer.from(providedSignature, 'hex'),\n  Buffer.from(computedSignature, 'hex')\n);\n\nif (!isValid) {\n  return {\n    hmac_valid: false,\n    error: 'Invalid HMAC signature',\n    http_code: 401,\n    debug: {\n      provided: providedSignature.substring(0, 16) + '...',\n      computed: computedSignature.substring(0, 16) + '...'\n    }\n  };\n}\n\nreturn {\n  hmac_valid: true,\n  body: body,\n  headers: headers\n};"
+        "action": "hmac",
+        "type": "SHA256",
+        "value": "={{ JSON.stringify($json.body) }}",
+        "secret": "={{ $env.N8N_RAG_WEBHOOK_SECRET }}",
+        "encoding": "hex",
+        "dataPropertyName": "computed_signature"
+      },
+      "id": "compute-hmac",
+      "name": "Compute HMAC",
+      "type": "n8n-nodes-base.crypto",
+      "typeVersion": 1,
+      "position": [760, 240]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Verification HMAC — signature calculee par le node Crypto 'Compute HMAC'\nconst input = $input.first().json;\nconst body = input.body || {};\nconst headers = input.headers || {};\nconst computed = String(input.computed_signature || '').toLowerCase();\nconst sigHeader = headers['x-webhook-signature'] || headers['X-Webhook-Signature'] || '';\nconst provided = sigHeader.replace('sha256=', '').toLowerCase();\n\nif (!sigHeader) {\n  return { hmac_valid: false, error: 'Missing X-Webhook-Signature header', http_code: 401, body, headers };\n}\nif (!computed) {\n  return { hmac_valid: false, error: 'HMAC non calcule (verifier N8N_RAG_WEBHOOK_SECRET / acces $env)', http_code: 500, body, headers };\n}\nif (provided.length !== computed.length || provided !== computed) {\n  return { hmac_valid: false, error: 'Invalid HMAC signature', http_code: 401, body, headers };\n}\nreturn { hmac_valid: true, body, headers };"
       },
       "id": "verify-hmac",
       "name": "Verify HMAC",
@@ -294,8 +309,11 @@
     }
   ],
   "connections": {
-    "Webhook": {
+    "Compute HMAC": {
       "main": [[{"node": "Verify HMAC", "type": "main", "index": 0}]]
+    },
+    "Webhook": {
+      "main": [[{"node": "Compute HMAC", "type": "main", "index": 0}]]
     },
     "Verify HMAC": {
       "main": [[{"node": "HMAC Valid?", "type": "main", "index": 0}]]


### PR DESCRIPTION
## Contexte
Trois correctifs n8n + outillage, issus de la session du 2026-06-29.

## Changements

### 1. `RAG - Ingest (RFC-099)` — node `Verify HMAC`
Le node utilisait `require('crypto')`, `Buffer` et `process.env.N8N_RAG_WEBHOOK_SECRET` — **tous bloqués dans le sandbox Code** de n8n.
→ Remplacé par un **node Crypto natif** (`hmac` / SHA256 / hex, secret via `{{ $env.N8N_RAG_WEBHOOK_SECRET }}` — champ d'expression, ≠ sandbox) + comparaison de strings en JS pur. Recâblage : `Webhook → Compute HMAC → Verify HMAC → HMAC Valid?`.

### 2. `LLM - Call Messages` — node `Merge`
Mode `combine` sans « Fields to Match » → crash `You need to define at least one pair of fields…` → **corps vide = 500** (remonté par l'équipe MCP). Passé en **`append`** : les 3 branches provider (mutuellement exclusives) convergent vers le Respond.

### 3. `scripts/n8n/export_snapshot.py`
Export des workflows actifs dans un dossier daté (ex. `workflows-2026-06-26`), nommage identique à `workflows/`, **garde-fou refusant d'écrire dans `workflows/`**.

### 4. `docs/daily/2026-06-29.md`

## À valider après réimport
- [ ] `{{ $env.N8N_RAG_WEBHOOK_SECRET }}` se résout bien dans le node Crypto (sinon `N8N_BLOCK_ENV_ACCESS_IN_NODE` à désactiver).
- [ ] Parité de sérialisation du body signé émetteur ↔ `JSON.stringify($json.body)` côté n8n.
- [ ] `LLM - Call Messages` répond bien un objet JSON sur toutes les branches (succès / erreur / timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)