### PR TITLE
fix(docker): DNS explicites + extra_hosts .local (EAI_AGAIN llm)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,9 +27,16 @@ services:
     networks:
       - n8n-network
 
+    # DNS explicites : le forward vers l'hôte est fragile (vécu : upstream IPv6
+    # inaccessible depuis le bridge sur llm → EAI_AGAIN sur toute résolution)
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     extra_hosts:
-      # Résolution DNS locale (si nécessaire)
-      - "databases.local:${DATABASES_LOCAL_IP:-127.0.0.1}"
+      # .local du parc — les DNS publics ne les connaissent pas, on les fixe ici
+      - "databases.local:${DATABASES_LOCAL_IP:-192.168.1.185}"
+      - "webs.local:${WEBS_LOCAL_IP:-192.168.1.186}"
+      - "host2.local:${HOST2_LOCAL_IP:-192.168.1.171}"
       - "pi6.local:${API_LOCAL_IP:-127.0.0.1}"
 
     healthcheck:


### PR DESCRIPTION
Fix de l'incident DNS llm (EAI_AGAIN sur toutes les résolutions externes : upstreams hôte IPv6 inaccessibles du bridge). `dns: 1.1.1.1/8.8.8.8` + `extra_hosts` complets pour les .local du parc (webs=Tika, host2=torah.api/redis-xadd, databases=PG). Défauts = IPs LAN réelles, surchargables par .env.local. Au passage : redis-xadd démarré+configuré sur host2 (host3:6381, healthy), URL corrigée dans les .env (`host2.local:8765`), télémétrie désactivée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)