### PR TITLE
feat(webhooks): BYOT backend — backend_api_url + secret au payload (13 webhooks)

### DIFF
--- a/scripts/n8n/n8n_api.py
+++ b/scripts/n8n/n8n_api.py
@@ -421,14 +421,26 @@ def update_workflow(workflow_id, json_file, activate_after=True):
         return None
 
 def find_workflow_by_name(name):
-    """Find workflow ID by exact name"""
-    response = api_request('GET', '/workflows')
-    if response and response.status_code == 200:
+    """Find workflow ID by exact name.
+
+    Paginates through ALL workflows: the API returns max 100 per page.
+    A single GET only sees the first page — with 300+ workflows in the
+    shared DB, that silently missed existing workflows and batch-reimport
+    created duplicates (webhook 409 conflicts).
+    """
+    cursor = None
+    while True:
+        endpoint = '/workflows?limit=100' + (f'&cursor={cursor}' if cursor else '')
+        response = api_request('GET', endpoint)
+        if not response or response.status_code != 200:
+            return None
         data = response.json()
         for w in data.get('data', []):
             if w['name'] == name:
                 return w
-    return None
+        cursor = data.get('nextCursor')
+        if not cursor:
+            return None
 
 
 def get_db_connection():
@@ -904,11 +916,19 @@ def batch_reimport(list_file, workflows_dir=None, dry_run=False, delete_old=True
 
         existing = find_workflow_by_name(workflow_name)
 
+        # Anti-duplicate guard: reimport means REPLACE an existing workflow.
+        # If the name lookup finds nothing, importing anyway would create a
+        # duplicate whose webhook paths conflict (409) with the real one.
+        if not existing:
+            log(f"  ❌ No existing workflow named '{workflow_name}' — refusing to create "
+                f"(use import-workflow for a genuinely new workflow)")
+            results['skipped'].append((name, "not found — refused to create"))
+            continue
+
         if dry_run:
-            if existing:
-                log(f"  [DRY RUN] Would deactivate: {existing['name']} (ID: {existing['id']})")
-                if delete_old:
-                    log(f"  [DRY RUN] Would delete: {existing['id']}")
+            log(f"  [DRY RUN] Would deactivate: {existing['name']} (ID: {existing['id']})")
+            if delete_old:
+                log(f"  [DRY RUN] Would delete: {existing['id']}")
             log(f"  [DRY RUN] Would import: {json_file}")
             log(f"  [DRY RUN] Would activate new workflow")
             results['success'].append((name, "DRY RUN"))
@@ -916,24 +936,21 @@ def batch_reimport(list_file, workflows_dir=None, dry_run=False, delete_old=True
 
         try:
             # Step 1: Deactivate existing workflow
-            if existing:
-                log(f"  1. Found existing: {existing['name']} (ID: {existing['id']}, active: {existing.get('active')})")
-                if existing.get('active'):
-                    log(f"     Deactivating...")
-                    api_request('POST', f"/workflows/{existing['id']}/deactivate")
+            log(f"  1. Found existing: {existing['name']} (ID: {existing['id']}, active: {existing.get('active')})")
+            if existing.get('active'):
+                log(f"     Deactivating...")
+                api_request('POST', f"/workflows/{existing['id']}/deactivate")
 
-                # Step 2: Delete existing workflow (if --delete flag)
-                if delete_old:
-                    log(f"  2. Deleting: {existing['id']}")
-                    resp = api_request('DELETE', f"/workflows/{existing['id']}")
-                    if resp and resp.status_code in [200, 204]:
-                        log(f"     Deleted successfully")
-                    else:
-                        log(f"     Delete failed: {resp.text if resp else 'No response'}")
+            # Step 2: Delete existing workflow (if --delete flag)
+            if delete_old:
+                log(f"  2. Deleting: {existing['id']}")
+                resp = api_request('DELETE', f"/workflows/{existing['id']}")
+                if resp and resp.status_code in [200, 204]:
+                    log(f"     Deleted successfully")
                 else:
-                    log(f"  2. Skipping delete (--no-delete flag)")
+                    log(f"     Delete failed: {resp.text if resp else 'No response'}")
             else:
-                log(f"  1-2. No existing workflow found with name: {workflow_name}")
+                log(f"  2. Skipping delete (--no-delete flag)")
 
             # Step 3: Import new workflow
             log(f"  3. Importing: {json_file.name}")

--- a/workflows/GUILD_-_Credits_Exhausted_Notification.json
+++ b/workflows/GUILD_-_Credits_Exhausted_Notification.json
@@ -34,13 +34,20 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL }}/api/discord/users/{{ $json.discord_user_id }}/dm",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "url": "={{ $('Webhook Trigger').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/discord/users/{{ $json.discord_user_id }}/dm",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"🔴 Crédits épuisés\",\n    \"description\": \"Vous avez utilisé tous vos crédits pour ce mois.\\n\\nVotre quota mensuel de **{{ $json.quota }}** crédits sera renouvelé automatiquement le premier du mois prochain.\",\n    \"color\": 15158332,\n    \"fields\": [\n      {\n        \"name\": \"Que faire ?\",\n        \"value\": \"• Attendez le renouvellement automatique\\n• Contactez l'administrateur de la guild pour une attribution exceptionnelle\",\n        \"inline\": false\n      }\n    ],\n    \"timestamp\": \"{{ $now.toISO() }}\"\n  }]\n}",
-        "options": {}
+        "options": {},
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Service-Token",
+              "value": "={{ $('Webhook Trigger').first().json.body.backend_service_token || $env.BACKEND_SERVICE_TOKEN }}"
+            }
+          ]
+        }
       },
       "id": "send-dm",
       "name": "Send DM to User",
@@ -49,24 +56,25 @@
       "position": [
         700,
         200
-      ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "backend-service-token",
-          "name": "Backend Service Token"
-        }
-      }
+      ]
     },
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL }}/api/discord/guilds/{{ $json.guild_id }}/admin-channel",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "url": "={{ $('Webhook Trigger').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/discord/guilds/{{ $json.guild_id }}/admin-channel",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\n  \"embeds\": [{\n    \"title\": \"🔴 Crédits épuisés\",\n    \"description\": \"<@{{ $json.discord_user_id }}> a épuisé son quota de crédits mensuel.\",\n    \"color\": 15158332,\n    \"fields\": [\n      {\n        \"name\": \"Quota mensuel\",\n        \"value\": \"{{ $json.quota }} crédits\",\n        \"inline\": true\n      },\n      {\n        \"name\": \"Action possible\",\n        \"value\": \"Attribution manuelle via le dashboard\",\n        \"inline\": true\n      }\n    ],\n    \"timestamp\": \"{{ $now.toISO() }}\"\n  }]\n}",
-        "options": {}
+        "options": {},
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Service-Token",
+              "value": "={{ $('Webhook Trigger').first().json.body.backend_service_token || $env.BACKEND_SERVICE_TOKEN }}"
+            }
+          ]
+        }
       },
       "id": "notify-admin",
       "name": "Notify Admin Channel",
@@ -75,13 +83,7 @@
       "position": [
         700,
         400
-      ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "backend-service-token",
-          "name": "Backend Service Token"
-        }
-      }
+      ]
     },
     {
       "parameters": {

--- a/workflows/GUILD_-_Member_Leave_Credits.json
+++ b/workflows/GUILD_-_Member_Leave_Credits.json
@@ -34,14 +34,21 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL }}/api/ecommerce/webhook/guild-member-leave",
-        "authentication": "genericCredentialType",
-        "genericAuthType": "httpHeaderAuth",
+        "url": "={{ $('Webhook Trigger').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/ecommerce/webhook/guild-member-leave",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={\n  \"guild_id\": \"{{ $json.guild_id }}\",\n  \"discord_user_id\": \"{{ $json.discord_user_id }}\"\n}",
         "options": {
           "timeout": 10000
+        },
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "X-Service-Token",
+              "value": "={{ $('Webhook Trigger').first().json.body.backend_service_token || $env.BACKEND_SERVICE_TOKEN }}"
+            }
+          ]
         }
       },
       "id": "call-backend",
@@ -51,13 +58,7 @@
       "position": [
         700,
         300
-      ],
-      "credentials": {
-        "httpHeaderAuth": {
-          "id": "backend-service-token",
-          "name": "Backend Service Token"
-        }
-      }
+      ]
     },
     {
       "parameters": {

--- a/workflows/MCP_-_Games_Add.json
+++ b/workflows/MCP_-_Games_Add.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games/add",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/games/add",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Games_Analysis.json
+++ b/workflows/MCP_-_Games_Analysis.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games/analysis",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/games/analysis",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Games_Lichess.json
+++ b/workflows/MCP_-_Games_Lichess.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games/lichess",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/games/lichess",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Games_List.json
+++ b/workflows/MCP_-_Games_List.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/games",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/games",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Lichess_Auth_Callback.json
+++ b/workflows/MCP_-_Lichess_Auth_Callback.json
@@ -256,7 +256,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth/store",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/oauth/store",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -266,7 +266,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",
@@ -299,7 +299,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/lichess",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/lichess",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -309,7 +309,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Lichess_Auth_Start.json
+++ b/workflows/MCP_-_Lichess_Auth_Start.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth/store",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/oauth/store",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_OAuth_Delete.json
+++ b/workflows/MCP_-_OAuth_Delete.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth/delete",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/oauth/delete",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_OAuth_Get.json
+++ b/workflows/MCP_-_OAuth_Get.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/oauth",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/oauth",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Progress_Delete.json
+++ b/workflows/MCP_-_Progress_Delete.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/delete",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/delete",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Progress_Get.json
+++ b/workflows/MCP_-_Progress_Get.json
@@ -92,7 +92,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -102,7 +102,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",

--- a/workflows/MCP_-_Progress_Update.json
+++ b/workflows/MCP_-_Progress_Update.json
@@ -184,7 +184,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/sessions",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/sessions",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -194,7 +194,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",
@@ -227,7 +227,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/lessons",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/lessons",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -237,7 +237,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",
@@ -270,7 +270,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/badges",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/badges",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -280,7 +280,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",
@@ -313,7 +313,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/preferences",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/preferences",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -323,7 +323,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",
@@ -356,7 +356,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL || 'https://api.azy.solutions' }}/api/n8n/progress/lichess",
+        "url": "={{ $('Webhook').first().json.body.backend_api_url || $env.BACKEND_API_URL }}/api/n8n/progress/lichess",
         "sendHeaders": true,
         "headerParameters": {
           "parameters": [
@@ -366,7 +366,7 @@
             },
             {
               "name": "X-API-Key",
-              "value": "={{ $env.N8N_API_KEY }}"
+              "value": "={{ $('Webhook').first().json.body.n8n_api_key || $env.N8N_API_KEY }}"
             },
             {
               "name": "X-Tenant-ID",


### PR DESCRIPTION
## Résumé

- **11 MCP-*** : `body.backend_api_url` / `body.n8n_api_key` prioritaires dans les nodes HTTP, fallback `$env` pendant la transition ; retrait du hardcode `https://api.azy.solutions`.
- **2 GUILD** (Credits Exhausted Notification, Member Leave Credits) : credential `backend-service-token` remplacé par header explicite `X-Service-Token` (body prioritaire, fallback `$env.BACKEND_SERVICE_TOKEN`) — même pattern que GUILD - Server Sync.
- **fix `n8n_api.py`** : `find_workflow_by_name` paginé (le GET unique ne voyait que 100 workflows → batch-reimport créait des doublons, 409 à l'activation) + garde anti-doublon (refus de créer si nom introuvable).

Crons GUILD inchangés (env-based staging). Contrat client annoncé dans azy.daily#110 (6 webhooks Games/Lichess à confirmer par plugin/chatbot.core).

## Déployé

Les 13 workflows ont été réimportés et activés en base partagée (visible host2 + llm), doublons de la 1re passe supprimés. Vérifié : 13/13 uniques et actifs, webhook `games-list` répond.

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)