### PR TITLE
fix(docker): ajouter llm2.local aux extra_hosts (API backend staging)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - "webs.local:${WEBS_LOCAL_IP:-192.168.1.186}"
       - "host2.local:${HOST2_LOCAL_IP:-192.168.1.171}"
       - "host3.local:${HOST3_LOCAL_IP:-192.168.1.33}"
+      - "llm2.local:${LLM2_LOCAL_IP:-192.168.1.97}"
       - "pi6.local:${API_LOCAL_IP:-127.0.0.1}"
 
     healthcheck:

--- a/docs/n8n/INSTALLATION-SERVEUR.md
+++ b/docs/n8n/INSTALLATION-SERVEUR.md
@@ -134,7 +134,8 @@ docker compose --env-file .env.local logs n8n --tail 100 | grep -c "Unrecognized
 |---|---|---|
 | **redis-xadd** | host2, Docker (`n8n-redis-xadd`) | Redis Streams en HTTP pour les workflows batch LLM (`REDIS_XADD_SERVICE_URL`) |
 | **Apache Tika** 3.3.1 | webs.local:9998, systemd natif (`tika.service`) | extraction Office/PDF natif pour le RAG (`MCP - Office Extractor`) — streaming, aucun stockage |
-| **torah.api** | host2:/storage4/torah.api, Docker (port 3031) | consommé par le workflow torah-corpus (`API_URL=http://host2.local:3031`) |
+| **torah.api** | host2:/storage4/torah.api, Docker (port 3031) | service torah (host2.local:3031) — **reste sur host2** |
+| **API backend** | **llm.local:3301 (dev)** / **llm2.local:3301 (staging)** | API applicative consommée par les workflows via `$env.API_URL` (ex. `Torah Corpus Sedarim` → `{{ $env.API_URL }}/api/corpus/…`). L'instance n8n de llm a `API_URL=http://llm2.local:3301` (staging). **llm2.local doit être dans les `extra_hosts`** (PR #388). |
 
 ## 7. Points de vigilance (tous vécus)
 


### PR DESCRIPTION
## Problème

Le webhook `torah-corpus-sedarim` échouait en boucle : `Invalid status code: "ENOTFOUND"`. Le node `Get Sedarim (API)` appelle `{{ $env.API_URL }}` = `http://llm2.local:3301` — mais **`llm2.local` était absent des `extra_hosts`** du conteneur (les DNS publics 1.1.1.1/8.8.8.8 ne résolvent pas les `.local`).

## Topologie (corrigée)

- **API backend** migrée : **dev = llm.local:3301**, **staging = llm2.local:3301** (192.168.1.97, HTTP 200 vérifié). L'instance n8n de llm a `API_URL=http://llm2.local:3301` (staging).
- **torah.api** n'a **pas** bougé — reste sur `host2:3031`.

## Correctif

- Ajout de `llm2.local:${LLM2_LOCAL_IP:-192.168.1.97}` aux `extra_hosts` (même pattern que host3.local, PR #387).
- `docs/n8n/INSTALLATION-SERVEUR.md` §6 mis à jour (topologie API dev/staging + torah.api reste host2).

Nécessite un `docker/deploy.sh` sur llm pour recharger les extra_hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)