### PR TITLE
feat(batch): Option B — n8n télécharge les documents Anthropic en base64 (azy.daily#134)

### DIFF
--- a/workflows/Claude_-_Batch_Poller.json
+++ b/workflows/Claude_-_Batch_Poller.json
@@ -318,6 +318,19 @@
         1800,
         340
       ]
+    },
+    {
+      "id": "download-files-base64",
+      "name": "Download Files (base64)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2130,
+        340
+      ],
+      "parameters": {
+        "jsCode": "// ============================================\n// OPTION B — Télécharge les fichiers depuis Anthropic avec l'api_key LOCAL\n// et les publie en base64 (files[].data). L'api_key ne quitte JAMAIS n8n.\n// _get_discord_file (plugin) gère déjà le champ `data` base64.\n// ============================================\nconst src = $input.first().json;\nconst apiKey = src.api_key;\nconst outFiles = [];\n\nfor (const f of (src.files || [])) {\n  if (!f.download_url) { outFiles.push(f); continue; }\n  try {\n    const response = await this.helpers.httpRequest({\n      method: 'GET',\n      url: f.download_url,\n      headers: { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01' },\n      encoding: 'arraybuffer',\n      returnFullResponse: true,\n    });\n    const b64 = Buffer.from(response.body).toString('base64');\n    outFiles.push({\n      file_id: f.file_id,\n      filename: f.filename,\n      mime_type: f.mime_type,\n      size_bytes: f.size_bytes || (response.body ? response.body.length : 0),\n      data: b64,                 // base64 → consommé par le plugin\n    });\n  } catch (e) {\n    // échec de téléchargement : on garde la trace, pas de data, pas de crash\n    outFiles.push({\n      file_id: f.file_id,\n      filename: f.filename,\n      mime_type: f.mime_type,\n      download_error: (e && e.message) ? e.message : String(e),\n    });\n  }\n}\n\nreturn [{ json: { ...src, files: outFiles, has_files: outFiles.length > 0 } }];\n"
+      }
     }
   ],
   "connections": {
@@ -421,7 +434,7 @@
       "main": [
         [
           {
-            "node": "Publish to Redis",
+            "node": "Download Files (base64)",
             "type": "main",
             "index": 0
           }
@@ -444,6 +457,17 @@
         [
           {
             "node": "Store Completed",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Download Files (base64)": {
+      "main": [
+        [
+          {
+            "node": "Publish to Redis",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Problème (azy.daily#134)

Sur une demande de **document**, aucun DM n'était envoyé. Cause : le Batch Poller publie dans le stream Redis un `files[].download_url` pointant sur l'**API Files d'Anthropic**, mais **sans api_key** (le message Redis ne contient pas la clé). Le plugin consommateur télécharge alors sans auth → 401/403 → pas de fichier → pas de DM.

## Option B retenue (vs faire télécharger le plugin)

Publier l'api_key dans Redis pour que le plugin télécharge (Option A) reviendrait à **exposer une clé Anthropic en clair dans un stream**. Refusé. À la place, **n8n matérialise le fichier** — la clé ne quitte jamais n8n.

## Changement

Nouveau node **`Download Files (base64)`** dans `Claude - Batch Poller`, entre `Process Results` et `Publish to Redis` :
- télécharge chaque `download_url` avec `this.helpers.httpRequest` (`x-api-key` + `anthropic-version: 2023-06-01`, `encoding: arraybuffer`) ;
- `Buffer.from(response.body).toString('base64')` → `files[].data` ;
- échec par-fichier catché (pas de crash du poller).

→ Le plugin reçoit `files[].data` (base64), **format déjà géré par `_get_discord_file`**. Aucune modif plugin, api_key jamais dans Redis.

Note : base64 dans le stream convient aux petits/moyens fichiers ; bascule B2+presign possible plus tard pour les gros (le plugin gère aussi B2).

## À faire au déploiement

Réimport `Claude - Batch Poller` (mode PUT) puis test d'un DM document réel.

Refs azy.daily#134

🤖 Generated with [Claude Code](https://claude.com/claude-code)