### PR TITLE
fix(docker): llm.local dans extra_hosts + gabarit .env.local remis à jour

### DIFF
--- a/docker/.env.local.example
+++ b/docker/.env.local.example
@@ -1,0 +1,176 @@
+# =============================================================================
+# n8n-workflows — gabarit de configuration
+# =============================================================================
+#   cp .env.local.example .env.local && chmod 600 .env.local
+#
+# ⚠️ Éditer .env.local n'a AUCUN effet tant que ./deploy.sh n'a pas été relancé
+#    (un conteneur « Up N days » tourne avec un environnement périmé).
+#
+# Guide complet : docs/n8n/INSTALLATION-SERVEUR.md
+# =============================================================================
+
+
+# =============================================================================
+# Base de données — PARTAGÉE par tout le parc
+# =============================================================================
+# Toutes les instances n8n utilisent la MÊME base : mêmes workflows, mêmes
+# credentials, mêmes exécutions. Règles associées :
+#   1. même version n8n partout, épinglée (une instance récente migre le schéma) ;
+#   2. même N8N_ENCRYPTION_KEY (les credentials chiffrés vivent dans cette base).
+DB_TYPE=postgresdb
+DB_POSTGRESDB_HOST=databases.local
+DB_POSTGRESDB_PORT=5435
+DB_POSTGRESDB_DATABASE=n8n
+DB_POSTGRESDB_USER=<utilisateur>
+DB_POSTGRESDB_PASSWORD=<mot-de-passe>
+
+# CRITIQUE — identique sur toutes les instances du parc.
+# Une clé différente rend les credentials de la base illisibles.
+N8N_ENCRYPTION_KEY=<cle-de-chiffrement-du-parc>
+
+
+# =============================================================================
+# Résolution DNS — interpolée par docker-compose.yml (extra_hosts)
+# =============================================================================
+# Le conteneur a des DNS explicites (1.1.1.1/8.8.8.8) qui ne résolvent AUCUN
+# nom en .local. Tout hôte .local qu'un workflow doit joindre DOIT figurer ici
+# et dans les extra_hosts du compose — sinon ENOTFOUND à l'exécution.
+DATABASES_LOCAL_IP=192.168.1.185
+WEBS_LOCAL_IP=192.168.1.186
+HOST2_LOCAL_IP=192.168.1.171
+HOST3_LOCAL_IP=192.168.1.33
+LLM_LOCAL_IP=192.168.1.180
+LLM2_LOCAL_IP=192.168.1.97
+API_LOCAL_IP=127.0.0.1
+
+
+# =============================================================================
+# Auto-références n8n → n8n : TOUJOURS localhost
+# =============================================================================
+# ⚠️ Ne JAMAIS utiliser le nom LAN de la machine (llm.local, host2.local…) :
+#    le conteneur tenterait de joindre l'IP LAN de son propre hôte sur son port
+#    publié — hairpin NAT → ReadTimeout. Vérifié : localhost:5678 répond,
+#    llm.local:5678 expire.
+# ⚠️ JAMAIS de slash final : les workflows font {{$env.X}}/webhook/... ;
+#    un slash en trop donne //webhook/... → 404 (le routeur ne normalise pas).
+N8N_BASE_URL=http://localhost:5678
+N8N_WEBHOOK_URL=http://localhost:5678
+N8N_WEBHOOK_BASE_URL=http://localhost:5678/webhook
+N8N_API_URL=http://localhost:5678/api/v1
+N8N_API_KEY=<cle-api-n8n>
+
+N8N_MCP_ENDPOINT=http://localhost:5678/mcp-server/http
+N8N_MCP_TOKEN=<jeton-mcp>
+N8N_REGISTRY=http://localhost:5678/webhook/mcp/tools/registry
+
+
+# =============================================================================
+# Fonctionnalités n8n
+# =============================================================================
+N8N_BLOCK_ENV_ACCESS_IN_NODE=false
+N8N_SECURE_COOKIE=false
+N8N_DIAGNOSTICS_ENABLED=false
+N8N_NODES_EXCLUDE=
+N8N_RAG_WEBHOOK_SECRET=<secret-webhook-rag>
+
+# Custom nodes buildés (hors git) — voir docs/n8n/INSTALLATION-SERVEUR.md §2.3
+CUSTOM_NODES_DIR=../custom-nodes-built
+
+
+# =============================================================================
+# Services du parc
+# =============================================================================
+# Génération de documents PDF (webs.local) — dépôt fsebbah/gotenberg.api
+GOTENBERG_API_URL=http://webs.local:3100
+
+# ⚠️ OBSOLÈTE — Gotenberg n'est plus publié sur le réseau (accessible seulement
+#    depuis gotenberg.api). Conservé le temps que d'anciens workflows migrent.
+# GOTENBERG_URL=http://webs.local:3000
+
+# Redis Streams en HTTP pour les workflows batch LLM. Service CENTRAL : un seul
+# pour tout le parc, hébergé sur host2 — ne pas en installer par instance.
+REDIS_XADD_SERVICE_URL=http://redis-xadd-service:8765
+
+# API applicative (ecommerce, guilds, learning)
+API_URL=http://llm2.local:3301
+BACKEND_API_URL=http://llm2.local:3301
+BACKEND_SERVICE_TOKEN=<jeton-service>
+
+# torah.api — contenu ET jobs torah/books/document.
+# ⚠️ NE PAS remplacer par API_URL : le backend principal n'a pas ces routes et
+#    protège les autres (CSRF, firebase_auth_required) — inutilisable serveur-à-serveur.
+TORAH_API_URL=http://host2.local:3031
+
+
+# =============================================================================
+# Redis
+# =============================================================================
+REDIS_HOST=host3.local
+REDIS_PORT=6381
+REDIS_PASSWORD=
+REDIS_DB=4
+REDIS_DB_NOTIFICATION=5
+
+
+# =============================================================================
+# Qdrant (base vectorielle)
+# =============================================================================
+QDRANT_SHARED_1_HOST=host3.local
+QDRANT_SHARED_1_PORT=20001
+QDRANT_SHARED_1_API_KEY=<cle-api-qdrant>
+QDRANT_SHARED_1_BASE=azychat_qdrant
+
+
+# =============================================================================
+# Modèles LLM
+# =============================================================================
+# ⚠️ Politique projet : les workflows ne lisent AUCUNE clé via $env.
+#    Les credentials arrivent par le payload (BYOT), poussés par chat.api/MCP.
+#    Les clés ci-dessous ne servent qu'aux rares usages hors workflow.
+ANTHROPIC_API_KEY=<cle-anthropic>
+OPENAI_API_KEY=<cle-openai>
+MISTRAL_API_KEY=<cle-mistral>
+MODEL_ANTHROPIC=claude-haiku-4-5-20251001
+MODEL_OPENAI=gpt-5-mini
+LLM_INTENTION_MODEL=claude-haiku-4-5-20251001
+
+
+# =============================================================================
+# Discord
+# =============================================================================
+DISCORD_TOKEN=Bot <jeton-discord>
+
+
+# =============================================================================
+# Sécurité applicative
+# =============================================================================
+JWT_SECRET_KEY=<cle-jwt>
+ADMIN_PASSWORD=<mot-de-passe-admin>
+ADMIN_TOKEN=<jeton-admin>
+
+
+# =============================================================================
+# Extraction distante (diapositives depuis vidéo)
+# =============================================================================
+EXTRACT_SERVER=<utilisateur>@<serveur>.local
+SSH_PORT=2222
+REMOTE_DIR=~/extract-slides
+
+
+# =============================================================================
+# Serveur de documentation des workflows (hors n8n)
+# =============================================================================
+HOST=127.0.0.1
+PORT=8000
+WORKFLOW_DB_PATH=database/workflows.db
+ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
+RATE_LIMIT_REQUESTS=60
+RATE_LIMIT_WINDOW=60
+
+
+# =============================================================================
+# Divers
+# =============================================================================
+STRIPE_WEBHOOK_URL=https://stripe.example.com
+SCRIPTORIUM_N8N_API_KEY=<cle-scriptorium>
+TZ=Europe/Paris

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - "host2.local:${HOST2_LOCAL_IP:-192.168.1.171}"
       - "host3.local:${HOST3_LOCAL_IP:-192.168.1.33}"
       - "llm2.local:${LLM2_LOCAL_IP:-192.168.1.97}"
+      - "llm.local:${LLM_LOCAL_IP:-192.168.1.180}"
       - "pi6.local:${API_LOCAL_IP:-127.0.0.1}"
 
     healthcheck:


### PR DESCRIPTION
Régularise deux fichiers qui traînaient non commités sur `llm` (`git status` :
`M docker/docker-compose.yml`, `?? docker/.env.local.example`).

## `docker-compose.yml` — un bug latent corrigé

L'ajout de `llm.local` aux `extra_hosts` est **nécessaire** : deux variables du
conteneur le référencent (`N8N_MCP_ENDPOINT`, `N8N_REGISTRY`) et les DNS explicites
du conteneur ne résolvent aucun `.local`.

Mais la version qui tournait portait un défaut :

```yaml
- "llm.local:${LLM2_LOCAL_IP:-192.168.1.180}"
              ^^^^^^^^^^^^^^ variable de llm2, valeur de llm
```

Cela **fonctionnait par accident** : `LLM2_LOCAL_IP` n'étant pas définie, la valeur
de repli — la bonne — s'appliquait. Déclarer `LLM2_LOCAL_IP=192.168.1.97`, ce à quoi
la variable sert, aurait fait pointer `llm.local` sur **llm2**.

→ `${LLM_LOCAL_IP:-192.168.1.180}`

## `.env.local.example` — le gabarit décrivait un parc disparu

| | |
|---|---|
| Références à `pi6.local` (décommissionné) | **7 → 0** |
| Variables réellement utilisées mais absentes | **23** |

Manquaient notamment `GOTENBERG_API_URL`, `REDIS_*`, `QDRANT_*`, `TORAH_API_URL`,
`BACKEND_*`, `CUSTOM_NODES_DIR`, `N8N_REGISTRY`.

Le gabarit documente désormais les pièges qui nous ont coûté du temps :

- **auto-références n8n → n8n en `localhost`, jamais le nom LAN** — hairpin NAT.
  Vérifié depuis le conteneur : `localhost:5678` répond, `llm.local:5678` **expire** ;
- **pas de slash final** sur les URL de webhook (`//webhook/...` → 404) ;
- **éditer `.env.local` sans relancer `./deploy.sh` n'a aucun effet** ;
- `TORAH_API_URL` ≠ `API_URL` — le backend principal n'a pas ces routes et protège
  les autres (CSRF, `firebase_auth_required`) ;
- `GOTENBERG_URL` marqué **obsolète** : Gotenberg n'est plus publié sur le réseau.

### Sécurité

Toutes les valeurs sensibles sont des espaces réservés (`<...>`), **vérifié
automatiquement et par relecture complète**. Aucun secret ne part sur GitHub.

`docker/.env.example` a été supprimé — redondant.

## Un problème révélé, à traiter à part

`N8N_MCP_ENDPOINT` et `N8N_REGISTRY` pointent en production sur `http://llm.local:5678`
— donc **inopérants** (hairpin NAT), alors que `N8N_API_URL` avait déjà été basculé sur
`localhost` pour cette raison exacte. Ces deux-là ont été oubliés.

Le gabarit donne la bonne valeur, mais **le `.env.local` de production reste à corriger**
puis `./deploy.sh`. Cela expliquerait des appels au registre MCP silencieusement en échec.