### PR TITLE
fix(vocalization): un échec de persistance ne passe plus pour un succès

### DIFF
--- a/workflows/Torah_Vocalization_Worker.json
+++ b/workflows/Torah_Vocalization_Worker.json
@@ -798,6 +798,19 @@
         520
       ],
       "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Finalise un item APRÈS tentative de save (branche « sauvegarde »).\n// Vérifie que la vocalisation a RÉELLEMENT été persistée : un échec de save ne\n// doit PAS passer pour un succès. azy.daily#150 — 0 ligne persistée sur ~1M\n// commentaires, car l'échec était avalé (onError) et Clean Response ne regardait\n// jamais le résultat du save.\nconst item = $('Extract GPT Response').first().json;\nconst response = { ...item };\ndelete response._saveData;\n\n// $input = réponse de « Save to Cache » pour l'item courant.\n// L'API renvoie { success: true, vocalized_at } quand l'UPDATE a eu lieu.\nconst saveResult = $input.first().json;\nconst persisted = saveResult && (saveResult.success === true || !!saveResult.vocalized_at);\nif (!persisted) {\n  response.success = false;\n  response.error = {\n    code: 'SAVE_FAILED',\n    message: 'vocalisation générée mais NON persistée en base',\n    detail: (saveResult && (saveResult.message || saveResult.error || saveResult.detail)) || null\n  };\n}\nreturn [{ json: response }];"
+      },
+      "id": "finalize-saved",
+      "name": "Finalize (Saved)",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        2832,
+        0
+      ]
     }
   ],
   "connections": {
@@ -1023,7 +1036,7 @@
       "main": [
         [
           {
-            "node": "Clean Response",
+            "node": "Finalize (Saved)",
             "type": "main",
             "index": 0
           }
@@ -1202,6 +1215,17 @@
         [
           {
             "node": "Validate Input",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Finalize (Saved)": {
+      "main": [
+        [
+          {
+            "node": "Batch or Single?",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
Suite au diagnostic torah-api sur azy.daily#150 (**0 vocalisation persistée sur ~1M commentaires**).

## Cause du 0 muet
L'endpoint `/api/vocalization/save` fonctionne (prouvé par l'API). Mais le workflow n'aurait remonté **aucun** échec d'écriture, deux causes cumulées :
1. `Save to Cache` : `onError: continueRegularOutput` → un 4xx est **avalé**.
2. `Clean Response` finalisait l'item depuis `$('Extract GPT Response')` **sans jamais regarder le résultat du save** → `success:true` reporté quoi qu'il arrive.

Une génération réussie mais non persistée passait donc pour un succès.

## Correction
Nouveau node **Finalize (Saved)** sur la branche sauvegarde :
```
Should Save? [true] → Save to Cache → Finalize (Saved) → …
```
Il lit la réponse du save et, si l'API ne confirme pas la persistance (ni `success:true` ni `vocalized_at`), passe l'item en `success:false` / `SAVE_FAILED` → compté dans `summary.errors`, remonté au job. `Clean Response` reste sur la branche « rien à sauver », inchangée.

## Important — ce n'est probablement PAS un bug d'écriture
Le code d'écriture est **correct** : `commentary_id` bien peuplé (mapping camelCase interne cohérent), `TORAH_API_URL=host2.local:3031` correct et joignable (422 sur body vide). Le `source_text_id: null` cité par l'API est **normal** en mode commentaire.

Le « 0 ligne » s'explique par **la feature jamais lancée** (cf. #150 : le bouton Nekudot ne génère rien, génération seulement via « Option C » peu empruntée) — pas par un write path cassé. Ce durcissement garantit qu'un vrai échec, **s'il survient**, sera désormais visible.

## À valider
E2E avec une clé OpenAI + un `commentary_id` réel : la ligne `commentary_details.vocalized_text` doit être écrite, et un save en échec doit faire `summary.errors > 0`. Suit #400.