### PR TITLE
feat(torah): chunker les segments longs du batch (Router) au lieu de rejeter

### DIFF
--- a/workflows/Torah_Router.json
+++ b/workflows/Torah_Router.json
@@ -37,7 +37,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\nconst CHUNK_THRESHOLD = 10000;\n\n// Generate job_id if not provided\nconst jobIdProvided = !!body.job_id;\nconst jobId = body.job_id || 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\nconst projectId = headers['x-project-id'] || body.project_id || 'default';\n\n// Determine pipeline type\nlet pipelineType = 'unknown';\nlet segments = [];\nlet needsChunking = false;\nlet totalSegments = 0;\n\nif (body.segments && Array.isArray(body.segments) && body.segments.length > 0) {\n  // Batch mode: multiple segments (commentaries)\n  pipelineType = 'batch';\n  segments = body.segments.map((s, idx) => ({\n    index: idx,\n    text: typeof s === 'string' ? s : (s.text || s.text_hebrew || s.hebrew_text),\n    segment_id: s.segment_id || null,\n    commentary_id: s.commentary_id || null,\n    source_text: typeof s === 'string' ? s : null,\n    // RFC bilingual-translations-en-pivot: EN pivot for quality\n    reference_translation: s.reference_translation || null,\n    char_count: (typeof s === 'string' ? s : (s.text || s.text_hebrew || s.hebrew_text || '')).length\n  }));\n  \n  // Check if any segment is too long\n  const tooLongSegment = segments.find(s => s.char_count > CHUNK_THRESHOLD);\n  if (tooLongSegment) {\n    return [{\n      json: {\n        valid: false,\n        error: {\n          code: 400,\n          message: `Segment ${tooLongSegment.index} is too long (${tooLongSegment.char_count} chars). Max: ${CHUNK_THRESHOLD}. Use chunking for long texts.`\n        }\n      }\n    }];\n  }\n  \n  totalSegments = segments.length;\n  \n} else if (body.text) {\n  // Single text mode\n  const textLength = body.text.length;\n  \n  if (textLength > CHUNK_THRESHOLD) {\n    pipelineType = 'chunk_then_translate';\n    needsChunking = true;\n    // Segments will be created by Chunk Worker\n    segments = [{ index: 0, text: body.text, segment_id: body.segment_id || null, source_text: body.text, char_count: textLength }];\n    totalSegments = 1; // Will be updated after chunking\n  } else {\n    pipelineType = 'translate_single';\n    segments = [{\n      index: 0,\n      text: body.text,\n      segment_id: body.segment_id || null,\n      source_text: body.text,\n      char_count: textLength\n    }];\n    totalSegments = 1;\n  }\n} else {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'Either segments[] or text is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId,\n    jobIdProvided: jobIdProvided,\n    needsJobCreation: !jobIdProvided,\n    projectId: projectId,\n    jobType: body.job_type || 'translation',\n    pipelineType: pipelineType,\n    needsChunking: needsChunking,\n    segments: segments,\n    totalSegments: totalSegments,\n    traite: body.traite,\n    page: body.page,\n    section: body.section,\n    commentator: body.commentator,\n    sourceLanguage: body.source_language || 'he',\n    targetLanguage: body.target_language || 'fr',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    context: body.context || {},\n    metadata: body.metadata || {},\n    requestId: body.request_id,\n    model: body.model || 'claude-sonnet-4-6',\n    provider: body.provider || 'anthropic',\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
+        "jsCode": "// Parse and validate input\nconst input = $input.first().json;\nconst body = input.body || input;\nconst headers = input.headers || {};\n\nconst CHUNK_THRESHOLD = 10000;\n\n// Generate job_id if not provided\nconst jobIdProvided = !!body.job_id;\nconst jobId = body.job_id || 'job_' + Date.now().toString(36) + Math.random().toString(36).substring(2, 8);\nconst projectId = headers['x-project-id'] || body.project_id || 'default';\n\n// Determine pipeline type\nlet pipelineType = 'unknown';\nlet segments = [];\nlet needsChunking = false;\nlet totalSegments = 0;\n\nif (body.segments && Array.isArray(body.segments) && body.segments.length > 0) {\n  // Batch mode: multiple segments (commentaries)\n  pipelineType = 'batch';\n  segments = body.segments.map((s, idx) => ({\n    index: idx,\n    text: typeof s === 'string' ? s : (s.text || s.text_hebrew || s.hebrew_text),\n    segment_id: s.segment_id || null,\n    commentary_id: s.commentary_id || null,\n    source_text: typeof s === 'string' ? s : null,\n    // RFC bilingual-translations-en-pivot: EN pivot for quality\n    reference_translation: s.reference_translation || null,\n    char_count: (typeof s === 'string' ? s : (s.text || s.text_hebrew || s.hebrew_text || '')).length\n  }));\n  \n  // Les segments trop longs ne sont plus rejetés : ils seront découpés puis\n  // traduits morceau par morceau et RÉASSEMBLÉS (node « Pre-Translate Long »),\n  // car le save est keyé par commentary_id (une ligne) — azy.daily#... (chunking batch).\n  segments = segments.map(s => ({ ...s, needsChunk: s.char_count > CHUNK_THRESHOLD }));\n  totalSegments = segments.length;\n  \n} else if (body.text) {\n  // Single text mode\n  const textLength = body.text.length;\n  \n  if (textLength > CHUNK_THRESHOLD) {\n    pipelineType = 'chunk_then_translate';\n    needsChunking = true;\n    // Segments will be created by Chunk Worker\n    segments = [{ index: 0, text: body.text, segment_id: body.segment_id || null, source_text: body.text, char_count: textLength }];\n    totalSegments = 1; // Will be updated after chunking\n  } else {\n    pipelineType = 'translate_single';\n    segments = [{\n      index: 0,\n      text: body.text,\n      segment_id: body.segment_id || null,\n      source_text: body.text,\n      char_count: textLength\n    }];\n    totalSegments = 1;\n  }\n} else {\n  return [{\n    json: {\n      valid: false,\n      error: { code: 400, message: 'Either segments[] or text is required' }\n    }\n  }];\n}\n\nreturn [{\n  json: {\n    valid: true,\n    jobId: jobId,\n    jobIdProvided: jobIdProvided,\n    needsJobCreation: !jobIdProvided,\n    projectId: projectId,\n    jobType: body.job_type || 'translation',\n    pipelineType: pipelineType,\n    needsChunking: needsChunking,\n    segments: segments,\n    totalSegments: totalSegments,\n    traite: body.traite,\n    page: body.page,\n    section: body.section,\n    commentator: body.commentator,\n    sourceLanguage: body.source_language || 'he',\n    targetLanguage: body.target_language || 'fr',\n    apiKey: body.api_key,\n    openaiApiKey: body.openai_api_key,\n    context: body.context || {},\n    metadata: body.metadata || {},\n    requestId: body.request_id,\n    model: body.model || 'claude-sonnet-4-6',\n    provider: body.provider || 'anthropic',\n    chunkThreshold: CHUNK_THRESHOLD\n  }\n}];"
       },
       "id": "parse-input",
       "name": "Parse Input",
@@ -342,7 +342,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Phase 2: Prepare save payload(s) - handle EN pivot generation\nconst loopItem = $('Loop Segments').first().json;\nconst translateResult = $input.first().json;\n\n// Base payload for target language translation\nconst targetPayload = {\n  jobId: loopItem.jobId,\n  segmentIndex: loopItem.index,\n  totalSegments: loopItem.totalSegments,\n  translation: translateResult.translation,\n  segment_id: loopItem.segment_id,\n  commentary_id: loopItem.commentary_id,\n  source_text: loopItem.source_text,\n  targetLanguage: loopItem.targetLanguage,\n  model: loopItem.model,\n  provider: loopItem.provider,\n  metadata: loopItem.metadata,\n  isChunk: loopItem.isChunk || false,\n  pipelineType: loopItem.pipelineType,\n  method: translateResult.method || 'unknown'\n};\n\n// Phase 2: If EN was generated, we need to save it first\nconst hasGeneratedEnglish = translateResult.generated_english === true && translateResult.english_pivot;\n\nif (hasGeneratedEnglish) {\n  // Return TWO items: first EN save, then target language save\n  const englishPayload = {\n    jobId: loopItem.jobId,\n    segmentIndex: loopItem.index,\n    totalSegments: loopItem.totalSegments,\n    translation: translateResult.english_pivot,\n    segment_id: loopItem.segment_id,\n    commentary_id: loopItem.commentary_id,\n    source_text: loopItem.source_text,\n    targetLanguage: 'en',\n    model: loopItem.model,\n    provider: loopItem.provider,\n    metadata: { ...loopItem.metadata, is_generated_pivot: true },\n    isChunk: false,\n    pipelineType: 'en_pivot_generation',\n    method: 'structured_generation',\n    isEnglishPivot: true\n  };\n  \n  return [\n    { json: englishPayload },\n    { json: { ...targetPayload, hasEnglishPivotSaved: true } }\n  ];\n}\n\n// No EN generation - just save target translation\nreturn [{ json: targetPayload }];"
+        "jsCode": "// Phase 2: Prepare save payload(s) - handle EN pivot generation\nconst loopItem = $('Loop Segments').first().json;\n// Deux sources : Call Translate Worker (segment normal) OU le segment déjà réassemblé\n// (long segment pré-traduit). On détecte via preTranslated.\nconst translateResult = loopItem.preTranslated\n  ? { translation: loopItem.translation, success: true, method: loopItem.method || 'chunked_reassembled', generated_english: false }\n  : $input.first().json;\n\n// Base payload for target language translation\nconst targetPayload = {\n  jobId: loopItem.jobId,\n  segmentIndex: loopItem.index,\n  totalSegments: loopItem.totalSegments,\n  translation: translateResult.translation,\n  segment_id: loopItem.segment_id,\n  commentary_id: loopItem.commentary_id,\n  source_text: loopItem.source_text,\n  targetLanguage: loopItem.targetLanguage,\n  model: loopItem.model,\n  provider: loopItem.provider,\n  metadata: loopItem.metadata,\n  isChunk: loopItem.isChunk || false,\n  pipelineType: loopItem.pipelineType,\n  method: translateResult.method || 'unknown'\n};\n\n// Phase 2: If EN was generated, we need to save it first\nconst hasGeneratedEnglish = translateResult.generated_english === true && translateResult.english_pivot;\n\nif (hasGeneratedEnglish) {\n  // Return TWO items: first EN save, then target language save\n  const englishPayload = {\n    jobId: loopItem.jobId,\n    segmentIndex: loopItem.index,\n    totalSegments: loopItem.totalSegments,\n    translation: translateResult.english_pivot,\n    segment_id: loopItem.segment_id,\n    commentary_id: loopItem.commentary_id,\n    source_text: loopItem.source_text,\n    targetLanguage: 'en',\n    model: loopItem.model,\n    provider: loopItem.provider,\n    metadata: { ...loopItem.metadata, is_generated_pivot: true },\n    isChunk: false,\n    pipelineType: 'en_pivot_generation',\n    method: 'structured_generation',\n    isEnglishPivot: true\n  };\n  \n  return [\n    { json: englishPayload },\n    { json: { ...targetPayload, hasEnglishPivotSaved: true } }\n  ];\n}\n\n// No EN generation - just save target translation\nreturn [{ json: targetPayload }];"
       },
       "id": "prepare-save",
       "name": "Prepare Save",
@@ -491,6 +491,85 @@
         4400,
         304
       ]
+    },
+    {
+      "parameters": {
+        "jsCode": "// Pré-traduit les segments TROP LONGS (needsChunk) : découpe via le Chunk Worker,\n// traduit chaque morceau via le Translate Worker, RÉASSEMBLE en UNE traduction.\n// Indispensable car le save est keyé par commentary_id (une ligne) : sauver N morceaux\n// sous le même id écraserait tout sauf le dernier. Les segments normaux passent inchangés.\nconst items = $input.all().map(i => i.json);\nconst nwh = $env.N8N_WEBHOOK_URL || 'http://localhost:5678';\n\nconst call = async (path, body) => this.helpers.httpRequest({\n  method: 'POST', url: nwh + '/webhook/' + path, body, json: true, timeout: 300000,\n});\n\nconst out = [];\nfor (const seg of items) {\n  if (!seg.needsChunk) { out.push(seg); continue; }\n\n  const ctx = { traite: seg.traite, page: seg.page, section: seg.section, commentator: seg.commentator };\n\n  // 1. découper (Claude Smart Split — coupe sémantique)\n  let chunkResp;\n  try {\n    chunkResp = await call('torah-chunk', {\n      job_id: seg.jobId, text: seg.text, segment_id: seg.segment_id,\n      threshold: seg.chunkThreshold, api_key: seg.apiKey, context: ctx,\n    });\n  } catch (e) { chunkResp = null; }\n\n  if (!chunkResp || !chunkResp.success || !Array.isArray(chunkResp.segments) || !chunkResp.segments.length) {\n    out.push({ ...seg, preTranslated: true, translation: null, longError: 'chunk_failed' });\n    continue;\n  }\n\n  // 2. traduire chaque morceau DANS L'ORDRE\n  const parts = [];\n  let failed = null;\n  for (const chunk of chunkResp.segments) {\n    let tr;\n    try {\n      tr = await call('torah-translate', {\n        job_id: seg.jobId, segment_id: seg.segment_id, text: chunk.text,\n        reference_translation: null,\n        source_language: seg.sourceLanguage, target_language: seg.targetLanguage,\n        api_key: seg.apiKey, model: seg.model, context: ctx, metadata: seg.metadata,\n      });\n    } catch (e) { tr = null; }\n    if (!tr || !tr.success || !tr.translation) { failed = 'chunk_translate_failed'; break; }\n    parts.push(tr.translation);\n  }\n\n  // 3. réassembler\n  out.push({\n    ...seg, preTranslated: true,\n    translation: failed ? null : parts.join('\\n\\n'),\n    longError: failed,\n    isChunk: false,\n    chunksReassembled: chunkResp.segments.length,\n    method: 'chunked_reassembled',\n  });\n}\nreturn out.map(json => ({ json }));"
+      },
+      "id": "pre-translate-long",
+      "name": "Pre-Translate Long",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1980,
+        672
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "caseSensitive": true,
+            "typeValidation": "loose"
+          },
+          "combinator": "and",
+          "conditions": [
+            {
+              "id": "is-pre",
+              "operator": {
+                "name": "filter.operator.true",
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              },
+              "leftValue": "={{ $json.preTranslated }}",
+              "rightValue": ""
+            }
+          ]
+        }
+      },
+      "id": "pre-translated-if",
+      "name": "Pre-Translated?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        2420,
+        304
+      ]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "version": 2,
+            "caseSensitive": true,
+            "typeValidation": "loose"
+          },
+          "combinator": "and",
+          "conditions": [
+            {
+              "id": "long-ok",
+              "operator": {
+                "name": "filter.operator.exists",
+                "type": "string",
+                "operation": "exists",
+                "singleValue": true
+              },
+              "leftValue": "={{ $json.translation }}",
+              "rightValue": ""
+            }
+          ]
+        }
+      },
+      "id": "long-ok-if",
+      "name": "Long Segment OK?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        2640,
+        464
+      ]
     }
   ],
   "connections": {
@@ -629,7 +708,7 @@
       "main": [
         [
           {
-            "node": "Loop Segments",
+            "node": "Pre-Translate Long",
             "type": "main",
             "index": 0
           }
@@ -647,7 +726,7 @@
         ],
         [
           {
-            "node": "Call Translate Worker",
+            "node": "Pre-Translated?",
             "type": "main",
             "index": 0
           }
@@ -761,6 +840,53 @@
         [
           {
             "node": "Done",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pre-Translate Long": {
+      "main": [
+        [
+          {
+            "node": "Loop Segments",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pre-Translated?": {
+      "main": [
+        [
+          {
+            "node": "Long Segment OK?",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call Translate Worker",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Long Segment OK?": {
+      "main": [
+        [
+          {
+            "node": "Prepare Save",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Call Error Handler",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Problème
`Torah Router / Parse Input` **rejetait tout un batch** dès qu'un segment dépassait 10 000 car. (`Segment 287 is too long (14339 chars)`). Une page valide devenait intraduisible pour un seul commentaire dense — alors que le chemin **texte-unique**, lui, chunke.

## Pourquoi c'était un garde-fou (pas un simple oubli)
Le Save Worker est **keyé par `commentary_id`** (`POST /api/translations/save`, une ligne). Chunker un segment keyé en N morceaux et sauver chacun sous le même id → **écrasement**, seul le dernier survit. Le rejet évitait cette perte. La vraie solution demande donc une **réassemblage** — qui n'existait pas.

## Option A — chunk → traduire → réassembler → sauver une fois
- **Parse Input** : ne rejette plus, marque `needsChunk` sur les segments > seuil.
- **Nouveau `Pre-Translate Long`** : pour chaque segment long → `/webhook/torah-chunk` (Claude Smart Split) → traduit chaque morceau via `/webhook/torah-translate` **dans l'ordre** → **concatène** en une seule traduction (`preTranslated=true` → une ligne au save).
- **`Pre-Translated?`** puis **`Long Segment OK?`** : réassemblé OK → Prepare Save ; échec (`translation:null`) → **Call Error Handler**. Segments normaux → Call Translate Worker (inchangé).
- **Prepare Save** : utilise la traduction réassemblée si `preTranslated`.

**Jamais de perte muette** : échec de découpage/traduction → `longError` explicite → Error Handler, pas un save `null`.

## Validé hors-ligne
| Cas | Résultat |
|---|---|
| segment normal | passthrough ✅ |
| segment long (14 339 car.) | 2 morceaux → traduits → réassemblés `TR[…]\n\nTR[…]` ✅ |
| échec découpage | `longError: chunk_failed`, translation null → Error Handler ✅ |
| échec traduction morceau | `longError: chunk_translate_failed` ✅ |

## ⚠️ À valider en E2E (non testable hors-ligne)
Les **appels réels** à `torah-chunk`/`torah-translate` (shape de réponse + clés API BYOT). Le mock suppose `{success, segments}` et `{success, translation}` — conforme au contrat lu, à confirmer sur une vraie page avec un segment > 10 000 car.

**Réserve annexe** : le chemin texte-unique a le même risque d'écrasement s'il reçoit un `segment_id` (hors périmètre, à traiter séparément).

## Qualité
Réassembler = concaténer les traductions de morceaux. Le Smart Split coupe sémantiquement → jointures propres, mais une nuance de contexte peut se perdre à la frontière de deux morceaux. Prix assumé pour traiter un segment de 14 000+ car.