### PR TITLE
fix(vocalization): propager openai_api_key au worker (nom de champ)

### DIFF
--- a/workflows/Torah_Vocalization_(Nekudot).json
+++ b/workflows/Torah_Vocalization_(Nekudot).json
@@ -144,7 +144,7 @@
         "url": "={{ $env.N8N_WEBHOOK_URL || 'http://localhost:5678' }}/webhook/torah-vocalization-worker",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={{ JSON.stringify({ job_id: $json.job_id, project_id: $('Validate Input').first().json.projectId, items: $('Validate Input').first().json.items, context: $('Validate Input').first().json.context, openaiApiKey: $('Validate Input').first().json.openaiApiKey }) }}",
+        "jsonBody": "={{ JSON.stringify({ job_id: $json.job_id, project_id: $('Validate Input').first().json.projectId, items: $('Validate Input').first().json.items, context: $('Validate Input').first().json.context, openai_api_key: $('Validate Input').first().json.openaiApiKey }) }}",
         "options": {
           "timeout": 5000
         }


### PR DESCRIPTION
Suite au diagnostic plugin sur azy.daily#150.

## Le bug
Le dispatcher `torah-vocalization` (#400) passait la clé au worker sous `openaiApiKey` (camel), alors que le worker lit `body.openai_api_key` (snake). La clé **était** dans le payload, mais introuvable côté worker → job échoue sur « openai_api_key requis ».

```
Launch Worker envoyait : { …, openaiApiKey: "sk-proj-…" }
Worker lit             : body.openai_api_key  → undefined
```

Contrat plugin **impeccable** (envoie `openai_api_key`, comme la traduction). Bug 100 % dans ma couture dispatcher→worker.

## Fix
`Launch Worker` envoie `openai_api_key`. Seul ce champ était en décalage — `job_id`/`project_id`/`items`/`context` correspondaient déjà (vérifié en comparant les champs lus par le worker aux champs envoyés).

## Sécurité (note du plugin respectée)
La clé reste **hors de `job.input`** : `Create Job` n'expose que `traite`/`page`/`items_count`/`metadata`. Pas de fuite BYOT dans le job stocké.

Après merge/réimport, la vocalisation tourne de bout en bout (le plugin est prêt et vérifié).