### PR TITLE
feat(llm): provider Gemini (google) — messages + stream (#151)

### DIFF
--- a/workflows/LLM_-_Call_Messages.json
+++ b/workflows/LLM_-_Call_Messages.json
@@ -37,7 +37,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Call Messages (BYOT)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider} (doit etre: ${validProviders.join(', ')})`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string' || model.trim().length === 0) {\n  errors.push('model requis (ex: claude-haiku-4-5-20251001, gpt-4o)');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length === 0) {\n  errors.push('api_key requis (BYOT pattern - aucun fallback sur env)');\n}\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis (array non vide)');\n}\n\n// --- Optional: system prompt ---\nconst system = body.system || ctx.system || null;\n\n// --- Optional: max_tokens ---\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 4096);\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 200000) {\n  errors.push('max_tokens doit etre entre 1 et 200000');\n}\n\n// --- Optional: temperature ---\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// --- Passthrough metadata ---\nconst metadata = body.metadata || ctx.metadata || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    metadata: metadata\n  };\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  temperature: temperature,\n  metadata: metadata,\n  startTime: Date.now()\n};"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Call Messages (BYOT)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral', 'google'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral, google)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider} (doit etre: ${validProviders.join(', ')})`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string' || model.trim().length === 0) {\n  errors.push('model requis (ex: claude-haiku-4-5-20251001, gpt-4o)');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string' || apiKey.trim().length === 0) {\n  errors.push('api_key requis (BYOT pattern - aucun fallback sur env)');\n}\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis (array non vide)');\n}\n\n// --- Optional: system prompt ---\nconst system = body.system || ctx.system || null;\n\n// --- Optional: max_tokens ---\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 4096);\nif (isNaN(maxTokens) || maxTokens < 1 || maxTokens > 200000) {\n  errors.push('max_tokens doit etre entre 1 et 200000');\n}\n\n// --- Optional: temperature ---\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nif (isNaN(temperature) || temperature < 0 || temperature > 2) {\n  errors.push('temperature doit etre entre 0 et 2');\n}\n\n// --- Passthrough metadata ---\nconst metadata = body.metadata || ctx.metadata || {};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    metadata: metadata\n  };\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  temperature: temperature,\n  metadata: metadata,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
@@ -187,6 +187,28 @@
               },
               "renameOutput": true,
               "outputKey": "mistral"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict"
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.provider }}",
+                    "rightValue": "google",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "google"
             }
           ]
         },
@@ -381,6 +403,53 @@
         1872,
         240
       ]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://generativelanguage.googleapis.com/v1beta/models/{{ $json.model }}:generateContent",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-goog-api-key",
+              "value": "={{ $json.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const data = $json;\n  const b = { contents: data.messages, generationConfig: { maxOutputTokens: data.max_tokens, temperature: data.temperature } };\n  if (data.system) b.systemInstruction = { parts: [{ text: data.system }] };\n  return JSON.stringify(b);\n})() }}",
+        "options": {
+          "timeout": 120000
+        }
+      },
+      "id": "gemini-api",
+      "name": "Gemini API",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1152,
+        420
+      ],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "// ============================================\n// FORMAT GEMINI (google) RESPONSE\n// ============================================\nconst input = $input.first().json;\nconst prevData = $('Validate Input').first().json;\nconst startTime = prevData.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\nif (input.error) {\n  return {\n    success: false,\n    error: {\n      code: input.error.status || input.error.code || 'GEMINI_ERROR',\n      message: input.error.message || 'Gemini API error',\n      http_status: 500\n    },\n    metadata: prevData.metadata,\n    _trace: { llm_response: null, service_response: input, provider: 'google',\n      model: prevData.model, tokens: { input: 0, output: 0 }, latency_ms: latencyMs }\n  };\n}\n\nconst parts = (input.candidates && input.candidates[0] && input.candidates[0].content && input.candidates[0].content.parts) || [];\nconst text = parts.map(p => p.text || '').join('');\nconst finishReason = (input.candidates && input.candidates[0] && input.candidates[0].finishReason) || 'STOP';\nconst usage = input.usageMetadata || {};\nconst modelUsed = prevData.model;\n\nreturn {\n  success: true,\n  data: { text: text, model: modelUsed, finish_reason: finishReason },\n  meta: { provider: 'google', model: modelUsed,\n    usage: {\n      prompt_tokens: usage.promptTokenCount || 0,\n      completion_tokens: usage.candidatesTokenCount || 0,\n      total_tokens: usage.totalTokenCount || 0\n    } },\n  metadata: prevData.metadata,\n  _trace: { llm_response: text, service_response: input, provider: 'google',\n    model: modelUsed,\n    tokens: { input: usage.promptTokenCount || 0, output: usage.candidatesTokenCount || 0 },\n    latency_ms: latencyMs }\n};"
+      },
+      "id": "format-gemini",
+      "name": "Format Gemini",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        1392,
+        420
+      ]
     }
   ],
   "connections": {
@@ -454,6 +523,13 @@
         [
           {
             "node": "Mistral API",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Gemini API",
             "type": "main",
             "index": 0
           }
@@ -531,6 +607,28 @@
         [
           {
             "node": "Respond",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gemini API": {
+      "main": [
+        [
+          {
+            "node": "Format Gemini",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Gemini": {
+      "main": [
+        [
+          {
+            "node": "Merge",
             "type": "main",
             "index": 0
           }

--- a/workflows/LLM_-_Call_Stream.json
+++ b/workflows/LLM_-_Call_Stream.json
@@ -37,7 +37,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Call Stream (BYOT)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider}`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string') {\n  errors.push('model requis');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string') {\n  errors.push('api_key requis (BYOT - aucun fallback)');\n}\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis (array non vide)');\n}\n\n// --- REQUIRED: callback_url ---\nconst callbackUrl = body.callback_url || ctx.callback_url;\nif (!callbackUrl || typeof callbackUrl !== 'string') {\n  errors.push('callback_url requis pour recevoir les paquets');\n}\n\n// --- REQUIRED: correlation_id ---\nconst correlationId = body.correlation_id || ctx.correlation_id;\nif (!correlationId || typeof correlationId !== 'string') {\n  errors.push('correlation_id requis pour le tracking');\n}\n\n// --- Optional ---\nconst system = body.system || ctx.system || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 4096);\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nconst metadata = body.metadata || ctx.metadata || {};\n\n// Stream config with defaults\nconst streamConfig = {\n  flush_timeout_ms: body.stream_config?.flush_timeout_ms || 500,\n  flush_token_count: body.stream_config?.flush_token_count || 20,\n  flush_size_bytes: body.stream_config?.flush_size_bytes || 4096\n};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    correlation_id: correlationId\n  };\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  temperature: temperature,\n  callback_url: callbackUrl,\n  correlation_id: correlationId,\n  stream_config: streamConfig,\n  metadata: metadata,\n  startTime: Date.now()\n};"
+        "jsCode": "// ============================================\n// VALIDATION INPUT - LLM Call Stream (BYOT)\n// ============================================\n\nconst input = $input.first().json;\nconst body = input.body || input;\nconst ctx = body.context || {};\n\nconst errors = [];\n\n// --- REQUIRED: provider ---\nconst provider = (body.provider || ctx.provider || '').toLowerCase();\nconst validProviders = ['anthropic', 'openai', 'mistral', 'google'];\nif (!provider) {\n  errors.push('provider requis (anthropic, openai, mistral)');\n} else if (!validProviders.includes(provider)) {\n  errors.push(`provider invalide: ${provider}`);\n}\n\n// --- REQUIRED: model ---\nconst model = body.model || ctx.model;\nif (!model || typeof model !== 'string') {\n  errors.push('model requis');\n}\n\n// --- REQUIRED: api_key (BYOT - NO FALLBACK) ---\nconst apiKey = body.api_key || ctx.api_key;\nif (!apiKey || typeof apiKey !== 'string') {\n  errors.push('api_key requis (BYOT - aucun fallback)');\n}\n\n// --- REQUIRED: messages ---\nconst messages = body.messages || ctx.messages;\nif (!messages || !Array.isArray(messages) || messages.length === 0) {\n  errors.push('messages requis (array non vide)');\n}\n\n// --- REQUIRED: callback_url ---\nconst callbackUrl = body.callback_url || ctx.callback_url;\nif (!callbackUrl || typeof callbackUrl !== 'string') {\n  errors.push('callback_url requis pour recevoir les paquets');\n}\n\n// --- REQUIRED: correlation_id ---\nconst correlationId = body.correlation_id || ctx.correlation_id;\nif (!correlationId || typeof correlationId !== 'string') {\n  errors.push('correlation_id requis pour le tracking');\n}\n\n// --- Optional ---\nconst system = body.system || ctx.system || null;\nconst maxTokens = parseInt(body.max_tokens || ctx.max_tokens || 4096);\nconst temperature = parseFloat(body.temperature ?? ctx.temperature ?? 0.7);\nconst metadata = body.metadata || ctx.metadata || {};\n\n// Stream config with defaults\nconst streamConfig = {\n  flush_timeout_ms: body.stream_config?.flush_timeout_ms || 500,\n  flush_token_count: body.stream_config?.flush_token_count || 20,\n  flush_size_bytes: body.stream_config?.flush_size_bytes || 4096\n};\n\nif (errors.length > 0) {\n  return {\n    valid: false,\n    errors: errors,\n    correlation_id: correlationId\n  };\n}\n\nreturn {\n  valid: true,\n  provider: provider,\n  model: model.trim(),\n  api_key: apiKey.trim(),\n  system: system,\n  messages: messages,\n  max_tokens: maxTokens,\n  temperature: temperature,\n  callback_url: callbackUrl,\n  correlation_id: correlationId,\n  stream_config: streamConfig,\n  metadata: metadata,\n  startTime: Date.now()\n};"
       },
       "id": "validate-input",
       "name": "Validate Input",
@@ -229,6 +229,29 @@
               },
               "renameOutput": true,
               "outputKey": "mistral"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 1
+                },
+                "conditions": [
+                  {
+                    "leftValue": "={{ $json.stream_request.provider }}",
+                    "rightValue": "google",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "google"
             }
           ]
         },
@@ -375,7 +398,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// ============================================\n// PROCESS STREAM RESPONSE & SEND TO CALLBACK\n// Note: n8n HTTP Request ne supporte pas le streaming SSE natif\n// La réponse est reçue en entier (non-streamé)\n// Pour un vrai streaming, utiliser un custom node ou script externe\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Stream').first().json;\nconst req = prevData.stream_request;\nconst startTime = req.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Déterminer le provider depuis le flux\nlet provider = req.provider;\nlet text = '';\nlet usage = { input_tokens: 0, output_tokens: 0 };\nlet finishReason = 'stop';\n\n// Parser selon le provider\nif (provider === 'anthropic') {\n  text = input.content?.[0]?.text || '';\n  usage = {\n    input_tokens: input.usage?.input_tokens || 0,\n    output_tokens: input.usage?.output_tokens || 0\n  };\n  finishReason = input.stop_reason || 'end_turn';\n} else {\n  // OpenAI / Mistral format\n  text = input.choices?.[0]?.message?.content || '';\n  usage = {\n    input_tokens: input.usage?.prompt_tokens || 0,\n    output_tokens: input.usage?.completion_tokens || 0\n  };\n  finishReason = input.choices?.[0]?.finish_reason || 'stop';\n}\n\n// Construire le paquet final\nconst finalPacket = {\n  correlation_id: req.correlation_id,\n  sequence: 1,\n  events: [\n    { type: 'content_block_delta', delta: { text: text } },\n    { type: 'message_stop' }\n  ],\n  final: true,\n  cumulative_tokens: usage.input_tokens + usage.output_tokens,\n  usage: usage,\n  provider: provider,\n  model: req.model,\n  duration_ms: latencyMs,\n  timestamp: new Date().toISOString(),\n  metadata: req.metadata\n};\n\nreturn {\n  callback_url: req.callback_url,\n  packet: finalPacket\n};"
+        "jsCode": "// ============================================\n// PROCESS STREAM RESPONSE & SEND TO CALLBACK\n// Note: n8n HTTP Request ne supporte pas le streaming SSE natif\n// La réponse est reçue en entier (non-streamé)\n// Pour un vrai streaming, utiliser un custom node ou script externe\n// ============================================\n\nconst input = $input.first().json;\nconst prevData = $('Prepare Stream').first().json;\nconst req = prevData.stream_request;\nconst startTime = req.startTime || Date.now();\nconst latencyMs = Date.now() - startTime;\n\n// Déterminer le provider depuis le flux\nlet provider = req.provider;\nlet text = '';\nlet usage = { input_tokens: 0, output_tokens: 0 };\nlet finishReason = 'stop';\n\n// Parser selon le provider\nif (provider === 'anthropic') {\n  text = input.content?.[0]?.text || '';\n  usage = {\n    input_tokens: input.usage?.input_tokens || 0,\n    output_tokens: input.usage?.output_tokens || 0\n  };\n  finishReason = input.stop_reason || 'end_turn';\n} else if (provider === 'google') {\n  const parts = input.candidates?.[0]?.content?.parts || [];\n  text = parts.map(p => p.text || '').join('');\n  usage = {\n    input_tokens: input.usageMetadata?.promptTokenCount || 0,\n    output_tokens: input.usageMetadata?.candidatesTokenCount || 0\n  };\n  finishReason = input.candidates?.[0]?.finishReason || 'STOP';\n} else {\n  // OpenAI / Mistral format\n  text = input.choices?.[0]?.message?.content || '';\n  usage = {\n    input_tokens: input.usage?.prompt_tokens || 0,\n    output_tokens: input.usage?.completion_tokens || 0\n  };\n  finishReason = input.choices?.[0]?.finish_reason || 'stop';\n}\n\n// Construire le paquet final\nconst finalPacket = {\n  correlation_id: req.correlation_id,\n  sequence: 1,\n  events: [\n    { type: 'content_block_delta', delta: { text: text } },\n    { type: 'message_stop' }\n  ],\n  final: true,\n  cumulative_tokens: usage.input_tokens + usage.output_tokens,\n  usage: usage,\n  provider: provider,\n  model: req.model,\n  duration_ms: latencyMs,\n  timestamp: new Date().toISOString(),\n  metadata: req.metadata\n};\n\nreturn {\n  callback_url: req.callback_url,\n  packet: finalPacket\n};"
       },
       "id": "process-response",
       "name": "Process Response",
@@ -426,6 +449,40 @@
           "name": "Scriptorium API Key"
         }
       },
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://generativelanguage.googleapis.com/v1beta/models/{{ $json.stream_request.model }}:generateContent",
+        "sendHeaders": true,
+        "headerParameters": {
+          "parameters": [
+            {
+              "name": "x-goog-api-key",
+              "value": "={{ $json.stream_request.api_key }}"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json"
+            }
+          ]
+        },
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ (() => {\n  const req = $json.stream_request;\n  const b = { contents: req.messages, generationConfig: { maxOutputTokens: req.max_tokens, temperature: req.temperature } };\n  if (req.system) b.systemInstruction = { parts: [{ text: req.system }] };\n  return JSON.stringify(b);\n})() }}",
+        "options": {
+          "timeout": 300000
+        }
+      },
+      "id": "gemini-stream",
+      "name": "Gemini Stream",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [
+        1392,
+        540
+      ],
       "onError": "continueRegularOutput"
     }
   ],
@@ -519,6 +576,13 @@
             "type": "main",
             "index": 0
           }
+        ],
+        [
+          {
+            "node": "Gemini Stream",
+            "type": "main",
+            "index": 0
+          }
         ]
       ]
     },
@@ -560,6 +624,17 @@
         [
           {
             "node": "Send to Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Gemini Stream": {
+      "main": [
+        [
+          {
+            "node": "Process Response",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Contexte
azy.daily#151 — support Gemini pour la vision multi-provider.

**Approche retenue : (a)** — `chat.api` envoie le **format natif Gemini** (`data.messages` = `contents` Gemini), n8n **n'ajoute que la branche Gemini**, sans couche d'harmonisation par provider.

## Modifications (2 webhooks)

### `LLM - Call Messages` (sync `/llm-call-messages`)
- `Validate Input` : `'google'` ajouté à `validProviders`
- `Switch Provider` : 4e sortie `google`
- **`Gemini API`** (httpRequest) : `POST …/v1beta/models/{model}:generateContent`, header `x-goog-api-key`, body `{contents, generationConfig:{maxOutputTokens,temperature}, systemInstruction?}`
- **`Format Gemini`** : shape canonique `{success,data,meta,metadata,_trace}` en parsant `candidates[0].content.parts[].text` + `usageMetadata`
- `Format Gemini → Merge` (input 0)

### `LLM - Call Stream` (`/llm-call-stream`)
- mêmes ajouts `Validate Input` / `Switch Provider`
- **`Gemini Stream`** (httpRequest) → `generateContent` (le webhook bufferise un seul JSON agrégé — pas de vrai SSE côté n8n)
- `Process Response` : branche `google` parsant `candidates[]/usageMetadata`

## Contrat côté chat.api
Pour `provider:'google'`, `messages` doit déjà être au format **`contents` Gemini** (`[{role, parts:[{text}|{inline_data}]}]`). `system` → `systemInstruction`. La clé arrive par le payload (`api_key`, BYOT).

## Notes
- Aucune clé lue via `$env`.
- Validé hors-ligne : structure connexions + `node --check` sur tous les Code nodes.
- Réimport à lancer côté n8n avant test bout-en-bout.

— équipe n8n

🤖 Generated with [Claude Code](https://claude.com/claude-code)