### PR TITLE
fix(vocalization): Save to Cache — URL sans '=' → save jamais persisté (#165)

### DIFF
--- a/workflows/Torah_Vocalization_Worker.json
+++ b/workflows/Torah_Vocalization_Worker.json
@@ -289,7 +289,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "{{ $env.TORAH_API_URL }}/api/vocalization/save",
+        "url": "={{ $env.TORAH_API_URL }}/api/vocalization/save",
         "sendBody": true,
         "specifyBody": "json",
         "jsonBody": "={{ JSON.stringify($json._saveData) }}",


### PR DESCRIPTION
## Symptôme (révélé par le fix #410)

Une fois la boucle batch réparée (PR #410), le save échoue sur les 3 items d'un test réel :
```
SAVE_FAILED — Invalid URL: {{ $env.TORAH_API_URL }}/api/vocalization/save. URL must start with "http" or "https".
```
La vocalisation est **générée** (GPT tourne, texte correct) mais **non persistée**.

## Cause racine

Le node **`Save to Cache`** a `url: "{{ $env.TORAH_API_URL }}/api/vocalization/save"` **sans le préfixe `=`**. En n8n, un champ n'est évalué comme **expression** que s'il commence par `=`. Sans lui, `{{ … }}` est transmis **littéralement** → URL invalide. Ce n'est pas un problème de valeur d'env (elle est bien définie) : l'expression n'est jamais exécutée.

`Save to Cache` était le **seul** httpRequest du worker sans `=` (tous les autres l'ont).

## Portée

Le save échouait en **single ET batch** (les deux atteignent `Save to Cache` via `Should Save?`). Donc **aucune vocalisation n'était persistée** — c'est la **2e cause** du « 0 octet écrit » de #165, cumulée avec la boucle cassée corrigée en #410.

## Fix

`url` : `{{ … }}` → `={{ … }}` (1 caractère, aligné sur les 7 autres httpRequest du worker). Validé hors-ligne ; re-scan : plus aucune URL-expression sans `=`.

## Test live (après réimport)
Rejouer un batch → `summary.generated == total`, `errors: 0`, et vérifier en Postgres que `commentary_details.vocalized_text` est bien peuplé (≠ NULL).

— équipe n8n

🤖 Generated with [Claude Code](https://claude.com/claude-code)