### PR TITLE
fix(guild): crons lisent backend_api_url via $json au lieu de $env

### DIFF
--- a/workflows/GUILD_-_Credits_Expire_Cron.json
+++ b/workflows/GUILD_-_Credits_Expire_Cron.json
@@ -25,7 +25,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $json.BACKEND_API_URL }}/api/ecommerce/admin/guilds/cron/expire-batches",
+        "url": "={{ $json.backend_api_url }}/api/ecommerce/admin/guilds/cron/expire-batches",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "options": {
@@ -204,7 +204,7 @@
       {
         "parameters": {
           "method": "POST",
-          "url": "={{ $json.BACKEND_API_URL }}/api/ecommerce/admin/guilds/cron/expire-batches",
+          "url": "={{ $json.backend_api_url }}/api/ecommerce/admin/guilds/cron/expire-batches",
           "authentication": "genericCredentialType",
           "genericAuthType": "httpHeaderAuth",
           "options": {

--- a/workflows/GUILD_-_Credits_Renew_Cron.json
+++ b/workflows/GUILD_-_Credits_Renew_Cron.json
@@ -25,7 +25,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL }}/api/ecommerce/admin/guilds/cron/renew-due",
+        "url": "={{ $json.backend_api_url }}/api/ecommerce/admin/guilds/cron/renew-due",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "options": {
@@ -203,7 +203,7 @@
       {
         "parameters": {
           "method": "POST",
-          "url": "={{ $env.BACKEND_API_URL }}/api/ecommerce/admin/guilds/cron/renew-due",
+          "url": "={{ $json.backend_api_url }}/api/ecommerce/admin/guilds/cron/renew-due",
           "authentication": "genericCredentialType",
           "genericAuthType": "httpHeaderAuth",
           "options": {

--- a/workflows/GUILD_-_Server_Sync_Cron.json
+++ b/workflows/GUILD_-_Server_Sync_Cron.json
@@ -25,7 +25,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "={{ $env.BACKEND_API_URL }}/api/discord/admin/guilds/cron/refresh-stale",
+        "url": "={{ $json.backend_api_url }}/api/discord/admin/guilds/cron/refresh-stale",
         "authentication": "genericCredentialType",
         "genericAuthType": "httpHeaderAuth",
         "sendBody": true,
@@ -206,7 +206,7 @@
       {
         "parameters": {
           "method": "POST",
-          "url": "={{ $env.BACKEND_API_URL }}/api/discord/admin/guilds/cron/refresh-stale",
+          "url": "={{ $json.backend_api_url }}/api/discord/admin/guilds/cron/refresh-stale",
           "authentication": "genericCredentialType",
           "genericAuthType": "httpHeaderAuth",
           "sendBody": true,


### PR DESCRIPTION
## Contexte

`BACKEND_API_URL` n'est plus une variable d'env valable : le parc a **plusieurs serveurs backend** (un par projet/serveur Discord), donc une variable globale unique ne peut plus désigner « le » backend. L'URL arrive désormais dans le **body** de l'appel — clé `backend_api_url` (minuscule) — passée par le plugin (*« auto-injected by chatbot-core »*), et les nodes la lisent en `$json`.

## Changements

Les **3 crons GUILD** étaient les seuls à utiliser `$env.BACKEND_API_URL` comme **source unique** (les 13 webhooks ne l'ont qu'en fallback `body.backend_api_url || $env…` et fonctionnent déjà → **non touchés**).

| Workflow | Endpoint | Avant → Après |
|---|---|---|
| `GUILD - Credits Expire Cron` | `…/cron/expire-batches` | `$json.BACKEND_API_URL` (maj.) → `$json.backend_api_url` |
| `GUILD - Credits Renew Cron` | `…/cron/renew-due` | `$env.BACKEND_API_URL` → `$json.backend_api_url` |
| `GUILD - Server Sync Cron` | `…/cron/refresh-stale` | `$env.BACKEND_API_URL` → `$json.backend_api_url` |

Node vivant **+ miroir `activeVersion`** corrigés dans chaque fichier. JSON validé, aucun `$env.BACKEND_API_URL` restant dans ces 3 fichiers.

## ⚠️ Point ouvert (déclencheur)

Ces 3 workflows restent des `scheduleTrigger` (cron horaire/quotidien). `$json.backend_api_url` ne sera **rempli que si le plugin appelle** ces workflows en passant le body. Tant que le déclencheur est un cron interne, le champ reste vide. → décision de passer en trigger **webhook** laissée au PO.

## Réimport

À réimporter sur llm : les 3 fichiers ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)